### PR TITLE
[Language Text] Use snapshot testing for analyze

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -9,7 +9,7 @@
         "Accept-Language": "en-US",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "687",
+        "Content-Length": "289",
         "Content-Type": "application/json",
         "Referer": "http://localhost:9876/",
         "sec-ch-ua": "",
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "138bc21b-de57-4d0f-88ed-2be4d7238dc4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f1714a5c-ac5c-419f-91d5-f924f230421e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -28,28 +28,13 @@
           "documents": [
             {
               "id": "1",
-              "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle",
-              "language": "en"
-            },
-            {
-              "id": "3",
               "text": "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
               "language": "en"
             },
             {
-              "id": "4",
-              "text": "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
-              "language": "es"
-            },
-            {
-              "id": "5",
-              "text": "La carretera estaba atascada. Hab\u00EDa mucho tr\u00E1fico el d\u00EDa de ayer.",
-              "language": "es"
+              "id": "2",
+              "text": "I didn\u0027t like the last book I read at all.",
+              "language": "en"
             }
           ]
         },
@@ -57,15 +42,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a441050-6ff6-4669-9105-c72157c81cf5",
-        "Content-Length": "1834",
+        "apim-request-id": "acafff35-1e2c-46d1-be67-9936ce446d76",
+        "Content-Length": "424",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:51 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
+        "Date": "Mon, 24 Oct 2022 05:17:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "87"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -73,82 +59,6 @@
           "documents": [
             {
               "id": "1",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 26,
-                      "length": 7,
-                      "confidenceScore": 0.21
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 65,
-                      "length": 12,
-                      "confidenceScore": 0.42
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "2",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 50,
-                      "length": 7,
-                      "confidenceScore": 0.2
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 90,
-                      "length": 12,
-                      "confidenceScore": 0.36
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "3",
               "entities": [
                 {
                   "bingId": "296617ab-4ddb-cc10-beba-56e0f42af76b",
@@ -170,29 +80,7 @@
               "warnings": []
             },
             {
-              "id": "4",
-              "entities": [
-                {
-                  "bingId": "9ae3e6ca-81ea-6fa1-ffa0-42e1d7890906",
-                  "name": "Monte Rainier",
-                  "matches": [
-                    {
-                      "text": "Monte Rainier",
-                      "offset": 29,
-                      "length": 13,
-                      "confidenceScore": 0.81
-                    }
-                  ],
-                  "language": "es",
-                  "id": "Monte Rainier",
-                  "url": "https://es.wikipedia.org/wiki/Monte_Rainier",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "5",
+              "id": "2",
               "entities": [],
               "warnings": []
             }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "26727b6e-662f-4610-84ce-3f1f50060636",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e1dfbbc7-1fe0-43d1-829d-d6dbcbe84562",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3ab6695b-82f6-40ef-9c78-46a04f34e481",
+        "apim-request-id": "a5a41589-eea6-4ee3-9885-a5617aab1acc",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "578d3360-100e-4783-b347-427f636fd2d4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4e0a9705-63e4-436d-a0c4-0238a4df59e1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cdc9584b-757b-4b40-9a04-f4f48af456a4",
+        "apim-request-id": "f0704ddc-8a31-4d62-9431-e3a9db0acd13",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4463015e-23f8-41ef-bd6e-56ae7a18f9ca",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d747b12a-ee92-4c52-9020-54140ce82762",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -62,13 +62,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "509d3044-e0fc-49b8-832f-971997ca9496",
+        "apim-request-id": "32f3fe78-fb23-4456-8567-8a04970216ba",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2ae32835-6172-4a28-9b36-7a7d3748b89a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "db5a9021-7f47-48f4-bc7a-e6631b7d8cdb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2c54d5aa-0fba-4775-b982-8c727d684e00",
+        "apim-request-id": "a84bc2ff-74a7-4121-bd52-f2c0368da010",
         "Content-Length": "408",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "2",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "74ed7e65-eff3-41e2-9321-3c42795d5660",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7e3aebf9-b846-4d59-ad7a-e0750b646150",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1fc7a54-5694-4f48-a4a1-04507fce25be",
+        "apim-request-id": "72081c8f-30bc-4130-a046-d598ec5d5d10",
         "Content-Length": "1462",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:38 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "44eeb3b6-9b43-49b0-8526-473afaeb6f48",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c18b7a4c-07a9-41fd-9552-dc5d6dfc27f5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a9018312-5aea-4b26-af10-35bfabff2bb9",
+        "apim-request-id": "01929600-ed44-4665-9584-640495c6986a",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:38 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9ee95ab0-8e93-477a-b5ce-674d5f38aea0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "22547cab-b3a9-493c-8a19-9ed140c5e41d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "acdaffe1-1c0a-41ec-b8df-357ae36ed184",
+        "apim-request-id": "d374cbf6-8fe2-4099-ab1e-7c9bea7c12c1",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:38 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "21e06d5e-e239-4fc6-9ac7-fba01426d243",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4da0646f-72ea-4b55-a801-3eb9a85232a8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -62,13 +62,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "9b29cd06-6e4b-4000-9412-230a88827d71",
+        "apim-request-id": "05135482-4a19-4ab9-b612-125c4f7675e4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "59171661-8911-41f3-8684-fb129a4724f0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5e650512-4eb3-4e7c-bee4-dedb526d5ad6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa8fe889-7867-4311-a821-12431c4c9877",
+        "apim-request-id": "099e0030-e28d-484a-bee4-09c28ee29b9c",
         "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:38 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7411f565-7e9e-4488-8e17-6525c2efa169",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5e8b4642-0827-480e-a3e0-8418e79642f6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a8ecad9-3bd6-4ecd-878e-968b87bcb0dc",
+        "apim-request-id": "313e733b-bea5-43fa-ae91-cb0df6e98e5e",
         "Content-Length": "524",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "15",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "09d2e18b-c7ea-45ab-9405-efc1bd75df73",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "69421769-2c86-48ff-b984-86478894815b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5bb717e4-c929-46c8-95a1-c98daa042dbe",
+        "apim-request-id": "1a6c509d-33ba-491d-be16-38b5f289d120",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "14",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "80fd3208-3fa9-4e4c-af66-f10d444a675a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ec458537-afc0-4055-9216-adf4f89a8d4d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "94f867e8-ba6f-454b-b4cd-6e2bc982ac0f",
+        "apim-request-id": "034197b0-fb43-4a59-ab86-6b949f7557b4",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:39 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "25167aab-f7f1-455c-ac10-77ebdceb0f8f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "64126bbc-c19a-45eb-b350-549536d3e108",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4f833b26-9e66-41eb-a488-a53f1705f0d7",
+        "apim-request-id": "dbc2d1e4-925a-4310-a008-bf69c4d150e7",
         "Content-Length": "704",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "992fbb1a-ea89-46d8-8770-5a3b3ff530d5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ad66f3ec-1674-49f3-a5bc-3c5f9b2ff021",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a415fded-77da-49cc-8043-442a56b9e69f",
+        "apim-request-id": "b70e9979-e862-45d5-81cc-e618e5cb8da7",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:35 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "451d3fea-59a8-497f-9776-1f8b747f9061",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3fefc3a8-a756-4b38-962c-ae0a53bc2b4c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -58,15 +58,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a74c1800-3b89-4330-af6d-1a1e0155723d",
+        "apim-request-id": "a3671141-13e1-40ac-8a35-e90a19b8fa71",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:36 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e4f5ace3-a18a-4190-bed0-b42835cc490e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c8e8a443-e38c-45ae-8547-ef1b318efc4b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ae62332-6bb1-4017-9782-3140e7c0b75e",
+        "apim-request-id": "783f2c7b-09f5-4d63-80f7-53fd5e9e5d76",
         "Content-Length": "517",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:35 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f0f9b3be-1baa-4ced-b4bb-51e95a9e47a5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3f009a26-f3d3-4f4a-8de1-2cbaa98c2e4a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1340a982-fc7a-435a-b252-06533adc079b",
+        "apim-request-id": "e5431462-2347-449b-81d1-a8212f7b0a18",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:36 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d536e9cc-9dde-43bd-8a5e-df124c1c2bca",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2ae30fd5-5dea-4636-ac69-b395e2fc9198",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3747c3a4-308d-407a-86ab-83fba81dfa8a",
+        "apim-request-id": "210901a6-befc-4e5a-8666-440bfb8b251c",
         "Content-Length": "206",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:36 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d787e2d6-6036-4688-b3e1-73560e5070a5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f5f81e48-055d-4e08-add2-c9a34a144f5b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47a280db-a741-48df-99c5-02690dcf89e8",
+        "apim-request-id": "d54a9b7c-87d2-4cc4-a8e9-c960b1023169",
         "Content-Length": "325",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:36 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7b6c428c-5e41-4c40-ac7c-11638fb403ba",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b7ea81d9-b32f-4990-be40-44b9f83c6156",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec731f6c-607c-4d94-9ef5-6d5b15015d56",
+        "apim-request-id": "b9463d28-a6de-4bb5-8cd5-a852ff60ff15",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "da8f3675-1b74-4794-9b46-965fbeea2a3d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f742e64a-e378-4c72-bde2-f2f8213a5d2d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -41,15 +41,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a0c957d-b0f1-4330-9566-949d2c56811f",
+        "apim-request-id": "b25ca0ef-d79d-4813-96af-ffdac3492f10",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f945666f-f85a-4ef9-aad5-02701dd9c6b1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c066f441-ced3-404e-b089-a85014535805",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68f1e56c-c3ac-44f8-ab15-822ccfa317be",
+        "apim-request-id": "63b73bca-06fd-4f73-a164-8c643a56a13b",
         "Content-Length": "1142",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "afb9c67a-f8fa-4649-b619-8fd055ceb21b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1c64f10a-ff81-43d8-855d-6b0331b116b3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "303de2f9-ae84-4854-97fa-b3d88ff05bb6",
+        "apim-request-id": "5bab3534-2741-4798-b42f-def37fa53bde",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "37",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c9d16318-7c02-4006-b933-9bd151798faa",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "285f4652-fc06-4fcc-9e20-db8aa3cac5e9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "81af90e9-58af-4127-b5f7-64f6fc388899",
+        "apim-request-id": "a46eadb7-8838-4fe8-b779-9fc22c0b8efd",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a74866c1-97c1-463f-8cb3-2cb44ed77109",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cdec9076-5c6c-4663-ace4-f62b47eb0021",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "977ee607-54ba-45f4-ae0a-5378da78a980",
+        "apim-request-id": "d82c372b-3f3e-4bf6-a25c-c4e2ec57059c",
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9ac1c4ea-f438-4f6e-b099-81443faf4767",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a619d21c-2acf-4695-b9ef-81237f668fef",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "69397780-a6e9-4f5f-a18d-0e2208fe83ca",
+        "apim-request-id": "262b212c-6aa4-4859-b825-68ad4442bac7",
         "Content-Length": "389",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -97,8 +98,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "502b818b-9bef-482e-aab9-437afd00d8ba",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "db3c1b49-fa43-49d1-aef5-553338f20299",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -119,15 +120,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7055fb6a-ebab-48a3-b33a-1107df603285",
+        "apim-request-id": "a1840fc5-ce53-4c23-a511-8effbe14e58b",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "241c0916-8d2d-403a-8bfa-9a2abc7eed28",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a9ef98bc-dcd8-4edf-b3c0-5b7c9c32744c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "482186c7-6ad0-4714-b869-fa1af280716c",
+        "apim-request-id": "18c703a0-8b79-465b-9669-de6632a1eb28",
         "Content-Length": "450",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0486abba-2e11-43d0-8ca2-d3b6efeaddf5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cff2e16d-aac4-4124-872a-86500af701bc",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "23b81cde-1c59-4362-bce1-6b3e90e27ec2",
+        "apim-request-id": "2de7d72c-dd18-4c9a-8f37-d3f30e33a624",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:32 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "de80dabb-8df4-4a0c-a562-776193b984eb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d8ef4a71-30b6-4bee-b4e0-55ad41ac78f6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "037efdff-887d-4d18-99a4-c22d5412c839",
+        "apim-request-id": "5355ef1e-16ba-4808-b0d7-b3a772339693",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:32 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4e8fc6ad-2266-4d93-b73b-a239a475bd7f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c7c9c9e0-3bcd-465a-8ea6-c395238d42f3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f1d238d-1ad8-47d5-9440-d1dc80f0894f",
+        "apim-request-id": "1fee13ec-2234-4aa2-8ca2-e96475bcddd9",
         "Content-Length": "2343",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:34 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "166",
+        "Content-Type": "application/json",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "d3829e82-c1d4-4ea2-acb2-241f1115ec32",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": {
+        "kind": "SentimentAnalysis",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "The food and service are not good",
+              "language": "en"
+            }
+          ]
+        },
+        "parameters": {
+          "opinionMining": true
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "867e6851-825f-41c1-88e0-b4c4f9e09bbe",
+        "Content-Length": "954",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Mon, 24 Oct 2022 05:17:34 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "kind": "SentimentAnalysisResults",
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "sentiment": "negative",
+              "confidenceScores": {
+                "positive": 0.0,
+                "neutral": 0.0,
+                "negative": 1.0
+              },
+              "sentences": [
+                {
+                  "sentiment": "negative",
+                  "confidenceScores": {
+                    "positive": 0.0,
+                    "neutral": 0.0,
+                    "negative": 1.0
+                  },
+                  "offset": 0,
+                  "length": 33,
+                  "text": "The food and service are not good",
+                  "targets": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 4,
+                      "length": 4,
+                      "text": "food",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    },
+                    {
+                      "sentiment": "positive",
+                      "confidenceScores": {
+                        "positive": 1.0,
+                        "negative": 0.0
+                      },
+                      "offset": 13,
+                      "length": 7,
+                      "text": "service",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    }
+                  ],
+                  "assessments": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 29,
+                      "length": 4,
+                      "text": "good",
+                      "isNegated": true
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2022-10-01"
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "46f2ca1d-ff9d-4f81-a119-c38cf080b59d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bb196be3-b341-4c14-91eb-22e41837d77c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d18074d8-6ada-4607-823a-c35b58b73008",
+        "apim-request-id": "c7f96570-7eea-46a9-a40f-a07d6c1dc53a",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:35 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "17",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f568922e-fa46-4e19-bb32-bb2d823abc93",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b0182f99-ea35-4f13-8978-ac0d9061808a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df6af7bb-487a-4f8c-bb2d-3132aabcfe5c",
+        "apim-request-id": "934e60fe-9958-4003-9006-12c870e6d36d",
         "Content-Length": "1009",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:34 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e7d8280e-10d2-439e-b00f-0be48fc1a81f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5437201d-e38d-4d31-80c3-4109b5ae6d1d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -69,15 +69,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ac3b86b-c943-4f89-9281-6d947dd036e5",
+        "apim-request-id": "3fd3191d-c511-4e4a-bdc0-c880e43a1121",
         "Content-Length": "7828",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=7,CognitiveServices.TextAnalytics.TextRecords=7",
-        "Date": "Sat, 15 Oct 2022 02:25:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:33 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f108da88-4aaa-4ea0-812b-aedaf93f28da",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e6fe8dce-aae1-4b48-9889-9215c90a2d37",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ac87ca93-63c8-4e42-8c75-cba72f34e2d9",
+        "apim-request-id": "38a4bbfe-45b3-4ae2-9e7c-5a8133cc3572",
         "Content-Length": "1734",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:33 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a581a84f-9654-489a-96b0-7731f0d49c31",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9ecbb9e5-0af6-4750-bf3c-9c1bd0681d0d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "396de6cc-37b0-48b8-af93-9cca0c0f7e4a",
+        "apim-request-id": "cb704276-d07a-46cf-b598-f371286b45ca",
         "Content-Length": "699",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:32 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c533e707-9055-448c-976f-00cb97d86810",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "42ea5db2-5191-492b-b20c-00471530eb60",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "354e31c0-8029-43b6-97a3-f5b25b1fd37e",
+        "apim-request-id": "dfac0e7b-5edb-4db1-a62c-d7b2999d595c",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "54b13837-8be9-4162-8b7c-1a0b842a70ff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "92e4853a-3e1b-4baa-a179-195dc214b254",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ed3e06a4-d917-4358-b00e-e4e47a3aef5b",
+        "apim-request-id": "7e989119-ea67-4d21-8994-4c1c38493c36",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a1053c8a-e993-4b9a-aa84-5eb1ec5d29fb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "79bfdb99-dcef-4e11-a9e9-11c0fe0e7c07",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "496996b8-d565-4f0b-97f3-a2b73e6680d5",
+        "apim-request-id": "431356f4-416e-435f-bd35-77b7b9804dce",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "91820c53-6948-4b40-b837-83d579bc4fde",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9175b4f8-a680-46d2-bdcb-82fe7d440af4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d96c6837-a0c2-4c05-b181-94867111b9d7",
+        "apim-request-id": "3c98f000-ffe3-44df-a337-897fc9ae87dd",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "00ecaeb9-6051-4647-a28e-2694155b2ff5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "13a3ba5e-d035-4a1e-a202-9ebf2e696e94",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0dd34604-bbca-46fd-a2d2-2356260d4d76",
+        "apim-request-id": "e4c4b1b8-71ea-4133-86ad-01c2caad879a",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d996ebae-454c-4bb6-97d3-7f5e674ec226",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "41b31aaf-8087-4547-94df-fbb58251303e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b4cbaf7-8464-44a7-8b40-0b0493ae8b08",
+        "apim-request-id": "94168233-4808-468a-9dc3-f02f2547de1a",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b8c8a4f2-b9a9-4b84-bca8-dd381b58f08a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2112ccec-b134-4a62-81f3-5e72d50b9633",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b9fb04e-25a0-4512-805f-f3aad5a4bf1c",
+        "apim-request-id": "263241e5-c3d5-4e61-946e-7280692cf32b",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1fabf323-7ea7-4a4c-9b51-eba236773541",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "303920f4-dc30-47d4-8b8a-e3485e246618",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "466a25e7-9971-4633-af0a-87902cf07c39",
+        "apim-request-id": "7b9956d8-a062-4e8f-9c2b-f1471a3d2b8e",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "001d46f1-5f70-47d2-ac46-420bb3341162",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "35a14772-4f32-4721-99ef-849887f4f34f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "071b449c-7236-450f-b7e2-17cb04caa9e1",
+        "apim-request-id": "217fc4eb-e174-456e-a092-66ab8cafa0a8",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "52"
+        "x-envoy-upstream-service-time": "60",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a773ac77-7705-49fa-8816-a0299acdd8b0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "57b81593-ebab-4262-8d7b-1f1013b85fce",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d9112e63-c157-4ced-bb61-d91176069a54",
+        "apim-request-id": "b61166af-fbd8-4764-8427-1d3afc917d31",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ee4514a2-761c-4304-834d-de4323468dcf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "30c7f6da-40bc-42f8-8b48-7b502e1e84cc",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3f281948-20db-4bff-8ca4-27f1ad3f601a",
+        "apim-request-id": "79be4e04-68b8-4779-82df-422e892ba70a",
         "Content-Length": "287",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
@@ -19,118 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0e24709b-25d3-4cbc-b45f-a87cc29c9572",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "TextElements_v8"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "615d9e93-4dab-4935-ab03-98057c0e2dc8",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:00 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "172",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0e24709b-25d3-4cbc-b45f-a87cc29c9572",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "TextElements_v8"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "74eca936-4c9b-4791-ae59-d771da920fb3",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:02 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "172",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0e24709b-25d3-4cbc-b45f-a87cc29c9572",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b0847f36-f8fa-4dab-b88a-46a3a02a1bc6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -149,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fc4c1482-f761-4570-8a1b-138c3b6130c0",
+        "apim-request-id": "555a68a2-09f7-4adb-8a78-cd654831868c",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:48 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7a6b7990-136a-4025-bf6f-ca6b8ca04cf2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7227e443-7452-41ab-a160-5c51b9a06e22",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "111d8223-f055-4f8f-8cc5-c205cbb78621",
+        "apim-request-id": "99ba38d9-2181-4d62-bb27-2eed5122f0e5",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:48 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ba23c226-22d6-416c-93c5-7297542c2eb0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "TextElements_v8"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "d42aee0d-f471-4103-94a4-fa59826ea4a6",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:03 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "193",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ba23c226-22d6-416c-93c5-7297542c2eb0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "91923b04-ee42-40f1-82a1-892e8d79aaec",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa7a2387-cad2-4f5d-97cb-d35bb90e1915",
+        "apim-request-id": "60a12a1f-e7a4-4c5e-913e-b0a928bd080a",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0eec9c65-00e8-4832-9fdc-4e144fbe9fff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69\uD83C\uDFFB\u200D\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDC67\uD83C\uDFFE\u200D\uD83D\uDC66\uD83C\uDFFF SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "TextElements_v8"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "e5ffcc3c-61df-4920-848d-31231c30d121",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:05 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "209",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0eec9c65-00e8-4832-9fdc-4e144fbe9fff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "04f55d7a-b406-4936-a409-8f869f40cde0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "000bfa40-349a-4f6f-b755-e63ac8ccde1e",
+        "apim-request-id": "47facdab-9858-4cfa-91c0-27b5ba37bc77",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f0cbc13e-62cf-4676-ab56-4c5d92830349",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "774fa431-69ba-492c-a7f8-8f86f910229b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ddd3a452-0298-41e5-9f2e-26170ef2df0d",
+        "apim-request-id": "f3dfd4c0-a3b2-4583-9934-a26854db507b",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3cdabd94-73a3-4d5a-baf6-608acf993796",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1b83d2a3-e66e-4bbe-96d6-46086e655982",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8418222b-9079-42e7-9a3b-9ca8a0b543c5",
+        "apim-request-id": "65f614b1-75ed-4e7c-86c9-811c9e1b6177",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:50 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b01a976d-5eb9-43db-a6e0-9c91032d4702",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4071bbbd-dff6-48fe-b7f2-6d3d0a23ccd4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a30e793-1344-4023-a43b-2107f094acb6",
+        "apim-request-id": "1b889237-41f3-423c-a190-4f0efa02da29",
         "Content-Length": "509",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:50 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "74"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6301ecd9-3cc0-4d8e-8e42-ee5bbff55b93",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "a\u00F1o SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "UnicodeCodePoint"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "a7b3ed66-8467-41f4-b6e0-c126e4265a44",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:25:58 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "173",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6301ecd9-3cc0-4d8e-8e42-ee5bbff55b93",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "434c3e52-4684-4b9c-880c-fa186105874e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b82365cb-df74-485f-bd20-89ebf3b0c0fb",
+        "apim-request-id": "b4b03a3b-1880-41da-ba0d-97cef6954bf7",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b9d53399-ab97-4f73-81e6-0ae5c5eb4bb8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2edf5481-7a51-4c64-9793-19f2a3089a88",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24a2db2b-2a9b-472a-ae40-9073f942ff0c",
+        "apim-request-id": "5acbbc3b-b9b2-4eb4-b581-d2ae0f285d59",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "48eecd27-4165-49b0-8272-43a181f47800",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "UnicodeCodePoint"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "7b03c6f0-9df1-42d4-891a-5a820a51e0a0",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:25:55 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "173",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "48eecd27-4165-49b0-8272-43a181f47800",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4a4cef9b-068c-4ea0-a252-e7da2d670d9b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c2010cfe-0841-4df3-9d8b-bb6e5917bfad",
+        "apim-request-id": "c7033363-8750-4062-9f14-604f28ed4981",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d614c729-a7c8-4b17-9885-c8e4b767776f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d5cc298b-ac3e-4b01-84e1-0cbeb90c57c1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2cf9c09d-d89a-462b-9c84-9a2f791aa53c",
+        "apim-request-id": "5f669866-4e61-403a-a511-dc3fa46c4bff",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1712b461-2155-4585-b044-55a07e4751db",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "UnicodeCodePoint"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "5ea8dae5-fb09-445d-ba50-7a71087d6fa9",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:25:56 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "194",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1712b461-2155-4585-b044-55a07e4751db",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b845ab5b-54d8-4e34-b043-45733fc891c5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "db84ecaa-50ad-4c04-b841-eeabb35dd0f0",
+        "apim-request-id": "5adc5be1-0a5a-4d5d-9e9b-11b529993ec2",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dd1ed8c5-ed45-45dd-a2b1-74ff8a57f767",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6a17d76f-662c-4dec-ae8d-062bef5d677e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e3630bbf-0d3f-4fb4-a70e-98e74e32b004",
+        "apim-request-id": "0d5b9435-996e-48c7-9ca1-d7d23009e24a",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
@@ -19,63 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d31643f2-daec-4e75-8dea-9b7ca432f7c6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": {
-        "kind": "PiiEntityRecognition",
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "\uC544\uAC00 SSN: 859-98-0987",
-              "language": "en"
-            }
-          ]
-        },
-        "parameters": {
-          "stringIndexType": "UnicodeCodePoint"
-        }
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "cf3a4466-ac5c-4255-b15a-0684ba32e69b",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:25:59 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Content-Length": "175",
-        "Content-Type": "application/json",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d31643f2-daec-4e75-8dea-9b7ca432f7c6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "16b738ad-087d-4a21-a8af-3cc34db43997",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -94,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04847015-872e-4e5d-b66c-440634634571",
+        "apim-request-id": "1855d2d9-c4be-4e63-a1dc-612af292952a",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "762e4fb7-0729-4425-8c02-3faec60096bc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "19068d23-27ab-47db-ad8e-c6dafa3514c5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f0e9e613-ce88-4142-97f9-8f58db0f2925",
+        "apim-request-id": "211f1898-7e6c-4d81-8e1c-7d78acfa2b31",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f34febcd-ad13-47f7-b51e-d58eb3b24abb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "610dec92-d8cb-49c0-9a06-ad47e81ab431",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e001e356-0d7c-41ed-833e-602118257f6f",
+        "apim-request-id": "120bbfe8-0b56-4b57-be0b-895698a4c11e",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:26:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:48 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "52"
+        "x-envoy-upstream-service-time": "50",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0df1ce42-c91d-45fe-b467-eaeee7e373d0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b268fdaf-dbd4-4503-aeb8-a9fcb2188370",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "95466b5d-ae5b-47e0-86bf-79584d67b469",
+        "apim-request-id": "26692aa2-72cd-425c-aa37-175b30461bcf",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:46 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:15 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/ed719d01-529d-4f8f-93de-bed28f589951?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "102"
+        "x-envoy-upstream-service-time": "176",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ed719d01-529d-4f8f-93de-bed28f589951?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,25 +72,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9aac1a71-68fd-4483-aa8e-85c873f8aa28",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3a2a6d13-2bc4-46cb-97a9-f0459f879029",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b9592891-44f1-407b-9101-6eaf6460b035",
+        "apim-request-id": "7de42d2f-ee4c-46fa-af20-05d99d1718d6",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5",
-        "lastUpdatedDateTime": "2022-10-15T02:28:46Z",
-        "createdDateTime": "2022-10-15T02:28:46Z",
-        "expirationDateTime": "2022-10-16T02:28:46Z",
+        "jobId": "ed719d01-529d-4f8f-93de-bed28f589951",
+        "lastUpdatedDateTime": "2022-10-24T05:20:16Z",
+        "createdDateTime": "2022-10-24T05:20:16Z",
+        "expirationDateTime": "2022-10-25T05:20:16Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ed719d01-529d-4f8f-93de-bed28f589951?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,26 +120,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b5e8ae4b-77a5-4c80-bd2a-f4596dfe7aaf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0f36edae-3c57-49a8-9e37-e0e16ab44d78",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "211445bd-9039-40e3-b2da-29b8c978245c",
-        "Content-Length": "283",
+        "apim-request-id": "055a63a6-0e6f-4455-abe6-11d67fd5af4e",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5",
-        "lastUpdatedDateTime": "2022-10-15T02:28:46Z",
-        "createdDateTime": "2022-10-15T02:28:46Z",
-        "expirationDateTime": "2022-10-16T02:28:46Z",
-        "status": "notStarted",
+        "jobId": "ed719d01-529d-4f8f-93de-bed28f589951",
+        "lastUpdatedDateTime": "2022-10-24T05:20:16Z",
+        "createdDateTime": "2022-10-24T05:20:16Z",
+        "expirationDateTime": "2022-10-25T05:20:16Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ed719d01-529d-4f8f-93de-bed28f589951?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c56d050e-622d-470f-a4cf-ee63dea6e50f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "425e15d0-e78f-49fb-8d05-22f2edf599b3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84227872-78ff-4608-bf70-4338a6f7dbc9",
+        "apim-request-id": "5aa8bd9b-dbd8-4176-8c3d-bdb44fca130d",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5",
-        "lastUpdatedDateTime": "2022-10-15T02:28:46Z",
-        "createdDateTime": "2022-10-15T02:28:46Z",
-        "expirationDateTime": "2022-10-16T02:28:46Z",
+        "jobId": "ed719d01-529d-4f8f-93de-bed28f589951",
+        "lastUpdatedDateTime": "2022-10-24T05:20:16Z",
+        "createdDateTime": "2022-10-24T05:20:16Z",
+        "expirationDateTime": "2022-10-25T05:20:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:46.3332581Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:16.6431216Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -327,7 +331,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ed719d01-529d-4f8f-93de-bed28f589951?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -343,25 +347,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "61e0ee07-1999-45a8-821e-a40dce653fc7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ec9bb99e-a639-45c7-984b-0a1b98f294de",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4e35ded-ed82-47ca-ba29-228f0b283c93",
+        "apim-request-id": "2cea4db1-a822-46df-ab26-8e6a8fb8169f",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d4f6f48-26e1-4ba8-9a6d-9c0ba1fd59e5",
-        "lastUpdatedDateTime": "2022-10-15T02:28:46Z",
-        "createdDateTime": "2022-10-15T02:28:46Z",
-        "expirationDateTime": "2022-10-16T02:28:46Z",
+        "jobId": "ed719d01-529d-4f8f-93de-bed28f589951",
+        "lastUpdatedDateTime": "2022-10-24T05:20:16Z",
+        "createdDateTime": "2022-10-24T05:20:16Z",
+        "expirationDateTime": "2022-10-25T05:20:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -372,7 +377,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:46.3332581Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:16.6431216Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5b6cb16c-ca01-4f3e-8314-60cb1ce54223",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9223644e-ce25-4d25-8ea8-7743c15e0a4c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f16b8755-43b5-4b85-9467-83fe1ef6e37d",
+        "apim-request-id": "12b34d9d-aaeb-45fa-a81f-b5382f04d660",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:50 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9b9dc3d5-d827-4489-b257-30afdf8b6a7f?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:20 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/da9321d0-ae47-4e41-9d15-14d9dd09655a?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "x-envoy-upstream-service-time": "98",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b9dc3d5-d827-4489-b257-30afdf8b6a7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/da9321d0-ae47-4e41-9d15-14d9dd09655a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,25 +72,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "407c25bd-b584-4879-b4f3-dc2207a1d396",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e37a32dd-bf36-4b42-beed-d8c957e09eca",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a1d9404-64b6-47ee-a771-24ccdb1a4ec5",
+        "apim-request-id": "32a1ff14-f489-4f49-8215-66d58ed80dd4",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9b9dc3d5-d827-4489-b257-30afdf8b6a7f",
-        "lastUpdatedDateTime": "2022-10-15T02:28:51Z",
-        "createdDateTime": "2022-10-15T02:28:51Z",
-        "expirationDateTime": "2022-10-16T02:28:51Z",
+        "jobId": "da9321d0-ae47-4e41-9d15-14d9dd09655a",
+        "lastUpdatedDateTime": "2022-10-24T05:20:21Z",
+        "createdDateTime": "2022-10-24T05:20:21Z",
+        "expirationDateTime": "2022-10-25T05:20:21Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b9dc3d5-d827-4489-b257-30afdf8b6a7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/da9321d0-ae47-4e41-9d15-14d9dd09655a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,25 +120,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a744a214-1243-4d25-a559-be656b99bf1b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8508422f-59eb-44d3-9b5f-f31711a8a377",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24205846-26d2-4d53-9bc7-ccc540506c56",
+        "apim-request-id": "515a42ac-790a-407b-ac2c-57ca03b415ad",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9b9dc3d5-d827-4489-b257-30afdf8b6a7f",
-        "lastUpdatedDateTime": "2022-10-15T02:28:51Z",
-        "createdDateTime": "2022-10-15T02:28:51Z",
-        "expirationDateTime": "2022-10-16T02:28:51Z",
+        "jobId": "da9321d0-ae47-4e41-9d15-14d9dd09655a",
+        "lastUpdatedDateTime": "2022-10-24T05:20:21Z",
+        "createdDateTime": "2022-10-24T05:20:21Z",
+        "expirationDateTime": "2022-10-25T05:20:21Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b9dc3d5-d827-4489-b257-30afdf8b6a7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/da9321d0-ae47-4e41-9d15-14d9dd09655a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5b55b4be-c644-4bba-a66a-a602bf000196",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "94e0bf33-07d3-4750-bc34-a4c4dffe5557",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f35d7f61-743a-4944-98a9-7dc1a96474be",
+        "apim-request-id": "43e51dc3-e6f7-4019-b9ee-a2af5fae844a",
         "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "70",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9b9dc3d5-d827-4489-b257-30afdf8b6a7f",
-        "lastUpdatedDateTime": "2022-10-15T02:28:51Z",
-        "createdDateTime": "2022-10-15T02:28:51Z",
-        "expirationDateTime": "2022-10-16T02:28:51Z",
+        "jobId": "da9321d0-ae47-4e41-9d15-14d9dd09655a",
+        "lastUpdatedDateTime": "2022-10-24T05:20:22Z",
+        "createdDateTime": "2022-10-24T05:20:21Z",
+        "expirationDateTime": "2022-10-25T05:20:21Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:51.3066988Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:22.0204252Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -214,7 +218,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b9dc3d5-d827-4489-b257-30afdf8b6a7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/da9321d0-ae47-4e41-9d15-14d9dd09655a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -230,25 +234,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c460446f-3ac1-4eb5-ad6e-1c6d7decbf07",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "aa7b3429-3ac0-4a34-83c2-abac191d8fdb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "901ab21a-a731-4e9d-95d8-21580bceb334",
+        "apim-request-id": "bf70f234-7106-432b-8d47-cf82fd2d01d4",
         "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9b9dc3d5-d827-4489-b257-30afdf8b6a7f",
-        "lastUpdatedDateTime": "2022-10-15T02:28:51Z",
-        "createdDateTime": "2022-10-15T02:28:51Z",
-        "expirationDateTime": "2022-10-16T02:28:51Z",
+        "jobId": "da9321d0-ae47-4e41-9d15-14d9dd09655a",
+        "lastUpdatedDateTime": "2022-10-24T05:20:22Z",
+        "createdDateTime": "2022-10-24T05:20:21Z",
+        "expirationDateTime": "2022-10-25T05:20:21Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -259,7 +264,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:51.3066988Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:22.0204252Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "03e9d6d7-656f-4391-86a7-b7292d291fe8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "df7e0b87-4cf7-4c0d-b097-a34bf265b463",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "872628c9-4b3e-4869-a441-e4f4f429319b",
+        "apim-request-id": "6c4e18a9-6f5e-4c4f-ae33-8e434e0b68c7",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:48 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/b0bf5f55-18e2-407d-93d3-86e1255b38db?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:18 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/4ba5185b-8408-4c10-a843-b177cef31fc2?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "x-envoy-upstream-service-time": "85",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0bf5f55-18e2-407d-93d3-86e1255b38db?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4ba5185b-8408-4c10-a843-b177cef31fc2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,25 +72,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "73ef5062-b5b5-4a64-87dd-4967afe2ea53",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8f9f4e0e-fbe1-4343-a553-799d342f5c7b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2a25b409-f18c-4a8f-a27e-e02d6a6e5795",
+        "apim-request-id": "b5606141-2c97-44a4-9451-d7f24949f8e3",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "17",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0bf5f55-18e2-407d-93d3-86e1255b38db",
-        "lastUpdatedDateTime": "2022-10-15T02:28:48Z",
-        "createdDateTime": "2022-10-15T02:28:48Z",
-        "expirationDateTime": "2022-10-16T02:28:48Z",
+        "jobId": "4ba5185b-8408-4c10-a843-b177cef31fc2",
+        "lastUpdatedDateTime": "2022-10-24T05:20:18Z",
+        "createdDateTime": "2022-10-24T05:20:18Z",
+        "expirationDateTime": "2022-10-25T05:20:18Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0bf5f55-18e2-407d-93d3-86e1255b38db?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4ba5185b-8408-4c10-a843-b177cef31fc2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,26 +120,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7d2d5a2a-e145-4f82-9fc0-0d1e96caffb5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9fa5dd2b-cb03-4ecb-b692-f73e936fba27",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "67220c38-5296-4823-8d6d-61655f11665a",
-        "Content-Length": "280",
+        "apim-request-id": "1c152ec6-5d04-4211-ad54-caf703188920",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0bf5f55-18e2-407d-93d3-86e1255b38db",
-        "lastUpdatedDateTime": "2022-10-15T02:28:48Z",
-        "createdDateTime": "2022-10-15T02:28:48Z",
-        "expirationDateTime": "2022-10-16T02:28:48Z",
-        "status": "running",
+        "jobId": "4ba5185b-8408-4c10-a843-b177cef31fc2",
+        "lastUpdatedDateTime": "2022-10-24T05:20:18Z",
+        "createdDateTime": "2022-10-24T05:20:18Z",
+        "expirationDateTime": "2022-10-25T05:20:18Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0bf5f55-18e2-407d-93d3-86e1255b38db?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4ba5185b-8408-4c10-a843-b177cef31fc2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9e25a404-e7af-4b11-bc8f-03f45287e5e2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "eeea40cc-34f1-483e-91b5-e32830f3ca48",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c2d3983-63f6-4e50-9af2-cb359ec06c0b",
+        "apim-request-id": "1148c14e-6187-4ce7-a6e7-b7c9d348af31",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0bf5f55-18e2-407d-93d3-86e1255b38db",
-        "lastUpdatedDateTime": "2022-10-15T02:28:48Z",
-        "createdDateTime": "2022-10-15T02:28:48Z",
-        "expirationDateTime": "2022-10-16T02:28:48Z",
+        "jobId": "4ba5185b-8408-4c10-a843-b177cef31fc2",
+        "lastUpdatedDateTime": "2022-10-24T05:20:19Z",
+        "createdDateTime": "2022-10-24T05:20:18Z",
+        "expirationDateTime": "2022-10-25T05:20:18Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:48.8002713Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:19.6958974Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -219,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0bf5f55-18e2-407d-93d3-86e1255b38db?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4ba5185b-8408-4c10-a843-b177cef31fc2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -235,25 +239,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "109b823c-fba1-439f-9ab8-9c6970002b74",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cd7c2f62-cca9-4fa1-9224-7e15bf012dc7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d5e0d8a4-aa4c-4fec-98ab-2fd6bbf6e882",
+        "apim-request-id": "b1b8dd66-b594-4d55-953c-22e9f0043a18",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0bf5f55-18e2-407d-93d3-86e1255b38db",
-        "lastUpdatedDateTime": "2022-10-15T02:28:48Z",
-        "createdDateTime": "2022-10-15T02:28:48Z",
-        "expirationDateTime": "2022-10-16T02:28:48Z",
+        "jobId": "4ba5185b-8408-4c10-a843-b177cef31fc2",
+        "lastUpdatedDateTime": "2022-10-24T05:20:19Z",
+        "createdDateTime": "2022-10-24T05:20:18Z",
+        "expirationDateTime": "2022-10-25T05:20:18Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -264,7 +269,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:48.8002713Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:19.6958974Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5f6c5ed3-4988-49a5-9853-6fd8bfdc7946",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "676206a3-46ca-461a-b93d-8bce51279717",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "567b7100-05fa-4164-a626-a3c8f99ec631",
+        "apim-request-id": "e793fc4b-b3a8-4e44-8c44-dfda2aeb50dc",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:30 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:57 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/0940edb7-3259-4cef-bd09-c04e8299fcb7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "100"
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0940edb7-3259-4cef-bd09-c04e8299fcb7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,25 +76,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "02e9fed8-784f-4c53-b4c0-34a7e5d2639b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3d45f127-e3d3-4fb2-9541-46946bab3aed",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27241895-cb73-464d-a140-1faa944d6924",
+        "apim-request-id": "d3209fe9-14f8-4b80-992d-2e152a953329",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07",
-        "lastUpdatedDateTime": "2022-10-15T02:28:30Z",
-        "createdDateTime": "2022-10-15T02:28:30Z",
-        "expirationDateTime": "2022-10-16T02:28:30Z",
+        "jobId": "0940edb7-3259-4cef-bd09-c04e8299fcb7",
+        "lastUpdatedDateTime": "2022-10-24T05:19:57Z",
+        "createdDateTime": "2022-10-24T05:19:57Z",
+        "expirationDateTime": "2022-10-25T05:19:57Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -106,7 +108,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0940edb7-3259-4cef-bd09-c04e8299fcb7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -122,25 +124,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fda55ff5-e3d2-40c6-b4a0-f8b6aa5f78c3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2150adcf-3a5f-4194-a7e4-8efc82879164",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f33d80ed-f075-49d2-bdfa-fc88133dd3fc",
+        "apim-request-id": "3a96fb6f-3817-4b24-98e7-d17b4d537891",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07",
-        "lastUpdatedDateTime": "2022-10-15T02:28:30Z",
-        "createdDateTime": "2022-10-15T02:28:30Z",
-        "expirationDateTime": "2022-10-16T02:28:30Z",
+        "jobId": "0940edb7-3259-4cef-bd09-c04e8299fcb7",
+        "lastUpdatedDateTime": "2022-10-24T05:19:57Z",
+        "createdDateTime": "2022-10-24T05:19:57Z",
+        "expirationDateTime": "2022-10-25T05:19:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -153,7 +156,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0940edb7-3259-4cef-bd09-c04e8299fcb7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -169,25 +172,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "703fe3d8-11c6-4c42-91b5-41fdb6d7ed0f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3e6d44ef-5204-4ce7-9bf2-8baaa1ee2f16",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3674d2b-0434-442c-a422-9bf6f8909629",
+        "apim-request-id": "d3148fbc-8429-4750-952e-2879a2b9a1c1",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07",
-        "lastUpdatedDateTime": "2022-10-15T02:28:31Z",
-        "createdDateTime": "2022-10-15T02:28:30Z",
-        "expirationDateTime": "2022-10-16T02:28:30Z",
+        "jobId": "0940edb7-3259-4cef-bd09-c04e8299fcb7",
+        "lastUpdatedDateTime": "2022-10-24T05:19:59Z",
+        "createdDateTime": "2022-10-24T05:19:57Z",
+        "expirationDateTime": "2022-10-25T05:19:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:31.5103057Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:59.3226481Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -336,7 +340,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0940edb7-3259-4cef-bd09-c04e8299fcb7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -352,25 +356,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d6edf243-f871-4a3a-8aa5-d36af055c533",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "17980964-b256-4bae-9dc0-288cf8e4b0dd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6fd2bfe0-4d6f-4a72-8ab4-391835cc94e5",
+        "apim-request-id": "bd0d7409-a579-48b0-a84f-42d1f820ae1e",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "53",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d6e3fa8c-2b9c-42dc-aae8-e1fcb1df7b07",
-        "lastUpdatedDateTime": "2022-10-15T02:28:31Z",
-        "createdDateTime": "2022-10-15T02:28:30Z",
-        "expirationDateTime": "2022-10-16T02:28:30Z",
+        "jobId": "0940edb7-3259-4cef-bd09-c04e8299fcb7",
+        "lastUpdatedDateTime": "2022-10-24T05:19:59Z",
+        "createdDateTime": "2022-10-24T05:19:57Z",
+        "expirationDateTime": "2022-10-25T05:19:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -381,7 +386,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:31.5103057Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:59.3226481Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2d9cecf4-72fd-4ee8-a6dc-7806884f1a45",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "64bfc721-8c01-4f3f-919f-dfc607451efe",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "79f2f34e-b680-493c-80b7-83bcc3eb1c77",
+        "apim-request-id": "e066c7e3-3a1e-4c6f-8e00-2013648bd046",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:23 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/2b979c92-a432-4153-b99f-5b2afd87fda6?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:52 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e259bad2-3f8b-4bee-bc15-4f13c44859ca?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "111"
+        "x-envoy-upstream-service-time": "181",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2b979c92-a432-4153-b99f-5b2afd87fda6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e259bad2-3f8b-4bee-bc15-4f13c44859ca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,25 +76,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0f9707ce-542c-45b9-b7c2-1779ab6c16fb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "83115e39-e70e-4822-a855-3c567b656870",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "49cc0c60-70d2-479f-8e3f-7a3e3831e155",
+        "apim-request-id": "f7c99c02-3d8f-4db6-a7cf-c26a1666cb09",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:24 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2b979c92-a432-4153-b99f-5b2afd87fda6",
-        "lastUpdatedDateTime": "2022-10-15T02:28:24Z",
-        "createdDateTime": "2022-10-15T02:28:24Z",
-        "expirationDateTime": "2022-10-16T02:28:24Z",
+        "jobId": "e259bad2-3f8b-4bee-bc15-4f13c44859ca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:52Z",
+        "createdDateTime": "2022-10-24T05:19:52Z",
+        "expirationDateTime": "2022-10-25T05:19:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -106,7 +108,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2b979c92-a432-4153-b99f-5b2afd87fda6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e259bad2-3f8b-4bee-bc15-4f13c44859ca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -122,25 +124,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c2bf5d13-1370-4b49-ae1b-eb8b9ec21d18",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bf61c3ea-c0b6-4a1b-933e-889460e8a602",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bb5f384-0317-4784-94f2-8c17a786c35e",
+        "apim-request-id": "f0963ec5-c242-4897-84e4-630b0fa0a58f",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:24 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2b979c92-a432-4153-b99f-5b2afd87fda6",
-        "lastUpdatedDateTime": "2022-10-15T02:28:24Z",
-        "createdDateTime": "2022-10-15T02:28:24Z",
-        "expirationDateTime": "2022-10-16T02:28:24Z",
+        "jobId": "e259bad2-3f8b-4bee-bc15-4f13c44859ca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:52Z",
+        "createdDateTime": "2022-10-24T05:19:52Z",
+        "expirationDateTime": "2022-10-25T05:19:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -153,7 +156,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2b979c92-a432-4153-b99f-5b2afd87fda6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e259bad2-3f8b-4bee-bc15-4f13c44859ca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -169,25 +172,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5ba16798-4acc-4c6a-8e4a-01b0936bc93f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c05a2ae4-8815-49ac-924b-62fdfdb1e7a2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "588d6c76-348d-4dbc-b635-04d8718739b1",
-        "Content-Length": "1069",
+        "apim-request-id": "9cdb5658-d953-4c29-b71a-d27e130411e2",
+        "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "362"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2b979c92-a432-4153-b99f-5b2afd87fda6",
-        "lastUpdatedDateTime": "2022-10-15T02:28:25Z",
-        "createdDateTime": "2022-10-15T02:28:24Z",
-        "expirationDateTime": "2022-10-16T02:28:24Z",
+        "jobId": "e259bad2-3f8b-4bee-bc15-4f13c44859ca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:54Z",
+        "createdDateTime": "2022-10-24T05:19:52Z",
+        "expirationDateTime": "2022-10-25T05:19:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:25.739021Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:54.2244206Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -266,7 +270,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2b979c92-a432-4153-b99f-5b2afd87fda6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e259bad2-3f8b-4bee-bc15-4f13c44859ca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -282,25 +286,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dada6a34-0dae-4f2b-b841-60eae1d25734",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d4a1e048-cbb1-4722-843a-3146fba270ba",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0ef8a07c-df22-4cda-a956-f968a0e499b8",
-        "Content-Length": "1069",
+        "apim-request-id": "7d9e4515-debc-49c7-9555-3a81fd4c77cc",
+        "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2b979c92-a432-4153-b99f-5b2afd87fda6",
-        "lastUpdatedDateTime": "2022-10-15T02:28:25Z",
-        "createdDateTime": "2022-10-15T02:28:24Z",
-        "expirationDateTime": "2022-10-16T02:28:24Z",
+        "jobId": "e259bad2-3f8b-4bee-bc15-4f13c44859ca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:54Z",
+        "createdDateTime": "2022-10-24T05:19:52Z",
+        "expirationDateTime": "2022-10-25T05:19:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -311,7 +316,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:25.739021Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:54.2244206Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "260c11de-907f-4fc6-ab40-9be356d3fe75",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a255c1e2-5010-4dea-a08c-02f7010b9e9d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,18 +51,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "38d0fc28-c0af-4f09-bcb3-360a31fd6281",
+        "apim-request-id": "6a558c01-6c1b-4059-bc05-fc377eac3602",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:42 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f09cf160-f48a-4d56-9ae3-151ec95f1c13?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:13 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/be17a854-2d4e-45ee-be8c-99be90b55628?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "140"
+        "x-envoy-upstream-service-time": "146",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f09cf160-f48a-4d56-9ae3-151ec95f1c13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/be17a854-2d4e-45ee-be8c-99be90b55628?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -78,25 +79,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "00d9f362-786a-4b4c-bb89-022da94044e2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "239a8250-e3b7-4a00-9cc1-57646969f9e5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6fa4060f-025a-4861-94d3-25553ee1604d",
+        "apim-request-id": "e13db755-f8f2-4181-ad52-928090eaed72",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f09cf160-f48a-4d56-9ae3-151ec95f1c13",
-        "lastUpdatedDateTime": "2022-10-15T02:28:43Z",
-        "createdDateTime": "2022-10-15T02:28:43Z",
-        "expirationDateTime": "2022-10-16T02:28:43Z",
+        "jobId": "be17a854-2d4e-45ee-be8c-99be90b55628",
+        "lastUpdatedDateTime": "2022-10-24T05:20:13Z",
+        "createdDateTime": "2022-10-24T05:20:13Z",
+        "expirationDateTime": "2022-10-25T05:20:13Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -109,7 +111,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f09cf160-f48a-4d56-9ae3-151ec95f1c13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/be17a854-2d4e-45ee-be8c-99be90b55628?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -125,25 +127,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e015ccec-2309-402e-b1df-c4bc53f0eb8e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d85ff90a-3b1b-4e04-8ebb-71c3b9656b84",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c59069b4-db11-4a9c-9c50-a39a1aa9f4ee",
+        "apim-request-id": "86b92c7a-eacc-4b70-b959-b70531e6342d",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f09cf160-f48a-4d56-9ae3-151ec95f1c13",
-        "lastUpdatedDateTime": "2022-10-15T02:28:43Z",
-        "createdDateTime": "2022-10-15T02:28:43Z",
-        "expirationDateTime": "2022-10-16T02:28:43Z",
+        "jobId": "be17a854-2d4e-45ee-be8c-99be90b55628",
+        "lastUpdatedDateTime": "2022-10-24T05:20:13Z",
+        "createdDateTime": "2022-10-24T05:20:13Z",
+        "expirationDateTime": "2022-10-25T05:20:13Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -156,7 +159,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f09cf160-f48a-4d56-9ae3-151ec95f1c13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/be17a854-2d4e-45ee-be8c-99be90b55628?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -172,25 +175,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3cebb544-a413-4897-86ee-bbdbe446411e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2620356e-6a3e-43ba-9ad0-55419fade52a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b9d6ade5-9b8c-4a46-8d3a-fe85547b58c4",
+        "apim-request-id": "8f6ca5f7-b439-4264-b5cf-5a9e9e6bb781",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
+        "x-envoy-upstream-service-time": "91",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f09cf160-f48a-4d56-9ae3-151ec95f1c13",
-        "lastUpdatedDateTime": "2022-10-15T02:28:44Z",
-        "createdDateTime": "2022-10-15T02:28:43Z",
-        "expirationDateTime": "2022-10-16T02:28:43Z",
+        "jobId": "be17a854-2d4e-45ee-be8c-99be90b55628",
+        "lastUpdatedDateTime": "2022-10-24T05:20:15Z",
+        "createdDateTime": "2022-10-24T05:20:13Z",
+        "expirationDateTime": "2022-10-25T05:20:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -201,7 +205,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:44.8179809Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:15.2419403Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1318,7 +1322,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f09cf160-f48a-4d56-9ae3-151ec95f1c13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/be17a854-2d4e-45ee-be8c-99be90b55628?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1334,25 +1338,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6175bc7c-f1e7-401d-b509-2d8b34dfb891",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0c698297-ec1b-4463-b68f-3803e7186df9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99550ed3-099f-43a7-97b2-01497edd9413",
+        "apim-request-id": "31fcf21b-addc-431c-bf30-2c339f5b217f",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "161"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f09cf160-f48a-4d56-9ae3-151ec95f1c13",
-        "lastUpdatedDateTime": "2022-10-15T02:28:44Z",
-        "createdDateTime": "2022-10-15T02:28:43Z",
-        "expirationDateTime": "2022-10-16T02:28:43Z",
+        "jobId": "be17a854-2d4e-45ee-be8c-99be90b55628",
+        "lastUpdatedDateTime": "2022-10-24T05:20:15Z",
+        "createdDateTime": "2022-10-24T05:20:13Z",
+        "expirationDateTime": "2022-10-25T05:20:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1363,7 +1368,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:44.8179809Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:15.2419403Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9c345eb5-c726-4886-8b7e-824317457770",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b7586986-99e2-472d-bcf3-097976ff3aeb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "086c20a3-edee-4e5c-99c5-3cabb78ec75f",
+        "apim-request-id": "e9e29623-16ed-491d-b497-807e0e97566d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:26 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/1f1e6cee-ff4b-4fad-9fc5-c37856f1834a?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:55 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/50c9b08f-a1bd-421a-874d-79bcfc3f84ed?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "105"
+        "x-envoy-upstream-service-time": "92",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1f1e6cee-ff4b-4fad-9fc5-c37856f1834a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/50c9b08f-a1bd-421a-874d-79bcfc3f84ed?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,26 +76,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8044b210-54db-4d49-b324-8c1e624719a3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0fe0367c-c2db-4de6-b57e-a997513380bb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ae5082c-2493-4603-ae9b-563784dd437e",
-        "Content-Length": "283",
+        "apim-request-id": "54947aed-a7b2-4f5f-84f6-8cdb3780bc31",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1f1e6cee-ff4b-4fad-9fc5-c37856f1834a",
-        "lastUpdatedDateTime": "2022-10-15T02:28:27Z",
-        "createdDateTime": "2022-10-15T02:28:27Z",
-        "expirationDateTime": "2022-10-16T02:28:27Z",
-        "status": "notStarted",
+        "jobId": "50c9b08f-a1bd-421a-874d-79bcfc3f84ed",
+        "lastUpdatedDateTime": "2022-10-24T05:19:55Z",
+        "createdDateTime": "2022-10-24T05:19:55Z",
+        "expirationDateTime": "2022-10-25T05:19:55Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -106,7 +108,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1f1e6cee-ff4b-4fad-9fc5-c37856f1834a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/50c9b08f-a1bd-421a-874d-79bcfc3f84ed?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -122,26 +124,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "117adbff-ff04-49aa-a6a4-c616b73cc713",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "534c8019-e688-4ef5-a610-a21d9609f5b1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4b0eadf-43d2-483c-a7e5-3e13eb8ef8f6",
-        "Content-Length": "283",
+        "apim-request-id": "59e1dafa-34ef-4bd2-beb5-8f31c79e8f00",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1f1e6cee-ff4b-4fad-9fc5-c37856f1834a",
-        "lastUpdatedDateTime": "2022-10-15T02:28:27Z",
-        "createdDateTime": "2022-10-15T02:28:27Z",
-        "expirationDateTime": "2022-10-16T02:28:27Z",
-        "status": "notStarted",
+        "jobId": "50c9b08f-a1bd-421a-874d-79bcfc3f84ed",
+        "lastUpdatedDateTime": "2022-10-24T05:19:55Z",
+        "createdDateTime": "2022-10-24T05:19:55Z",
+        "expirationDateTime": "2022-10-25T05:19:55Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -153,7 +156,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1f1e6cee-ff4b-4fad-9fc5-c37856f1834a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/50c9b08f-a1bd-421a-874d-79bcfc3f84ed?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -169,25 +172,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "633b37ae-87b7-4f3f-a7ae-70612db8c58c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "627f391d-39f6-42f2-b8f8-7ad7b37fda29",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8614292c-6fea-4bb2-bbe6-89b504eaae77",
+        "apim-request-id": "6c9b5312-e4fd-45b4-809d-941224191e77",
         "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-envoy-upstream-service-time": "85",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1f1e6cee-ff4b-4fad-9fc5-c37856f1834a",
-        "lastUpdatedDateTime": "2022-10-15T02:28:29Z",
-        "createdDateTime": "2022-10-15T02:28:27Z",
-        "expirationDateTime": "2022-10-16T02:28:27Z",
+        "jobId": "50c9b08f-a1bd-421a-874d-79bcfc3f84ed",
+        "lastUpdatedDateTime": "2022-10-24T05:19:56Z",
+        "createdDateTime": "2022-10-24T05:19:55Z",
+        "expirationDateTime": "2022-10-25T05:19:55Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:28.9993181Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:56.5968164Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -230,7 +234,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1f1e6cee-ff4b-4fad-9fc5-c37856f1834a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/50c9b08f-a1bd-421a-874d-79bcfc3f84ed?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -246,25 +250,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2da738a8-05aa-485a-bc61-da498f04922f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7191208f-0178-4d2d-abb0-c2237c26aef4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93af6ac6-ee71-4716-8f9c-f16268506789",
+        "apim-request-id": "17cab1d7-f993-43fb-bd26-c35ddeb864e8",
         "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "251"
+        "x-envoy-upstream-service-time": "39",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1f1e6cee-ff4b-4fad-9fc5-c37856f1834a",
-        "lastUpdatedDateTime": "2022-10-15T02:28:29Z",
-        "createdDateTime": "2022-10-15T02:28:27Z",
-        "expirationDateTime": "2022-10-16T02:28:27Z",
+        "jobId": "50c9b08f-a1bd-421a-874d-79bcfc3f84ed",
+        "lastUpdatedDateTime": "2022-10-24T05:19:56Z",
+        "createdDateTime": "2022-10-24T05:19:55Z",
+        "expirationDateTime": "2022-10-25T05:19:55Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -275,7 +280,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:28.9993181Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:56.5968164Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5f995fd2-8946-4c9f-b2fb-ac28b00da60d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ea3902d5-757b-4a7d-a2fd-b9ec7367332b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -53,18 +53,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1ae073d7-7c68-4c0d-8742-55889b19bd09",
+        "apim-request-id": "5fd66e8b-46c2-418d-a8c2-d2054fba2ff7",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:32 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/a98cc1d8-065d-4f74-95c6-e4a0f01c5da2?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:00 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/90a50f26-b9ff-42ad-8875-df4ed1433a23?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "378"
+        "x-envoy-upstream-service-time": "116",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a98cc1d8-065d-4f74-95c6-e4a0f01c5da2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90a50f26-b9ff-42ad-8875-df4ed1433a23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -80,25 +81,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "593d6b6b-4a87-4a00-9521-7dea3172cfdb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "40a7f8b9-ab01-49f2-b988-25eea5563424",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0f6b741-b8d6-412f-bad7-04ed390de969",
+        "apim-request-id": "e3a22a66-8b5f-4623-87c1-8d394d96e573",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a98cc1d8-065d-4f74-95c6-e4a0f01c5da2",
-        "lastUpdatedDateTime": "2022-10-15T02:28:32Z",
-        "createdDateTime": "2022-10-15T02:28:32Z",
-        "expirationDateTime": "2022-10-16T02:28:32Z",
+        "jobId": "90a50f26-b9ff-42ad-8875-df4ed1433a23",
+        "lastUpdatedDateTime": "2022-10-24T05:20:00Z",
+        "createdDateTime": "2022-10-24T05:20:00Z",
+        "expirationDateTime": "2022-10-25T05:20:00Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -111,7 +113,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a98cc1d8-065d-4f74-95c6-e4a0f01c5da2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90a50f26-b9ff-42ad-8875-df4ed1433a23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -127,25 +129,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "080e1013-ea49-4d62-af9e-e16010684632",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "eb536a2a-0ebe-4be7-8d24-0141e3257c9e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2690b637-4ef5-4a78-87b0-d676f29105d3",
+        "apim-request-id": "1f7f606b-4b05-4915-ac48-b3687c6ff550",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a98cc1d8-065d-4f74-95c6-e4a0f01c5da2",
-        "lastUpdatedDateTime": "2022-10-15T02:28:32Z",
-        "createdDateTime": "2022-10-15T02:28:32Z",
-        "expirationDateTime": "2022-10-16T02:28:32Z",
+        "jobId": "90a50f26-b9ff-42ad-8875-df4ed1433a23",
+        "lastUpdatedDateTime": "2022-10-24T05:20:00Z",
+        "createdDateTime": "2022-10-24T05:20:00Z",
+        "expirationDateTime": "2022-10-25T05:20:00Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -158,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a98cc1d8-065d-4f74-95c6-e4a0f01c5da2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90a50f26-b9ff-42ad-8875-df4ed1433a23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -174,25 +177,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "27bdb75f-255e-4275-9035-cac59cd5c589",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "35fd790d-2e3e-4c68-94bb-0bc53e9a88e3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3d21d13c-d3a5-4d32-81a7-889e0eda4d15",
+        "apim-request-id": "cb5aa303-90b7-4af8-a568-3d3f62ba64af",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "x-envoy-upstream-service-time": "72",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a98cc1d8-065d-4f74-95c6-e4a0f01c5da2",
-        "lastUpdatedDateTime": "2022-10-15T02:28:34Z",
-        "createdDateTime": "2022-10-15T02:28:32Z",
-        "expirationDateTime": "2022-10-16T02:28:32Z",
+        "jobId": "90a50f26-b9ff-42ad-8875-df4ed1433a23",
+        "lastUpdatedDateTime": "2022-10-24T05:20:02Z",
+        "createdDateTime": "2022-10-24T05:20:00Z",
+        "expirationDateTime": "2022-10-25T05:20:00Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -203,7 +207,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:34.7771109Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:02.5221329Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -265,7 +269,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a98cc1d8-065d-4f74-95c6-e4a0f01c5da2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90a50f26-b9ff-42ad-8875-df4ed1433a23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -281,25 +285,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c44acdc1-c7c1-4764-8419-4f392a0ca471",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3927dfc0-38ef-485c-83bd-355f68962c77",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66b0ad59-fe93-4177-a38b-801f77106b76",
+        "apim-request-id": "89fe9ec3-a52a-45f7-9940-996df0fe8cc1",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
+        "x-envoy-upstream-service-time": "49",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a98cc1d8-065d-4f74-95c6-e4a0f01c5da2",
-        "lastUpdatedDateTime": "2022-10-15T02:28:34Z",
-        "createdDateTime": "2022-10-15T02:28:32Z",
-        "expirationDateTime": "2022-10-16T02:28:32Z",
+        "jobId": "90a50f26-b9ff-42ad-8875-df4ed1433a23",
+        "lastUpdatedDateTime": "2022-10-24T05:20:02Z",
+        "createdDateTime": "2022-10-24T05:20:00Z",
+        "expirationDateTime": "2022-10-25T05:20:00Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -310,7 +315,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:34.7771109Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:02.5221329Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0b84278e-816f-48bc-b0b5-5dfa50a5f0ee",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5fe45302-7792-4620-8eb6-ed33e356368f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,18 +51,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c2c26748-6e05-4046-b696-eebb0de1618d",
+        "apim-request-id": "01b9011c-0c70-43a3-8739-9239de1e1f01",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:35 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/47b21836-d0c4-478c-9cd5-8f6008e69798?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:02 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/5a147835-ce05-4f3d-b366-e46df7323409?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "95",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b21836-d0c4-478c-9cd5-8f6008e69798?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a147835-ce05-4f3d-b366-e46df7323409?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -78,26 +79,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "28cba4c2-a85c-4058-843b-0fe51cf96bd5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "aeb0fbc8-a0bb-4fb8-b6cc-affd2ec1feb6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65d672b1-6527-44ed-90cd-f5d074f6ad06",
-        "Content-Length": "280",
+        "apim-request-id": "9e6a8a7d-cc6f-4b3e-b30b-774f0f69c904",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "47b21836-d0c4-478c-9cd5-8f6008e69798",
-        "lastUpdatedDateTime": "2022-10-15T02:28:35Z",
-        "createdDateTime": "2022-10-15T02:28:35Z",
-        "expirationDateTime": "2022-10-16T02:28:35Z",
-        "status": "running",
+        "jobId": "5a147835-ce05-4f3d-b366-e46df7323409",
+        "lastUpdatedDateTime": "2022-10-24T05:20:03Z",
+        "createdDateTime": "2022-10-24T05:20:03Z",
+        "expirationDateTime": "2022-10-25T05:20:03Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -109,7 +111,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b21836-d0c4-478c-9cd5-8f6008e69798?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a147835-ce05-4f3d-b366-e46df7323409?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -125,26 +127,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9e431f44-a4c7-46a7-ad39-d8ef19d6b0d8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9efa671f-606f-4688-ae23-c0b779df6e10",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e61d5ac2-2cbb-47bc-82c0-bc6e0ab39550",
-        "Content-Length": "280",
+        "apim-request-id": "c4dca1f2-1a2d-4d64-8c80-8a7545a07c33",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "47b21836-d0c4-478c-9cd5-8f6008e69798",
-        "lastUpdatedDateTime": "2022-10-15T02:28:35Z",
-        "createdDateTime": "2022-10-15T02:28:35Z",
-        "expirationDateTime": "2022-10-16T02:28:35Z",
-        "status": "running",
+        "jobId": "5a147835-ce05-4f3d-b366-e46df7323409",
+        "lastUpdatedDateTime": "2022-10-24T05:20:03Z",
+        "createdDateTime": "2022-10-24T05:20:03Z",
+        "expirationDateTime": "2022-10-25T05:20:03Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -156,7 +159,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b21836-d0c4-478c-9cd5-8f6008e69798?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a147835-ce05-4f3d-b366-e46df7323409?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -172,25 +175,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f7d9ebf0-f378-4ab5-aa1f-992f50034d2f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6a05e003-02e4-4434-a1b3-ebc8d38027c2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9c9086ff-3df1-40ab-becf-203a83b03cd0",
+        "apim-request-id": "11476fe5-b5cc-4ac8-941d-a0cfa56fbc9a",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "47b21836-d0c4-478c-9cd5-8f6008e69798",
-        "lastUpdatedDateTime": "2022-10-15T02:28:36Z",
-        "createdDateTime": "2022-10-15T02:28:35Z",
-        "expirationDateTime": "2022-10-16T02:28:35Z",
+        "jobId": "5a147835-ce05-4f3d-b366-e46df7323409",
+        "lastUpdatedDateTime": "2022-10-24T05:20:05Z",
+        "createdDateTime": "2022-10-24T05:20:03Z",
+        "expirationDateTime": "2022-10-25T05:20:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -201,7 +205,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:36.8997645Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:05.3387193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -235,7 +239,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b21836-d0c4-478c-9cd5-8f6008e69798?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a147835-ce05-4f3d-b366-e46df7323409?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -251,25 +255,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "da6403e8-67c7-404b-8e8e-5f2b28db0a79",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f3e4e2cd-5495-4d4d-a34b-1dbc7899bdf2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "386e86f9-19d3-488f-a313-713ef8466809",
+        "apim-request-id": "2af54cce-e054-4db9-917a-8f75e268ad0f",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "52",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "47b21836-d0c4-478c-9cd5-8f6008e69798",
-        "lastUpdatedDateTime": "2022-10-15T02:28:36Z",
-        "createdDateTime": "2022-10-15T02:28:35Z",
-        "expirationDateTime": "2022-10-16T02:28:35Z",
+        "jobId": "5a147835-ce05-4f3d-b366-e46df7323409",
+        "lastUpdatedDateTime": "2022-10-24T05:20:05Z",
+        "createdDateTime": "2022-10-24T05:20:03Z",
+        "expirationDateTime": "2022-10-25T05:20:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -280,7 +285,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:36.8997645Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:05.3387193Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c3977b8b-b597-4503-b27b-2598240f91c5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0004bdba-ffb9-4672-9f94-112971718ecb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -49,18 +49,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f8ce3a17-0cbe-45d1-9fd2-4266745e193f",
+        "apim-request-id": "5ba9b5fa-b294-4222-a3d2-01a0b8b0f659",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:37 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/fb7b903c-dfd8-45ee-84a0-30226b62ed97?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:05 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "121"
+        "x-envoy-upstream-service-time": "83",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/fb7b903c-dfd8-45ee-84a0-30226b62ed97?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -76,25 +77,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3c6e88f0-867c-40e1-b0ac-79e37b440c54",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3d839c7a-b1ef-4ccb-b6f6-73f45bcd5825",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0f08a035-451f-46c3-9ae2-f1dc38e87bbb",
+        "apim-request-id": "f0d74950-18fa-4beb-baac-19d08951e84a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "fb7b903c-dfd8-45ee-84a0-30226b62ed97",
-        "lastUpdatedDateTime": "2022-10-15T02:28:38Z",
-        "createdDateTime": "2022-10-15T02:28:37Z",
-        "expirationDateTime": "2022-10-16T02:28:37Z",
+        "jobId": "8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:05Z",
+        "createdDateTime": "2022-10-24T05:20:05Z",
+        "expirationDateTime": "2022-10-25T05:20:05Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -107,7 +109,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/fb7b903c-dfd8-45ee-84a0-30226b62ed97?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -123,25 +125,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "23ef5f1b-bb22-457f-bd4f-d51b98d5c4a2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f57eda64-3c11-4125-8ee6-2c472803f42f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2170a304-757f-4880-8f82-98e11f60764a",
+        "apim-request-id": "bde9a4db-7fa5-4672-8924-57105f0c41e1",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "fb7b903c-dfd8-45ee-84a0-30226b62ed97",
-        "lastUpdatedDateTime": "2022-10-15T02:28:38Z",
-        "createdDateTime": "2022-10-15T02:28:37Z",
-        "expirationDateTime": "2022-10-16T02:28:37Z",
+        "jobId": "8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:05Z",
+        "createdDateTime": "2022-10-24T05:20:05Z",
+        "expirationDateTime": "2022-10-25T05:20:05Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -154,7 +157,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/fb7b903c-dfd8-45ee-84a0-30226b62ed97?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -170,25 +173,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c059ab23-a4e0-4a94-9191-7e47706e7d87",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "890c86fe-cdb9-447e-8c6c-99fd3cb6ca78",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f047f214-baf8-4e82-9715-9c51896744bb",
-        "Content-Length": "1496",
+        "apim-request-id": "1c00628c-715c-4974-a272-470565cddfad",
+        "Content-Length": "1494",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "fb7b903c-dfd8-45ee-84a0-30226b62ed97",
-        "lastUpdatedDateTime": "2022-10-15T02:28:39Z",
-        "createdDateTime": "2022-10-15T02:28:37Z",
-        "expirationDateTime": "2022-10-16T02:28:37Z",
+        "jobId": "8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:08Z",
+        "createdDateTime": "2022-10-24T05:20:05Z",
+        "expirationDateTime": "2022-10-25T05:20:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -199,7 +203,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:39.7226923Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:08.01139Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -276,7 +280,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/fb7b903c-dfd8-45ee-84a0-30226b62ed97?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -292,25 +296,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "531cb54e-6504-4b08-a9bd-dc6d3fea35f0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "47ab7107-01c1-4701-aa92-85b4f5c4e264",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a8bbba6-24d5-4748-8b0f-acc967c692d3",
-        "Content-Length": "1496",
+        "apim-request-id": "2df3313a-e57f-47c0-87a8-32a63cefda05",
+        "Content-Length": "1494",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "fb7b903c-dfd8-45ee-84a0-30226b62ed97",
-        "lastUpdatedDateTime": "2022-10-15T02:28:39Z",
-        "createdDateTime": "2022-10-15T02:28:37Z",
-        "expirationDateTime": "2022-10-16T02:28:37Z",
+        "jobId": "8ef328ac-e3dc-4bfa-9e4a-7270adf4daa0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:08Z",
+        "createdDateTime": "2022-10-24T05:20:05Z",
+        "expirationDateTime": "2022-10-25T05:20:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -321,7 +326,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:39.7226923Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:08.01139Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e6861797-030d-41b8-a33e-78a3874c1846",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "12e6f595-8d29-4a66-95a0-1f7e10450ccd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -74,18 +74,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "198b1c6c-6bc9-4a65-a1ae-0faacac412c8",
+        "apim-request-id": "4d2b09bc-12e3-4866-9b28-0f7fb229639f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:40 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/7387eeeb-4f20-49bc-a449-cdf602275ba9?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:08 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "220"
+        "x-envoy-upstream-service-time": "261",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7387eeeb-4f20-49bc-a449-cdf602275ba9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -101,26 +102,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8b8b8086-1c70-49d1-aa05-69147220ae57",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "60af152c-250a-4ac3-9a40-35f6038e765e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb45c911-0850-47e3-93e0-8c2a3e209fd6",
-        "Content-Length": "283",
+        "apim-request-id": "0e682b8c-d0be-4b94-8bcb-a13e9b83759c",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7387eeeb-4f20-49bc-a449-cdf602275ba9",
-        "lastUpdatedDateTime": "2022-10-15T02:28:40Z",
-        "createdDateTime": "2022-10-15T02:28:40Z",
-        "expirationDateTime": "2022-10-16T02:28:40Z",
-        "status": "notStarted",
+        "jobId": "54bfadd0-2521-4bec-8e7b-19f34c2a930c",
+        "lastUpdatedDateTime": "2022-10-24T05:20:08Z",
+        "createdDateTime": "2022-10-24T05:20:08Z",
+        "expirationDateTime": "2022-10-25T05:20:08Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -132,7 +134,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7387eeeb-4f20-49bc-a449-cdf602275ba9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -148,26 +150,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "97364fc2-cd15-4b6a-ad28-c6426f2305f9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9790b8af-336b-4ae6-a1ce-5d873f79e577",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d73e1425-7e5d-4521-9d18-a6f234e8423d",
-        "Content-Length": "283",
+        "apim-request-id": "4f365fd6-65b1-4d2d-b782-39fef81ece01",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7387eeeb-4f20-49bc-a449-cdf602275ba9",
-        "lastUpdatedDateTime": "2022-10-15T02:28:40Z",
-        "createdDateTime": "2022-10-15T02:28:40Z",
-        "expirationDateTime": "2022-10-16T02:28:40Z",
-        "status": "notStarted",
+        "jobId": "54bfadd0-2521-4bec-8e7b-19f34c2a930c",
+        "lastUpdatedDateTime": "2022-10-24T05:20:08Z",
+        "createdDateTime": "2022-10-24T05:20:08Z",
+        "expirationDateTime": "2022-10-25T05:20:08Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -179,7 +182,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7387eeeb-4f20-49bc-a449-cdf602275ba9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -195,25 +198,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "278a2b88-0d01-416a-b7b5-a75b067440a8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8e164e3e-4358-4ea6-85c7-f616de7c34bf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "11479371-e026-4167-b70a-32038d99a9f6",
+        "apim-request-id": "26f2d93a-442e-4458-8418-7a84a2b4962d",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "54bfadd0-2521-4bec-8e7b-19f34c2a930c",
+        "lastUpdatedDateTime": "2022-10-24T05:20:08Z",
+        "createdDateTime": "2022-10-24T05:20:08Z",
+        "expirationDateTime": "2022-10-25T05:20:08Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "7ef81791-c7d2-4ec8-a069-90f348ad2a3a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b8b25676-083d-4405-82c1-682df3271295",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "123"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7387eeeb-4f20-49bc-a449-cdf602275ba9",
-        "lastUpdatedDateTime": "2022-10-15T02:28:42Z",
-        "createdDateTime": "2022-10-15T02:28:40Z",
-        "expirationDateTime": "2022-10-16T02:28:40Z",
+        "jobId": "54bfadd0-2521-4bec-8e7b-19f34c2a930c",
+        "lastUpdatedDateTime": "2022-10-24T05:20:11Z",
+        "createdDateTime": "2022-10-24T05:20:08Z",
+        "expirationDateTime": "2022-10-25T05:20:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -224,7 +276,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:42.7291454Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:11.5215691Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -854,7 +906,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7387eeeb-4f20-49bc-a449-cdf602275ba9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/54bfadd0-2521-4bec-8e7b-19f34c2a930c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -870,25 +922,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "aa1fb1e0-007e-4d4b-a851-7f15aa6f0b98",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1a85142e-ba2c-4f0e-bdc1-1d8fe90e540b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c48d205b-ba18-434d-b570-017b33f53b11",
+        "apim-request-id": "15694a06-883c-4ac9-af24-aec611736c46",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "x-envoy-upstream-service-time": "88",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7387eeeb-4f20-49bc-a449-cdf602275ba9",
-        "lastUpdatedDateTime": "2022-10-15T02:28:42Z",
-        "createdDateTime": "2022-10-15T02:28:40Z",
-        "expirationDateTime": "2022-10-16T02:28:40Z",
+        "jobId": "54bfadd0-2521-4bec-8e7b-19f34c2a930c",
+        "lastUpdatedDateTime": "2022-10-24T05:20:11Z",
+        "createdDateTime": "2022-10-24T05:20:08Z",
+        "expirationDateTime": "2022-10-25T05:20:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -899,7 +952,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:42.7291454Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:11.5215691Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b4af63bb-b47f-40a9-aab9-3062db606a1d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "89a12717-73fa-4dee-aee6-318d09d11a33",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1df237f0-998e-4a70-bd78-861460ab4315",
+        "apim-request-id": "42e0c621-f8bb-4acd-876d-c790048db52b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:58 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9862f58d-2762-4f4d-aae3-5b16d41e36fe?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:31 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "207"
+        "x-envoy-upstream-service-time": "148",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9862f58d-2762-4f4d-aae3-5b16d41e36fe?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3d0de7e9-e09d-429e-a117-cbc76fbbebba",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c931fb67-01fc-4347-a658-557fdc0eb3de",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cdac65d9-ba10-486b-9939-c87b32d60d7c",
+        "apim-request-id": "79e1244d-1928-4e53-a9b9-bf852d236b88",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9862f58d-2762-4f4d-aae3-5b16d41e36fe",
-        "lastUpdatedDateTime": "2022-10-15T02:28:59Z",
-        "createdDateTime": "2022-10-15T02:28:58Z",
-        "expirationDateTime": "2022-10-16T02:28:58Z",
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:31Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9862f58d-2762-4f4d-aae3-5b16d41e36fe?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,25 +135,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f25fae80-815c-44d3-bdb6-83ab2a159bc2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d99d60db-047d-4a77-b980-0cf0ef97a183",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "23db1cb4-4216-4267-94cb-fda6e546d985",
+        "apim-request-id": "e446ec69-5958-419e-984c-2fe88a851fe9",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9862f58d-2762-4f4d-aae3-5b16d41e36fe",
-        "lastUpdatedDateTime": "2022-10-15T02:28:59Z",
-        "createdDateTime": "2022-10-15T02:28:58Z",
-        "expirationDateTime": "2022-10-16T02:28:58Z",
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:31Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9862f58d-2762-4f4d-aae3-5b16d41e36fe?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,36 +183,85 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "92b96ee0-b305-4f1e-a8b5-33a68a63b0a5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0a00c531-10de-4c5c-aeea-e9f9a8357c24",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6462f915-a6df-4cf4-b232-0c11c1c46d77",
-        "Content-Length": "3109",
+        "apim-request-id": "af58fdbc-3e7a-416d-b8f5-5cbe5be68c2b",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "166"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9862f58d-2762-4f4d-aae3-5b16d41e36fe",
-        "lastUpdatedDateTime": "2022-10-15T02:29:01Z",
-        "createdDateTime": "2022-10-15T02:28:58Z",
-        "expirationDateTime": "2022-10-16T02:28:58Z",
-        "status": "succeeded",
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:32Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "a2f4ee81-4da3-4e63-b0a1-b08a4fbd34fb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "dcbdb857-e4a7-4ad7-8dcc-61f97232486e",
+        "Content-Length": "2004",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:34Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:00.8331567Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.155932Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -253,7 +305,281 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:00.8660607Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.2808866Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "22025917-aae8-4d27-a7e1-9756ff8c6c2e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3bb351ac-c653-4e36-ba23-8cd0716cfa14",
+        "Content-Length": "2004",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "72",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:34Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.155932Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.2808866Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "d260110b-3819-4b46-a375-c73f4220ead5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3c5389dd-dd81-4f9e-a8a2-da4f7c083327",
+        "Content-Length": "3108",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:38Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.155932Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.2808866Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -297,7 +623,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:01.1653969Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:38.7275522Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -344,7 +670,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9862f58d-2762-4f4d-aae3-5b16d41e36fe?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f772b9fc-7719-4b49-afbe-2532ad030184?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -360,25 +686,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3ce5bd1f-eeb5-46fa-9d08-d615071a3d31",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "28592c9a-d218-4f00-beb6-b42327e514cc",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13e05f4e-f01b-4598-aaba-e6c5e42d19d0",
-        "Content-Length": "3109",
+        "apim-request-id": "82b45d1f-10a1-450d-803e-6c5dd5958f46",
+        "Content-Length": "3108",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "140"
+        "x-envoy-upstream-service-time": "206",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9862f58d-2762-4f4d-aae3-5b16d41e36fe",
-        "lastUpdatedDateTime": "2022-10-15T02:29:01Z",
-        "createdDateTime": "2022-10-15T02:28:58Z",
-        "expirationDateTime": "2022-10-16T02:28:58Z",
+        "jobId": "f772b9fc-7719-4b49-afbe-2532ad030184",
+        "lastUpdatedDateTime": "2022-10-24T05:20:38Z",
+        "createdDateTime": "2022-10-24T05:20:31Z",
+        "expirationDateTime": "2022-10-25T05:20:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -389,7 +716,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:00.8331567Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.155932Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -433,7 +760,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:00.8660607Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:34.2808866Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -477,7 +804,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:01.1653969Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:38.7275522Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e4492be8-fa5c-41b6-a4a9-bd51693b94a2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4b4865cb-044c-4776-944e-9d7b92251609",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -49,18 +49,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b5820038-21f1-43d3-92b1-dfc505c1f743",
+        "apim-request-id": "a99cad94-7ca2-405f-8013-6cba36537e92",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:32 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5bbc96ad-0009-4663-9b61-a9530701bd2e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:05 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b35e31b1-b03c-4a45-b95e-55948694265a?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5bbc96ad-0009-4663-9b61-a9530701bd2e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35e31b1-b03c-4a45-b95e-55948694265a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -76,25 +77,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "63d84211-1897-41c5-a6b4-ee03a1ae416a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "515592e0-9236-456d-aa95-3a8228c08a41",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "104b7a38-b37d-4f67-97a0-0feef4e520a3",
+        "apim-request-id": "95f32fa6-9978-4fa0-85df-15984b9f2282",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5bbc96ad-0009-4663-9b61-a9530701bd2e",
-        "lastUpdatedDateTime": "2022-10-15T02:29:32Z",
-        "createdDateTime": "2022-10-15T02:29:32Z",
-        "expirationDateTime": "2022-10-16T02:29:32Z",
+        "jobId": "b35e31b1-b03c-4a45-b95e-55948694265a",
+        "lastUpdatedDateTime": "2022-10-24T05:21:05Z",
+        "createdDateTime": "2022-10-24T05:21:05Z",
+        "expirationDateTime": "2022-10-25T05:21:05Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -107,7 +109,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5bbc96ad-0009-4663-9b61-a9530701bd2e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35e31b1-b03c-4a45-b95e-55948694265a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -123,26 +125,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6a27f5d6-078c-4b33-a5e4-77260ab0eb4a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "364add09-ea01-4f28-a5a9-1ec26f2f8133",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48ec7851-ce67-45bf-bad9-fc9c0dfd8086",
-        "Content-Length": "283",
+        "apim-request-id": "90340114-a700-4661-b0ff-98feeddc8a3e",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5bbc96ad-0009-4663-9b61-a9530701bd2e",
-        "lastUpdatedDateTime": "2022-10-15T02:29:32Z",
-        "createdDateTime": "2022-10-15T02:29:32Z",
-        "expirationDateTime": "2022-10-16T02:29:32Z",
-        "status": "notStarted",
+        "jobId": "b35e31b1-b03c-4a45-b95e-55948694265a",
+        "lastUpdatedDateTime": "2022-10-24T05:21:05Z",
+        "createdDateTime": "2022-10-24T05:21:05Z",
+        "expirationDateTime": "2022-10-25T05:21:05Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -154,7 +157,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5bbc96ad-0009-4663-9b61-a9530701bd2e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35e31b1-b03c-4a45-b95e-55948694265a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -170,25 +173,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f52b44b6-239b-4100-8a51-3d023981144b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "07bc9e3b-0d8c-4b25-9175-075fca616729",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6c9cdc9e-a93e-41f8-aa2c-34a64bee55a9",
+        "apim-request-id": "d8a7e539-da8e-4045-915d-ea54fe69f174",
         "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "54"
+        "x-envoy-upstream-service-time": "79",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5bbc96ad-0009-4663-9b61-a9530701bd2e",
-        "lastUpdatedDateTime": "2022-10-15T02:29:34Z",
-        "createdDateTime": "2022-10-15T02:29:32Z",
-        "expirationDateTime": "2022-10-16T02:29:32Z",
+        "jobId": "b35e31b1-b03c-4a45-b95e-55948694265a",
+        "lastUpdatedDateTime": "2022-10-24T05:21:07Z",
+        "createdDateTime": "2022-10-24T05:21:05Z",
+        "expirationDateTime": "2022-10-25T05:21:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -199,7 +203,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:33.9303433Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:07.6308939Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -221,7 +225,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:33.9127965Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:07.6046999Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -243,7 +247,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:34.2416982Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:06.9280402Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -268,7 +272,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5bbc96ad-0009-4663-9b61-a9530701bd2e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35e31b1-b03c-4a45-b95e-55948694265a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -284,25 +288,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ef0a1837-3a75-4029-b559-585d8435c682",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "603d53cf-fd98-4591-9635-5714fe016d17",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b015c75-d118-4e3f-9deb-11f9bf325763",
+        "apim-request-id": "a30af76d-8ff3-4826-b9f7-4c6a18608bf8",
         "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "63"
+        "x-envoy-upstream-service-time": "92",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5bbc96ad-0009-4663-9b61-a9530701bd2e",
-        "lastUpdatedDateTime": "2022-10-15T02:29:34Z",
-        "createdDateTime": "2022-10-15T02:29:32Z",
-        "expirationDateTime": "2022-10-16T02:29:32Z",
+        "jobId": "b35e31b1-b03c-4a45-b95e-55948694265a",
+        "lastUpdatedDateTime": "2022-10-24T05:21:07Z",
+        "createdDateTime": "2022-10-24T05:21:05Z",
+        "expirationDateTime": "2022-10-25T05:21:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -313,7 +318,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:33.9303433Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:07.6308939Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -335,7 +340,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:33.9127965Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:07.6046999Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -357,7 +362,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:34.2416982Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:06.9280402Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "22beaa62-3edc-485d-9648-fd83d8cfb2ea",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "20810862-1b65-4f33-abd9-b4d22fcc4993",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "displayName": "testJob",
@@ -42,18 +42,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d905f47e-ecd2-460b-8cd4-60c21aa47cc6",
+        "apim-request-id": "c54b5135-733e-4b4b-a7c0-7547d80daf5a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:43 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/31a17732-f705-4284-8463-e3b5011d2c98?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:16 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/d45128bb-57f3-4b04-921c-958e73747c23?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110"
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/31a17732-f705-4284-8463-e3b5011d2c98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d45128bb-57f3-4b04-921c-958e73747c23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -69,25 +70,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4630e873-98ec-4112-89d1-ff72c408f056",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4b82d9d1-130d-46ac-bd5d-9df041c2edf3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "623a8f7d-356e-45da-92ab-cd5acd87dfc4",
+        "apim-request-id": "eb44052a-22e1-45be-8813-a8e7837f6fc9",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "31a17732-f705-4284-8463-e3b5011d2c98",
-        "lastUpdatedDateTime": "2022-10-15T02:29:43Z",
-        "createdDateTime": "2022-10-15T02:29:43Z",
-        "expirationDateTime": "2022-10-16T02:29:43Z",
+        "jobId": "d45128bb-57f3-4b04-921c-958e73747c23",
+        "lastUpdatedDateTime": "2022-10-24T05:21:16Z",
+        "createdDateTime": "2022-10-24T05:21:16Z",
+        "expirationDateTime": "2022-10-25T05:21:16Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/31a17732-f705-4284-8463-e3b5011d2c98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d45128bb-57f3-4b04-921c-958e73747c23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,25 +119,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3619b66e-1256-477c-8199-a6024e4a47c5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "aa622226-33d9-4b96-a6ad-e0ba2d2411a2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "14a600f2-5048-45dc-8f63-ee07255252a3",
+        "apim-request-id": "250b898f-2235-4328-9e21-a179d858d6e6",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "31a17732-f705-4284-8463-e3b5011d2c98",
-        "lastUpdatedDateTime": "2022-10-15T02:29:43Z",
-        "createdDateTime": "2022-10-15T02:29:43Z",
-        "expirationDateTime": "2022-10-16T02:29:43Z",
+        "jobId": "d45128bb-57f3-4b04-921c-958e73747c23",
+        "lastUpdatedDateTime": "2022-10-24T05:21:16Z",
+        "createdDateTime": "2022-10-24T05:21:16Z",
+        "expirationDateTime": "2022-10-25T05:21:16Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/31a17732-f705-4284-8463-e3b5011d2c98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d45128bb-57f3-4b04-921c-958e73747c23?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b0906b95-24c0-40d1-8958-f0deb5d5b76a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "09ff0b21-0702-4da3-88e5-875cde65f58d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca7a0464-4685-4641-b19d-ac9bee8cdadb",
+        "apim-request-id": "a30a4eec-bc86-4710-bbbe-7f9b6f6d3adf",
         "Content-Length": "853",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "48"
+        "x-envoy-upstream-service-time": "51",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "31a17732-f705-4284-8463-e3b5011d2c98",
-        "lastUpdatedDateTime": "2022-10-15T02:29:45Z",
-        "createdDateTime": "2022-10-15T02:29:43Z",
-        "expirationDateTime": "2022-10-16T02:29:43Z",
+        "jobId": "d45128bb-57f3-4b04-921c-958e73747c23",
+        "lastUpdatedDateTime": "2022-10-24T05:21:18Z",
+        "createdDateTime": "2022-10-24T05:21:16Z",
+        "expirationDateTime": "2022-10-25T05:21:16Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "testJob",
@@ -195,7 +199,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:45.1199169Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:18.6590314Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "65ab9d14-0c4e-4664-b0e4-76440ab23856",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7678e336-b201-4828-ad63-02e124a9c178",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -64,18 +64,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "99ceedaf-eafd-40b5-b652-78f4cdefb65f",
+        "apim-request-id": "05272962-cf6b-4205-acd7-e3442a70f79d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:12 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:46 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "209"
+        "x-envoy-upstream-service-time": "242",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -91,210 +92,39 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e14d165c-a75a-49a5-8278-b837d60021a6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "50e670c6-57bf-4363-913d-c57a4cf41460",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "38e9de6c-2e27-4ddc-8176-512eb0a8cbcd",
-        "Content-Length": "283",
+        "apim-request-id": "64d12459-9a97-478a-9fa6-dccb39577fa2",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "90b3fe48-82bc-4213-bc60-ec252cd8b1df",
-        "lastUpdatedDateTime": "2022-10-15T02:29:13Z",
-        "createdDateTime": "2022-10-15T02:29:13Z",
-        "expirationDateTime": "2022-10-16T02:29:13Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a1d5599f-3442-4c6b-8dc9-f182620f0b01",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8df5784f-5b12-4f41-b772-b273bb38ff2d",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "90b3fe48-82bc-4213-bc60-ec252cd8b1df",
-        "lastUpdatedDateTime": "2022-10-15T02:29:13Z",
-        "createdDateTime": "2022-10-15T02:29:13Z",
-        "expirationDateTime": "2022-10-16T02:29:13Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6c4c6d29-52fd-46bd-aab8-86db2b3c13ea",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e382f0b4-b90a-4c30-81d0-cfc9693c9f25",
-        "Content-Length": "1133",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:14 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "135"
-      },
-      "ResponseBody": {
-        "jobId": "90b3fe48-82bc-4213-bc60-ec252cd8b1df",
-        "lastUpdatedDateTime": "2022-10-15T02:29:15Z",
-        "createdDateTime": "2022-10-15T02:29:13Z",
-        "expirationDateTime": "2022-10-16T02:29:13Z",
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:46Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 2,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.2288686Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "56",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "22",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "19",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.4143874Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": ":)",
-                    "id": "56",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":(",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "w",
-                    "id": "22",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":P",
-                    "id": "19",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":D",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -310,113 +140,85 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6314965f-e7f3-4382-a405-06b345947e5a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "24440663-faa3-40bb-9776-0ed0c6fb0f82",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1688174b-1154-418a-88f7-0e81a3cfbe51",
-        "Content-Length": "1523",
+        "apim-request-id": "11259c0f-10ca-406d-8c6d-dc72ae23f98c",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "167"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "90b3fe48-82bc-4213-bc60-ec252cd8b1df",
-        "lastUpdatedDateTime": "2022-10-15T02:29:15Z",
-        "createdDateTime": "2022-10-15T02:29:13Z",
-        "expirationDateTime": "2022-10-16T02:29:13Z",
-        "status": "succeeded",
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:46Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "c5f5fe67-389c-4564-8b2e-3bb807ee20a2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e100540f-43fa-4c7e-a2c0-25cbdb6eaf8d",
+        "Content-Length": "667",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "130",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:48Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 2,
           "total": 3,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.2288686Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "56",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "22",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "19",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.4143874Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": ":)",
-                    "id": "56",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":(",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "w",
-                    "id": "22",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":P",
-                    "id": "19",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":D",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.8187649Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:48.6077584Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -455,7 +257,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/90b3fe48-82bc-4213-bc60-ec252cd8b1df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -471,25 +273,147 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a4f5a568-0a53-4e8d-b9f2-fef7b4f27b6d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d3dbc24c-dd13-48e9-87e5-78e6cb38f4ed",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d847e81d-a79b-4d23-a4f3-e7dc9492f5b8",
-        "Content-Length": "1523",
+        "apim-request-id": "1a41b660-7607-4d0e-a5e5-88ff5d6a3bc3",
+        "Content-Length": "1043",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "173"
+        "x-envoy-upstream-service-time": "129",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "90b3fe48-82bc-4213-bc60-ec252cd8b1df",
-        "lastUpdatedDateTime": "2022-10-15T02:29:15Z",
-        "createdDateTime": "2022-10-15T02:29:13Z",
-        "expirationDateTime": "2022-10-16T02:29:13Z",
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:49Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:49.7235384Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "56",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "0",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "22",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:48.6077584Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "56",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "22",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "577b79ec-d1f6-41a3-a2f0-24492fb09615",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a42f7381-7dd4-43a0-9594-04598f9fe1b3",
+        "Content-Length": "1523",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "238",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:51Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -500,7 +424,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.2288686Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:49.7235384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -536,7 +460,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.4143874Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:51.5150294Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -577,7 +501,169 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:15.8187649Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:48.6077584Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "56",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "22",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b7e29b56-29f4-433c-ba54-2fac1c7a0bfb?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "2ce11cf1-b5d8-4031-9f40-cb00145914a3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "03ddfc3c-bb64-453d-b8c5-5961bf80d44a",
+        "Content-Length": "1523",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "b7e29b56-29f4-433c-ba54-2fac1c7a0bfb",
+        "lastUpdatedDateTime": "2022-10-24T05:20:51Z",
+        "createdDateTime": "2022-10-24T05:20:46Z",
+        "expirationDateTime": "2022-10-25T05:20:46Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:49.7235384Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "56",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "0",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "22",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:51.5150294Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "56",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "0",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "w",
+                    "id": "22",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "19",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:48.6077584Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "08de7449-7365-48b8-8678-81fe19f4f80e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4a232d54-b0e7-4e07-b869-0942504dbe9e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -64,18 +64,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f6d0c4b7-1ad5-4433-9dbb-3058529a9cbf",
+        "apim-request-id": "01936f6d-bc3d-4588-ae36-17dd31b79e9b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:01 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:40 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "205"
+        "x-envoy-upstream-service-time": "193",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -91,119 +92,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dcb54c02-0324-4ab5-bfdb-fa266045cf3b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ccd49a81-ce3a-40d1-9813-e6ae38476781",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab9c3738-4b3e-4523-b268-3340d1ec2234",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:02Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "47776deb-d8af-4090-837b-82a17f667873",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fdc8a13a-1cdb-40dc-aded-49a3c5c175b3",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:02Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "afcd67d6-3dbd-4b90-bfcb-44fd9da3ccce",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "145cfb2a-a541-41eb-bea9-e0bc42882691",
+        "apim-request-id": "a693bbe3-16e0-4e6b-8d1d-033a1b3d9a88",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:02Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
+        "jobId": "a462e202-699c-4845-8baa-fc4d35a3fb10",
+        "lastUpdatedDateTime": "2022-10-24T05:20:41Z",
+        "createdDateTime": "2022-10-24T05:20:41Z",
+        "expirationDateTime": "2022-10-25T05:20:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -216,7 +124,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -232,411 +140,85 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f73c8cd3-a2d5-4250-9ef5-dc71b08be23d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a4574b98-08f9-4bf6-9a67-864ca18702a0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d2383653-fe8e-4859-840f-bf84b7d7ceb6",
-        "Content-Length": "1149",
+        "apim-request-id": "ebb05d9c-d3da-402a-b7e3-bc76cdfb2b19",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:05Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
+        "jobId": "a462e202-699c-4845-8baa-fc4d35a3fb10",
+        "lastUpdatedDateTime": "2022-10-24T05:20:41Z",
+        "createdDateTime": "2022-10-24T05:20:41Z",
+        "expirationDateTime": "2022-10-25T05:20:41Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "6e049f06-89a1-4728-9df3-b12d9ea1d53d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0dfcce86-bcc3-4eb4-942e-c0aa7c5284de",
+        "Content-Length": "1656",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a462e202-699c-4845-8baa-fc4d35a3fb10",
+        "lastUpdatedDateTime": "2022-10-24T05:20:43Z",
+        "createdDateTime": "2022-10-24T05:20:41Z",
+        "expirationDateTime": "2022-10-25T05:20:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
           "completed": 2,
           "failed": 0,
           "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:05.2500794Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "one",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "two",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "three",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "four",
-                    "id": "4",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "five",
-                    "id": "5",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:04.3179936Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5a09358c-0d34-4126-bf40-19c0ad09ed1e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "45cbc8b5-df31-42ae-a8c7-4406b52da149",
-        "Content-Length": "1149",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "222"
-      },
-      "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:05Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:05.2500794Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "one",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "two",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "three",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "four",
-                    "id": "4",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "five",
-                    "id": "5",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:04.3179936Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "35736f45-95a5-476a-9c9d-2ce228a9aadd",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8e0cb99c-719d-4673-862d-05f4c160a747",
-        "Content-Length": "1149",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:10 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "129"
-      },
-      "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:05Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:05.2500794Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "one",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "two",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "three",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "four",
-                    "id": "4",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "five",
-                    "id": "5",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:04.3179936Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "49a1d053-cb0d-4c42-81de-98154f74399a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ab91fc97-9e27-4532-ba2d-bdccb6e7e4c3",
-        "Content-Length": "2043",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "194"
-      },
-      "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:10Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 0,
           "total": 3,
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:10.9075278Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4212534Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -717,7 +299,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:05.2500794Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4698692Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -755,49 +337,13 @@
                 "errors": [],
                 "modelVersion": "2021-01-15"
               }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:04.3179936Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
             }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd8bcefa-f749-430d-8a36-25d0ea193113?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -813,25 +359,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1e4cebf4-9f66-4e5a-9c98-bb8fedc46aff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3d574042-7c3e-402f-a766-d539b75c85c0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3952dec9-f04d-43c0-bb2f-6efec5c70537",
+        "apim-request-id": "404612e3-552d-42f9-a46a-9e7c07dc4d45",
         "Content-Length": "2043",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "190"
+        "x-envoy-upstream-service-time": "225",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "bd8bcefa-f749-430d-8a36-25d0ea193113",
-        "lastUpdatedDateTime": "2022-10-15T02:29:10Z",
-        "createdDateTime": "2022-10-15T02:29:01Z",
-        "expirationDateTime": "2022-10-16T02:29:01Z",
+        "jobId": "a462e202-699c-4845-8baa-fc4d35a3fb10",
+        "lastUpdatedDateTime": "2022-10-24T05:20:43Z",
+        "createdDateTime": "2022-10-24T05:20:41Z",
+        "expirationDateTime": "2022-10-25T05:20:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -842,7 +389,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:10.9075278Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4212534Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -923,7 +470,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:05.2500794Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4698692Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -964,7 +511,214 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:04.3179936Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.6049154Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a462e202-699c-4845-8baa-fc4d35a3fb10?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "500211f9-3c89-435b-9986-2c54ebfcc582",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "601afcee-46e0-4f3b-8b98-a6461be64cbc",
+        "Content-Length": "2043",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "172",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a462e202-699c-4845-8baa-fc4d35a3fb10",
+        "lastUpdatedDateTime": "2022-10-24T05:20:43Z",
+        "createdDateTime": "2022-10-24T05:20:41Z",
+        "expirationDateTime": "2022-10-25T05:20:41Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4212534Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.4698692Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "one",
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "two",
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "three",
+                    "id": "3",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "four",
+                    "id": "4",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "five",
+                    "id": "5",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:43.6049154Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "57cf7ff9-087f-45d4-b7a5-266d8569d439",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bd3c9fbb-9911-4f14-b531-33a2bca63177",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -165,18 +165,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "013b838f-dfe6-4d84-b193-0ed58307abcf",
+        "apim-request-id": "1d648686-bba3-4710-945b-d97c0da0166b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:35 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:08 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "751"
+        "x-envoy-upstream-service-time": "629",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -192,25 +193,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e93a7d1c-bbd2-4904-a5ed-d8b7acb32b63",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b3b2e085-c560-4e9a-82e8-09fd02ca67d8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7f0dd655-e142-4fb2-bdc6-5a53f2da27bf",
+        "apim-request-id": "401f55c1-9bdd-4c0f-89ab-7ce6365c7ed1",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:35Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:08Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -223,7 +225,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -239,25 +241,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "47df1623-22d3-4501-b42e-62fb96b84c6a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "06e3fdd3-38e2-4432-a4c4-aef375a78351",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9bbb457-fcc3-42ed-8c9d-e70f54021d18",
+        "apim-request-id": "149e6f05-11e6-4c9d-b8d2-6d5d72073a27",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:35Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:08Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -270,7 +273,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -286,25 +289,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4074613e-de6e-402d-98f7-79c70b71d1c6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "805210bd-5058-448f-9c72-b9f037f34890",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "676d23fd-7ad6-4cae-9c5b-3dc22805e0f9",
+        "apim-request-id": "8a1efed2-a763-481d-ae50-ccd798c72a81",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:36Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:09Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -317,7 +321,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -333,25 +337,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "adfb71b8-b443-4d07-808a-70bccfcdc2b5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7ce1db3a-8076-455c-b404-025fa47b8eca",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4f1237b5-7fa9-479f-bbdb-29ddc72b6f57",
+        "apim-request-id": "271d060e-2ad0-4b43-a874-0379775d4794",
         "Content-Length": "1696",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "186"
+        "x-envoy-upstream-service-time": "247",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:39Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:12Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -362,7 +367,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:39.6611806Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:12.6749215Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -513,11 +518,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -533,25 +538,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ab8c17a8-dc2b-4283-bc34-f087338c9202",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "eb899736-43d7-41f3-be8a-6c56b39438ea",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61861333-1ed2-4361-a2a1-1298735532f9",
+        "apim-request-id": "bd3b5138-7da8-4554-9c94-b8ae0eb5a9fb",
         "Content-Length": "2666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "392"
+        "x-envoy-upstream-service-time": "402",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:41Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:14Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -562,7 +568,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:41.4616332Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:14.0120334Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -673,7 +679,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:39.6611806Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:12.6749215Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -824,11 +830,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?api-version=2022-05-01\u0026top=10",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?api-version=2022-05-01\u0026top=10",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -844,25 +850,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "87591bdf-09b9-4959-a2ac-994cf62a35e0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a83e83f1-a9ba-4ce6-88fd-5517a6af37ca",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3ec651d9-4d30-4b40-9dc2-08cf75ca2ae8",
+        "apim-request-id": "94de3329-8c79-4f78-9305-1a6b28eded9a",
         "Content-Length": "1717",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "294"
+        "x-envoy-upstream-service-time": "273",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:41Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:14Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -873,7 +880,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:41.4616332Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:14.0120334Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -934,7 +941,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:39.6611806Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:12.6749215Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1015,11 +1022,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1035,25 +1042,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0c4ba143-1706-4e8c-992e-0c01ee8b962d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "caea27aa-1be9-49aa-a95f-4bc7e9f89fee",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f8a5c30f-bc53-4d60-b483-71bddf432aa2",
+        "apim-request-id": "4dd1fd53-f18f-48c7-be38-d2e74fef7325",
         "Content-Length": "1736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "x-envoy-upstream-service-time": "219",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:41Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:14Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1064,7 +1072,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:41.4616332Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:14.0120334Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1125,7 +1133,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:39.6611806Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:12.6749215Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1206,11 +1214,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/0120d5f3-4195-40ef-9c8a-1f27fd261c44?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/43e73aac-3b08-4ef9-bdab-88a16ff9dafb?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1226,25 +1234,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e6e76330-435d-4c6f-91dd-f28503ec0e34",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "267f1607-6db2-4afd-9254-60010383bca9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27bbadc4-8abd-4c1e-8053-519dc919beb5",
+        "apim-request-id": "0a34b05c-9d25-476e-9825-8db9b1d7862e",
         "Content-Length": "1404",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "151"
+        "x-envoy-upstream-service-time": "136",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "0120d5f3-4195-40ef-9c8a-1f27fd261c44",
-        "lastUpdatedDateTime": "2022-10-15T02:29:41Z",
-        "createdDateTime": "2022-10-15T02:29:34Z",
-        "expirationDateTime": "2022-10-16T02:29:34Z",
+        "jobId": "43e73aac-3b08-4ef9-bdab-88a16ff9dafb",
+        "lastUpdatedDateTime": "2022-10-24T05:21:14Z",
+        "createdDateTime": "2022-10-24T05:21:08Z",
+        "expirationDateTime": "2022-10-25T05:21:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1255,7 +1264,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:41.4616332Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:14.0120334Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1313,7 +1322,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:39.6611806Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:12.6749215Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "782f5e69-635a-428c-ab5e-d3d05e03c70f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f6450b69-2bf7-4208-aca0-e07ac276b0df",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -60,18 +60,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f2ca54f3-2738-47ed-8548-919263390699",
+        "apim-request-id": "e7220de5-fceb-4e75-bc20-2587cd455485",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:45 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:18 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "192"
+        "x-envoy-upstream-service-time": "153",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -87,72 +88,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d4151f60-df32-4ff7-8da7-9a8ff3763f85",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bb1faeb6-d007-4849-9ab5-fedcedb35a0b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "086e5ae4-421f-46e4-b080-a18fe7d572ad",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:45 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:46Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 4,
-          "total": 4,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4805e978-4a34-461e-a85d-42b93dd42ac8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ea47a630-e99e-417b-abfc-43416967a046",
+        "apim-request-id": "a47b04a8-8cd7-469d-b1f1-4fe28e9d746c",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:46Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:19Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -165,7 +120,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -181,25 +136,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "10155342-968a-4f6f-aa2f-c625bb5100db",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "522df8cb-e72a-45a1-8f4f-62032c307e91",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "675af638-598e-45fc-862a-c2e9a2136222",
+        "apim-request-id": "f51d9928-04e2-4e3c-af4e-d22ed70de919",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:46Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:19Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -212,7 +168,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -228,25 +184,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b93935eb-45b4-4b0e-b191-e4acbf619619",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c1043907-4725-4cc2-81e2-74a8ec5d93d3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c694c4f9-5c40-4a9f-b850-49e23ad9804f",
-        "Content-Length": "6372",
+        "apim-request-id": "64a8bb7e-78c0-4883-b73a-7237657e632b",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "363"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:48Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:19Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 4,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "a6c541fc-c866-4f07-9472-3761fce80d7e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c116e088-6ea2-4867-baa7-5213eb452b8e",
+        "Content-Length": "6372",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:21:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:21Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -257,7 +262,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6491821Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.1123771Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -650,7 +655,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.0859392Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.4150665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -703,7 +708,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.1285987Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.5261441Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -743,7 +748,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6920126Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:20.7107592Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -807,7 +812,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -823,25 +828,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c770587d-0115-4f45-8dbc-c00a56d21ffd",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "736b24e1-b80a-4251-a94a-42a06df034c1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0351f5e-0c0b-4315-9177-b79365ab5c38",
+        "apim-request-id": "a85dd728-4e15-46a8-a743-30f08b6a1d17",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "152"
+        "x-envoy-upstream-service-time": "100",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:48Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:21Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -852,7 +858,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6491821Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.1123771Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1245,7 +1251,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.0859392Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.4150665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1298,7 +1304,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.1285987Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.5261441Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1338,7 +1344,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6920126Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:20.7107592Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1402,7 +1408,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1418,25 +1424,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "71d4ba61-fb22-4b87-ad9b-410d7bda597f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f59fc809-3a85-47c6-b9b4-e6643349e80d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d131bab7-00ee-44ff-ac26-29a38d9223cd",
+        "apim-request-id": "67b0087b-25e7-4a3e-b3ba-475f4ae70788",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "129"
+        "x-envoy-upstream-service-time": "109",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:48Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:21Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1447,7 +1454,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6491821Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.1123771Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1840,7 +1847,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.0859392Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.4150665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1893,7 +1900,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.1285987Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.5261441Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1933,7 +1940,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6920126Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:20.7107592Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1997,7 +2004,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc723d26-1a4b-4c99-80a3-a41ce9aa29ef?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e268412b-8399-4c6a-8465-7d915eb06b00?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -2013,25 +2020,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9cccd7de-edc8-4b01-88c7-39113b712da9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "63cde36f-4dd2-4bcc-87d9-9575ca9d5597",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c02b732d-8a1a-4ae8-9334-acfb91fa25a0",
+        "apim-request-id": "c1cedcf9-693c-4b20-b2c8-1e266c92e3c8",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "123"
+        "x-envoy-upstream-service-time": "125",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cc723d26-1a4b-4c99-80a3-a41ce9aa29ef",
-        "lastUpdatedDateTime": "2022-10-15T02:29:48Z",
-        "createdDateTime": "2022-10-15T02:29:45Z",
-        "expirationDateTime": "2022-10-16T02:29:45Z",
+        "jobId": "e268412b-8399-4c6a-8465-7d915eb06b00",
+        "lastUpdatedDateTime": "2022-10-24T05:21:21Z",
+        "createdDateTime": "2022-10-24T05:21:19Z",
+        "expirationDateTime": "2022-10-25T05:21:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -2042,7 +2050,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6491821Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.1123771Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2435,7 +2443,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.0859392Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.4150665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2488,7 +2496,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:48.1285987Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:21.5261441Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2528,7 +2536,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:47.6920126Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:20.7107592Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ed34a0f1-b246-4c1c-9f9a-99e1f9f64189",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4f4338de-0a0f-4d0d-819b-db2392b138d9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a9ae6701-e6b7-47ff-919d-85dd5eaca671",
+        "apim-request-id": "4ef6cef3-0230-4637-899c-d189391fb74f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:55 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/4f830736-7089-424f-86ca-182a51954b45?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:26 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "160"
+        "x-envoy-upstream-service-time": "160",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4f830736-7089-424f-86ca-182a51954b45?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,26 +87,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "00d59cd3-ac65-4c8f-8c5c-dbee1fea154b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3715542c-ea5f-499d-93f0-40949116d953",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f66c2a11-b742-4752-8426-0e0cec9c68c0",
-        "Content-Length": "283",
+        "apim-request-id": "4fd0c5c4-d004-4633-9520-d9844c6ed1dc",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4f830736-7089-424f-86ca-182a51954b45",
-        "lastUpdatedDateTime": "2022-10-15T02:28:56Z",
-        "createdDateTime": "2022-10-15T02:28:56Z",
-        "expirationDateTime": "2022-10-16T02:28:56Z",
-        "status": "notStarted",
+        "jobId": "1e92892c-ae0b-4090-af22-d0d42cabff83",
+        "lastUpdatedDateTime": "2022-10-24T05:20:27Z",
+        "createdDateTime": "2022-10-24T05:20:26Z",
+        "expirationDateTime": "2022-10-25T05:20:26Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4f830736-7089-424f-86ca-182a51954b45?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,26 +135,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c45cf0c5-680e-4ad6-bf44-d2f3ef59d488",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "edbbc8ef-773f-4feb-910e-9e671d61b36f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "af20fe66-3ec0-406c-8fab-13cbf569c80d",
-        "Content-Length": "283",
+        "apim-request-id": "8b744b28-3598-466b-a17f-024a488e32bb",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4f830736-7089-424f-86ca-182a51954b45",
-        "lastUpdatedDateTime": "2022-10-15T02:28:56Z",
-        "createdDateTime": "2022-10-15T02:28:56Z",
-        "expirationDateTime": "2022-10-16T02:28:56Z",
-        "status": "notStarted",
+        "jobId": "1e92892c-ae0b-4090-af22-d0d42cabff83",
+        "lastUpdatedDateTime": "2022-10-24T05:20:27Z",
+        "createdDateTime": "2022-10-24T05:20:26Z",
+        "expirationDateTime": "2022-10-25T05:20:26Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4f830736-7089-424f-86ca-182a51954b45?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,124 +183,37 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9272dbc5-66c9-4e40-a54a-16b3cb0994f0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a6745ca6-e4f7-4d7a-a591-f3c71cd94466",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f766922-2a45-4cc3-bc44-2570c95a3ec3",
-        "Content-Length": "2954",
+        "apim-request-id": "b7ac7e65-94cd-4437-a322-e220192d1f83",
+        "Content-Length": "1282",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "130"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4f830736-7089-424f-86ca-182a51954b45",
-        "lastUpdatedDateTime": "2022-10-15T02:28:58Z",
-        "createdDateTime": "2022-10-15T02:28:56Z",
-        "expirationDateTime": "2022-10-16T02:28:56Z",
-        "status": "succeeded",
+        "jobId": "1e92892c-ae0b-4090-af22-d0d42cabff83",
+        "lastUpdatedDateTime": "2022-10-24T05:20:29Z",
+        "createdDateTime": "2022-10-24T05:20:26Z",
+        "expirationDateTime": "2022-10-25T05:20:26Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 2,
           "total": 3,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:57.9734835Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "3",
-                    "entities": [
-                      {
-                        "text": "restaurant",
-                        "category": "Location",
-                        "subcategory": "Structural",
-                        "offset": 4,
-                        "length": 10,
-                        "confidenceScore": 0.97
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:58.0096852Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "The restaurant had really good food. I recommend you try it.",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:58.5566463Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:28.7032225Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -342,7 +258,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4f830736-7089-424f-86ca-182a51954b45?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -358,25 +274,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "45f6f3a1-795d-4ebe-b918-71ab548dfe37",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a4dd617f-033c-4408-ae36-689fda9d0f17",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0c2a5b2-ca2e-4a11-868f-a19da46b1d9d",
+        "apim-request-id": "c7e1de8c-9960-4087-873b-4fdadc69ccc5",
         "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
+        "x-envoy-upstream-service-time": "191",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4f830736-7089-424f-86ca-182a51954b45",
-        "lastUpdatedDateTime": "2022-10-15T02:28:58Z",
-        "createdDateTime": "2022-10-15T02:28:56Z",
-        "expirationDateTime": "2022-10-16T02:28:56Z",
+        "jobId": "1e92892c-ae0b-4090-af22-d0d42cabff83",
+        "lastUpdatedDateTime": "2022-10-24T05:20:29Z",
+        "createdDateTime": "2022-10-24T05:20:26Z",
+        "expirationDateTime": "2022-10-25T05:20:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -387,7 +304,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:57.9734835Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:29.2184803Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -435,7 +352,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:58.0096852Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:29.2319859Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -475,7 +392,186 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:58.5566463Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:28.7032225Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "3",
+                    "keyPhrases": [
+                      "good food",
+                      "restaurant"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: de,en,es,fr,it,pt-BR,pt-PT,af,am,ar,as,az,be,bg,bn,br,bs,ca,cs,cy,da,el,eo,et,eu,fa,fi,fil,fy,ga,gd,gl,gu,ha,he,hi,hr,hu,hy,id,ja,jv,ka,kk,km,kn,ko,ku,ky,la,lo,lt,lv,mg,mk,ml,mn,mr,ms,my,ne,nl,no,om,or,pa,pl,ps,ro,ru,sa,sd,si,sk,sl,so,sq,sr,su,sv,sw,ta,te,th,tr,ug,uk,ur,uz,vi,xh,yi,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e92892c-ae0b-4090-af22-d0d42cabff83?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "cde3c2dd-7f18-4a40-9ba8-59d6036db020",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "19d7fa00-53af-4db6-b764-132d2caa1cd2",
+        "Content-Length": "2954",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:20:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "1e92892c-ae0b-4090-af22-d0d42cabff83",
+        "lastUpdatedDateTime": "2022-10-24T05:20:29Z",
+        "createdDateTime": "2022-10-24T05:20:26Z",
+        "expirationDateTime": "2022-10-25T05:20:26Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:29.2184803Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "restaurant",
+                        "category": "Location",
+                        "subcategory": "Structural",
+                        "offset": 4,
+                        "length": 10,
+                        "confidenceScore": 0.97
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:29.2319859Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "The restaurant had really good food. I recommend you try it.",
+                    "id": "3",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:20:28.7032225Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "feaace84-e358-4009-ae3a-5b520f7ca9bd",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4f72cde0-2eac-4128-a8cc-bbe854b151a3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -69,18 +69,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a95c1dd8-6127-4a40-be5f-4899423ceb05",
+        "apim-request-id": "e11cff55-91d5-4837-9be9-ab47ce6f4dc9",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:18 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:53 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/9ab877e9-44c8-4c33-8515-65c8556a3d3f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "250"
+        "x-envoy-upstream-service-time": "251",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ab877e9-44c8-4c33-8515-65c8556a3d3f?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -96,25 +97,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b5f90fa2-8fda-4980-b489-0a11e0598d9f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1c9f3760-2a50-4466-be3e-a4a9b7afb6cf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "42a8ad3b-6be6-423b-8523-b29df793a5b9",
+        "apim-request-id": "bb26bbf9-4145-441b-9830-7ce31d96aafa",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0aaccef-1109-4797-8352-533483b61c2b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:18Z",
-        "createdDateTime": "2022-10-15T02:29:18Z",
-        "expirationDateTime": "2022-10-16T02:29:18Z",
+        "jobId": "9ab877e9-44c8-4c33-8515-65c8556a3d3f",
+        "lastUpdatedDateTime": "2022-10-24T05:20:54Z",
+        "createdDateTime": "2022-10-24T05:20:53Z",
+        "expirationDateTime": "2022-10-25T05:20:53Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -127,7 +129,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ab877e9-44c8-4c33-8515-65c8556a3d3f?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -143,220 +145,39 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "18ce31a1-f161-4f06-a808-169b4df602e4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a512d22b-4766-4730-809a-1b7f87278556",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04e56744-bfc6-4b13-a64d-ab098bcb6560",
-        "Content-Length": "283",
+        "apim-request-id": "a54cea14-68c0-4355-a18a-09e4c1d83d4c",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0aaccef-1109-4797-8352-533483b61c2b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:18Z",
-        "createdDateTime": "2022-10-15T02:29:18Z",
-        "expirationDateTime": "2022-10-16T02:29:18Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01\u0026showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dd4fc29d-beb9-4e95-b88d-26a5cbdc0aef",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a8c555bd-2338-42d3-bc94-b1a358157216",
-        "Content-Length": "2026",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:20 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "123"
-      },
-      "ResponseBody": {
-        "jobId": "b0aaccef-1109-4797-8352-533483b61c2b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:20Z",
-        "createdDateTime": "2022-10-15T02:29:18Z",
-        "expirationDateTime": "2022-10-16T02:29:18Z",
+        "jobId": "9ab877e9-44c8-4c33-8515-65c8556a3d3f",
+        "lastUpdatedDateTime": "2022-10-24T05:20:54Z",
+        "createdDateTime": "2022-10-24T05:20:53Z",
+        "expirationDateTime": "2022-10-25T05:20:53Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 2,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3914051Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3536762Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "redactedText": ":)",
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":(",
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":P",
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":D",
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ab877e9-44c8-4c33-8515-65c8556a3d3f?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -372,25 +193,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fbcad63a-7ba7-4651-a582-9a6f13e5b222",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8cd37e31-8908-47be-827e-d58c8bcd2122",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5efc2fa0-02e2-4894-b140-0c007bc5df96",
+        "apim-request-id": "03e7537b-bc33-44f3-9387-ae1bf57de423",
         "Content-Length": "2870",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:22 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183"
+        "x-envoy-upstream-service-time": "182",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0aaccef-1109-4797-8352-533483b61c2b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:20Z",
-        "createdDateTime": "2022-10-15T02:29:18Z",
-        "expirationDateTime": "2022-10-16T02:29:18Z",
+        "jobId": "9ab877e9-44c8-4c33-8515-65c8556a3d3f",
+        "lastUpdatedDateTime": "2022-10-24T05:20:56Z",
+        "createdDateTime": "2022-10-24T05:20:53Z",
+        "expirationDateTime": "2022-10-25T05:20:53Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -401,7 +223,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3914051Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:55.7889442Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -466,7 +288,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3536762Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:55.8180188Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -535,7 +357,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.8454807Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:56.0449586Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -603,7 +425,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b0aaccef-1109-4797-8352-533483b61c2b?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ab877e9-44c8-4c33-8515-65c8556a3d3f?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -619,25 +441,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "19c88669-ed12-4c1c-8cd6-eb673a6bfac8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "24b31a3f-d17b-41aa-b30e-3dc0a18f78b1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b4788cc5-4adf-41e2-890f-c60be6f84de1",
+        "apim-request-id": "09ccc15e-624c-491c-9185-9a1a207c640b",
         "Content-Length": "2870",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:22 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "173"
+        "x-envoy-upstream-service-time": "224",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b0aaccef-1109-4797-8352-533483b61c2b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:20Z",
-        "createdDateTime": "2022-10-15T02:29:18Z",
-        "expirationDateTime": "2022-10-16T02:29:18Z",
+        "jobId": "9ab877e9-44c8-4c33-8515-65c8556a3d3f",
+        "lastUpdatedDateTime": "2022-10-24T05:20:56Z",
+        "createdDateTime": "2022-10-24T05:20:53Z",
+        "expirationDateTime": "2022-10-25T05:20:53Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -648,7 +471,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3914051Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:55.7889442Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -713,7 +536,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.3536762Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:55.8180188Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -782,7 +605,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:20.8454807Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:56.0449586Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fffa5a68-b5bf-4a2b-8d83-ff5a6fa719d0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "43f0e59a-68a1-4572-bf71-b140f42fb15a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -47,18 +47,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "9423d3f2-a0ad-4913-9875-4a76aedf0de6",
+        "apim-request-id": "36ef464b-3c0b-4fde-9cfa-8a66c2b5bc76",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:52 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c626c343-41e7-4127-9536-f30847efecd3?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:23 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b657ddb6-7118-46aa-b815-dc8329b0ffc8?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "121"
+        "x-envoy-upstream-service-time": "136",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c626c343-41e7-4127-9536-f30847efecd3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b657ddb6-7118-46aa-b815-dc8329b0ffc8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -74,25 +75,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "acdb8422-7d64-496d-ac1f-89ff8e89b549",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3e4ad83a-489c-4993-be9d-fa4c434116a6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d4124154-bf8a-42df-91cb-755f51552495",
+        "apim-request-id": "db177487-6edd-4b5b-91b6-f817f284e807",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c626c343-41e7-4127-9536-f30847efecd3",
-        "lastUpdatedDateTime": "2022-10-15T02:28:53Z",
-        "createdDateTime": "2022-10-15T02:28:53Z",
-        "expirationDateTime": "2022-10-16T02:28:53Z",
+        "jobId": "b657ddb6-7118-46aa-b815-dc8329b0ffc8",
+        "lastUpdatedDateTime": "2022-10-24T05:20:24Z",
+        "createdDateTime": "2022-10-24T05:20:24Z",
+        "expirationDateTime": "2022-10-25T05:20:24Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -105,7 +107,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c626c343-41e7-4127-9536-f30847efecd3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b657ddb6-7118-46aa-b815-dc8329b0ffc8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -121,25 +123,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "176087b9-76fa-476c-adbc-3acd4a59e2fa",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0b8d8ac3-13ad-4fc2-969b-7a196382f184",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eec72050-c4d4-49cf-9baf-a2d6b720b390",
+        "apim-request-id": "ef246d6e-903b-4e22-bf60-9a621e5f1567",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c626c343-41e7-4127-9536-f30847efecd3",
-        "lastUpdatedDateTime": "2022-10-15T02:28:53Z",
-        "createdDateTime": "2022-10-15T02:28:53Z",
-        "expirationDateTime": "2022-10-16T02:28:53Z",
+        "jobId": "b657ddb6-7118-46aa-b815-dc8329b0ffc8",
+        "lastUpdatedDateTime": "2022-10-24T05:20:24Z",
+        "createdDateTime": "2022-10-24T05:20:24Z",
+        "expirationDateTime": "2022-10-25T05:20:24Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -152,7 +155,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c626c343-41e7-4127-9536-f30847efecd3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b657ddb6-7118-46aa-b815-dc8329b0ffc8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -168,25 +171,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b3883ce9-d47b-4c5f-af47-40ebffbd3b68",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "51733af8-bf3b-4dd3-8420-f5624bbd8800",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "699a5aff-4521-49c5-bdb0-367b8d22e9ab",
+        "apim-request-id": "1ab78f49-e2c0-4c10-af2f-cacfcd25c159",
         "Content-Length": "843",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "153"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c626c343-41e7-4127-9536-f30847efecd3",
-        "lastUpdatedDateTime": "2022-10-15T02:28:55Z",
-        "createdDateTime": "2022-10-15T02:28:53Z",
-        "expirationDateTime": "2022-10-16T02:28:53Z",
+        "jobId": "b657ddb6-7118-46aa-b815-dc8329b0ffc8",
+        "lastUpdatedDateTime": "2022-10-24T05:20:26Z",
+        "createdDateTime": "2022-10-24T05:20:24Z",
+        "expirationDateTime": "2022-10-25T05:20:24Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:28:55.6784577Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:26.4526426Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -216,7 +220,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:28:55.6068956Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:26.3479831Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -236,7 +240,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c626c343-41e7-4127-9536-f30847efecd3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b657ddb6-7118-46aa-b815-dc8329b0ffc8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -252,25 +256,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9a446b9c-18c0-413d-a8fa-661d6867f99b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "93562d99-21d8-46ab-b1ee-507bd721516a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55d44c56-d3ee-43f6-8e0c-dabae3c3d77d",
+        "apim-request-id": "a4001c34-89a1-4f4f-98b9-1f46aa704119",
         "Content-Length": "843",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c626c343-41e7-4127-9536-f30847efecd3",
-        "lastUpdatedDateTime": "2022-10-15T02:28:55Z",
-        "createdDateTime": "2022-10-15T02:28:53Z",
-        "expirationDateTime": "2022-10-16T02:28:53Z",
+        "jobId": "b657ddb6-7118-46aa-b815-dc8329b0ffc8",
+        "lastUpdatedDateTime": "2022-10-24T05:20:26Z",
+        "createdDateTime": "2022-10-24T05:20:24Z",
+        "expirationDateTime": "2022-10-25T05:20:24Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -282,7 +287,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:28:55.6784577Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:26.4526426Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -300,7 +305,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:28:55.6068956Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:26.3479831Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b0d98e51-8f81-42fa-872c-f15d530fee0f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4aa0ca94-0a0c-4959-8703-8d73c01d9df4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -56,18 +56,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6321c243-d7ad-46a1-aba2-4cdafe22d6a8",
+        "apim-request-id": "c7f2be2c-dc8e-4927-8824-2d38ae61a747",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:28 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/7395ac44-6ed3-4e9c-aaad-bc1033032f7b?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:02 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/4036c831-a04f-4652-a6f2-57dd6ad7a069?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "197"
+        "x-envoy-upstream-service-time": "164",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7395ac44-6ed3-4e9c-aaad-bc1033032f7b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4036c831-a04f-4652-a6f2-57dd6ad7a069?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -83,25 +84,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8f9b84dc-ca3d-4104-ac29-ceba2df02a98",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "149138a5-34c4-4e4c-a637-98b2cd2a18aa",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47ba81f9-5d7c-47c5-a9c7-4da93c51b6ce",
+        "apim-request-id": "89eabb73-d7ec-4951-916d-9a8957c55d2c",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7395ac44-6ed3-4e9c-aaad-bc1033032f7b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:29Z",
-        "createdDateTime": "2022-10-15T02:29:29Z",
-        "expirationDateTime": "2022-10-16T02:29:29Z",
+        "jobId": "4036c831-a04f-4652-a6f2-57dd6ad7a069",
+        "lastUpdatedDateTime": "2022-10-24T05:21:02Z",
+        "createdDateTime": "2022-10-24T05:21:02Z",
+        "expirationDateTime": "2022-10-25T05:21:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -114,7 +116,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7395ac44-6ed3-4e9c-aaad-bc1033032f7b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4036c831-a04f-4652-a6f2-57dd6ad7a069?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -130,25 +132,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "22810dd6-ceab-449f-b525-29a300241ae4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "05428b74-592c-4b4d-8870-32d4f46d1542",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "46ec3680-cc4a-4005-b677-97197601abad",
+        "apim-request-id": "fa6d7494-3fb7-42ad-bd98-ba95df772c76",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7395ac44-6ed3-4e9c-aaad-bc1033032f7b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:29Z",
-        "createdDateTime": "2022-10-15T02:29:29Z",
-        "expirationDateTime": "2022-10-16T02:29:29Z",
+        "jobId": "4036c831-a04f-4652-a6f2-57dd6ad7a069",
+        "lastUpdatedDateTime": "2022-10-24T05:21:02Z",
+        "createdDateTime": "2022-10-24T05:21:02Z",
+        "expirationDateTime": "2022-10-25T05:21:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -161,7 +164,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7395ac44-6ed3-4e9c-aaad-bc1033032f7b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4036c831-a04f-4652-a6f2-57dd6ad7a069?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -177,25 +180,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4343227b-4813-4df1-a724-126b3cd4a486",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "75235b74-e759-42ec-af3e-3b7af90a56a2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb62b0b2-a90d-439a-ad12-e5a0ceb8c439",
+        "apim-request-id": "edf8d6ed-3f92-4422-9ed3-2e4f6472c25a",
         "Content-Length": "1510",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "220"
+        "x-envoy-upstream-service-time": "145",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7395ac44-6ed3-4e9c-aaad-bc1033032f7b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:31Z",
-        "createdDateTime": "2022-10-15T02:29:29Z",
-        "expirationDateTime": "2022-10-16T02:29:29Z",
+        "jobId": "4036c831-a04f-4652-a6f2-57dd6ad7a069",
+        "lastUpdatedDateTime": "2022-10-24T05:21:04Z",
+        "createdDateTime": "2022-10-24T05:21:02Z",
+        "expirationDateTime": "2022-10-25T05:21:02Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -206,7 +210,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.0499268Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.7230186Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -248,7 +252,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.1094292Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.7699905Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -277,7 +281,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.4333888Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.5913604Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -313,7 +317,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7395ac44-6ed3-4e9c-aaad-bc1033032f7b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4036c831-a04f-4652-a6f2-57dd6ad7a069?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -329,25 +333,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7d60e75b-183e-4d77-a8a9-44e662b33833",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4dce3dab-51d3-4141-93f6-4edd02bba962",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "74c3e7a6-f7ab-4010-a5ad-ba27433dd5a7",
+        "apim-request-id": "a46ea835-2d44-4bf8-9621-4e6abd8d757e",
         "Content-Length": "1510",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "247"
+        "x-envoy-upstream-service-time": "167",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7395ac44-6ed3-4e9c-aaad-bc1033032f7b",
-        "lastUpdatedDateTime": "2022-10-15T02:29:31Z",
-        "createdDateTime": "2022-10-15T02:29:29Z",
-        "expirationDateTime": "2022-10-16T02:29:29Z",
+        "jobId": "4036c831-a04f-4652-a6f2-57dd6ad7a069",
+        "lastUpdatedDateTime": "2022-10-24T05:21:04Z",
+        "createdDateTime": "2022-10-24T05:21:02Z",
+        "expirationDateTime": "2022-10-25T05:21:02Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -358,7 +363,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.0499268Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.7230186Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -400,7 +405,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.1094292Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.7699905Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -429,7 +434,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:31.4333888Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:04.5913604Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0fdc2c54-ba81-4416-b73c-54931f234357",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "643b1483-b250-401d-88f0-f9841a18c10c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b1ab2726-c0ef-4abe-a160-9716cd894e82",
+        "apim-request-id": "8b0491b0-02a9-449c-bc63-b9cee83ac06c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:23 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/858c4933-5446-4fb3-9489-e29f0b110add?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:57 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/2596cf24-85de-422a-a774-d361cb45d5f0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "155"
+        "x-envoy-upstream-service-time": "196",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/858c4933-5446-4fb3-9489-e29f0b110add?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2596cf24-85de-422a-a774-d361cb45d5f0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b71da098-9222-45c8-8405-67d83e2edff3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "fb489123-2a09-4fd5-ab64-d87cbb5a03b1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e89de68f-9e7d-4cad-aec7-953d2f930d78",
+        "apim-request-id": "3f28d176-0ab1-46b7-b7a7-1a63ec447b41",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "858c4933-5446-4fb3-9489-e29f0b110add",
-        "lastUpdatedDateTime": "2022-10-15T02:29:23Z",
-        "createdDateTime": "2022-10-15T02:29:23Z",
-        "expirationDateTime": "2022-10-16T02:29:23Z",
+        "jobId": "2596cf24-85de-422a-a774-d361cb45d5f0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:57Z",
+        "createdDateTime": "2022-10-24T05:20:56Z",
+        "expirationDateTime": "2022-10-25T05:20:56Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/858c4933-5446-4fb3-9489-e29f0b110add?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2596cf24-85de-422a-a774-d361cb45d5f0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,26 +135,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "eb5dcc4c-64c1-4384-a1f9-4848a06a6c93",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ff2100d2-b7cb-4431-b593-3cb6bda7e009",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59534a7c-8383-469e-95ba-8e48e2658040",
-        "Content-Length": "283",
+        "apim-request-id": "21db4924-5968-4d6e-8cf9-83e4a22f7efd",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "858c4933-5446-4fb3-9489-e29f0b110add",
-        "lastUpdatedDateTime": "2022-10-15T02:29:23Z",
-        "createdDateTime": "2022-10-15T02:29:23Z",
-        "expirationDateTime": "2022-10-16T02:29:23Z",
-        "status": "notStarted",
+        "jobId": "2596cf24-85de-422a-a774-d361cb45d5f0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:57Z",
+        "createdDateTime": "2022-10-24T05:20:56Z",
+        "expirationDateTime": "2022-10-25T05:20:56Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/858c4933-5446-4fb3-9489-e29f0b110add?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2596cf24-85de-422a-a774-d361cb45d5f0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,25 +183,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d1aba61e-b19e-414b-8927-fce883cf8bbf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c2ae51f8-3133-4efd-bdc0-554d5af563ee",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "db6c65d7-781c-40f3-be49-f5ea74ec8f69",
-        "Content-Length": "1601",
+        "apim-request-id": "0d605802-e75a-4683-b484-cb2d2891d5f9",
+        "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "131"
+        "x-envoy-upstream-service-time": "181",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "858c4933-5446-4fb3-9489-e29f0b110add",
-        "lastUpdatedDateTime": "2022-10-15T02:29:25Z",
-        "createdDateTime": "2022-10-15T02:29:23Z",
-        "expirationDateTime": "2022-10-16T02:29:23Z",
+        "jobId": "2596cf24-85de-422a-a774-d361cb45d5f0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:58Z",
+        "createdDateTime": "2022-10-24T05:20:56Z",
+        "expirationDateTime": "2022-10-25T05:20:56Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -209,7 +213,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.2043739Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.6620034Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -252,7 +256,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.226116Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.7558695Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -281,7 +285,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.7571386Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.9064244Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -317,7 +321,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/858c4933-5446-4fb3-9489-e29f0b110add?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2596cf24-85de-422a-a774-d361cb45d5f0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -333,25 +337,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7677196c-955d-4455-9534-de5be9172200",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "84a57af5-8337-4f4c-b27f-d1045d7651d8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8346d679-fc0f-4472-8938-4a7add0ed31d",
-        "Content-Length": "1601",
+        "apim-request-id": "a0b7e5c6-4e8f-42df-8e67-72aeafeb4a48",
+        "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "167"
+        "x-envoy-upstream-service-time": "114",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "858c4933-5446-4fb3-9489-e29f0b110add",
-        "lastUpdatedDateTime": "2022-10-15T02:29:25Z",
-        "createdDateTime": "2022-10-15T02:29:23Z",
-        "expirationDateTime": "2022-10-16T02:29:23Z",
+        "jobId": "2596cf24-85de-422a-a774-d361cb45d5f0",
+        "lastUpdatedDateTime": "2022-10-24T05:20:58Z",
+        "createdDateTime": "2022-10-24T05:20:56Z",
+        "expirationDateTime": "2022-10-25T05:20:56Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -362,7 +367,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.2043739Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.6620034Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -405,7 +410,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.226116Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.7558695Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -434,7 +439,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:25.7571386Z",
+              "lastUpdateDateTime": "2022-10-24T05:20:58.9064244Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a106ec5b-a840-47c2-a248-e2399fa9b249",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d5b2989b-07f9-46ed-a84f-59a78e5bee00",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "dac871f5-5f62-418e-b775-b5bb3c17eecd",
+        "apim-request-id": "c6ef31b8-e54a-4a93-aad5-2734f93a62ed",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:25 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/2d731198-eea4-4ab3-99c8-07e2a24231d8?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:20:59 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/93195862-8604-4b7b-94fc-a56355db0cc5?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "161"
+        "x-envoy-upstream-service-time": "187",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2d731198-eea4-4ab3-99c8-07e2a24231d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/93195862-8604-4b7b-94fc-a56355db0cc5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b80c0828-95c2-49a7-8f6f-d65aad4cbf9b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d4b38e4c-adf3-4d7f-994f-d6ac6e5ddc5d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d67bab8-0937-47c3-b6b6-5d10417de6a6",
+        "apim-request-id": "a81df47f-18f3-4ed2-a382-01855b532176",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2d731198-eea4-4ab3-99c8-07e2a24231d8",
-        "lastUpdatedDateTime": "2022-10-15T02:29:26Z",
-        "createdDateTime": "2022-10-15T02:29:26Z",
-        "expirationDateTime": "2022-10-16T02:29:26Z",
+        "jobId": "93195862-8604-4b7b-94fc-a56355db0cc5",
+        "lastUpdatedDateTime": "2022-10-24T05:20:59Z",
+        "createdDateTime": "2022-10-24T05:20:59Z",
+        "expirationDateTime": "2022-10-25T05:20:59Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2d731198-eea4-4ab3-99c8-07e2a24231d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/93195862-8604-4b7b-94fc-a56355db0cc5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,25 +135,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5bb4f398-4af8-4a44-a309-d44b55903731",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d3652edf-530e-43b7-a558-f4df183cf155",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84e2fdf6-7e63-403c-9525-613b620fab7a",
+        "apim-request-id": "60828757-f114-4998-879a-b12d2c97ab64",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:20:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2d731198-eea4-4ab3-99c8-07e2a24231d8",
-        "lastUpdatedDateTime": "2022-10-15T02:29:26Z",
-        "createdDateTime": "2022-10-15T02:29:26Z",
-        "expirationDateTime": "2022-10-16T02:29:26Z",
+        "jobId": "93195862-8604-4b7b-94fc-a56355db0cc5",
+        "lastUpdatedDateTime": "2022-10-24T05:20:59Z",
+        "createdDateTime": "2022-10-24T05:20:59Z",
+        "expirationDateTime": "2022-10-25T05:20:59Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2d731198-eea4-4ab3-99c8-07e2a24231d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/93195862-8604-4b7b-94fc-a56355db0cc5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,25 +183,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3253ad8f-73b0-4770-a2c2-7707684c5be5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d5d93a4b-a20a-44cc-942d-4d224ff9e845",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "71d4e06f-fb0c-47b9-b236-1a449df8a7dd",
-        "Content-Length": "1602",
+        "apim-request-id": "88b6d076-3a1b-47e0-984a-6d20f69af0f7",
+        "Content-Length": "1601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "240"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2d731198-eea4-4ab3-99c8-07e2a24231d8",
-        "lastUpdatedDateTime": "2022-10-15T02:29:28Z",
-        "createdDateTime": "2022-10-15T02:29:26Z",
-        "expirationDateTime": "2022-10-16T02:29:26Z",
+        "jobId": "93195862-8604-4b7b-94fc-a56355db0cc5",
+        "lastUpdatedDateTime": "2022-10-24T05:21:01Z",
+        "createdDateTime": "2022-10-24T05:20:59Z",
+        "expirationDateTime": "2022-10-25T05:20:59Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -209,7 +213,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.0062251Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.7301101Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -252,7 +256,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.0781858Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.7760813Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -281,7 +285,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.4792912Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.922085Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -317,7 +321,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2d731198-eea4-4ab3-99c8-07e2a24231d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/93195862-8604-4b7b-94fc-a56355db0cc5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -333,25 +337,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "60319856-1cf5-45d8-acd4-99548adb4fef",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "44f65fbf-4a85-4274-aec9-a83920c95829",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f1df7090-b2e9-47de-80e8-db6d5ddf08f0",
-        "Content-Length": "1602",
+        "apim-request-id": "2d0869f0-c445-4c04-9d70-88a75533566c",
+        "Content-Length": "1601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "x-envoy-upstream-service-time": "161",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2d731198-eea4-4ab3-99c8-07e2a24231d8",
-        "lastUpdatedDateTime": "2022-10-15T02:29:28Z",
-        "createdDateTime": "2022-10-15T02:29:26Z",
-        "expirationDateTime": "2022-10-16T02:29:26Z",
+        "jobId": "93195862-8604-4b7b-94fc-a56355db0cc5",
+        "lastUpdatedDateTime": "2022-10-24T05:21:01Z",
+        "createdDateTime": "2022-10-24T05:20:59Z",
+        "expirationDateTime": "2022-10-25T05:20:59Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -362,7 +367,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.0062251Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.7301101Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -405,7 +410,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.0781858Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.7760813Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -434,7 +439,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:28.4792912Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:01.922085Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8c81b655-3297-49cf-9e8c-082f18f4d5e6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "31474550-85f7-4592-b6b8-cd2aa05821e6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -41,13 +41,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "b351a6ca-f4dd-43be-8810-6f100324a50b",
+        "apim-request-id": "645ca91c-3560-4e97-9ec7-82678967533a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "522ec25a-8ac2-48af-8d78-20f2a047ef28",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d44168ac-d58b-4d4b-ad24-be8093ef76b1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -41,18 +41,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "10e5ff28-4673-426f-b56c-a06bef94aa36",
+        "apim-request-id": "510548a1-8e9a-4b8e-9338-ad3bc33e2b09",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:51 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:23 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "108"
+        "x-envoy-upstream-service-time": "75",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -68,119 +69,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "766cf6f1-03a3-4f9d-a12b-1ab7a3f479be",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "08aa007e-5e5e-44da-9e75-946d730c71f9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "21f362c8-ba32-460e-b319-d5f8a83cf0f6",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
-      },
-      "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:51Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "852b3297-1b34-472c-ac43-92d18c6e61f5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c5edceb9-fb11-4572-8c48-76a7df0034fa",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:51Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "abc2a7c4-3f7e-489f-8595-2a9b505b07c9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0c4b678b-1e0b-458b-95a0-75f7c0d8dfff",
+        "apim-request-id": "9a6224e1-9f77-49a2-938e-6db88697f515",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:51Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:23Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -193,7 +101,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -209,25 +117,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "273e8790-4248-4840-8828-d65a747f8ddf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0de52c48-78d2-4f0c-add1-56520cb89e17",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3b0aa336-ef85-48a5-a4dc-fc79a054e064",
+        "apim-request-id": "b23d096d-7d65-4e97-b34e-621315ae9ba3",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:51Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:23Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -240,7 +149,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -256,25 +165,170 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "91cb3de9-b090-4b69-97bc-a0dd2cb5084a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "86549ece-09b8-46cd-8b90-febf598710c0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8da5b301-4fdd-4826-875a-8cec7809b6a7",
+        "apim-request-id": "c6713683-6efb-4ec0-9db9-873cabaf7b5f",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:21:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:23Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "12b844f7-cc8d-4441-99fc-8dce4d4a01d9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5b1cdd22-5911-4c49-9940-99840c5435ae",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:21:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:23Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "38f2679a-8d07-4492-9e73-bbc35a1a51d4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "21e65bd5-dd80-468e-95d5-b49ecce1da18",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:21:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:23Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "2731be7c-09fa-4cad-8b7d-e36a0085e087",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5e1d70af-d960-4478-98e2-c36b7de7e53c",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:56Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:30Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -285,7 +339,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:56.2216662Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:30.4219704Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -310,7 +364,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bed68ea2-ae05-4385-8d33-436e41510211?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -326,25 +380,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cf23a352-eb09-457e-a1d9-b3e5defab9c4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "34aab5df-9074-46d3-85dd-e7cc4728a136",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1a53ad6-8679-4383-ae61-fddc6b99356f",
+        "apim-request-id": "2d0482ef-702d-445c-848a-0c2d2677771c",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a11a8d45-7ee6-4e2d-afa4-7a9f425d2b03",
-        "lastUpdatedDateTime": "2022-10-15T02:29:56Z",
-        "createdDateTime": "2022-10-15T02:29:51Z",
-        "expirationDateTime": "2022-10-16T02:29:51Z",
+        "jobId": "bed68ea2-ae05-4385-8d33-436e41510211",
+        "lastUpdatedDateTime": "2022-10-24T05:21:30Z",
+        "createdDateTime": "2022-10-24T05:21:23Z",
+        "expirationDateTime": "2022-10-25T05:21:23Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -355,7 +410,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:56.2216662Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:30.4219704Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1f3035df-03b3-4fd6-a43c-1a5cf79b9c7a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3c1c4f5c-6e57-4777-a5a2-9cb5bf32fce4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -45,13 +45,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "d9056acb-1507-4289-a71d-75d47cab9382",
+        "apim-request-id": "bd0532a4-41ed-4b00-9d30-689ad99d159d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9f338935-0959-4183-a253-cec16a232f64",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ed37c357-5019-4e89-a1a1-7ef941e6d8c6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,13 +43,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "b903c05d-920f-438b-bb05-3e63a399b1b1",
+        "apim-request-id": "436f039c-1fb5-429c-b609-6017966083fa",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "61f8bf13-1827-4729-aa66-33b26c846ab9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9b3d0047-09f4-4ea2-9ca7-c3f8a1c1a39e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -2536,13 +2536,14 @@
       },
       "StatusCode": 413,
       "ResponseHeaders": {
-        "apim-request-id": "0d2cc2a1-40a5-4fcd-9588-cfb9511fe4b7",
+        "apim-request-id": "8d70189f-0183-4daf-995e-9ef41f87b979",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
+        "x-envoy-upstream-service-time": "17",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cf459e18-3df9-4354-b96a-254879ab8de0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1383c48f-b296-414b-84f4-58b3fc4e3d8e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -166,13 +166,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "1be3d04b-287d-4fb8-8f03-5da83f1743c8",
+        "apim-request-id": "495f9e3e-3d4c-46bc-9f7d-d9add667b653",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "edd95fe3-26a7-423d-bbba-8c5c8d576ede",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ed1c4301-d2e0-443b-810a-481f0a39c4bb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3cb3005a-1380-4b89-aeae-1bfb0bd6168d",
+        "apim-request-id": "44cf0888-8657-4ab3-a8ff-aa4742d50dcc",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:57 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5e2ec226-8424-4937-b19e-ab185274f967?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:32 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/3894a85e-0f5c-460b-9eed-f5d22d3eff0f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "133"
+        "x-envoy-upstream-service-time": "130",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5e2ec226-8424-4937-b19e-ab185274f967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3894a85e-0f5c-460b-9eed-f5d22d3eff0f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,25 +71,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8849ccd4-4764-466c-a88f-722da369eb46",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "fef7acda-6381-480d-9e78-59db56cef4ae",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93f07dae-c79d-4bf5-96dd-13c5a22ccca2",
+        "apim-request-id": "12e807b5-a68f-44bb-825c-f4f30716a5b2",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5e2ec226-8424-4937-b19e-ab185274f967",
-        "lastUpdatedDateTime": "2022-10-15T02:29:57Z",
-        "createdDateTime": "2022-10-15T02:29:57Z",
-        "expirationDateTime": "2022-10-16T02:29:57Z",
+        "jobId": "3894a85e-0f5c-460b-9eed-f5d22d3eff0f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:32Z",
+        "createdDateTime": "2022-10-24T05:21:32Z",
+        "expirationDateTime": "2022-10-25T05:21:32Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5e2ec226-8424-4937-b19e-ab185274f967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3894a85e-0f5c-460b-9eed-f5d22d3eff0f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,26 +119,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "eb736762-1a50-445e-b0e3-df838d6cd29d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d0dca88b-fc51-4e17-a356-f9f32720ac92",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8e06416a-eaaa-436e-9d5d-8a14f470c15e",
-        "Content-Length": "280",
+        "apim-request-id": "afbd354e-c7a8-4376-b3f7-ad2f89db656d",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5e2ec226-8424-4937-b19e-ab185274f967",
-        "lastUpdatedDateTime": "2022-10-15T02:29:57Z",
-        "createdDateTime": "2022-10-15T02:29:57Z",
-        "expirationDateTime": "2022-10-16T02:29:57Z",
-        "status": "running",
+        "jobId": "3894a85e-0f5c-460b-9eed-f5d22d3eff0f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:32Z",
+        "createdDateTime": "2022-10-24T05:21:32Z",
+        "expirationDateTime": "2022-10-25T05:21:32Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -148,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5e2ec226-8424-4937-b19e-ab185274f967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3894a85e-0f5c-460b-9eed-f5d22d3eff0f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -164,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "212bc2c3-4950-4022-b267-3541b977669c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2dafdfc4-9814-4f43-9302-9caf8e8eabad",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f42854a4-1b66-4dd4-93a5-9768af70bbc6",
-        "Content-Length": "682",
+        "apim-request-id": "4955cf71-5082-4f18-9004-b44c5166002b",
+        "Content-Length": "681",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5e2ec226-8424-4937-b19e-ab185274f967",
-        "lastUpdatedDateTime": "2022-10-15T02:29:59Z",
-        "createdDateTime": "2022-10-15T02:29:57Z",
-        "expirationDateTime": "2022-10-16T02:29:57Z",
+        "jobId": "3894a85e-0f5c-460b-9eed-f5d22d3eff0f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:34Z",
+        "createdDateTime": "2022-10-24T05:21:32Z",
+        "expirationDateTime": "2022-10-25T05:21:32Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +197,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:59.2414643Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:34.834809Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -221,7 +225,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5e2ec226-8424-4937-b19e-ab185274f967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3894a85e-0f5c-460b-9eed-f5d22d3eff0f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -237,25 +241,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3d63821c-f6ab-4fa5-85cb-073d21a37308",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "99928382-6d47-45a4-8641-beacc1313d3a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c68e3422-f5cb-43d7-8787-95eed1cacb72",
-        "Content-Length": "682",
+        "apim-request-id": "e894c1c5-e6a0-43fc-85f5-bd79c1dec9ed",
+        "Content-Length": "681",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5e2ec226-8424-4937-b19e-ab185274f967",
-        "lastUpdatedDateTime": "2022-10-15T02:29:59Z",
-        "createdDateTime": "2022-10-15T02:29:57Z",
-        "expirationDateTime": "2022-10-16T02:29:57Z",
+        "jobId": "3894a85e-0f5c-460b-9eed-f5d22d3eff0f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:34Z",
+        "createdDateTime": "2022-10-24T05:21:32Z",
+        "expirationDateTime": "2022-10-25T05:21:32Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -266,7 +271,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:29:59.2414643Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:34.834809Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a2ee9c91-3a0d-405a-8145-a817266e3fbe",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "36d1ce99-6fbc-4408-9e10-b4c974f4dece",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "59b010e5-0c36-42a0-8b5f-f9e3d1283900",
+        "apim-request-id": "5de2bfcb-198c-45a1-8f0f-43c5c959e02a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:30:02 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:37 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/d1ff5823-0520-444a-9eab-d9fdd3bc8faa?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110"
+        "x-envoy-upstream-service-time": "128",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d1ff5823-0520-444a-9eab-d9fdd3bc8faa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,64 +71,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bd87062f-04e6-47ee-aefb-1c5458716cb1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "c199b8a1-a7ef-458d-a25c-061e834df733",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:30:02 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bd87062f-04e6-47ee-aefb-1c5458716cb1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5db0b2d7-ef05-45f7-89e8-a2197bebe8d0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bdb7d6d6-0f69-4716-8edb-f9aeaa7187b4",
+        "apim-request-id": "fb5a8939-f532-40c7-b4d4-1c4e8ff84f61",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "adad1186-1dd3-4fce-bebf-df784c29779e",
-        "lastUpdatedDateTime": "2022-10-15T02:30:02Z",
-        "createdDateTime": "2022-10-15T02:30:02Z",
-        "expirationDateTime": "2022-10-16T02:30:02Z",
+        "jobId": "d1ff5823-0520-444a-9eab-d9fdd3bc8faa",
+        "lastUpdatedDateTime": "2022-10-24T05:21:38Z",
+        "createdDateTime": "2022-10-24T05:21:37Z",
+        "expirationDateTime": "2022-10-25T05:21:37Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -140,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d1ff5823-0520-444a-9eab-d9fdd3bc8faa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -156,25 +119,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a4628071-e1ae-4b2b-9985-e4a2f899a25f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2cce4440-3a25-421b-9378-fbd9d8055cc4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d3d9626-323f-4abf-9edd-e46eb49f57f8",
+        "apim-request-id": "51220a63-f92a-40cb-a92e-3f5480345066",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "adad1186-1dd3-4fce-bebf-df784c29779e",
-        "lastUpdatedDateTime": "2022-10-15T02:30:02Z",
-        "createdDateTime": "2022-10-15T02:30:02Z",
-        "expirationDateTime": "2022-10-16T02:30:02Z",
+        "jobId": "d1ff5823-0520-444a-9eab-d9fdd3bc8faa",
+        "lastUpdatedDateTime": "2022-10-24T05:21:38Z",
+        "createdDateTime": "2022-10-24T05:21:37Z",
+        "expirationDateTime": "2022-10-25T05:21:37Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -187,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d1ff5823-0520-444a-9eab-d9fdd3bc8faa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -203,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b9381d4a-665a-4897-99f2-e8fab8d5f37e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "10169e7a-b736-45d5-ad03-53f44cba343f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0363d472-f8ea-4279-94f4-09b797d1ddd9",
-        "Content-Length": "1788",
+        "apim-request-id": "629877b4-abc5-4fbc-a356-e436f1109ef1",
+        "Content-Length": "1787",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "130"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "adad1186-1dd3-4fce-bebf-df784c29779e",
-        "lastUpdatedDateTime": "2022-10-15T02:30:04Z",
-        "createdDateTime": "2022-10-15T02:30:02Z",
-        "expirationDateTime": "2022-10-16T02:30:02Z",
+        "jobId": "d1ff5823-0520-444a-9eab-d9fdd3bc8faa",
+        "lastUpdatedDateTime": "2022-10-24T05:21:39Z",
+        "createdDateTime": "2022-10-24T05:21:37Z",
+        "expirationDateTime": "2022-10-25T05:21:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -232,7 +197,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:30:04.1811831Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:39.381796Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -383,7 +348,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/adad1186-1dd3-4fce-bebf-df784c29779e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d1ff5823-0520-444a-9eab-d9fdd3bc8faa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -399,25 +364,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bf7c7565-0347-47fa-9b47-6500907e38ef",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1d10c024-bb97-461f-90c1-db094a24e0fd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc7f7ba7-ea86-41e1-8190-e4baaa7cf459",
-        "Content-Length": "1788",
+        "apim-request-id": "9f3f392c-dd59-4907-9107-8056d02d27fb",
+        "Content-Length": "1787",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "adad1186-1dd3-4fce-bebf-df784c29779e",
-        "lastUpdatedDateTime": "2022-10-15T02:30:04Z",
-        "createdDateTime": "2022-10-15T02:30:02Z",
-        "expirationDateTime": "2022-10-16T02:30:02Z",
+        "jobId": "d1ff5823-0520-444a-9eab-d9fdd3bc8faa",
+        "lastUpdatedDateTime": "2022-10-24T05:21:39Z",
+        "createdDateTime": "2022-10-24T05:21:37Z",
+        "expirationDateTime": "2022-10-25T05:21:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -428,7 +394,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:30:04.1811831Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:39.381796Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8f039fae-ece4-4916-a1e4-b2753cbd15ab",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ad003193-11c3-4e7d-b17a-a9cb07f90df7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "75187be3-17a2-428c-b68e-5a264d152d93",
+        "apim-request-id": "330b6a1b-5ba8-47e5-bff6-1cb37bee90eb",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:29:59 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/ece7ece9-86ce-4a83-8770-8aa2d31123f2?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:21:34 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/c128f6f9-c838-4a00-8c31-bdcdb5d61b2f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
+        "x-envoy-upstream-service-time": "67",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ece7ece9-86ce-4a83-8770-8aa2d31123f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c128f6f9-c838-4a00-8c31-bdcdb5d61b2f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,25 +71,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6baf3f9b-c784-4b60-8796-91de16f50e10",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bc6e4922-523d-4c43-bba5-d9473b20af22",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a885b7c8-7892-4613-b3e7-4e58aa19eeb1",
+        "apim-request-id": "8c14a1cf-25a3-4baa-9c14-2b079fd5a8e1",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ece7ece9-86ce-4a83-8770-8aa2d31123f2",
-        "lastUpdatedDateTime": "2022-10-15T02:30:00Z",
-        "createdDateTime": "2022-10-15T02:30:00Z",
-        "expirationDateTime": "2022-10-16T02:30:00Z",
+        "jobId": "c128f6f9-c838-4a00-8c31-bdcdb5d61b2f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:35Z",
+        "createdDateTime": "2022-10-24T05:21:35Z",
+        "expirationDateTime": "2022-10-25T05:21:35Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ece7ece9-86ce-4a83-8770-8aa2d31123f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c128f6f9-c838-4a00-8c31-bdcdb5d61b2f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,26 +119,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "01833311-1e41-4be9-9cb7-13bdce3bef17",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8d14f27b-bc1e-4976-b35f-9e5ea0a678bb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "41186429-3028-4ee4-afa6-df8b5ff41c63",
-        "Content-Length": "280",
+        "apim-request-id": "e4488188-e560-42d0-9bb0-de5a0fe7b201",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:29:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ece7ece9-86ce-4a83-8770-8aa2d31123f2",
-        "lastUpdatedDateTime": "2022-10-15T02:30:00Z",
-        "createdDateTime": "2022-10-15T02:30:00Z",
-        "expirationDateTime": "2022-10-16T02:30:00Z",
-        "status": "running",
+        "jobId": "c128f6f9-c838-4a00-8c31-bdcdb5d61b2f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:35Z",
+        "createdDateTime": "2022-10-24T05:21:35Z",
+        "expirationDateTime": "2022-10-25T05:21:35Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -148,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ece7ece9-86ce-4a83-8770-8aa2d31123f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c128f6f9-c838-4a00-8c31-bdcdb5d61b2f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -164,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a1cc558f-590f-4101-91d8-6840bec6f08f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "150cef52-032e-4a4c-b2be-d0c7f801c110",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26914492-0fb4-4b52-a270-305a62231934",
-        "Content-Length": "1788",
+        "apim-request-id": "283ef39b-0ce8-4f33-aed2-5353812697f5",
+        "Content-Length": "1787",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ece7ece9-86ce-4a83-8770-8aa2d31123f2",
-        "lastUpdatedDateTime": "2022-10-15T02:30:01Z",
-        "createdDateTime": "2022-10-15T02:30:00Z",
-        "expirationDateTime": "2022-10-16T02:30:00Z",
+        "jobId": "c128f6f9-c838-4a00-8c31-bdcdb5d61b2f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:37Z",
+        "createdDateTime": "2022-10-24T05:21:35Z",
+        "expirationDateTime": "2022-10-25T05:21:35Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +197,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:30:01.7099271Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:37.101434Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -344,7 +348,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ece7ece9-86ce-4a83-8770-8aa2d31123f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c128f6f9-c838-4a00-8c31-bdcdb5d61b2f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -360,25 +364,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c62ce294-5a0f-4427-abfc-e22c5ac316cc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c17daba8-e78e-4ce4-b12b-c423445a2fa2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5af0af7-1a50-4cab-8f4a-c9e8b5991edc",
-        "Content-Length": "1788",
+        "apim-request-id": "515c0be8-9346-42f9-b3a5-b2500a776c32",
+        "Content-Length": "1787",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:30:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ece7ece9-86ce-4a83-8770-8aa2d31123f2",
-        "lastUpdatedDateTime": "2022-10-15T02:30:01Z",
-        "createdDateTime": "2022-10-15T02:30:00Z",
-        "expirationDateTime": "2022-10-16T02:30:00Z",
+        "jobId": "c128f6f9-c838-4a00-8c31-bdcdb5d61b2f",
+        "lastUpdatedDateTime": "2022-10-24T05:21:37Z",
+        "createdDateTime": "2022-10-24T05:21:35Z",
+        "expirationDateTime": "2022-10-25T05:21:35Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -389,7 +394,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:30:01.7099271Z",
+              "lastUpdateDateTime": "2022-10-24T05:21:37.101434Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/api_key_textanalysisclient_client_options/recording_service_version.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/api_key_textanalysisclient_client_options/recording_service_version.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "de5c5b9d-5d72-46f0-9244-6ac393cd76c2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "41b15396-ac35-4a22-8827-1d2b4740c806",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -42,18 +42,19 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "576d8a8c-a2d7-4c55-a6a0-f8fb9fa65f7a",
+        "apim-request-id": "c166d356-9e77-46f1-ae11-c515c5548ae0",
         "Content-Length": "712",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Sat, 15 Oct 2022 02:30:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "warn-agent": "-",
         "warn-code": "299",
         "warn-text": "Microsoft Cognitive Services Language APIs version 2022-04-01-preview is retired and will be removed by Dec 1, 2022. The latest supported version is 2022-05-01. For more information please check http://aka.ms/language-api-versions.",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -138,8 +139,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f3ef665c-b961-49e0-a78f-453b0732c385",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5797ab5e-7ad9-4ca4-82ad-b09db7468649",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -161,15 +162,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eaf9d45e-09ff-4654-b6c2-b386101215d9",
+        "apim-request-id": "31efa9c5-d252-40a3-96db-0d5afe6a66c7",
         "Content-Length": "712",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Sat, 15 Oct 2022 02:30:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:21:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -8,7 +8,7 @@
         "Accept-Encoding": "gzip, deflate, br",
         "Accept-Language": "en-US",
         "Connection": "keep-alive",
-        "Content-Length": "687",
+        "Content-Length": "289",
         "Content-Type": "application/json",
         "ocp-apim-subscription-key": "api_key",
         "Referer": "http://localhost:9876/",
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c57fff46-cf63-4f53-83fe-ae5756ff2386",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6e10e3b5-701a-4e06-bcb3-9e7d19e09adb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -28,28 +28,13 @@
           "documents": [
             {
               "id": "1",
-              "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle",
-              "language": "en"
-            },
-            {
-              "id": "3",
               "text": "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
               "language": "en"
             },
             {
-              "id": "4",
-              "text": "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
-              "language": "es"
-            },
-            {
-              "id": "5",
-              "text": "La carretera estaba atascada. Hab\u00EDa mucho tr\u00E1fico el d\u00EDa de ayer.",
-              "language": "es"
+              "id": "2",
+              "text": "I didn\u0027t like the last book I read at all.",
+              "language": "en"
             }
           ]
         },
@@ -57,15 +42,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bd6e470-f12d-4cf0-a169-d282c8df37df",
-        "Content-Length": "1834",
+        "apim-request-id": "9c38cf4a-60ed-4510-86b0-3080b8cb76ab",
+        "Content-Length": "424",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
+        "Date": "Mon, 24 Oct 2022 05:17:23 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "261"
+        "x-envoy-upstream-service-time": "18",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -73,82 +59,6 @@
           "documents": [
             {
               "id": "1",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 26,
-                      "length": 7,
-                      "confidenceScore": 0.21
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 65,
-                      "length": 12,
-                      "confidenceScore": 0.42
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "2",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 50,
-                      "length": 7,
-                      "confidenceScore": 0.2
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 90,
-                      "length": 12,
-                      "confidenceScore": 0.36
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "3",
               "entities": [
                 {
                   "bingId": "296617ab-4ddb-cc10-beba-56e0f42af76b",
@@ -170,29 +80,7 @@
               "warnings": []
             },
             {
-              "id": "4",
-              "entities": [
-                {
-                  "bingId": "9ae3e6ca-81ea-6fa1-ffa0-42e1d7890906",
-                  "name": "Monte Rainier",
-                  "matches": [
-                    {
-                      "text": "Monte Rainier",
-                      "offset": 29,
-                      "length": 13,
-                      "confidenceScore": 0.81
-                    }
-                  ],
-                  "language": "es",
-                  "id": "Monte Rainier",
-                  "url": "https://es.wikipedia.org/wiki/Monte_Rainier",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "5",
+              "id": "2",
               "entities": [],
               "warnings": []
             }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1164d09d-d282-4822-9904-f9c558fde621",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "aec8a165-9df2-42e8-8786-b4b6371e8b59",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50aab1fe-712e-46d8-a896-1be15f7cd0fb",
+        "apim-request-id": "ed565da5-0f57-4994-8fe4-871c0f80ea37",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:23 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "18",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "52a18533-ee76-477d-87b5-03584a8b8377",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "74bc6dd3-2096-45d8-9917-bb8c0c7386ce",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "230a4bea-3f14-4719-ab62-dd126bc3dd98",
+        "apim-request-id": "5066fbc6-fa52-4a48-84b7-ca69578090b1",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:23 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "90283339-a4a4-44a2-a9ec-dbe53315e99b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "dfca6236-d366-4da1-aa57-cb7d64b1ab3e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -62,13 +62,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "ca0008ab-6d5a-44b7-a309-f593690eb647",
+        "apim-request-id": "a20ab569-d387-4cba-b8c3-d5b72feec4f1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a20489a5-b742-4139-9f11-44e6b2091514",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "adbcba78-2ff7-4bd5-8378-70742b47efeb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77d7228b-39a2-4bed-9072-aba74c955545",
+        "apim-request-id": "65441e13-0752-4259-8965-aa51781c7c9c",
         "Content-Length": "408",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:23 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1"
+        "x-envoy-upstream-service-time": "2",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ab1da0a3-e18d-4782-88a3-f2990b09d709",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "265ae574-ed95-4165-b9fc-ff48572228e6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a65882f-0cb6-4bf8-b53a-4df5be999d39",
+        "apim-request-id": "4f62a970-0aa9-4b4b-a36b-7fbdf1d95a9d",
         "Content-Length": "1462",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:18 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8b8d2da5-e4aa-4374-801a-667c21d62bfb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "eff265ef-5eb8-4e91-9d80-e0cd3e81c411",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b928f163-0b81-473b-81c9-99cdb2fd4dd0",
+        "apim-request-id": "a25f1af3-abce-4872-866d-47cc35c16850",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:18 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "45153f34-ce53-4b03-b26d-cd9408b513d4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b52cd627-0fcf-4de0-b452-cdbe6551e82e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "517c5cf9-a857-4666-a9dc-be5efa670adb",
+        "apim-request-id": "f8b6daa5-4e29-44bd-8f35-c683e3f64743",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:17 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "51",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e4603890-e165-40ee-ad51-4dabe349dcb1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5624abb7-9646-413b-8621-e76e18c3fce7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -62,13 +62,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f20e8052-91cb-4c71-ab61-bd3921831802",
+        "apim-request-id": "39752d27-2c6d-4225-89a0-6a366810878d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a191ba14-b7ba-4124-9d91-56150fe419cf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9fdb371d-02ce-4d22-933b-bf02868ef92c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6e3aaf67-5e20-4e58-8196-a532662147f3",
+        "apim-request-id": "0f90301e-2eab-41ed-b113-2553c6d8e799",
         "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:18 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7852008a-54f4-41d1-a37d-9ee1c81ef87e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8cd3d491-4d5d-4d9e-8184-074e3914a8da",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "45ebae67-e468-471f-bfc8-8aa40e2017d8",
+        "apim-request-id": "b2b3a847-558c-4bd9-9995-740831691078",
         "Content-Length": "524",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:19 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "15",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "33cb7f60-fbdb-4304-b3b1-c89f4511c576",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "25b43d62-8c1a-4bbc-89aa-5cc514814398",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cd121e4f-4bb8-4c05-af17-28957db100cd",
+        "apim-request-id": "363ffe1e-e41a-40d4-b070-134d4ff636e4",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:19 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e046fee7-8acc-4bae-be39-7542faa709c2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "074276b0-32be-453a-bd27-0b6edbb677d7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77554f7e-678f-47cd-9318-2c76bd584cf0",
+        "apim-request-id": "683ec8e4-9958-40ae-a6c7-2f6746c13a24",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:19 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "15",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2763b3df-e785-410d-a895-a82109a8628c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "978d38ce-90e3-43ea-9f7c-11c44fdbb9ce",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0308e845-3b65-43da-a768-bcc450b9a80c",
+        "apim-request-id": "3797521d-18d2-4901-b237-b12d63e98b6c",
         "Content-Length": "704",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:19 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "44a16bbf-bb95-44a1-b1b4-26293b1c0a5c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2e575ccc-bb47-494e-8fc6-e90349d6ac9d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa8abe05-cb3d-43ba-b897-86948cfd0db0",
+        "apim-request-id": "94b0901f-f026-4000-8748-64a163ec3a49",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:16 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "75406ce4-0b0f-436f-867c-bf093c0953c0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "37936547-2a70-4d7e-86fa-2bf9c57119b1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -58,15 +58,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "963f1e0d-3f08-4cfe-9059-58b85b29b6ce",
+        "apim-request-id": "cdb81592-2499-455c-983b-3b753202de67",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:17 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "27fa1d83-181e-46f0-8e4d-279a75d3e4ff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "265ce0cc-6c2d-4bee-b72a-2e5c31c459d6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "82e9f0e7-04fe-42dd-a3bb-c5ca30445b8c",
+        "apim-request-id": "a90441b5-2679-415d-9f23-e4f19385dd3a",
         "Content-Length": "517",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:16 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "539e7cdb-ba9c-4ac5-99f4-5215228711f7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9d53f751-b905-4ee6-b507-4f5445f430bf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ab5688a-1a88-402d-8d06-717269ce8465",
+        "apim-request-id": "0f6a69d4-b9b1-41d5-b91d-52d5b2bdeef3",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:17 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3dd444ad-8d46-472e-bb2c-82db6dcdf6cf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1adb75c8-9b05-4296-a5a4-a8a9c8de6cde",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c210de38-4a74-4ccc-820f-6a37342dc8e2",
+        "apim-request-id": "62316fd8-6502-4746-a643-0587ef23215f",
         "Content-Length": "206",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:16 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "66334421-3e5e-41ad-a3b2-f1c9b9bc5054",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "798492df-e938-4be1-a5ae-bb198e28b17b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e542d04-a455-4652-b5e9-4aab93a9516d",
+        "apim-request-id": "5bd2358b-5b13-409c-8a8a-93808b043e10",
         "Content-Length": "325",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:17 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "2",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e963ca37-a6de-44ab-b3be-072f703c0724",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "24da0e6a-77cd-49b3-8b54-153776797069",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e20a6ee3-fbfc-456a-b784-d1df1aca7ddb",
+        "apim-request-id": "57706bdc-0d3d-4128-b34c-1f730dacc9fb",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:21 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "39",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "15539fba-5c53-4318-9275-ca8231678a21",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f76c81e7-48e9-49fa-88e1-48acfd8c0224",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -41,15 +41,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c77da564-a60f-4c2c-b850-3e9e96c18c9e",
+        "apim-request-id": "b4790011-a947-4ba1-9c2b-3d26699e8c56",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:21 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5dcb99c4-12cd-4d55-a1e5-f54514fe20da",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "47768a17-0078-402e-9f65-bbd4c12a9a0d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0a47cfed-c6db-4e8e-ad03-875594b90869",
+        "apim-request-id": "091814fa-07ab-4ce8-ab9a-0024aa3a23d2",
         "Content-Length": "1142",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:21 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
+        "x-envoy-upstream-service-time": "37",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "250e7745-a230-4e9b-96f2-5eeeb34d960c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e4e2eef5-20ad-4e88-b000-27c26ef4bddc",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2aec8c41-ebd8-46f7-809d-a2514088fa6a",
+        "apim-request-id": "70d32d4d-4b1b-4140-8e21-bf1529c417be",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:20 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "42",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c284f66a-4825-4ebf-86d9-9e3241e3af2d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1c7cf709-bd0c-40fc-a9a0-f30175d2c651",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "981e1097-81af-4dec-bb61-d0db95b27d81",
+        "apim-request-id": "56cdfca7-b58f-43c0-a60a-caaed9aebd1b",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:20 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "52",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1efdc5e5-5dd2-4c91-b529-c363ff34addb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7064dde0-2e6f-4c8e-bbd5-c341cb1524ca",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e624871-06ad-4935-8208-0d6bcf33092a",
+        "apim-request-id": "acf5e1ea-5acc-44f6-9242-44cbc4a8c69f",
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:20 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7ea973bf-6254-4412-ab70-65b8f0fbbd98",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9bb0e66e-e8cb-4583-b486-6a4d7f779261",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,15 +37,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "35160035-c9dc-4efe-8657-b967654c4212",
+        "apim-request-id": "c5ed393a-7fae-489d-a382-ad34fa08d4b2",
         "Content-Length": "389",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:21 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -97,8 +98,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5f88a095-a750-4b55-9d2e-de5389e1b280",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f6112aa7-c662-48cd-b8ad-0c5b48859521",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -119,15 +120,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c7a4338f-5577-41f3-84e2-1959abbb586b",
+        "apim-request-id": "dc247077-d06f-4fd7-a9ac-14d67e847f33",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:21 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ad9473bb-ff33-4134-abe0-78e3b4e9c9d3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "92773886-c0f4-440e-b85b-af7698fabae2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c338ae40-4c2e-4f33-9a06-6f59574bd10e",
+        "apim-request-id": "57ec3d29-a9b7-4287-ab0b-8c5bb36c7e45",
         "Content-Length": "450",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:20 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7c619b8a-c43e-4b45-a1ec-d98b61a7ff97",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "07565a08-fe25-4b4f-b707-07a3b460493b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b158b9a1-ba39-4d5f-8801-28101ea6c33d",
+        "apim-request-id": "0428efcc-d1be-4c22-adea-d97bf6eb0bcc",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:12 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6145ad10-728d-48ea-bcfb-62405cdaa003",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a8aa39c0-f451-4fad-8dba-e1eb4de8e113",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -52,15 +52,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "98b52f94-5b25-46be-82c9-735e30f70eb4",
+        "apim-request-id": "c0f056d8-a188-408a-ad6b-22672f30cabf",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a408ed95-b161-4867-858d-acf9b7fd96cc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c8f12d19-8ebd-4ebe-9905-ea9ca4f54c2a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -62,15 +62,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbc8308e-07cd-4444-9a9f-c58a5c4c8a89",
+        "apim-request-id": "cd82b897-f011-41be-90c9-07a6ef4128d6",
         "Content-Length": "2343",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:15 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "Content-Length": "166",
+        "Content-Type": "application/json",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "90f0a16f-392f-4f25-b6fb-050c2214bc2d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": {
+        "kind": "SentimentAnalysis",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "The food and service are not good",
+              "language": "en"
+            }
+          ]
+        },
+        "parameters": {
+          "opinionMining": true
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c75426f3-9722-4b49-bb5a-15031d6b86ae",
+        "Content-Length": "954",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Mon, 24 Oct 2022 05:17:15 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "kind": "SentimentAnalysisResults",
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "sentiment": "negative",
+              "confidenceScores": {
+                "positive": 0.0,
+                "neutral": 0.0,
+                "negative": 1.0
+              },
+              "sentences": [
+                {
+                  "sentiment": "negative",
+                  "confidenceScores": {
+                    "positive": 0.0,
+                    "neutral": 0.0,
+                    "negative": 1.0
+                  },
+                  "offset": 0,
+                  "length": 33,
+                  "text": "The food and service are not good",
+                  "targets": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 4,
+                      "length": 4,
+                      "text": "food",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    },
+                    {
+                      "sentiment": "positive",
+                      "confidenceScores": {
+                        "positive": 1.0,
+                        "negative": 0.0
+                      },
+                      "offset": 13,
+                      "length": 7,
+                      "text": "service",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    }
+                  ],
+                  "assessments": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 29,
+                      "length": 4,
+                      "text": "good",
+                      "isNegated": true
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2022-10-01"
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d7d08577-5b91-4b89-8c87-6a97395f06f0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "45eb70e4-c2b9-4235-8dc5-dc3348e648a7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb0ec885-e7a0-48de-ac86-bb31f2bb4ce6",
+        "apim-request-id": "01c2ca23-19bc-4ee8-9d24-5de07349e017",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:16 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "18",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1cde1605-0623-4093-b68c-8079fc7dbf02",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "066989f4-778f-4222-89f2-3aa0bda54976",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2712c5b5-5190-4b84-95f8-b920b53f3308",
+        "apim-request-id": "7f96f728-1ec3-4665-bec5-b7977ebcaaea",
         "Content-Length": "1009",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:15 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a46a06b0-8a39-4425-bc9c-3d2071069c9b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "35d512ea-e63e-410f-94d5-3a2fbca30b51",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -69,15 +69,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2110dbb7-572a-4682-b8c8-7bba89a9365f",
+        "apim-request-id": "a70860b2-9b3d-4502-93c6-6578b26e31c2",
         "Content-Length": "7828",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=7,CognitiveServices.TextAnalytics.TextRecords=7",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5ebe9555-5222-41bc-9e8e-a62316c81819",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "38080820-24c1-4293-a1de-1f36483b5f69",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -57,15 +57,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1e92736b-478a-446a-bd37-27bcb706a746",
+        "apim-request-id": "d15ac6f5-53cb-4c35-8bc8-fc6e50b3ab89",
         "Content-Length": "1734",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "346",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b41140b8-fee0-4de2-ba5d-61d205d9c28b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "36460d5d-bbac-48d6-8211-078a5900f5c9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -37,14 +37,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c042358-4ac2-4150-b80e-8a869744e92f",
+        "apim-request-id": "32e70ac2-8084-4723-be87-975bd215bda7",
         "Content-Length": "699",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "aeaae85c-095b-4830-a9b1-1c2722f1d9a6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f2324b67-225c-40fc-a296-7ef5bbbc46bf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d46d3726-7f61-4256-abe5-a7a2c707fa98",
+        "apim-request-id": "02061382-8011-4346-bb43-356054a25264",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:25 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "06c25bf2-b827-489f-94dd-a83691475217",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e12379dd-e71a-40f7-b9f5-9a506a3b54b4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fb7a4921-3ce7-4b0c-8e24-f6f17cd325a4",
+        "apim-request-id": "45c8fa17-eda5-4126-96e3-b6754f4d5905",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:25 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7bd15dcd-b5a2-429c-a955-6f7056c9357b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5b46b3f9-07c4-4dc2-8966-3ce2a90c8feb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3efa1a1f-66e7-4c86-a415-bc4e6bbec08c",
+        "apim-request-id": "99339e9f-ebbe-4bfe-abdd-0b289a161ef0",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:24 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "db5ab6a7-f67c-47ba-9df5-82d6882b0e4b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c800f7f0-abff-43c0-9e96-01398af98d7a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a993e16b-73c8-45af-886f-26201c153698",
+        "apim-request-id": "cfb09c67-ff61-4f34-89ca-f605526e2d5b",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:24 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0c7f5fb7-f041-472c-95af-de641b692c50",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "93adf7c0-cd69-4192-bb76-a949d9de9461",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "64d8740a-e1c5-4117-ba47-d1ecb8013c67",
+        "apim-request-id": "c64c8421-af3a-49cf-907f-f167802a7b65",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:24 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6f0e3c32-3362-4ed2-93d4-8bc6d806c0e3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "01f3ed4b-ab74-4199-8abc-ceeffebbe6ac",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb47ae4a-58df-4d84-82c3-7f2084af670a",
+        "apim-request-id": "6c000678-8ed5-41c8-a81e-5b095cb8f7c8",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:25 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "345d31ed-d05d-4f4a-9f5a-1cef1fb95cc3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f4c6d4b9-086a-4136-87a0-7b78a6e18095",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20321e54-1837-4c04-9eb2-88362ef4ee17",
+        "apim-request-id": "8b256dea-d78b-41a4-a8df-000ca0c3b1db",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:25 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3d09ea0d-623b-4a6d-893f-dacc5103c6f9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "fb6c2356-1093-4bc5-a7ff-0703e8f40a87",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65f36d6a-77f4-45c4-8e6c-cc2cd22ad1ee",
+        "apim-request-id": "8ae0edf3-d7c5-4b8d-b333-da7cb7d692b5",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:26 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "05abe799-7a00-4994-a987-89954e5c3aff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f8513fcc-264d-4b67-8e52-102802397141",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "911ad131-5f2a-45e2-912b-7883c5f186e3",
+        "apim-request-id": "79e3e8b6-ddc5-464a-9fab-63a2b9dde7c7",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:26 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "60"
+        "x-envoy-upstream-service-time": "61",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3079854b-3bbc-4fd8-b724-6021c74dbfa6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5ebc7683-5cc2-445e-a5bc-a7fe7eb78a77",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c38d4f38-fd41-4b6d-aa55-c4eb0a184152",
+        "apim-request-id": "d3666468-ec67-4ae0-a29e-6249dfeccd9a",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:30 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c16cd691-0826-4c8d-a9dc-496f0be9411b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "666bd35d-6d14-4b5c-86fa-6ba31876cd42",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6b83bbe1-ec6e-4f88-b3e8-fac42890cd6f",
+        "apim-request-id": "d5e1b5da-18c6-4c70-b478-37fd66a6b90d",
         "Content-Length": "287",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:30 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "759fd32d-cc98-42fa-af09-7f35386828f1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6d839483-f869-4de3-8ed9-92d5ef4d9193",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c90b0d38-80ec-4ef8-a6b4-b97a4c053af0",
+        "apim-request-id": "7331bc99-d73a-4ef0-b5ba-f219f44360a1",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "093da4e9-9b84-45a0-99dd-0533e39756c0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5618ca8d-6274-4e89-9615-2e871c20e43c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4997f9b4-cf8b-46d1-8bd2-bd63559e6962",
+        "apim-request-id": "4ec822c5-bf33-4781-92ce-d1d90a458837",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:30 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a12a8ff1-3215-45f3-ad04-9623b1ff2120",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b722d44f-da38-468b-a811-fb9e1f251cbd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0859bdac-00b9-4434-a020-8d8057f25c57",
+        "apim-request-id": "d7724ab3-fb42-4c5f-9bd4-220ae25c7fe4",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:30 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8ab1786c-b433-4826-a63b-8b66f06a0f03",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8eaf2c1d-15bd-4a4f-a2ab-ad55c8316ff8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80c18589-b9ea-4b38-9c0d-27623f817b41",
+        "apim-request-id": "5bc3ab19-6d54-4a53-a6c9-dc0e4e7150a4",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:30 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bfa3ec7a-7d6d-4705-a22e-aa7ec85fc322",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "765f3936-c240-46db-8011-abf976a14dc7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f931baee-d773-4bbf-9c63-dc78874b1e99",
+        "apim-request-id": "616215df-7ebc-4086-92c9-b4d4f178cf53",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:31 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ea0be18e-cc37-4b39-b403-c3de457e4046",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "746ac301-976d-4435-8d96-8df8454c187a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "40d38aea-ac4d-44fb-951d-f600104318ae",
+        "apim-request-id": "2b174e24-3b18-4cb4-9058-440a67474372",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:31 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "84786acf-21c4-4a6e-997e-f099e416b060",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "22049743-6e94-4685-97a5-41073cf41bd8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4fbeba74-dd8f-414c-b4cc-4c0483501f88",
+        "apim-request-id": "75beb9ad-74b6-4457-ba10-130138307b19",
         "Content-Length": "509",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:31 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "60"
+        "x-envoy-upstream-service-time": "72",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "66f32667-f048-420f-877a-f8486331d0c2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "be489344-2dbb-4efc-ad7c-8133ee5d4175",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cffc5903-a808-4fa4-b865-aec80534d4b2",
+        "apim-request-id": "72411f7f-8454-4745-972c-3c0f6cc60935",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:28 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d7077852-f364-4281-918b-c115036a5fff",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a9d8d31c-fc78-4c11-a038-35949d26d289",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5460a4dc-14f6-4364-9175-21cc8a260b8d",
+        "apim-request-id": "248a6cce-1323-4361-8fba-1a0dcd2b5a8a",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:28 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "24ed0aad-9c60-4af0-9072-a591589b737b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "46415c61-5034-448c-830a-465afc95f326",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2883904b-22f0-4b49-8821-fb7d58407d96",
+        "apim-request-id": "e6f96224-2c6b-4e6c-a362-717019081400",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e391fbf0-eda1-4d04-90fc-50315eb0527f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ea6136ca-530b-43e2-a8e7-3befa904495a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a8ec3a88-c69f-4aae-86db-d4c50ae7285d",
+        "apim-request-id": "b80ada5d-d3a1-4fd3-b686-2b92a09b3186",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "512a1e50-c2da-47de-bc77-850e94dccd4d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "68c004d8-a855-461d-b897-d07e4fbdd3c0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff5e89fc-90ea-4706-bda5-853eb5c8130c",
+        "apim-request-id": "6a724680-fe37-4982-8065-536e466c1a1a",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ff0f216b-7ed5-40c4-a43b-a5df265a57a8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2bb84efb-1b46-48ba-992e-bdafc63a206d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2cced086-4ad0-43b7-9135-8a6cd54b9d50",
+        "apim-request-id": "3217774f-dcaf-4bc0-89f7-e72254521bdf",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:28 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "51d1a060-90af-4a2e-9054-c5696cd69027",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0a289902-c09f-4e6c-a7d1-89c3e23757a2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "248a41d1-3f2f-49b7-b1be-66e44efa18e0",
+        "apim-request-id": "3e1e455e-0f76-4911-bc18-aba121a0a98b",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9c943ab6-477a-4870-ab8d-80cae727fec8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "65a42bd6-e704-4604-a412-d2f6ecf34637",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b085a1de-bfed-498d-9268-9eb0cc7e7c88",
+        "apim-request-id": "be157434-7777-4177-a878-749ee2b2e434",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "50f47dcd-d9bb-4962-ba57-1c18f09210da",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b44d1cfa-4107-4be7-8728-67e65bbd0d7a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9174e47e-9ae0-4483-bc9a-d8de246a2dc8",
+        "apim-request-id": "86f25f65-62b9-49d7-9bf5-34503afb5314",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:25:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
+        "x-envoy-upstream-service-time": "55",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5b4bb9a8-ac08-4191-868a-9cd93c332bd2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3e6a2d96-bd03-48f5-9c46-c4494e6291cc",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5f2a284f-70a4-4a4d-a53d-b5c9656b8200",
+        "apim-request-id": "52fe6d23-5c8a-461f-9a19-a16953da448c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:38 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c7cc2231-dbff-4538-9421-c31d833a0e34?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:26 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/162c1d06-9294-4759-b421-d9b034f90003?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "417"
+        "x-envoy-upstream-service-time": "301",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c7cc2231-dbff-4538-9421-c31d833a0e34?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/162c1d06-9294-4759-b421-d9b034f90003?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,26 +72,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f89c87fe-c469-4b1d-a2aa-6414614a4360",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8e999119-1a41-4548-9f7f-4fbca8287196",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f20dee3-9fee-419f-b546-2d7d0e0822d9",
-        "Content-Length": "283",
+        "apim-request-id": "36e3e029-eb7d-431d-b5c4-47e01f5a8fa9",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c7cc2231-dbff-4538-9421-c31d833a0e34",
-        "lastUpdatedDateTime": "2022-10-15T02:26:39Z",
-        "createdDateTime": "2022-10-15T02:26:39Z",
-        "expirationDateTime": "2022-10-16T02:26:39Z",
-        "status": "notStarted",
+        "jobId": "162c1d06-9294-4759-b421-d9b034f90003",
+        "lastUpdatedDateTime": "2022-10-24T05:18:27Z",
+        "createdDateTime": "2022-10-24T05:18:27Z",
+        "expirationDateTime": "2022-10-25T05:18:27Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c7cc2231-dbff-4538-9421-c31d833a0e34?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/162c1d06-9294-4759-b421-d9b034f90003?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,26 +120,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ca8852b1-d2dc-4862-bf1d-8f8c4ac1d083",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3b95019e-b466-463b-80aa-d7a230fe1704",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2c5807d3-6bec-4a9a-affe-a55c1624d269",
-        "Content-Length": "283",
+        "apim-request-id": "8b4524d7-3f66-40e7-ac2a-ca19bf815dc8",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c7cc2231-dbff-4538-9421-c31d833a0e34",
-        "lastUpdatedDateTime": "2022-10-15T02:26:39Z",
-        "createdDateTime": "2022-10-15T02:26:39Z",
-        "expirationDateTime": "2022-10-16T02:26:39Z",
-        "status": "notStarted",
+        "jobId": "162c1d06-9294-4759-b421-d9b034f90003",
+        "lastUpdatedDateTime": "2022-10-24T05:18:27Z",
+        "createdDateTime": "2022-10-24T05:18:27Z",
+        "expirationDateTime": "2022-10-25T05:18:27Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c7cc2231-dbff-4538-9421-c31d833a0e34?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/162c1d06-9294-4759-b421-d9b034f90003?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c69b8d15-45bf-45df-87a1-d952209b8ec9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c2be81b2-552a-415f-9163-0a789394392c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a73c737f-998b-427e-96e9-b8383cbf71bd",
+        "apim-request-id": "11ce098e-4f6c-4e38-bdb5-8a36b098911a",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "101",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c7cc2231-dbff-4538-9421-c31d833a0e34",
-        "lastUpdatedDateTime": "2022-10-15T02:26:40Z",
-        "createdDateTime": "2022-10-15T02:26:39Z",
-        "expirationDateTime": "2022-10-16T02:26:39Z",
+        "jobId": "162c1d06-9294-4759-b421-d9b034f90003",
+        "lastUpdatedDateTime": "2022-10-24T05:18:27Z",
+        "createdDateTime": "2022-10-24T05:18:27Z",
+        "expirationDateTime": "2022-10-25T05:18:27Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:40.2362115Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:27.6372906Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -327,7 +331,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c7cc2231-dbff-4538-9421-c31d833a0e34?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/162c1d06-9294-4759-b421-d9b034f90003?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -343,25 +347,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4cb5f33d-4c71-4650-b6bf-d060c1f815ae",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "005ff028-fc68-4280-9a60-e2d4ab0bc9b7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0ff5aca2-e9c5-4dc1-aa7d-b31c9787a574",
+        "apim-request-id": "f500e319-fa0b-47d2-a70c-748f15a2a96e",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c7cc2231-dbff-4538-9421-c31d833a0e34",
-        "lastUpdatedDateTime": "2022-10-15T02:26:40Z",
-        "createdDateTime": "2022-10-15T02:26:39Z",
-        "expirationDateTime": "2022-10-16T02:26:39Z",
+        "jobId": "162c1d06-9294-4759-b421-d9b034f90003",
+        "lastUpdatedDateTime": "2022-10-24T05:18:27Z",
+        "createdDateTime": "2022-10-24T05:18:27Z",
+        "expirationDateTime": "2022-10-25T05:18:27Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -372,7 +377,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:40.2362115Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:27.6372906Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f45f52da-269e-4774-abad-2805a630274c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6c7af7fb-3208-4400-8e42-3296be3a38f6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e4262745-e9e4-4090-b6b7-7ffc91150ec3",
+        "apim-request-id": "107e0e35-6af7-4b9e-956e-e86cfa15638b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:43 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/ff670e69-02ad-41cb-86bd-65c500a145fc?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:32 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/13b9fc38-316c-445a-8af1-f45cc838207b?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "139"
+        "x-envoy-upstream-service-time": "124",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ff670e69-02ad-41cb-86bd-65c500a145fc?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/13b9fc38-316c-445a-8af1-f45cc838207b?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,25 +72,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "287dc0f2-110f-4541-916c-c029205b5ab7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b6401ad3-e1d6-41c8-a9ef-fb4bbaf93d26",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "58b4b471-774f-42de-9a56-58a0751a49dd",
+        "apim-request-id": "50699d29-be40-41f5-a54a-c5e888cd6402",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ff670e69-02ad-41cb-86bd-65c500a145fc",
-        "lastUpdatedDateTime": "2022-10-15T02:26:43Z",
-        "createdDateTime": "2022-10-15T02:26:43Z",
-        "expirationDateTime": "2022-10-16T02:26:43Z",
+        "jobId": "13b9fc38-316c-445a-8af1-f45cc838207b",
+        "lastUpdatedDateTime": "2022-10-24T05:18:32Z",
+        "createdDateTime": "2022-10-24T05:18:32Z",
+        "expirationDateTime": "2022-10-25T05:18:32Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ff670e69-02ad-41cb-86bd-65c500a145fc?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/13b9fc38-316c-445a-8af1-f45cc838207b?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,25 +120,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6a880a62-9107-4abf-9416-e5fcc069c369",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bdcd2397-f491-418e-b5aa-17895fdecca7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "34cc2967-7ecd-4788-af5c-c1995bde6112",
+        "apim-request-id": "b3c4401d-d3a5-4265-90fe-7de59a4fce04",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ff670e69-02ad-41cb-86bd-65c500a145fc",
-        "lastUpdatedDateTime": "2022-10-15T02:26:43Z",
-        "createdDateTime": "2022-10-15T02:26:43Z",
-        "expirationDateTime": "2022-10-16T02:26:43Z",
+        "jobId": "13b9fc38-316c-445a-8af1-f45cc838207b",
+        "lastUpdatedDateTime": "2022-10-24T05:18:32Z",
+        "createdDateTime": "2022-10-24T05:18:32Z",
+        "expirationDateTime": "2022-10-25T05:18:32Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ff670e69-02ad-41cb-86bd-65c500a145fc?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/13b9fc38-316c-445a-8af1-f45cc838207b?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "aa088268-96a0-4deb-964d-87174653cf3f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3c7a6090-c4dd-4f33-bab0-a2ff7d1a1555",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65c78648-30f1-4870-9f3c-eed0a9d3ae99",
-        "Content-Length": "534",
+        "apim-request-id": "a2382e40-b893-4610-8ce3-5b8e9b07bb42",
+        "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ff670e69-02ad-41cb-86bd-65c500a145fc",
-        "lastUpdatedDateTime": "2022-10-15T02:26:44Z",
-        "createdDateTime": "2022-10-15T02:26:43Z",
-        "expirationDateTime": "2022-10-16T02:26:43Z",
+        "jobId": "13b9fc38-316c-445a-8af1-f45cc838207b",
+        "lastUpdatedDateTime": "2022-10-24T05:18:32Z",
+        "createdDateTime": "2022-10-24T05:18:32Z",
+        "expirationDateTime": "2022-10-25T05:18:32Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:44.390453Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:32.7328515Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -214,7 +218,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ff670e69-02ad-41cb-86bd-65c500a145fc?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/13b9fc38-316c-445a-8af1-f45cc838207b?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -230,25 +234,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3221d381-368e-4ea3-a769-70c749890a33",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ac397d92-c820-43fe-aaa8-eae624c81bb2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a554f307-b086-4614-8989-ac78e963e900",
-        "Content-Length": "534",
+        "apim-request-id": "7a785e48-ed64-470d-bcb0-c08461a53f36",
+        "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ff670e69-02ad-41cb-86bd-65c500a145fc",
-        "lastUpdatedDateTime": "2022-10-15T02:26:44Z",
-        "createdDateTime": "2022-10-15T02:26:43Z",
-        "expirationDateTime": "2022-10-16T02:26:43Z",
+        "jobId": "13b9fc38-316c-445a-8af1-f45cc838207b",
+        "lastUpdatedDateTime": "2022-10-24T05:18:32Z",
+        "createdDateTime": "2022-10-24T05:18:32Z",
+        "expirationDateTime": "2022-10-25T05:18:32Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -259,7 +264,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:44.390453Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:32.7328515Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c3f66dd8-4d86-40f3-8f4d-3c7677d67f03",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1d2ac22c-7364-43ce-9c1f-289def05bbf8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,18 +44,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d2e1b4ea-cfff-4430-842c-f30fcfe4001f",
+        "apim-request-id": "de95cd62-8348-4fbb-8c85-17816ee88815",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:40 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5918d567-e884-48f2-a68a-94b45105fd17?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:29 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/538b9001-2c32-4292-9d3f-c3df2fc3eb5d?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
+        "x-envoy-upstream-service-time": "138",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5918d567-e884-48f2-a68a-94b45105fd17?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/538b9001-2c32-4292-9d3f-c3df2fc3eb5d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -71,25 +72,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4d6495ff-3f62-41a3-83b2-fb3441e5c3b3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c1c60fd8-e996-4fd8-8a1e-08ab5c7636e8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7be561bb-33c1-456e-a140-62275bfef422",
+        "apim-request-id": "5488d7ea-a78a-4708-bb7c-46c66d16976d",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5918d567-e884-48f2-a68a-94b45105fd17",
-        "lastUpdatedDateTime": "2022-10-15T02:26:41Z",
-        "createdDateTime": "2022-10-15T02:26:41Z",
-        "expirationDateTime": "2022-10-16T02:26:41Z",
+        "jobId": "538b9001-2c32-4292-9d3f-c3df2fc3eb5d",
+        "lastUpdatedDateTime": "2022-10-24T05:18:29Z",
+        "createdDateTime": "2022-10-24T05:18:29Z",
+        "expirationDateTime": "2022-10-25T05:18:29Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -102,7 +104,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5918d567-e884-48f2-a68a-94b45105fd17?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/538b9001-2c32-4292-9d3f-c3df2fc3eb5d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -118,25 +120,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bf3d88d1-4c8d-434a-88db-0d01e2bf994a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "39e52d9f-31bf-4e08-9b44-84b2d6f13bdd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "631271de-cc53-45a3-9675-171676b66ded",
+        "apim-request-id": "74f663b5-a536-4222-abac-72925cc76d96",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:40 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5918d567-e884-48f2-a68a-94b45105fd17",
-        "lastUpdatedDateTime": "2022-10-15T02:26:41Z",
-        "createdDateTime": "2022-10-15T02:26:41Z",
-        "expirationDateTime": "2022-10-16T02:26:41Z",
+        "jobId": "538b9001-2c32-4292-9d3f-c3df2fc3eb5d",
+        "lastUpdatedDateTime": "2022-10-24T05:18:29Z",
+        "createdDateTime": "2022-10-24T05:18:29Z",
+        "expirationDateTime": "2022-10-25T05:18:29Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5918d567-e884-48f2-a68a-94b45105fd17?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/538b9001-2c32-4292-9d3f-c3df2fc3eb5d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6ba2979f-31e3-4214-adb1-a633d9588c17",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e1b4560c-a088-4ef4-8880-09b04ea10c87",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09e13dc3-87e0-4f39-97e3-cd5fd895ffac",
+        "apim-request-id": "50885de6-ea6f-46a4-aa31-bf0cdde4d6b2",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "119",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5918d567-e884-48f2-a68a-94b45105fd17",
-        "lastUpdatedDateTime": "2022-10-15T02:26:42Z",
-        "createdDateTime": "2022-10-15T02:26:41Z",
-        "expirationDateTime": "2022-10-16T02:26:41Z",
+        "jobId": "538b9001-2c32-4292-9d3f-c3df2fc3eb5d",
+        "lastUpdatedDateTime": "2022-10-24T05:18:30Z",
+        "createdDateTime": "2022-10-24T05:18:29Z",
+        "expirationDateTime": "2022-10-25T05:18:29Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -194,7 +198,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:42.4316225Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:30.4499829Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -219,7 +223,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5918d567-e884-48f2-a68a-94b45105fd17?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/538b9001-2c32-4292-9d3f-c3df2fc3eb5d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -235,25 +239,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5a9decd6-d982-4786-8fb0-ce72ac783ad0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "facc3609-883d-4b09-a53c-01481d609ce0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a6f6a79-c4cc-4ecd-b0f5-31028699b72c",
+        "apim-request-id": "71cff5c1-b5f7-4b3e-8ad4-3f385e660503",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5918d567-e884-48f2-a68a-94b45105fd17",
-        "lastUpdatedDateTime": "2022-10-15T02:26:42Z",
-        "createdDateTime": "2022-10-15T02:26:41Z",
-        "expirationDateTime": "2022-10-16T02:26:41Z",
+        "jobId": "538b9001-2c32-4292-9d3f-c3df2fc3eb5d",
+        "lastUpdatedDateTime": "2022-10-24T05:18:30Z",
+        "createdDateTime": "2022-10-24T05:18:29Z",
+        "expirationDateTime": "2022-10-25T05:18:29Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -264,7 +269,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:42.4316225Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:30.4499829Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4c03ec81-1d05-4e5c-b75d-ae06c6421fe6",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ddaa022d-cd0c-4be4-ba94-418cf9a6c7ef",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "17ba125a-7a03-40e1-8806-cdefe53a8bdd",
+        "apim-request-id": "3a1ed296-054e-4624-8bb9-ed9c6d7427fa",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:13 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:01 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b35acdcc-197d-4acd-b0e0-f50d99041e56?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "140"
+        "x-envoy-upstream-service-time": "172",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35acdcc-197d-4acd-b0e0-f50d99041e56?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,25 +76,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "44c09c34-0922-4d50-a004-371202d312e8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b38d0322-a683-4c5e-83c3-35b9e58d09ad",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "334ee154-d071-4b9e-8ecc-db627f2487a9",
+        "apim-request-id": "5a89b1e6-56a3-4a42-82d9-5b8ca0086b15",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1e9b38d6-477c-41e1-86f1-8bc32041058e",
-        "lastUpdatedDateTime": "2022-10-15T02:26:13Z",
-        "createdDateTime": "2022-10-15T02:26:13Z",
-        "expirationDateTime": "2022-10-16T02:26:13Z",
+        "jobId": "b35acdcc-197d-4acd-b0e0-f50d99041e56",
+        "lastUpdatedDateTime": "2022-10-24T05:18:01Z",
+        "createdDateTime": "2022-10-24T05:18:00Z",
+        "expirationDateTime": "2022-10-25T05:18:00Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -106,7 +108,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35acdcc-197d-4acd-b0e0-f50d99041e56?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -122,72 +124,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f9bd8b88-ab12-4cf2-9406-db2c611e76cb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "80363a58-23e3-4b6a-8f99-f0a8c6ae630c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56f2ef34-b165-4ba6-8af6-1e2a940dd440",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "1e9b38d6-477c-41e1-86f1-8bc32041058e",
-        "lastUpdatedDateTime": "2022-10-15T02:26:13Z",
-        "createdDateTime": "2022-10-15T02:26:13Z",
-        "expirationDateTime": "2022-10-16T02:26:13Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "afab7051-2689-44d6-9ce6-75856e7a4368",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "34d283f2-c5da-4a5e-800c-fdda5b2576c8",
+        "apim-request-id": "3f0b8b9a-0a99-400d-8ddd-ce3b7ec7e2e9",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1e9b38d6-477c-41e1-86f1-8bc32041058e",
-        "lastUpdatedDateTime": "2022-10-15T02:26:13Z",
-        "createdDateTime": "2022-10-15T02:26:13Z",
-        "expirationDateTime": "2022-10-16T02:26:13Z",
+        "jobId": "b35acdcc-197d-4acd-b0e0-f50d99041e56",
+        "lastUpdatedDateTime": "2022-10-24T05:18:01Z",
+        "createdDateTime": "2022-10-24T05:18:00Z",
+        "expirationDateTime": "2022-10-25T05:18:00Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -200,7 +156,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35acdcc-197d-4acd-b0e0-f50d99041e56?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -216,25 +172,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2dba455f-8e52-4dac-9e52-c603ce437530",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bf8c88b1-3bd1-4d59-bdb8-1862c7862c27",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff7b114e-0046-4cfb-bb4b-e1e6b6d6b1b2",
+        "apim-request-id": "5bea77e2-ecf6-40ce-9756-3252cd2066fc",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
+        "x-envoy-upstream-service-time": "48",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1e9b38d6-477c-41e1-86f1-8bc32041058e",
-        "lastUpdatedDateTime": "2022-10-15T02:26:15Z",
-        "createdDateTime": "2022-10-15T02:26:13Z",
-        "expirationDateTime": "2022-10-16T02:26:13Z",
+        "jobId": "b35acdcc-197d-4acd-b0e0-f50d99041e56",
+        "lastUpdatedDateTime": "2022-10-24T05:18:02Z",
+        "createdDateTime": "2022-10-24T05:18:00Z",
+        "expirationDateTime": "2022-10-25T05:18:00Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -245,7 +202,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:15.8839024Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:02.6453639Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -383,7 +340,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1e9b38d6-477c-41e1-86f1-8bc32041058e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b35acdcc-197d-4acd-b0e0-f50d99041e56?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -399,25 +356,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ed585888-a3aa-41c3-adff-91125061c35a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ecfc4c8b-9be6-4f25-8934-bea52d22ee21",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "463dd216-5e1c-4c6d-8b86-44b7ab9b1e21",
+        "apim-request-id": "8e91ae33-d41e-4d79-811a-f94fef7559db",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1e9b38d6-477c-41e1-86f1-8bc32041058e",
-        "lastUpdatedDateTime": "2022-10-15T02:26:15Z",
-        "createdDateTime": "2022-10-15T02:26:13Z",
-        "expirationDateTime": "2022-10-16T02:26:13Z",
+        "jobId": "b35acdcc-197d-4acd-b0e0-f50d99041e56",
+        "lastUpdatedDateTime": "2022-10-24T05:18:02Z",
+        "createdDateTime": "2022-10-24T05:18:00Z",
+        "expirationDateTime": "2022-10-25T05:18:00Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -428,7 +386,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:15.8839024Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:02.6453639Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "40e33949-1db1-482a-80df-2529502df67a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "32c712f8-3548-43dc-8e68-ea93b3a205ee",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "403845b1-67d8-490d-b49c-bda74cbac967",
+        "apim-request-id": "90889cf0-f9e1-4ae3-a42d-d3915fc574ad",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:07 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:17:50 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "x-envoy-upstream-service-time": "144",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,64 +76,122 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "763843ce-4d05-4852-8e20-24c1028321f2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "f8d1b64e-964e-44c8-81cb-a731cf42037a",
-        "Content-Length": "337",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:07 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the Get analysis status and results Operation under Microsoft Cognitive Language Service have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "763843ce-4d05-4852-8e20-24c1028321f2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "bcd8d889-d922-42b0-ba33-52c477669e41",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4be4e4c7-cf66-4f8d-9abf-84f83e45f50f",
-        "Content-Length": "280",
+        "apim-request-id": "43c2be87-a9c4-460e-9555-28e08f246d75",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c87528ff-a764-4222-94bf-567ec8ad282c",
-        "lastUpdatedDateTime": "2022-10-15T02:26:08Z",
-        "createdDateTime": "2022-10-15T02:26:07Z",
-        "expirationDateTime": "2022-10-16T02:26:07Z",
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:51Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "6b787e11-5563-4b01-bc76-dd79bec7020d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6c1faf13-b757-49e7-8b8e-333da3090d33",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:17:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:51Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "78fc8c02-6a34-4fdf-8dcb-eae102a9c2a6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5f473aba-fd88-40d6-88ab-ceb8c46f2f1d",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:17:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:52Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -145,7 +204,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -161,64 +220,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "49c3cd8b-6ac2-49da-87c6-52bbc8b49648",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "e00f93d9-2ffe-4853-a30c-262784881818",
-        "Content-Length": "337",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:26:08 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the Get analysis status and results Operation under Microsoft Cognitive Language Service have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "49c3cd8b-6ac2-49da-87c6-52bbc8b49648",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f89196e5-5bb4-440c-a200-ff894b8cd9c4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7cbd127d-3900-45e9-8f37-a308d7c60a78",
-        "Content-Length": "1069",
+        "apim-request-id": "1a5f1ed9-2ac5-4786-adfb-41cd0dddc068",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c87528ff-a764-4222-94bf-567ec8ad282c",
-        "lastUpdatedDateTime": "2022-10-15T02:26:09Z",
-        "createdDateTime": "2022-10-15T02:26:07Z",
-        "expirationDateTime": "2022-10-16T02:26:07Z",
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:52Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "5089b193-6c73-4697-a167-47153455468c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "dd7b9b90-3302-49d7-9018-16fa028899ce",
+        "Content-Length": "1070",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:17:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "60",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:56Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -229,7 +298,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:09.903872Z",
+              "lastUpdateDateTime": "2022-10-24T05:17:56.2974709Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -297,7 +366,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c87528ff-a764-4222-94bf-567ec8ad282c?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/240238ce-ba83-4c0e-96bb-98d9e325fee0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -313,25 +382,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c378fe94-4f5f-447c-bad4-84058f217b08",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ad8825a3-b824-4bb8-b0ad-7fbd73e6ec5d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d4ca25ab-e89d-4ce6-80fc-f7a320f43b38",
-        "Content-Length": "1069",
+        "apim-request-id": "11be72aa-8395-4f0c-a128-d26a25b5e5ba",
+        "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "39",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c87528ff-a764-4222-94bf-567ec8ad282c",
-        "lastUpdatedDateTime": "2022-10-15T02:26:09Z",
-        "createdDateTime": "2022-10-15T02:26:07Z",
-        "expirationDateTime": "2022-10-16T02:26:07Z",
+        "jobId": "240238ce-ba83-4c0e-96bb-98d9e325fee0",
+        "lastUpdatedDateTime": "2022-10-24T05:17:56Z",
+        "createdDateTime": "2022-10-24T05:17:51Z",
+        "expirationDateTime": "2022-10-25T05:17:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -342,7 +412,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:09.903872Z",
+              "lastUpdateDateTime": "2022-10-24T05:17:56.2974709Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e824fa67-8ea2-4d97-a89b-81dd3c0ae684",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3add2cfb-36a2-4fca-8b85-f2e479d6ffd4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,18 +51,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a3c8c1f1-a78f-4bcf-88d4-506e8ef4e8ec",
+        "apim-request-id": "283d8ab4-3c7d-4cdc-92c2-7e19c3556a2f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:36 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/212fd9ae-7ca4-430c-905e-7d8ea4ccafec?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:24 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/16de79d8-2e8a-4f56-a632-bb2df27bd43f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "199"
+        "x-envoy-upstream-service-time": "168",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/212fd9ae-7ca4-430c-905e-7d8ea4ccafec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/16de79d8-2e8a-4f56-a632-bb2df27bd43f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -78,25 +79,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "470bb3de-adda-4e9e-beaa-b606404cbcd0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "423a0d51-7d7f-439b-8b1d-433129ff10f0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d33e0337-b7f6-4230-a1f2-c7e449a9afd4",
+        "apim-request-id": "34d8143d-cb47-44df-9c07-ad51505af84f",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "212fd9ae-7ca4-430c-905e-7d8ea4ccafec",
-        "lastUpdatedDateTime": "2022-10-15T02:26:36Z",
-        "createdDateTime": "2022-10-15T02:26:36Z",
-        "expirationDateTime": "2022-10-16T02:26:36Z",
+        "jobId": "16de79d8-2e8a-4f56-a632-bb2df27bd43f",
+        "lastUpdatedDateTime": "2022-10-24T05:18:24Z",
+        "createdDateTime": "2022-10-24T05:18:24Z",
+        "expirationDateTime": "2022-10-25T05:18:24Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -109,7 +111,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/212fd9ae-7ca4-430c-905e-7d8ea4ccafec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/16de79d8-2e8a-4f56-a632-bb2df27bd43f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -125,26 +127,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "31bd23ff-dfe8-465f-91a5-44364ded7a7f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "eee2ad53-93d7-45e1-b0d3-dd83b72a2264",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e949c4dc-7a13-493a-8688-c5c88a9dfa9c",
-        "Content-Length": "283",
+        "apim-request-id": "a92ed146-5172-4e44-b26d-f066e3440220",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "212fd9ae-7ca4-430c-905e-7d8ea4ccafec",
-        "lastUpdatedDateTime": "2022-10-15T02:26:36Z",
-        "createdDateTime": "2022-10-15T02:26:36Z",
-        "expirationDateTime": "2022-10-16T02:26:36Z",
-        "status": "notStarted",
+        "jobId": "16de79d8-2e8a-4f56-a632-bb2df27bd43f",
+        "lastUpdatedDateTime": "2022-10-24T05:18:24Z",
+        "createdDateTime": "2022-10-24T05:18:24Z",
+        "expirationDateTime": "2022-10-25T05:18:24Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -156,7 +159,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/212fd9ae-7ca4-430c-905e-7d8ea4ccafec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/16de79d8-2e8a-4f56-a632-bb2df27bd43f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -172,25 +175,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2025c3d0-6c33-4187-b50c-81b35d8f43a1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8fe4e053-adbf-429f-9e57-4215c578fb5a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d1706e9-aba8-457c-8eba-3fc32427288a",
+        "apim-request-id": "b901bb71-e846-4808-b276-5ffe39cafb8d",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "77"
+        "x-envoy-upstream-service-time": "125",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "212fd9ae-7ca4-430c-905e-7d8ea4ccafec",
-        "lastUpdatedDateTime": "2022-10-15T02:26:38Z",
-        "createdDateTime": "2022-10-15T02:26:36Z",
-        "expirationDateTime": "2022-10-16T02:26:36Z",
+        "jobId": "16de79d8-2e8a-4f56-a632-bb2df27bd43f",
+        "lastUpdatedDateTime": "2022-10-24T05:18:26Z",
+        "createdDateTime": "2022-10-24T05:18:24Z",
+        "expirationDateTime": "2022-10-25T05:18:24Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -201,7 +205,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:38.1396979Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:26.1100081Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1318,7 +1322,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/212fd9ae-7ca4-430c-905e-7d8ea4ccafec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/16de79d8-2e8a-4f56-a632-bb2df27bd43f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1334,25 +1338,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "8933c269-c19f-4595-b9b1-956c5d5dddad",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "158bd335-61ee-4c02-ba8e-1ab92426c514",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "40479052-f8a4-4d7e-99fc-6ea9c453692e",
+        "apim-request-id": "4f7ca7eb-1757-4fca-b614-9bd6b17f6ffa",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "70"
+        "x-envoy-upstream-service-time": "60",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "212fd9ae-7ca4-430c-905e-7d8ea4ccafec",
-        "lastUpdatedDateTime": "2022-10-15T02:26:38Z",
-        "createdDateTime": "2022-10-15T02:26:36Z",
-        "expirationDateTime": "2022-10-16T02:26:36Z",
+        "jobId": "16de79d8-2e8a-4f56-a632-bb2df27bd43f",
+        "lastUpdatedDateTime": "2022-10-24T05:18:26Z",
+        "createdDateTime": "2022-10-24T05:18:24Z",
+        "expirationDateTime": "2022-10-25T05:18:24Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1363,7 +1368,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:38.1396979Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:26.1100081Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d6492d70-9ab3-4c93-b2fc-a29b2f50d67c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cadbdde5-b212-41b7-85c5-1ea1d4c9e15f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -48,18 +48,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4b0d7978-aacf-4bd2-a69f-f284bab8af33",
+        "apim-request-id": "3b8436ef-544a-4bfa-887b-a27d9c7b974b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:10 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/170470c2-a2b6-49b6-aaf3-c25fa2ef4642?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:17:57 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/2f71f19e-df09-45f7-9a4c-069f61afdaba?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "150"
+        "x-envoy-upstream-service-time": "86",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/170470c2-a2b6-49b6-aaf3-c25fa2ef4642?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2f71f19e-df09-45f7-9a4c-069f61afdaba?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -75,25 +76,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0632a61b-5338-4a0f-97d4-930259af7674",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6e423d67-1c81-4447-b48e-909fc2f8857e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27eb8d8d-4614-48c3-91e6-6e824c031094",
+        "apim-request-id": "9b8f2c4c-f4ab-4fe7-aad3-1d1ec242123c",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "170470c2-a2b6-49b6-aaf3-c25fa2ef4642",
-        "lastUpdatedDateTime": "2022-10-15T02:26:10Z",
-        "createdDateTime": "2022-10-15T02:26:10Z",
-        "expirationDateTime": "2022-10-16T02:26:10Z",
+        "jobId": "2f71f19e-df09-45f7-9a4c-069f61afdaba",
+        "lastUpdatedDateTime": "2022-10-24T05:17:58Z",
+        "createdDateTime": "2022-10-24T05:17:58Z",
+        "expirationDateTime": "2022-10-25T05:17:58Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -106,7 +108,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/170470c2-a2b6-49b6-aaf3-c25fa2ef4642?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2f71f19e-df09-45f7-9a4c-069f61afdaba?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -122,25 +124,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "18a01008-4d61-4e72-bc82-45cb06008cd4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "996dad86-0f3c-41b3-9542-a1d61f591285",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b167c738-03dd-4b48-ab17-87e3ec00bc27",
+        "apim-request-id": "2a833fc9-d163-41df-806c-5753cd450303",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:17:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "170470c2-a2b6-49b6-aaf3-c25fa2ef4642",
-        "lastUpdatedDateTime": "2022-10-15T02:26:10Z",
-        "createdDateTime": "2022-10-15T02:26:10Z",
-        "expirationDateTime": "2022-10-16T02:26:10Z",
+        "jobId": "2f71f19e-df09-45f7-9a4c-069f61afdaba",
+        "lastUpdatedDateTime": "2022-10-24T05:17:58Z",
+        "createdDateTime": "2022-10-24T05:17:58Z",
+        "expirationDateTime": "2022-10-25T05:17:58Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -153,7 +156,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/170470c2-a2b6-49b6-aaf3-c25fa2ef4642?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2f71f19e-df09-45f7-9a4c-069f61afdaba?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -169,25 +172,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ee943172-2c2c-4cb5-8ba0-a8f463bb0d0d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5bf49ce8-d607-42ee-b792-dd36cc565ae3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5c052fb2-5c26-4f3c-8dd8-4076d18db2d0",
+        "apim-request-id": "dc265b9b-a371-4cc5-8ab5-bc271cf0cf2c",
         "Content-Length": "616",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "170470c2-a2b6-49b6-aaf3-c25fa2ef4642",
-        "lastUpdatedDateTime": "2022-10-15T02:26:12Z",
-        "createdDateTime": "2022-10-15T02:26:10Z",
-        "expirationDateTime": "2022-10-16T02:26:10Z",
+        "jobId": "2f71f19e-df09-45f7-9a4c-069f61afdaba",
+        "lastUpdatedDateTime": "2022-10-24T05:17:59Z",
+        "createdDateTime": "2022-10-24T05:17:58Z",
+        "expirationDateTime": "2022-10-25T05:17:58Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:12.614059Z",
+              "lastUpdateDateTime": "2022-10-24T05:17:59.843452Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -230,7 +234,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/170470c2-a2b6-49b6-aaf3-c25fa2ef4642?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2f71f19e-df09-45f7-9a4c-069f61afdaba?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -246,25 +250,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "efdbf5fc-2395-4706-b6f5-d8130faaa3ea",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "aadfef76-7095-4099-a838-a15e8b8d684c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4c7f4b6-b07b-424c-9c3e-547561a3b617",
+        "apim-request-id": "f4861968-880b-46e5-b81f-f6f8c43efc22",
         "Content-Length": "616",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "170470c2-a2b6-49b6-aaf3-c25fa2ef4642",
-        "lastUpdatedDateTime": "2022-10-15T02:26:12Z",
-        "createdDateTime": "2022-10-15T02:26:10Z",
-        "expirationDateTime": "2022-10-16T02:26:10Z",
+        "jobId": "2f71f19e-df09-45f7-9a4c-069f61afdaba",
+        "lastUpdatedDateTime": "2022-10-24T05:17:59Z",
+        "createdDateTime": "2022-10-24T05:17:58Z",
+        "expirationDateTime": "2022-10-25T05:17:58Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -275,7 +280,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:12.614059Z",
+              "lastUpdateDateTime": "2022-10-24T05:17:59.843452Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7e84664d-0523-44fc-a618-d4577f6a4524",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0052e739-bb31-4021-a9db-e10db536c8bf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -53,18 +53,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5f0fc34f-54d7-4111-9c22-367d8e4d7556",
+        "apim-request-id": "5f51c98a-60e3-452a-a449-dc7d5372246d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:17 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:03 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "142",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -80,25 +81,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fa9ab66c-f203-4807-a6cf-f48f67ee75ef",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7bb59724-4211-4655-804f-380d597db580",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4948b8c-07d2-4d6e-aa8a-9d7fb61b48df",
+        "apim-request-id": "a301eff5-b555-4f88-a8b1-f89036a47b9b",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:17Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
+        "jobId": "b6089c6b-2239-4cc0-aa38-47f73ffb4aac",
+        "lastUpdatedDateTime": "2022-10-24T05:18:03Z",
+        "createdDateTime": "2022-10-24T05:18:03Z",
+        "expirationDateTime": "2022-10-25T05:18:03Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -111,7 +113,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -127,25 +129,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c283a5f6-3b2c-4e5e-ae4b-8e0e3eddc7ea",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f64ec450-b4d7-4f06-99c3-7389f699af42",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a585beff-1a13-4dbc-b0fa-a2b579765ea7",
+        "apim-request-id": "c6e0e54a-5b4a-4317-a93e-20c951bc6092",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:17Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
+        "jobId": "b6089c6b-2239-4cc0-aa38-47f73ffb4aac",
+        "lastUpdatedDateTime": "2022-10-24T05:18:03Z",
+        "createdDateTime": "2022-10-24T05:18:03Z",
+        "expirationDateTime": "2022-10-25T05:18:03Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -158,7 +161,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -174,25 +177,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1277efff-8a34-4abd-a1c0-2c9a79f05b24",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6e3ede08-363f-4f72-a9fa-91b442fc0b54",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f48887c1-2ab2-4073-96e1-245959abd47b",
+        "apim-request-id": "60771b23-6233-41df-9b23-dd30968680dc",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:17Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
+        "jobId": "b6089c6b-2239-4cc0-aa38-47f73ffb4aac",
+        "lastUpdatedDateTime": "2022-10-24T05:18:04Z",
+        "createdDateTime": "2022-10-24T05:18:03Z",
+        "expirationDateTime": "2022-10-25T05:18:03Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -205,7 +209,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -221,119 +225,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "14938ff1-565c-420c-a115-51101223195e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d7684791-1006-4b14-a902-72f3d7e8ef7f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "126e2d87-8ecd-4f5b-8eea-a3500bb3fc70",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:17Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "706be79f-0a02-4747-8771-f4b25e5264e9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bfd14886-e3de-46b9-baf9-4fcc5dcf6ee4",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:17Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "448f3698-80aa-4901-a99a-48b6a33c1edc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "59455bd2-e84d-4e00-9d1f-d52fcee2893d",
+        "apim-request-id": "0acb63f2-286b-4b98-870c-6d2eba3179de",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "48"
+        "x-envoy-upstream-service-time": "75",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:25Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
+        "jobId": "b6089c6b-2239-4cc0-aa38-47f73ffb4aac",
+        "lastUpdatedDateTime": "2022-10-24T05:18:06Z",
+        "createdDateTime": "2022-10-24T05:18:03Z",
+        "expirationDateTime": "2022-10-25T05:18:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +255,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:25.1398137Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:06.5384202Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -406,7 +317,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/df1e62db-99d5-44d0-8210-04dce747b7ba?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6089c6b-2239-4cc0-aa38-47f73ffb4aac?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -422,25 +333,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d2dca259-cf1c-4e0b-b5b2-9e1f9915f340",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ca45fedc-931d-4006-b2f0-2282d14b066b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "321e706f-a48e-4033-b943-34432f1d53a2",
+        "apim-request-id": "f8305825-138b-4bef-9452-8fdedef47f97",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "47"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "df1e62db-99d5-44d0-8210-04dce747b7ba",
-        "lastUpdatedDateTime": "2022-10-15T02:26:25Z",
-        "createdDateTime": "2022-10-15T02:26:17Z",
-        "expirationDateTime": "2022-10-16T02:26:17Z",
+        "jobId": "b6089c6b-2239-4cc0-aa38-47f73ffb4aac",
+        "lastUpdatedDateTime": "2022-10-24T05:18:06Z",
+        "createdDateTime": "2022-10-24T05:18:03Z",
+        "expirationDateTime": "2022-10-25T05:18:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -451,7 +363,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:25.1398137Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:06.5384202Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "aec7fdfe-0aaa-46a8-ba59-1c65f8fff343",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "58a4f09f-b685-4307-9db2-e1b04e3dab60",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,18 +51,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "65ff877d-b92c-427f-b5fb-2d7b793cd001",
+        "apim-request-id": "3e83ea83-faaa-48af-8151-210897c3330a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:25 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:07 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/f3a51e6d-4663-43ac-b031-7403532d7fd5?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "188"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3a51e6d-4663-43ac-b031-7403532d7fd5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -78,25 +79,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "613d32df-48e1-4519-9b91-4a0027fa3fd2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9600ff06-0471-4cdc-98ed-e634d12704e5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d848e5b-06f5-43ea-a2dc-a8760397f303",
+        "apim-request-id": "328b888e-5804-4745-af5d-17d0c7bfe813",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c9f5abcc-1baf-4ace-97a9-105d341de3b9",
-        "lastUpdatedDateTime": "2022-10-15T02:26:26Z",
-        "createdDateTime": "2022-10-15T02:26:26Z",
-        "expirationDateTime": "2022-10-16T02:26:26Z",
+        "jobId": "f3a51e6d-4663-43ac-b031-7403532d7fd5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:08Z",
+        "createdDateTime": "2022-10-24T05:18:08Z",
+        "expirationDateTime": "2022-10-25T05:18:08Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -109,7 +111,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3a51e6d-4663-43ac-b031-7403532d7fd5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -125,25 +127,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "96cf383a-d884-4450-b864-b756bffa8422",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0053fd16-63a8-43e3-801b-9168f1efff71",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8e51747f-3a9d-472a-a876-d1af6f7b89c9",
+        "apim-request-id": "8a3403fa-8df5-4747-bc0e-d70d440cc18d",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:25 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c9f5abcc-1baf-4ace-97a9-105d341de3b9",
-        "lastUpdatedDateTime": "2022-10-15T02:26:26Z",
-        "createdDateTime": "2022-10-15T02:26:26Z",
-        "expirationDateTime": "2022-10-16T02:26:26Z",
+        "jobId": "f3a51e6d-4663-43ac-b031-7403532d7fd5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:08Z",
+        "createdDateTime": "2022-10-24T05:18:08Z",
+        "expirationDateTime": "2022-10-25T05:18:08Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -156,7 +159,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3a51e6d-4663-43ac-b031-7403532d7fd5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -172,72 +175,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "065f8d52-7052-4cf5-8268-a3e303eb535b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e738f61b-05d9-4c41-97f1-27d1de41b647",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4fd71277-d6eb-4d9c-814a-a9010570a798",
-        "Content-Length": "280",
+        "apim-request-id": "5f7f2b60-7bbc-40b0-b16a-257d72f64053",
+        "Content-Length": "916",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "54",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c9f5abcc-1baf-4ace-97a9-105d341de3b9",
-        "lastUpdatedDateTime": "2022-10-15T02:26:26Z",
-        "createdDateTime": "2022-10-15T02:26:26Z",
-        "expirationDateTime": "2022-10-16T02:26:26Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9b4f35d7-423c-410f-bcfd-bcc367f30bed",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d5d1ffc3-4b16-4301-845c-fd9a05bdf13f",
-        "Content-Length": "917",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:30 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "58"
-      },
-      "ResponseBody": {
-        "jobId": "c9f5abcc-1baf-4ace-97a9-105d341de3b9",
-        "lastUpdatedDateTime": "2022-10-15T02:26:28Z",
-        "createdDateTime": "2022-10-15T02:26:26Z",
-        "expirationDateTime": "2022-10-16T02:26:26Z",
+        "jobId": "f3a51e6d-4663-43ac-b031-7403532d7fd5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:10Z",
+        "createdDateTime": "2022-10-24T05:18:08Z",
+        "expirationDateTime": "2022-10-25T05:18:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -248,7 +205,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:28.5662736Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:10.307573Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -282,7 +239,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c9f5abcc-1baf-4ace-97a9-105d341de3b9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3a51e6d-4663-43ac-b031-7403532d7fd5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -298,25 +255,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "62cc663e-f3c9-4fb6-8370-1d6dc0092524",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "341ba1dd-db2a-45be-a8da-94bb9330e7ba",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7e79965-87f5-40eb-b75d-c1950b31bae1",
-        "Content-Length": "917",
+        "apim-request-id": "054c9ae4-a877-47fb-9e89-cba730f8a2f2",
+        "Content-Length": "916",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c9f5abcc-1baf-4ace-97a9-105d341de3b9",
-        "lastUpdatedDateTime": "2022-10-15T02:26:28Z",
-        "createdDateTime": "2022-10-15T02:26:26Z",
-        "expirationDateTime": "2022-10-16T02:26:26Z",
+        "jobId": "f3a51e6d-4663-43ac-b031-7403532d7fd5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:10Z",
+        "createdDateTime": "2022-10-24T05:18:08Z",
+        "expirationDateTime": "2022-10-25T05:18:08Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -327,7 +285,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:28.5662736Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:10.307573Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b4f3772c-084f-42d7-bf56-2fe5df0829b0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "250bf720-72b6-4e9b-871c-93bb420e3961",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -49,18 +49,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "39144cb5-1f6d-4ba7-aef1-22b09160f1b4",
+        "apim-request-id": "6cbea78f-c35d-42b7-88d6-13ad1d67fc3c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:30 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/e662efa3-c903-4012-a0d2-86d38aa4a639?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:10 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
+        "x-envoy-upstream-service-time": "99",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e662efa3-c903-4012-a0d2-86d38aa4a639?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -76,25 +77,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "71194297-fb81-4ed7-951d-111aa8c9d428",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9f72228b-ca68-46c0-9480-8078b55540dd",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0fdce96d-3b79-4a5e-a970-2ab2e9db4a5e",
+        "apim-request-id": "609de2e7-4fe7-4902-9975-bdd273c6df39",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e662efa3-c903-4012-a0d2-86d38aa4a639",
-        "lastUpdatedDateTime": "2022-10-15T02:26:31Z",
-        "createdDateTime": "2022-10-15T02:26:30Z",
-        "expirationDateTime": "2022-10-16T02:26:30Z",
+        "jobId": "a83ba9f6-f855-4056-96c0-ea9461a4de09",
+        "lastUpdatedDateTime": "2022-10-24T05:18:10Z",
+        "createdDateTime": "2022-10-24T05:18:10Z",
+        "expirationDateTime": "2022-10-25T05:18:10Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -107,7 +109,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e662efa3-c903-4012-a0d2-86d38aa4a639?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -123,25 +125,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a3d2c590-9865-49b9-bc20-4b40b6a95aa0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "de99d6c8-4aaf-4bb7-b552-1ba59a641234",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b4defd7f-e971-4c3b-8d14-a20cbd80ba82",
+        "apim-request-id": "80480be4-6608-45b6-998d-cbc921671079",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e662efa3-c903-4012-a0d2-86d38aa4a639",
-        "lastUpdatedDateTime": "2022-10-15T02:26:31Z",
-        "createdDateTime": "2022-10-15T02:26:30Z",
-        "expirationDateTime": "2022-10-16T02:26:30Z",
+        "jobId": "a83ba9f6-f855-4056-96c0-ea9461a4de09",
+        "lastUpdatedDateTime": "2022-10-24T05:18:10Z",
+        "createdDateTime": "2022-10-24T05:18:10Z",
+        "expirationDateTime": "2022-10-25T05:18:10Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -154,7 +157,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e662efa3-c903-4012-a0d2-86d38aa4a639?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -170,25 +173,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dbdd4a55-6804-4878-a939-c2444f0a8310",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cfa3be26-fbc0-4b79-a23d-050b2883e38b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53ffe379-c8dd-444f-ba83-a03cd658aca7",
+        "apim-request-id": "ddd2d023-778f-4910-a865-d6a0e3d4b14c",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a83ba9f6-f855-4056-96c0-ea9461a4de09",
+        "lastUpdatedDateTime": "2022-10-24T05:18:11Z",
+        "createdDateTime": "2022-10-24T05:18:10Z",
+        "expirationDateTime": "2022-10-25T05:18:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "77e45641-dd1a-4006-84b7-1e62f9473500",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d111296a-9815-4e9e-b829-4ec250a8af0b",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "64"
+        "x-envoy-upstream-service-time": "109",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e662efa3-c903-4012-a0d2-86d38aa4a639",
-        "lastUpdatedDateTime": "2022-10-15T02:26:33Z",
-        "createdDateTime": "2022-10-15T02:26:30Z",
-        "expirationDateTime": "2022-10-16T02:26:30Z",
+        "jobId": "a83ba9f6-f855-4056-96c0-ea9461a4de09",
+        "lastUpdatedDateTime": "2022-10-24T05:18:13Z",
+        "createdDateTime": "2022-10-24T05:18:10Z",
+        "expirationDateTime": "2022-10-25T05:18:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -199,7 +251,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:33.0535981Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:13.7216645Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -276,7 +328,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e662efa3-c903-4012-a0d2-86d38aa4a639?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a83ba9f6-f855-4056-96c0-ea9461a4de09?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -292,25 +344,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a2bcf4da-3ccc-4e74-8425-3a405e97581c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4432cfec-8b14-492a-aedd-e32a27a09eb7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d1082e6-8d9c-4d35-8788-5829ba4c469b",
+        "apim-request-id": "b25be727-dde9-456f-b0b4-de332ff44408",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "51",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e662efa3-c903-4012-a0d2-86d38aa4a639",
-        "lastUpdatedDateTime": "2022-10-15T02:26:33Z",
-        "createdDateTime": "2022-10-15T02:26:30Z",
-        "expirationDateTime": "2022-10-16T02:26:30Z",
+        "jobId": "a83ba9f6-f855-4056-96c0-ea9461a4de09",
+        "lastUpdatedDateTime": "2022-10-24T05:18:13Z",
+        "createdDateTime": "2022-10-24T05:18:10Z",
+        "expirationDateTime": "2022-10-25T05:18:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -321,7 +374,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:33.0535981Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:13.7216645Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e0db6f33-a179-4643-9c0c-1425c4bbe283",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "867b8ab4-96b3-44ea-9854-a27e9d780ef1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -74,18 +74,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f59083dc-7014-425e-b8c8-6bc50b6c8a1f",
+        "apim-request-id": "10e3b81d-2415-49a6-bbae-16b193821dab",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:33 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/b026e98b-6dd1-49a3-a622-0649cb55a404?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:14 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "235"
+        "x-envoy-upstream-service-time": "208",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b026e98b-6dd1-49a3-a622-0649cb55a404?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -101,25 +102,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5711d6aa-d950-4330-9998-c5b2571e322e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e8abe7c8-1e06-48ba-bbc4-b3e1851d9242",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a1b3f23-b811-4dad-8905-7fe8996bca55",
+        "apim-request-id": "b1eed0ec-9f0f-4b2f-9951-35ea35f2f945",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b026e98b-6dd1-49a3-a622-0649cb55a404",
-        "lastUpdatedDateTime": "2022-10-15T02:26:33Z",
-        "createdDateTime": "2022-10-15T02:26:33Z",
-        "expirationDateTime": "2022-10-16T02:26:33Z",
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:15Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -132,7 +134,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b026e98b-6dd1-49a3-a622-0649cb55a404?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -148,25 +150,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fc5d4938-a663-489f-8309-ebe677865b60",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c268e4e3-8e80-4688-a1d3-b91327e1329d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83184a9a-cef6-41ff-bf82-78fd3bd43af1",
+        "apim-request-id": "489cae28-111e-4dbe-b2f8-c3638adffbee",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b026e98b-6dd1-49a3-a622-0649cb55a404",
-        "lastUpdatedDateTime": "2022-10-15T02:26:33Z",
-        "createdDateTime": "2022-10-15T02:26:33Z",
-        "expirationDateTime": "2022-10-16T02:26:33Z",
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:15Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -179,7 +182,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b026e98b-6dd1-49a3-a622-0649cb55a404?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -195,25 +198,170 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6844586e-e1a6-4e5c-a27e-973f8657a7eb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d75bc0a3-024d-4060-b5f8-94d6597e98b5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d2d8b385-0a79-459b-9c9d-934be0eb425e",
+        "apim-request-id": "ddc9cc66-9b77-471f-b5cd-e246fd36b725",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:15Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "3f65959d-6ba9-4900-8592-1a72f6a0ab1f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9d3b5127-d959-43fd-b6a0-b6e5a00746a8",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:15Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "1aa92cd3-6106-4d2d-9277-3069d83d9cca",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3b15823f-7e32-4af5-b574-b1b4d7a899d1",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:15Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "68105bdb-c7fa-4bbf-a614-e9897f2c94e4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c5c0ec49-bf14-4835-b2cd-fb0773828a61",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "128"
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b026e98b-6dd1-49a3-a622-0649cb55a404",
-        "lastUpdatedDateTime": "2022-10-15T02:26:35Z",
-        "createdDateTime": "2022-10-15T02:26:33Z",
-        "expirationDateTime": "2022-10-16T02:26:33Z",
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:23Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -224,7 +372,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:35.4294234Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:23.3889543Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -854,7 +1002,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b026e98b-6dd1-49a3-a622-0649cb55a404?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a826e2b8-ae46-4a33-a7f4-09d4f1937295?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -870,25 +1018,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "db38d580-3b9a-481a-8a0d-3d8437981ab3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "67c75c87-43d4-4c90-9bbb-a34ac5b14b32",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8ed4f043-61d1-4ac8-a97d-9a4910dda303",
+        "apim-request-id": "6eefebdd-1126-4ec8-8008-e77efa8d54fb",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "100"
+        "x-envoy-upstream-service-time": "108",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b026e98b-6dd1-49a3-a622-0649cb55a404",
-        "lastUpdatedDateTime": "2022-10-15T02:26:35Z",
-        "createdDateTime": "2022-10-15T02:26:33Z",
-        "expirationDateTime": "2022-10-16T02:26:33Z",
+        "jobId": "a826e2b8-ae46-4a33-a7f4-09d4f1937295",
+        "lastUpdatedDateTime": "2022-10-24T05:18:23Z",
+        "createdDateTime": "2022-10-24T05:18:15Z",
+        "expirationDateTime": "2022-10-25T05:18:15Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -899,7 +1048,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:35.4294234Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:23.3889543Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "54c9ce38-678e-4586-823e-5af25f94d19b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9441c7e4-ec8e-43a7-a633-9c9d66311b0f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "40ad3758-0dcb-49da-853d-a2bcb04d007b",
+        "apim-request-id": "ae713322-c85f-4471-9cab-581c01b8ea9f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:52 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:39 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/7af12532-cb94-417f-8469-40b2baea63d0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "161"
+        "x-envoy-upstream-service-time": "165",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7af12532-cb94-417f-8469-40b2baea63d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d320676c-f818-44a8-b4b2-3a3800fdd813",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1fa4c577-30d9-48f6-8dd7-766aea700e5b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4151fbe1-173f-4496-a352-148293b46239",
+        "apim-request-id": "cee13511-762d-41df-88a2-d35229299004",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9d8d8b79-ceec-473c-9ba1-3302f2807581",
-        "lastUpdatedDateTime": "2022-10-15T02:26:53Z",
-        "createdDateTime": "2022-10-15T02:26:53Z",
-        "expirationDateTime": "2022-10-16T02:26:53Z",
+        "jobId": "7af12532-cb94-417f-8469-40b2baea63d0",
+        "lastUpdatedDateTime": "2022-10-24T05:18:40Z",
+        "createdDateTime": "2022-10-24T05:18:39Z",
+        "expirationDateTime": "2022-10-25T05:18:39Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7af12532-cb94-417f-8469-40b2baea63d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,25 +135,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7a0a6c84-2b41-47fe-95e4-467afb6b717a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4329df6b-b024-4db0-8a19-1d2d43eb0eb2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3365de1-ee7d-4e5f-8392-b48b379e8ff3",
+        "apim-request-id": "a1447fcb-d3ef-4667-a049-47a092d5311f",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9d8d8b79-ceec-473c-9ba1-3302f2807581",
-        "lastUpdatedDateTime": "2022-10-15T02:26:53Z",
-        "createdDateTime": "2022-10-15T02:26:53Z",
-        "expirationDateTime": "2022-10-16T02:26:53Z",
+        "jobId": "7af12532-cb94-417f-8469-40b2baea63d0",
+        "lastUpdatedDateTime": "2022-10-24T05:18:40Z",
+        "createdDateTime": "2022-10-24T05:18:39Z",
+        "expirationDateTime": "2022-10-25T05:18:39Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7af12532-cb94-417f-8469-40b2baea63d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,36 +183,125 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1569f562-1034-4908-8d13-35409557fab3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4d341bee-8139-4974-89d1-655b22d9bf4f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f5b21831-fe86-4f13-84e6-d56a218b9419",
-        "Content-Length": "1381",
+        "apim-request-id": "cac7d5ce-70f0-4b20-9082-6c1affa59012",
+        "Content-Length": "3108",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "66"
+        "x-envoy-upstream-service-time": "232",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9d8d8b79-ceec-473c-9ba1-3302f2807581",
-        "lastUpdatedDateTime": "2022-10-15T02:26:55Z",
-        "createdDateTime": "2022-10-15T02:26:53Z",
-        "expirationDateTime": "2022-10-16T02:26:53Z",
-        "status": "running",
+        "jobId": "7af12532-cb94-417f-8469-40b2baea63d0",
+        "lastUpdatedDateTime": "2022-10-24T05:18:41Z",
+        "createdDateTime": "2022-10-24T05:18:39Z",
+        "expirationDateTime": "2022-10-25T05:18:39Z",
+        "status": "succeeded",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 3,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 0,
           "total": 3,
           "items": [
             {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.8227747Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.767785Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.0611512Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.9736177Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -256,7 +348,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7af12532-cb94-417f-8469-40b2baea63d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -272,25 +364,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f8eb8622-db21-423b-b5db-003654546f76",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "516df2b5-2f57-4f9a-8527-8775c4e2c8da",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d81f6ed6-3779-4ea3-9e09-851ff5e05d69",
-        "Content-Length": "3109",
+        "apim-request-id": "bf1dd9d7-e0be-4d38-b9b0-d9d36f7c7eca",
+        "Content-Length": "3108",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "228"
+        "x-envoy-upstream-service-time": "168",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9d8d8b79-ceec-473c-9ba1-3302f2807581",
-        "lastUpdatedDateTime": "2022-10-15T02:26:55Z",
-        "createdDateTime": "2022-10-15T02:26:53Z",
-        "expirationDateTime": "2022-10-16T02:26:53Z",
+        "jobId": "7af12532-cb94-417f-8469-40b2baea63d0",
+        "lastUpdatedDateTime": "2022-10-24T05:18:41Z",
+        "createdDateTime": "2022-10-24T05:18:39Z",
+        "expirationDateTime": "2022-10-25T05:18:39Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -301,7 +394,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.7799267Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.8227747Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -345,7 +438,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.8148773Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.767785Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -389,187 +482,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.0611512Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: de,en,es,fr,it,pt-BR,pt-PT,af,am,ar,as,az,be,bg,bn,br,bs,ca,cs,cy,da,el,eo,et,eu,fa,fi,fil,fy,ga,gd,gl,gu,ha,he,hi,hr,hu,hy,id,ja,jv,ka,kk,km,kn,ko,ku,ky,la,lo,lt,lv,mg,mk,ml,mn,mr,ms,my,ne,nl,no,om,or,pa,pl,ps,ro,ru,sa,sd,si,sk,sl,so,sq,sr,su,sv,sw,ta,te,th,tr,ug,uk,ur,uz,vi,xh,yi,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction"
-                      }
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d8d8b79-ceec-473c-9ba1-3302f2807581?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "27281a83-5664-4d55-b9f5-c2f557031765",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "43289b10-4da8-4faa-a22c-c626630fbd81",
-        "Content-Length": "3109",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:57 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "104"
-      },
-      "ResponseBody": {
-        "jobId": "9d8d8b79-ceec-473c-9ba1-3302f2807581",
-        "lastUpdatedDateTime": "2022-10-15T02:26:55Z",
-        "createdDateTime": "2022-10-15T02:26:53Z",
-        "expirationDateTime": "2022-10-16T02:26:53Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 0,
-          "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.7799267Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.8148773Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:55.0611512Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:41.9736177Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6c55e307-7802-4b3e-abb2-a061b55f69a8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1ff6e1a4-79fc-4150-b4a3-dd9c46fe8d22",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -49,18 +49,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e0e7b677-5cc5-4d25-9df8-682df65f2110",
+        "apim-request-id": "d9c769b2-a9f1-46a1-9ef8-cc37cdc9194d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:46 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/d06a9cfd-75b7-4f28-8f56-e5251a4b1020?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:13 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/6af2db57-dc4a-4d4e-a1b0-56826bb04889?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "126"
+        "x-envoy-upstream-service-time": "120",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d06a9cfd-75b7-4f28-8f56-e5251a4b1020?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6af2db57-dc4a-4d4e-a1b0-56826bb04889?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -76,25 +77,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7d8515bb-d021-4d9b-a3c6-de2e4007647b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "fec77dcd-9151-4d94-a7a8-eef32288d7c2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "199ccffa-a7c5-441e-9831-805b8bb3e439",
+        "apim-request-id": "42c5ef07-80de-41a2-b074-3618d1965bbc",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d06a9cfd-75b7-4f28-8f56-e5251a4b1020",
-        "lastUpdatedDateTime": "2022-10-15T02:27:47Z",
-        "createdDateTime": "2022-10-15T02:27:46Z",
-        "expirationDateTime": "2022-10-16T02:27:46Z",
+        "jobId": "6af2db57-dc4a-4d4e-a1b0-56826bb04889",
+        "lastUpdatedDateTime": "2022-10-24T05:19:13Z",
+        "createdDateTime": "2022-10-24T05:19:13Z",
+        "expirationDateTime": "2022-10-25T05:19:13Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -107,7 +109,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d06a9cfd-75b7-4f28-8f56-e5251a4b1020?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6af2db57-dc4a-4d4e-a1b0-56826bb04889?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -123,26 +125,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6b9c5c51-1bad-4c39-8d65-e10a607738cf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "93fbc05e-5faa-4b88-a96b-8ade8150db13",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04c57bcc-3356-44c7-b2e4-2d5f4d4aee37",
-        "Content-Length": "283",
+        "apim-request-id": "9df36a15-c984-4a1e-9d36-f55b76403d16",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d06a9cfd-75b7-4f28-8f56-e5251a4b1020",
-        "lastUpdatedDateTime": "2022-10-15T02:27:47Z",
-        "createdDateTime": "2022-10-15T02:27:46Z",
-        "expirationDateTime": "2022-10-16T02:27:46Z",
-        "status": "notStarted",
+        "jobId": "6af2db57-dc4a-4d4e-a1b0-56826bb04889",
+        "lastUpdatedDateTime": "2022-10-24T05:19:13Z",
+        "createdDateTime": "2022-10-24T05:19:13Z",
+        "expirationDateTime": "2022-10-25T05:19:13Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -154,7 +157,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d06a9cfd-75b7-4f28-8f56-e5251a4b1020?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6af2db57-dc4a-4d4e-a1b0-56826bb04889?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -170,25 +173,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "15b66251-a058-4bbe-bf9f-a533ab5b17f7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "872a2bf4-42be-40b1-8c7e-b3b0116ca10e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "849e24dd-e279-4b41-b0d1-8c8ed027314c",
-        "Content-Length": "2145",
+        "apim-request-id": "d5ef6b44-a5af-4c46-91d0-a7808364df74",
+        "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "62"
+        "x-envoy-upstream-service-time": "53",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d06a9cfd-75b7-4f28-8f56-e5251a4b1020",
-        "lastUpdatedDateTime": "2022-10-15T02:27:49Z",
-        "createdDateTime": "2022-10-15T02:27:46Z",
-        "expirationDateTime": "2022-10-16T02:27:46Z",
+        "jobId": "6af2db57-dc4a-4d4e-a1b0-56826bb04889",
+        "lastUpdatedDateTime": "2022-10-24T05:19:15Z",
+        "createdDateTime": "2022-10-24T05:19:13Z",
+        "expirationDateTime": "2022-10-25T05:19:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -199,7 +203,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:49.1202942Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.6805737Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -221,7 +225,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:49.086901Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.6558015Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -243,7 +247,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:48.6182124Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.1838774Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -268,7 +272,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d06a9cfd-75b7-4f28-8f56-e5251a4b1020?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6af2db57-dc4a-4d4e-a1b0-56826bb04889?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -284,25 +288,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cc190bd0-83c5-401c-b05d-102fc710f189",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4ff55c6b-a72f-4977-b088-3c8e9eca93aa",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "709eed95-6ce8-403d-8748-a50b52745746",
-        "Content-Length": "2145",
+        "apim-request-id": "bd33b42b-3de3-419a-b642-57207d4a0ab6",
+        "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "65"
+        "x-envoy-upstream-service-time": "70",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d06a9cfd-75b7-4f28-8f56-e5251a4b1020",
-        "lastUpdatedDateTime": "2022-10-15T02:27:49Z",
-        "createdDateTime": "2022-10-15T02:27:46Z",
-        "expirationDateTime": "2022-10-16T02:27:46Z",
+        "jobId": "6af2db57-dc4a-4d4e-a1b0-56826bb04889",
+        "lastUpdatedDateTime": "2022-10-24T05:19:15Z",
+        "createdDateTime": "2022-10-24T05:19:13Z",
+        "expirationDateTime": "2022-10-25T05:19:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -313,7 +318,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:49.1202942Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.6805737Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -335,7 +340,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:49.086901Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.6558015Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -357,7 +362,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:48.6182124Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:15.1838774Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5fbe9228-1124-40f6-ae5b-852b45ff8e76",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "55b95aea-bfd6-4fee-a730-88ce709b28b6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "displayName": "testJob",
@@ -42,18 +42,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1c8f30dd-a05c-4638-bb6d-554f4d17fe96",
+        "apim-request-id": "0d3193e8-0bee-4e71-9d3e-b5a595c36c41",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9ec25677-bb1a-43c5-94c0-9739b8c9f3d8?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:29 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/233d1cb1-dd56-4e00-8926-ede422b7a938?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "113"
+        "x-envoy-upstream-service-time": "131",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ec25677-bb1a-43c5-94c0-9739b8c9f3d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/233d1cb1-dd56-4e00-8926-ede422b7a938?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -69,25 +70,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "96c1d816-2c08-453a-8680-5a0b62f3851a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "688ba4d6-2d89-4568-829d-bb7bc339e027",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aaea503e-f2f0-4c89-b7e7-b55fbc87fdfb",
+        "apim-request-id": "3ae97a32-ea58-4862-a33b-22ceafc084c0",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9ec25677-bb1a-43c5-94c0-9739b8c9f3d8",
-        "lastUpdatedDateTime": "2022-10-15T02:27:57Z",
-        "createdDateTime": "2022-10-15T02:27:57Z",
-        "expirationDateTime": "2022-10-16T02:27:57Z",
+        "jobId": "233d1cb1-dd56-4e00-8926-ede422b7a938",
+        "lastUpdatedDateTime": "2022-10-24T05:19:29Z",
+        "createdDateTime": "2022-10-24T05:19:29Z",
+        "expirationDateTime": "2022-10-25T05:19:29Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ec25677-bb1a-43c5-94c0-9739b8c9f3d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/233d1cb1-dd56-4e00-8926-ede422b7a938?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,25 +119,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7ca7c5df-80f2-4c63-8f7b-2aae1694d3d2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "938f073f-2256-4717-8a1e-c56f10a4415e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4fe9503-ade3-4c8c-8026-4d3be44bc8ee",
+        "apim-request-id": "6d0faa25-948d-499a-9ce0-aca9892f0a5e",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9ec25677-bb1a-43c5-94c0-9739b8c9f3d8",
-        "lastUpdatedDateTime": "2022-10-15T02:27:57Z",
-        "createdDateTime": "2022-10-15T02:27:57Z",
-        "expirationDateTime": "2022-10-16T02:27:57Z",
+        "jobId": "233d1cb1-dd56-4e00-8926-ede422b7a938",
+        "lastUpdatedDateTime": "2022-10-24T05:19:29Z",
+        "createdDateTime": "2022-10-24T05:19:29Z",
+        "expirationDateTime": "2022-10-25T05:19:29Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -149,7 +152,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9ec25677-bb1a-43c5-94c0-9739b8c9f3d8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/233d1cb1-dd56-4e00-8926-ede422b7a938?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -165,25 +168,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c63b7ea7-70a2-4845-8d54-4c3f70760525",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1748fe4c-89a8-4fd4-a5e0-7f8ff5492c48",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be44bc32-201d-4d78-b64a-70c6b8966686",
+        "apim-request-id": "7ca5e363-ae8e-4025-a5e1-ee94f04883dc",
         "Content-Length": "853",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9ec25677-bb1a-43c5-94c0-9739b8c9f3d8",
-        "lastUpdatedDateTime": "2022-10-15T02:27:59Z",
-        "createdDateTime": "2022-10-15T02:27:57Z",
-        "expirationDateTime": "2022-10-16T02:27:57Z",
+        "jobId": "233d1cb1-dd56-4e00-8926-ede422b7a938",
+        "lastUpdatedDateTime": "2022-10-24T05:19:31Z",
+        "createdDateTime": "2022-10-24T05:19:29Z",
+        "expirationDateTime": "2022-10-25T05:19:29Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "testJob",
@@ -195,7 +199,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:59.4312111Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:31.0090219Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "16bba3c9-256c-4c75-84b4-9132a10867cd",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ae4c7810-cefa-472e-8e1f-27a99786f9fb",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -64,18 +64,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a6d0b2a3-e1be-40df-818b-cafc9b1f1b8f",
+        "apim-request-id": "45843859-9856-4ade-8f35-52dff173cb2a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:09 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:52 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "185"
+        "x-envoy-upstream-service-time": "233",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -91,25 +92,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "769c8fa4-92bf-4cb4-9e48-4b234e92af49",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4dce38ce-333e-47fe-8341-3812884bdff9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12b256d6-893c-4dbe-a997-458737574148",
-        "Content-Length": "280",
+        "apim-request-id": "1cc669cb-954b-4d5d-ba75-46543724c626",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "40ff14ef-aa6a-4388-b089-a69af65c0690",
-        "lastUpdatedDateTime": "2022-10-15T02:27:09Z",
-        "createdDateTime": "2022-10-15T02:27:09Z",
-        "expirationDateTime": "2022-10-16T02:27:09Z",
+        "jobId": "4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:52Z",
+        "createdDateTime": "2022-10-24T05:18:52Z",
+        "expirationDateTime": "2022-10-25T05:18:52Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "7d26e115-72ca-46a4-9b21-e845feaa9954",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "965aac82-0fd2-4bd7-9c79-2cbf120a30c0",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:52Z",
+        "createdDateTime": "2022-10-24T05:18:52Z",
+        "expirationDateTime": "2022-10-25T05:18:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -122,7 +172,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -138,72 +188,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0a692865-3ae5-42ac-8f3a-bce79ab5e7b4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ddd1b3b0-71a9-44f7-ad23-b13a0cb1b1d0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a996bb2f-31c6-4045-ac5d-2a98e569567a",
-        "Content-Length": "280",
+        "apim-request-id": "4b61db28-4799-460f-920f-c309b6275c63",
+        "Content-Length": "1142",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "149",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "40ff14ef-aa6a-4388-b089-a69af65c0690",
-        "lastUpdatedDateTime": "2022-10-15T02:27:09Z",
-        "createdDateTime": "2022-10-15T02:27:09Z",
-        "expirationDateTime": "2022-10-16T02:27:09Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "99904f26-b867-4c7b-9a56-1444f4441fca",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e65c51b9-3939-44fe-bb49-0465c698e25a",
-        "Content-Length": "1145",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
-      },
-      "ResponseBody": {
-        "jobId": "40ff14ef-aa6a-4388-b089-a69af65c0690",
-        "lastUpdatedDateTime": "2022-10-15T02:27:11Z",
-        "createdDateTime": "2022-10-15T02:27:09Z",
-        "expirationDateTime": "2022-10-16T02:27:09Z",
+        "jobId": "4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:54Z",
+        "createdDateTime": "2022-10-24T05:18:52Z",
+        "expirationDateTime": "2022-10-25T05:18:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -214,7 +218,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.4386978Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.1334732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -255,7 +259,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.5018852Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.3357Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -294,7 +298,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -310,25 +314,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7baf756d-5c6f-4c92-a638-50d6e9d153fb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a629265c-bac7-4670-a207-fc8f220940b9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6501b50f-d0c1-4e90-8e67-08673e927baa",
-        "Content-Length": "1523",
+        "apim-request-id": "11a6574e-c88e-4ee0-849c-40a3a7a0602e",
+        "Content-Length": "1520",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "185",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "40ff14ef-aa6a-4388-b089-a69af65c0690",
-        "lastUpdatedDateTime": "2022-10-15T02:27:12Z",
-        "createdDateTime": "2022-10-15T02:27:09Z",
-        "expirationDateTime": "2022-10-16T02:27:09Z",
+        "jobId": "4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:54Z",
+        "createdDateTime": "2022-10-24T05:18:52Z",
+        "expirationDateTime": "2022-10-25T05:18:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -339,7 +344,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:12.0493018Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.7938665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -375,7 +380,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.4386978Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.1334732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -416,7 +421,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.5018852Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.3357Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -455,7 +460,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/40ff14ef-aa6a-4388-b089-a69af65c0690?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -471,25 +476,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5c219bfc-eb14-485a-b482-d8b861c65f5f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "600a7cf7-f432-412f-a756-31735c19a406",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "071c4122-4217-4008-a685-2f21c6800ec1",
-        "Content-Length": "1523",
+        "apim-request-id": "7dc4da2d-7848-4fd0-a4db-d68580d3e2a1",
+        "Content-Length": "1520",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183"
+        "x-envoy-upstream-service-time": "177",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "40ff14ef-aa6a-4388-b089-a69af65c0690",
-        "lastUpdatedDateTime": "2022-10-15T02:27:12Z",
-        "createdDateTime": "2022-10-15T02:27:09Z",
-        "expirationDateTime": "2022-10-16T02:27:09Z",
+        "jobId": "4b90bc83-2e5d-440a-87e6-1b2bbc0a4fb5",
+        "lastUpdatedDateTime": "2022-10-24T05:18:54Z",
+        "createdDateTime": "2022-10-24T05:18:52Z",
+        "expirationDateTime": "2022-10-25T05:18:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -500,7 +506,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:12.0493018Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.7938665Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -536,7 +542,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.4386978Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.1334732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -577,7 +583,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:11.5018852Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:54.3357Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e1bac66e-7092-4251-a3d1-7251142b68bb",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0da1b3ca-6c10-4a8d-bf04-6a61b04dfe43",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -64,18 +64,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4e4bbc02-7652-4958-aabf-9323f0463964",
+        "apim-request-id": "4adef4fb-36d6-40c0-beed-5593b3d34fb9",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:57 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:42 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "201"
+        "x-envoy-upstream-service-time": "180",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -91,25 +92,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "be0b8ff9-393a-43b9-8314-29c25a758451",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "86133d0e-9da5-4a2f-a173-185067eff821",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "af792e13-bd6e-4f5e-8b6e-e40de6bbe7b5",
+        "apim-request-id": "17c5c80f-b791-460b-9c0f-6e84aa2701cf",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:26:58Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:43Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,7 +124,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -138,25 +140,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bf8a5a70-7016-4914-9584-21665edc1048",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "72b6d316-d0a0-4b40-b561-71664b852c71",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b6ba445-83fd-453d-ae73-fd91036be3ff",
+        "apim-request-id": "5c741bba-56a1-463c-ac14-4f9a768696a0",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:26:58Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:43Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -169,7 +172,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -185,277 +188,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "358d6554-76ac-4777-a6a8-edefa5a5cfd7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c08be953-b010-4f09-bf9a-3717eb6e1917",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7421e4c5-708b-403b-809d-9be21906f0aa",
-        "Content-Length": "664",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:59 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99"
-      },
-      "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:00Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e638afb5-3bc6-40d8-a2be-791a53bdfde7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "49d94318-25cf-4220-9b26-177e4eebc732",
-        "Content-Length": "664",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "61"
-      },
-      "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:00Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "43cf8c07-d2b2-41e8-b0f2-08d6e746f461",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "dd525322-0416-4c56-be79-e2fde38b31a3",
-        "Content-Length": "664",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:04 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "64"
-      },
-      "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:00Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "61c9880c-c86e-4168-b2f6-7284fa1a1137",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "24b20464-6120-4bca-9ddb-a1a963a2eb76",
+        "apim-request-id": "2f3f98d1-f6c3-47f5-a722-4d686817a7bf",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "118"
+        "x-envoy-upstream-service-time": "138",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:05Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:45Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -466,7 +218,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:05.3397003Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:44.9541041Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -547,7 +299,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:45.1284301Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -586,7 +338,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -602,25 +354,358 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "00d0d72f-abd3-47c8-b113-ef4ca8740f5f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9baa45e5-5382-4cef-96fe-b522b33ad777",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ea21553c-92b5-4e32-a0d6-b1d5e7afb079",
-        "Content-Length": "2043",
+        "apim-request-id": "dea6429d-6111-4ba1-be65-6c05051e57b0",
+        "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "181"
+        "x-envoy-upstream-service-time": "105",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:07Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:45Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:44.9541041Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:45.1284301Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "b2a7e36d-beab-4de6-925d-d9ac227bad50",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a1b74ea2-1344-410f-91a7-7c7ecbaabc8f",
+        "Content-Length": "1556",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "136",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:45Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:44.9541041Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:45.1284301Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "7675d413-d97b-4bb2-a0c5-9d1bfd116a12",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7f9af01b-f96e-4378-b2a2-5e78e0f72844",
+        "Content-Length": "2043",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:51Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -631,7 +716,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:05.3397003Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:44.9541041Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -712,7 +797,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:07.2169991Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:51.1237742Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -753,7 +838,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:45.1284301Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -792,7 +877,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/18e092b7-8893-4cea-ba29-986a296b20ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9a36c88d-e560-4b72-9fad-ec2c5664fab1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -808,25 +893,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b1e76090-42f3-4b79-9c0e-21e54f0a7d2d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4eb00c98-388d-4372-a9c7-b223004b01d5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e2c87402-5006-4f67-ae6c-e637a54864e5",
+        "apim-request-id": "adcf3fd7-da94-47a9-83c4-2556c5e38573",
         "Content-Length": "2043",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "201",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "18e092b7-8893-4cea-ba29-986a296b20ff",
-        "lastUpdatedDateTime": "2022-10-15T02:27:07Z",
-        "createdDateTime": "2022-10-15T02:26:58Z",
-        "expirationDateTime": "2022-10-16T02:26:58Z",
+        "jobId": "9a36c88d-e560-4b72-9fad-ec2c5664fab1",
+        "lastUpdatedDateTime": "2022-10-24T05:18:51Z",
+        "createdDateTime": "2022-10-24T05:18:42Z",
+        "expirationDateTime": "2022-10-25T05:18:42Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -837,7 +923,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:05.3397003Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:44.9541041Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -918,7 +1004,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:07.2169991Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:51.1237742Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -959,7 +1045,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:00.4115064Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:45.1284301Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5d63d849-9730-4247-b26c-9abaefd191df",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3e62bcc6-7c57-4e9d-9fc6-8ad8c4d1ab5b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -165,18 +165,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1fa81409-fc9a-403d-a65f-3f05468efb99",
+        "apim-request-id": "fa8093fb-d45f-4cf7-9bad-80fa431aea2f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:49 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:15 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "784"
+        "x-envoy-upstream-service-time": "631",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -192,119 +193,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "06a9fa7f-15da-49f4-b812-3dea5d557179",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a4de6636-274f-4692-9319-72ea8a2a4f3f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b1c032b-b39f-45ad-9ad7-441704d5c938",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:49 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:50Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "de18accd-2d6b-49e3-b0d0-6215cd91c0d9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8a8fa955-8a4c-4aab-b9b4-21846eab9e78",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:49 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
-      },
-      "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:50Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "15d346f8-f508-4444-acce-eb3934e4aef9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "79fa1fa9-a9aa-4ec5-ac40-568e77fc6bab",
+        "apim-request-id": "aa71b4d8-e956-4a88-a38d-57a012ccf18a",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:50Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:16Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -317,7 +225,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -333,25 +241,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b45d1fe0-e0e4-4b03-bbb0-a76c06acc0e3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8838c1b9-e947-448a-8f26-3dd243c5f9cf",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "734554c3-3639-40f4-ab03-3154f68f9c25",
+        "apim-request-id": "9f0c006c-a2d1-44a7-95a3-0f364218006d",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:54Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:17Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -364,7 +273,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -380,25 +289,524 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "87f2127a-275d-4dfd-bb0c-c8c13773d6b5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2df91f95-432d-4002-80e0-44d9d2dde46c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2544d54e-8901-415d-b055-4fbacdd7997b",
+        "apim-request-id": "281162ed-f271-43ac-9b92-29c07216df4b",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:17Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "93aa3c40-7770-469c-a1d2-fd03593cbf8b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "51054ff9-c7c8-4eba-989f-0bb193e5cde5",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:20Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "fc1d5204-0779-4db0-9236-9077c3350bce",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1e59d76a-5919-4b25-8529-7403ee917a8f",
+        "Content-Length": "1696",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "215",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:21Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "items": [
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "6",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "7",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "8",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "9",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "10",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "11",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "12",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "13",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "14",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "15",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "16",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "17",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "18",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        },
+        "nextLink": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "3096e8fd-9740-4049-be23-2c91e5b9bd66",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c3a97332-d97c-472c-b80d-7b61d5c95ee9",
+        "Content-Length": "1696",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "212",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:25Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "items": [
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "6",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "7",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "8",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "9",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "10",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "11",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "12",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "13",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "14",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "15",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "16",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "17",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "18",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        },
+        "nextLink": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "5b73e108-ed62-4564-aa1e-d85f3ea418fe",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "de9ac0f0-8b8b-4e26-8cc9-df4c3f3f4953",
         "Content-Length": "2666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "449"
+        "x-envoy-upstream-service-time": "389",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:54Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:26Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -409,7 +817,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.7464439Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:26.3540414Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -520,7 +928,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.5403665Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -671,11 +1079,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?api-version=2022-05-01\u0026top=10",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?api-version=2022-05-01\u0026top=10",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -691,25 +1099,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0a4a460e-55c3-4c47-aa51-1079e266f187",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9ee30a71-9191-429c-81e5-6ac46cbf25e8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9cb6c806-b922-44dd-abc9-68109efa64c7",
+        "apim-request-id": "cdfea8c2-3ed0-443b-9dc8-51144ed06a2d",
         "Content-Length": "1717",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "197"
+        "x-envoy-upstream-service-time": "312",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:54Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:26Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -720,7 +1129,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.7464439Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:26.3540414Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -781,7 +1190,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.5403665Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -862,11 +1271,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -882,25 +1291,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fca52c51-ccbd-4320-9e7c-b15efb1b3374",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "892273b2-b83c-4bfe-b016-a80adb8d944d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26b9349b-2543-40b0-b9e5-1df8e3dfc07c",
+        "apim-request-id": "124a8f2c-25a9-45d1-ad74-196ced429ea0",
         "Content-Length": "1736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "238"
+        "x-envoy-upstream-service-time": "228",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:54Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:26Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -911,7 +1321,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.7464439Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:26.3540414Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -972,7 +1382,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.5403665Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1053,11 +1463,11 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/136ec846-48bb-4941-9684-22e948e2ff03?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a478e5d7-d20f-44ac-8766-7b98ab330dca?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1073,25 +1483,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "bf7d7b8b-f6cf-4ab5-be38-55031eb12bd0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f9dc3b8c-b5a6-4aef-bae8-768785b26da8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1b708ed2-4800-4277-9784-252a4c5e7769",
+        "apim-request-id": "0aec6712-a4ed-4bfe-bde1-b139a5f7067f",
         "Content-Length": "1404",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "125"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "136ec846-48bb-4941-9684-22e948e2ff03",
-        "lastUpdatedDateTime": "2022-10-15T02:27:54Z",
-        "createdDateTime": "2022-10-15T02:27:49Z",
-        "expirationDateTime": "2022-10-16T02:27:49Z",
+        "jobId": "a478e5d7-d20f-44ac-8766-7b98ab330dca",
+        "lastUpdatedDateTime": "2022-10-24T05:19:26Z",
+        "createdDateTime": "2022-10-24T05:19:16Z",
+        "expirationDateTime": "2022-10-25T05:19:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1102,7 +1513,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.7464439Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:26.3540414Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1160,7 +1571,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:54.5403665Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:21.5031457Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ae0a1753-32b9-458f-9da1-8dc594e704d5",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5a25daff-6037-4e22-8567-dbea6b694d61",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -60,18 +60,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ecb423a7-5916-456c-8178-fafc5fff25d2",
+        "apim-request-id": "bd071fad-0f69-4825-935c-a9f79d4c5e0a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:59 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:31 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "137"
+        "x-envoy-upstream-service-time": "224",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -87,25 +88,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "59b8596b-c4fb-4dfe-989f-9d27efc3bc22",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0420de50-7012-4e66-b12f-6d1da63c7956",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "610adb49-018d-4a54-b431-15dd80ab2f4c",
+        "apim-request-id": "8ff8e87e-5286-420f-abe2-a144dcb89753",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:00Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:31Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -118,7 +120,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -134,25 +136,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a62d0ec6-ed1a-4e9e-9f11-ad9a9df8c087",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "38540e6c-8ef7-45c9-a223-a3f50c0c7c74",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb6cb803-ba02-44f3-9fca-6f1ffdb20b53",
+        "apim-request-id": "2a15527c-1a18-4b18-b327-1a1cd64cf6b0",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:00Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:31Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -165,7 +168,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -181,25 +184,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9046c54c-2202-4810-9f00-87e50999728f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "44daa494-372d-42d3-9424-1039d4379ce9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1e13ced3-a6e3-4ddc-a5ab-8865210a35b3",
+        "apim-request-id": "d0e66182-095c-4535-80fe-099f954c143a",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:00Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:31Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -212,7 +216,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -228,36 +232,37 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1b436a49-6ad4-4097-a4c8-79cf23ab4fd2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "dd371e82-005c-47b4-8223-ea4ba3e3495f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91f6c036-57da-49be-8cef-95296878d267",
-        "Content-Length": "5533",
+        "apim-request-id": "43d3bc6e-6d12-441b-b88e-a92de1fd73ee",
+        "Content-Length": "5146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "154"
+        "x-envoy-upstream-service-time": "68",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:01Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:33Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 2,
           "total": 4,
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.0378454Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -646,1706 +651,11 @@
                 ],
                 "errors": [],
                 "modelVersion": "2022-03-01"
-              }
-            },
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "******* does not suffer from high blood pressure.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "47373eed-3816-4583-9867-e71152971b69",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e210d424-824c-4a1a-bd6d-0a2d112b4468",
-        "Content-Length": "5533",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:03 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "106"
-      },
-      "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:01Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 4,
-          "items": [
-            {
-              "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "offset": 29,
-                        "length": 19,
-                        "text": "high blood pressure",
-                        "category": "SymptomOrSign",
-                        "confidenceScore": 1.0,
-                        "assertion": {
-                          "certainty": "negative"
-                        },
-                        "name": "Hypertensive disease",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020538"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000023317"
-                          },
-                          {
-                            "dataSource": "BI",
-                            "id": "BI00001"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "1017493"
-                          },
-                          {
-                            "dataSource": "CCS",
-                            "id": "7.1"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000015800"
-                          },
-                          {
-                            "dataSource": "COSTAR",
-                            "id": "397"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "0571-5243"
-                          },
-                          {
-                            "dataSource": "CST",
-                            "id": "HYPERTENS"
-                          },
-                          {
-                            "dataSource": "DXP",
-                            "id": "U002034"
-                          },
-                          {
-                            "dataSource": "HPO",
-                            "id": "HP:0000822"
-                          },
-                          {
-                            "dataSource": "ICD10",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10AM",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10CM",
-                            "id": "I10"
-                          },
-                          {
-                            "dataSource": "ICD9CM",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "ICPC2ICD10ENG",
-                            "id": "MTHU035456"
-                          },
-                          {
-                            "dataSource": "ICPC2P",
-                            "id": "K85004"
-                          },
-                          {
-                            "dataSource": "LCH",
-                            "id": "U002317"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh85063723"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LA14293-7"
-                          },
-                          {
-                            "dataSource": "MDR",
-                            "id": "10020772"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "33288"
-                          },
-                          {
-                            "dataSource": "MEDLINEPLUS",
-                            "id": "34"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D006973"
-                          },
-                          {
-                            "dataSource": "MTH",
-                            "id": "005"
-                          },
-                          {
-                            "dataSource": "MTHICD9",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "NANDA-I",
-                            "id": "00905"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CPTAC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CTCAE",
-                            "id": "E13785"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "1908"
-                          },
-                          {
-                            "dataSource": "NCI_GDC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000458091"
-                          },
-                          {
-                            "dataSource": "NCI_NICHD",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_caDSR",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NOC",
-                            "id": "060808"
-                          },
-                          {
-                            "dataSource": "OMIM",
-                            "id": "MTHU002068"
-                          },
-                          {
-                            "dataSource": "PCDS",
-                            "id": "PRB_11000.06"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000686951"
-                          },
-                          {
-                            "dataSource": "PSY",
-                            "id": "23830"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "XE0Ub"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "F-70700"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "D3-02000"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "38341003"
-                          },
-                          {
-                            "dataSource": "WHO",
-                            "id": "0210"
-                          }
-                        ]
-                      }
-                    ],
-                    "relations": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "offset": 11,
-                        "length": 5,
-                        "text": "100mg",
-                        "category": "Dosage",
-                        "confidenceScore": 0.98
-                      },
-                      {
-                        "offset": 17,
-                        "length": 9,
-                        "text": "ibuprofen",
-                        "category": "MedicationName",
-                        "confidenceScore": 1.0,
-                        "name": "ibuprofen",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020740"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000019879"
-                          },
-                          {
-                            "dataSource": "ATC",
-                            "id": "M01AE01"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "0046165"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000006519"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "2270-2077"
-                          },
-                          {
-                            "dataSource": "DRUGBANK",
-                            "id": "DB01050"
-                          },
-                          {
-                            "dataSource": "GS",
-                            "id": "1611"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh97005926"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LP16165-0"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "40458"
-                          },
-                          {
-                            "dataSource": "MMSL",
-                            "id": "d00015"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D007052"
-                          },
-                          {
-                            "dataSource": "MTHSPL",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_DCP",
-                            "id": "00803"
-                          },
-                          {
-                            "dataSource": "NCI_DTP",
-                            "id": "NSC0256857"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000613511"
-                          },
-                          {
-                            "dataSource": "NDDF",
-                            "id": "002377"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000040475"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "x02MO"
-                          },
-                          {
-                            "dataSource": "RXNORM",
-                            "id": "5640"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "E-7772"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "C-603C0"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "387207008"
-                          },
-                          {
-                            "dataSource": "USP",
-                            "id": "m39860"
-                          },
-                          {
-                            "dataSource": "USPMG",
-                            "id": "MTHU000060"
-                          },
-                          {
-                            "dataSource": "VANDF",
-                            "id": "4017840"
-                          }
-                        ]
-                      },
-                      {
-                        "offset": 34,
-                        "length": 11,
-                        "text": "twice daily",
-                        "category": "Frequency",
-                        "confidenceScore": 1.0
-                      }
-                    ],
-                    "relations": [
-                      {
-                        "relationType": "DosageOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/0",
-                            "role": "Dosage"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          }
-                        ]
-                      },
-                      {
-                        "relationType": "FrequencyOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/2",
-                            "role": "Frequency"
-                          }
-                        ]
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-03-01"
-              }
-            },
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "******* does not suffer from high blood pressure.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "85dfe1a6-c7c8-481e-90ef-bde1ef18fd1c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e0bb373e-bab9-4aed-9d6d-ed70a65c06fd",
-        "Content-Length": "5533",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:05 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "104"
-      },
-      "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:01Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 4,
-          "items": [
-            {
-              "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "offset": 29,
-                        "length": 19,
-                        "text": "high blood pressure",
-                        "category": "SymptomOrSign",
-                        "confidenceScore": 1.0,
-                        "assertion": {
-                          "certainty": "negative"
-                        },
-                        "name": "Hypertensive disease",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020538"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000023317"
-                          },
-                          {
-                            "dataSource": "BI",
-                            "id": "BI00001"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "1017493"
-                          },
-                          {
-                            "dataSource": "CCS",
-                            "id": "7.1"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000015800"
-                          },
-                          {
-                            "dataSource": "COSTAR",
-                            "id": "397"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "0571-5243"
-                          },
-                          {
-                            "dataSource": "CST",
-                            "id": "HYPERTENS"
-                          },
-                          {
-                            "dataSource": "DXP",
-                            "id": "U002034"
-                          },
-                          {
-                            "dataSource": "HPO",
-                            "id": "HP:0000822"
-                          },
-                          {
-                            "dataSource": "ICD10",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10AM",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10CM",
-                            "id": "I10"
-                          },
-                          {
-                            "dataSource": "ICD9CM",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "ICPC2ICD10ENG",
-                            "id": "MTHU035456"
-                          },
-                          {
-                            "dataSource": "ICPC2P",
-                            "id": "K85004"
-                          },
-                          {
-                            "dataSource": "LCH",
-                            "id": "U002317"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh85063723"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LA14293-7"
-                          },
-                          {
-                            "dataSource": "MDR",
-                            "id": "10020772"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "33288"
-                          },
-                          {
-                            "dataSource": "MEDLINEPLUS",
-                            "id": "34"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D006973"
-                          },
-                          {
-                            "dataSource": "MTH",
-                            "id": "005"
-                          },
-                          {
-                            "dataSource": "MTHICD9",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "NANDA-I",
-                            "id": "00905"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CPTAC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CTCAE",
-                            "id": "E13785"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "1908"
-                          },
-                          {
-                            "dataSource": "NCI_GDC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000458091"
-                          },
-                          {
-                            "dataSource": "NCI_NICHD",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_caDSR",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NOC",
-                            "id": "060808"
-                          },
-                          {
-                            "dataSource": "OMIM",
-                            "id": "MTHU002068"
-                          },
-                          {
-                            "dataSource": "PCDS",
-                            "id": "PRB_11000.06"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000686951"
-                          },
-                          {
-                            "dataSource": "PSY",
-                            "id": "23830"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "XE0Ub"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "F-70700"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "D3-02000"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "38341003"
-                          },
-                          {
-                            "dataSource": "WHO",
-                            "id": "0210"
-                          }
-                        ]
-                      }
-                    ],
-                    "relations": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "offset": 11,
-                        "length": 5,
-                        "text": "100mg",
-                        "category": "Dosage",
-                        "confidenceScore": 0.98
-                      },
-                      {
-                        "offset": 17,
-                        "length": 9,
-                        "text": "ibuprofen",
-                        "category": "MedicationName",
-                        "confidenceScore": 1.0,
-                        "name": "ibuprofen",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020740"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000019879"
-                          },
-                          {
-                            "dataSource": "ATC",
-                            "id": "M01AE01"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "0046165"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000006519"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "2270-2077"
-                          },
-                          {
-                            "dataSource": "DRUGBANK",
-                            "id": "DB01050"
-                          },
-                          {
-                            "dataSource": "GS",
-                            "id": "1611"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh97005926"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LP16165-0"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "40458"
-                          },
-                          {
-                            "dataSource": "MMSL",
-                            "id": "d00015"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D007052"
-                          },
-                          {
-                            "dataSource": "MTHSPL",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_DCP",
-                            "id": "00803"
-                          },
-                          {
-                            "dataSource": "NCI_DTP",
-                            "id": "NSC0256857"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000613511"
-                          },
-                          {
-                            "dataSource": "NDDF",
-                            "id": "002377"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000040475"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "x02MO"
-                          },
-                          {
-                            "dataSource": "RXNORM",
-                            "id": "5640"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "E-7772"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "C-603C0"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "387207008"
-                          },
-                          {
-                            "dataSource": "USP",
-                            "id": "m39860"
-                          },
-                          {
-                            "dataSource": "USPMG",
-                            "id": "MTHU000060"
-                          },
-                          {
-                            "dataSource": "VANDF",
-                            "id": "4017840"
-                          }
-                        ]
-                      },
-                      {
-                        "offset": 34,
-                        "length": 11,
-                        "text": "twice daily",
-                        "category": "Frequency",
-                        "confidenceScore": 1.0
-                      }
-                    ],
-                    "relations": [
-                      {
-                        "relationType": "DosageOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/0",
-                            "role": "Dosage"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          }
-                        ]
-                      },
-                      {
-                        "relationType": "FrequencyOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/2",
-                            "role": "Frequency"
-                          }
-                        ]
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-03-01"
-              }
-            },
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "******* does not suffer from high blood pressure.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "470ad6be-6bfb-41dd-ba80-5d45a455cd70",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b0cf7619-d88e-462d-b33e-260b47f9322e",
-        "Content-Length": "6372",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "149"
-      },
-      "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:07Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 4,
-          "failed": 0,
-          "inProgress": 0,
-          "total": 4,
-          "items": [
-            {
-              "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "offset": 29,
-                        "length": 19,
-                        "text": "high blood pressure",
-                        "category": "SymptomOrSign",
-                        "confidenceScore": 1.0,
-                        "assertion": {
-                          "certainty": "negative"
-                        },
-                        "name": "Hypertensive disease",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020538"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000023317"
-                          },
-                          {
-                            "dataSource": "BI",
-                            "id": "BI00001"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "1017493"
-                          },
-                          {
-                            "dataSource": "CCS",
-                            "id": "7.1"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000015800"
-                          },
-                          {
-                            "dataSource": "COSTAR",
-                            "id": "397"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "0571-5243"
-                          },
-                          {
-                            "dataSource": "CST",
-                            "id": "HYPERTENS"
-                          },
-                          {
-                            "dataSource": "DXP",
-                            "id": "U002034"
-                          },
-                          {
-                            "dataSource": "HPO",
-                            "id": "HP:0000822"
-                          },
-                          {
-                            "dataSource": "ICD10",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10AM",
-                            "id": "I10-I15.9"
-                          },
-                          {
-                            "dataSource": "ICD10CM",
-                            "id": "I10"
-                          },
-                          {
-                            "dataSource": "ICD9CM",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "ICPC2ICD10ENG",
-                            "id": "MTHU035456"
-                          },
-                          {
-                            "dataSource": "ICPC2P",
-                            "id": "K85004"
-                          },
-                          {
-                            "dataSource": "LCH",
-                            "id": "U002317"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh85063723"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LA14293-7"
-                          },
-                          {
-                            "dataSource": "MDR",
-                            "id": "10020772"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "33288"
-                          },
-                          {
-                            "dataSource": "MEDLINEPLUS",
-                            "id": "34"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D006973"
-                          },
-                          {
-                            "dataSource": "MTH",
-                            "id": "005"
-                          },
-                          {
-                            "dataSource": "MTHICD9",
-                            "id": "997.91"
-                          },
-                          {
-                            "dataSource": "NANDA-I",
-                            "id": "00905"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CPTAC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_CTCAE",
-                            "id": "E13785"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "1908"
-                          },
-                          {
-                            "dataSource": "NCI_GDC",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000458091"
-                          },
-                          {
-                            "dataSource": "NCI_NICHD",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NCI_caDSR",
-                            "id": "C3117"
-                          },
-                          {
-                            "dataSource": "NOC",
-                            "id": "060808"
-                          },
-                          {
-                            "dataSource": "OMIM",
-                            "id": "MTHU002068"
-                          },
-                          {
-                            "dataSource": "PCDS",
-                            "id": "PRB_11000.06"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000686951"
-                          },
-                          {
-                            "dataSource": "PSY",
-                            "id": "23830"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "XE0Ub"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "F-70700"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "D3-02000"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "38341003"
-                          },
-                          {
-                            "dataSource": "WHO",
-                            "id": "0210"
-                          }
-                        ]
-                      }
-                    ],
-                    "relations": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "offset": 11,
-                        "length": 5,
-                        "text": "100mg",
-                        "category": "Dosage",
-                        "confidenceScore": 0.98
-                      },
-                      {
-                        "offset": 17,
-                        "length": 9,
-                        "text": "ibuprofen",
-                        "category": "MedicationName",
-                        "confidenceScore": 1.0,
-                        "name": "ibuprofen",
-                        "links": [
-                          {
-                            "dataSource": "UMLS",
-                            "id": "C0020740"
-                          },
-                          {
-                            "dataSource": "AOD",
-                            "id": "0000019879"
-                          },
-                          {
-                            "dataSource": "ATC",
-                            "id": "M01AE01"
-                          },
-                          {
-                            "dataSource": "CCPSS",
-                            "id": "0046165"
-                          },
-                          {
-                            "dataSource": "CHV",
-                            "id": "0000006519"
-                          },
-                          {
-                            "dataSource": "CSP",
-                            "id": "2270-2077"
-                          },
-                          {
-                            "dataSource": "DRUGBANK",
-                            "id": "DB01050"
-                          },
-                          {
-                            "dataSource": "GS",
-                            "id": "1611"
-                          },
-                          {
-                            "dataSource": "LCH_NW",
-                            "id": "sh97005926"
-                          },
-                          {
-                            "dataSource": "LNC",
-                            "id": "LP16165-0"
-                          },
-                          {
-                            "dataSource": "MEDCIN",
-                            "id": "40458"
-                          },
-                          {
-                            "dataSource": "MMSL",
-                            "id": "d00015"
-                          },
-                          {
-                            "dataSource": "MSH",
-                            "id": "D007052"
-                          },
-                          {
-                            "dataSource": "MTHSPL",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_CTRP",
-                            "id": "C561"
-                          },
-                          {
-                            "dataSource": "NCI_DCP",
-                            "id": "00803"
-                          },
-                          {
-                            "dataSource": "NCI_DTP",
-                            "id": "NSC0256857"
-                          },
-                          {
-                            "dataSource": "NCI_FDA",
-                            "id": "WK2XYI10QM"
-                          },
-                          {
-                            "dataSource": "NCI_NCI-GLOSS",
-                            "id": "CDR0000613511"
-                          },
-                          {
-                            "dataSource": "NDDF",
-                            "id": "002377"
-                          },
-                          {
-                            "dataSource": "PDQ",
-                            "id": "CDR0000040475"
-                          },
-                          {
-                            "dataSource": "RCD",
-                            "id": "x02MO"
-                          },
-                          {
-                            "dataSource": "RXNORM",
-                            "id": "5640"
-                          },
-                          {
-                            "dataSource": "SNM",
-                            "id": "E-7772"
-                          },
-                          {
-                            "dataSource": "SNMI",
-                            "id": "C-603C0"
-                          },
-                          {
-                            "dataSource": "SNOMEDCT_US",
-                            "id": "387207008"
-                          },
-                          {
-                            "dataSource": "USP",
-                            "id": "m39860"
-                          },
-                          {
-                            "dataSource": "USPMG",
-                            "id": "MTHU000060"
-                          },
-                          {
-                            "dataSource": "VANDF",
-                            "id": "4017840"
-                          }
-                        ]
-                      },
-                      {
-                        "offset": 34,
-                        "length": 11,
-                        "text": "twice daily",
-                        "category": "Frequency",
-                        "confidenceScore": 1.0
-                      }
-                    ],
-                    "relations": [
-                      {
-                        "relationType": "DosageOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/0",
-                            "role": "Dosage"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          }
-                        ]
-                      },
-                      {
-                        "relationType": "FrequencyOfMedication",
-                        "entities": [
-                          {
-                            "ref": "#/results/documents/1/entities/1",
-                            "role": "Medication"
-                          },
-                          {
-                            "ref": "#/results/documents/1/entities/2",
-                            "role": "Frequency"
-                          }
-                        ]
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-03-01"
-              }
-            },
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "******* does not suffer from high blood pressure.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
               }
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:07.7614012Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.1734666Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2409,7 +719,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -2425,25 +735,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9be4562d-8d07-4146-be94-f6fd3483b175",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "49dec2d9-4e0a-4449-8e9b-ccb1703adbf5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "548dc0ef-4413-4309-9bf5-ecb97af4043e",
-        "Content-Length": "6372",
+        "apim-request-id": "0988c2d9-006f-4514-813f-c9c2a8bff87b",
+        "Content-Length": "6370",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "125"
+        "x-envoy-upstream-service-time": "167",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:07Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:34Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -2454,7 +765,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.0378454Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2847,7 +1158,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.89019Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2900,7 +1211,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:34.0053631Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2940,7 +1251,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:07.7614012Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.1734666Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3004,7 +1315,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -3020,25 +1331,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "290112fe-73cc-43fd-8c01-6e1e780b3723",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "b1ab7549-559c-4329-98c6-a50ea7cbc34e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c8858d31-c589-40f5-a6b5-a0a727d5b14d",
-        "Content-Length": "6372",
+        "apim-request-id": "33ac9393-e067-46c6-8cce-92a4709db842",
+        "Content-Length": "6370",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "169"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:07Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:34Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -3049,7 +1361,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.0378454Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3442,7 +1754,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.89019Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3495,7 +1807,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:34.0053631Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3535,7 +1847,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:07.7614012Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.1734666Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3599,7 +1911,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/44b184ea-207b-4dbd-b49d-a672b3857d00?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -3615,25 +1927,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b66ee8bd-10d3-4eea-9766-397e768650ed",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "c6299a08-aca7-45be-b112-778a4ec6799d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3927ae14-87c7-4982-89c0-bf83d857e2e7",
-        "Content-Length": "6372",
+        "apim-request-id": "8b5d6cbb-c74e-46b1-9b4b-2a3ec6428f30",
+        "Content-Length": "6370",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "106"
+        "x-envoy-upstream-service-time": "121",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "44b184ea-207b-4dbd-b49d-a672b3857d00",
-        "lastUpdatedDateTime": "2022-10-15T02:28:07Z",
-        "createdDateTime": "2022-10-15T02:27:59Z",
-        "expirationDateTime": "2022-10-16T02:27:59Z",
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:34Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -3644,7 +1957,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.4950557Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.0378454Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -4037,7 +2350,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5174791Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.89019Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -4090,7 +2403,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:01.5273709Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:34.0053631Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -4130,7 +2443,603 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:07.7614012Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.1734666Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.46,
+                      "neutral": 0.5,
+                      "negative": 0.05
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.46,
+                          "neutral": 0.5,
+                          "negative": 0.05
+                        },
+                        "offset": 0,
+                        "length": 49,
+                        "text": "Patient does not suffer from high blood pressure.",
+                        "targets": [],
+                        "assessments": []
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 46,
+                        "text": "Prescribed 100mg ibuprofen, taken twice daily.",
+                        "targets": [],
+                        "assessments": []
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0b95b160-a55f-40d1-9463-0be3ede75ce8?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "548ab8b6-73c5-496e-ad04-e9990ee075c7",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "41f93671-82f2-441c-a588-f56732734598",
+        "Content-Length": "6370",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "0b95b160-a55f-40d1-9463-0be3ede75ce8",
+        "lastUpdatedDateTime": "2022-10-24T05:19:34Z",
+        "createdDateTime": "2022-10-24T05:19:31Z",
+        "expirationDateTime": "2022-10-25T05:19:31Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 4,
+          "items": [
+            {
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.0378454Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 29,
+                        "length": 19,
+                        "text": "high blood pressure",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 1.0,
+                        "assertion": {
+                          "certainty": "negative"
+                        },
+                        "name": "Hypertensive disease",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020538"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000023317"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00001"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017493"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.1"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000015800"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "397"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "0571-5243"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "HYPERTENS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002034"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0000822"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I10-I15.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I10-I15.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I10"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "997.91"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU035456"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K85004"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002317"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85063723"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA14293-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10020772"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "33288"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "34"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D006973"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "005"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "997.91"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "00905"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_CPTAC",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E13785"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1908"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000458091"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "060808"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU002068"
+                          },
+                          {
+                            "dataSource": "PCDS",
+                            "id": "PRB_11000.06"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000686951"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "23830"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "XE0Ub"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-70700"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-02000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "38341003"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0210"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "offset": 11,
+                        "length": 5,
+                        "text": "100mg",
+                        "category": "Dosage",
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "offset": 17,
+                        "length": 9,
+                        "text": "ibuprofen",
+                        "category": "MedicationName",
+                        "confidenceScore": 1.0,
+                        "name": "ibuprofen",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020740"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019879"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "M01AE01"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0046165"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006519"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2270-2077"
+                          },
+                          {
+                            "dataSource": "DRUGBANK",
+                            "id": "DB01050"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "1611"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh97005926"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP16165-0"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40458"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00015"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007052"
+                          },
+                          {
+                            "dataSource": "MTHSPL",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_DCP",
+                            "id": "00803"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0256857"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000613511"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "002377"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000040475"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x02MO"
+                          },
+                          {
+                            "dataSource": "RXNORM",
+                            "id": "5640"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7772"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-603C0"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "387207008"
+                          },
+                          {
+                            "dataSource": "USP",
+                            "id": "m39860"
+                          },
+                          {
+                            "dataSource": "USPMG",
+                            "id": "MTHU000060"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4017840"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 34,
+                        "length": 11,
+                        "text": "twice daily",
+                        "category": "Frequency",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "relations": [
+                      {
+                        "relationType": "DosageOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/1/entities/0",
+                            "role": "Dosage"
+                          },
+                          {
+                            "ref": "#/results/documents/1/entities/1",
+                            "role": "Medication"
+                          }
+                        ]
+                      },
+                      {
+                        "relationType": "FrequencyOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/1/entities/1",
+                            "role": "Medication"
+                          },
+                          {
+                            "ref": "#/results/documents/1/entities/2",
+                            "role": "Frequency"
+                          }
+                        ]
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
+            },
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.89019Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Patient",
+                        "category": "PersonType",
+                        "offset": 0,
+                        "length": 7,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "100mg",
+                        "category": "Quantity",
+                        "subcategory": "Dimension",
+                        "offset": 11,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "ibuprofen",
+                        "category": "Product",
+                        "offset": 17,
+                        "length": 9,
+                        "confidenceScore": 0.89
+                      },
+                      {
+                        "text": "daily",
+                        "category": "DateTime",
+                        "subcategory": "Set",
+                        "offset": 40,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:34.0053631Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "******* does not suffer from high blood pressure.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Patient",
+                        "category": "PersonType",
+                        "offset": 0,
+                        "length": 7,
+                        "confidenceScore": 0.94
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "daily",
+                        "category": "DateTime",
+                        "subcategory": "Set",
+                        "offset": 40,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "SentimentAnalysisLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:33.1734666Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "dbfcea4d-2a30-4665-a003-84dc55173d72",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "67d08b7c-99bc-40d8-a89d-92130addeb57",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c7bc3afc-3db6-4628-b970-b6225b507a51",
+        "apim-request-id": "59afe722-c0d3-4e3c-bb75-323630d6c0a2",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:47 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:37 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/cac235b5-74a0-40d9-8993-80f25e36e835?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "165"
+        "x-envoy-upstream-service-time": "216",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cac235b5-74a0-40d9-8993-80f25e36e835?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,221 +87,39 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5c45b521-1595-48f5-a5fb-65eb0378f019",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4e6b9a77-d016-4128-9c82-ef4eeb2be12d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7da05071-06e6-4a9d-8784-bbe1516f24a1",
-        "Content-Length": "283",
+        "apim-request-id": "bf72f6d5-3b54-4c1a-8071-e9ff19f17999",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8df51c70-495a-43a9-afc4-c73a5f635b98",
-        "lastUpdatedDateTime": "2022-10-15T02:26:48Z",
-        "createdDateTime": "2022-10-15T02:26:48Z",
-        "expirationDateTime": "2022-10-16T02:26:48Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "beb46428-4303-4d9d-94ce-5fc16b1de34c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b34c0771-dc30-4118-9640-d889a0d73279",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:47 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "8df51c70-495a-43a9-afc4-c73a5f635b98",
-        "lastUpdatedDateTime": "2022-10-15T02:26:48Z",
-        "createdDateTime": "2022-10-15T02:26:48Z",
-        "expirationDateTime": "2022-10-16T02:26:48Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "18b571dd-9cc9-438c-b4c6-8be6a0bde0ad",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3a3e0e4d-1588-48dc-9bb9-3ee7cad92b4a",
-        "Content-Length": "1948",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:50 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "98"
-      },
-      "ResponseBody": {
-        "jobId": "8df51c70-495a-43a9-afc4-c73a5f635b98",
-        "lastUpdatedDateTime": "2022-10-15T02:26:50Z",
-        "createdDateTime": "2022-10-15T02:26:48Z",
-        "expirationDateTime": "2022-10-16T02:26:48Z",
+        "jobId": "cac235b5-74a0-40d9-8993-80f25e36e835",
+        "lastUpdatedDateTime": "2022-10-24T05:18:37Z",
+        "createdDateTime": "2022-10-24T05:18:37Z",
+        "expirationDateTime": "2022-10-25T05:18:37Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 2,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.7938866Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "3",
-                    "entities": [
-                      {
-                        "text": "restaurant",
-                        "category": "Location",
-                        "subcategory": "Structural",
-                        "offset": 4,
-                        "length": 10,
-                        "confidenceScore": 0.97
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.844536Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "The restaurant had really good food. I recommend you try it.",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cac235b5-74a0-40d9-8993-80f25e36e835?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -316,25 +135,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6aca7603-95ac-479e-aca8-c900739cc169",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "75bbd1a7-cd71-4ca6-a8c9-5e90df9585b9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6e2ed881-db96-4eb3-b0e7-f753cef10397",
-        "Content-Length": "2953",
+        "apim-request-id": "11a0f3e5-ef88-4d73-80ee-1cae5b2f0de8",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "125"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8df51c70-495a-43a9-afc4-c73a5f635b98",
-        "lastUpdatedDateTime": "2022-10-15T02:26:50Z",
-        "createdDateTime": "2022-10-15T02:26:48Z",
-        "expirationDateTime": "2022-10-16T02:26:48Z",
+        "jobId": "cac235b5-74a0-40d9-8993-80f25e36e835",
+        "lastUpdatedDateTime": "2022-10-24T05:18:37Z",
+        "createdDateTime": "2022-10-24T05:18:37Z",
+        "expirationDateTime": "2022-10-25T05:18:37Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cac235b5-74a0-40d9-8993-80f25e36e835?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "c6655470-45d9-4410-8c10-b1ab3a2d4944",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b84b4f0b-10d7-49f2-918d-89c353aa773f",
+        "Content-Length": "2954",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:18:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cac235b5-74a0-40d9-8993-80f25e36e835",
+        "lastUpdatedDateTime": "2022-10-24T05:18:39Z",
+        "createdDateTime": "2022-10-24T05:18:37Z",
+        "expirationDateTime": "2022-10-25T05:18:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -345,7 +213,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.7938866Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:38.8969411Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -393,7 +261,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.844536Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:38.8716997Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -433,7 +301,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.9402288Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:39.0789384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -478,7 +346,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8df51c70-495a-43a9-afc4-c73a5f635b98?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cac235b5-74a0-40d9-8993-80f25e36e835?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -494,25 +362,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "25ee8c9b-11a5-4422-966c-29b5a755fa1f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "dad064ae-dd12-4de7-a8ae-bc7e27c0c0b3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "818eb97b-3342-4551-b218-3749c3d4ad15",
-        "Content-Length": "2953",
+        "apim-request-id": "1d28280e-b84b-4ae8-ac08-8239f4554463",
+        "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "160"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8df51c70-495a-43a9-afc4-c73a5f635b98",
-        "lastUpdatedDateTime": "2022-10-15T02:26:50Z",
-        "createdDateTime": "2022-10-15T02:26:48Z",
-        "expirationDateTime": "2022-10-16T02:26:48Z",
+        "jobId": "cac235b5-74a0-40d9-8993-80f25e36e835",
+        "lastUpdatedDateTime": "2022-10-24T05:18:39Z",
+        "createdDateTime": "2022-10-24T05:18:37Z",
+        "expirationDateTime": "2022-10-25T05:18:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -523,7 +392,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.7938866Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:38.8969411Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -571,7 +440,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.844536Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:38.8716997Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -611,7 +480,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:26:50.9402288Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:39.0789384Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "54816854-7d08-48cd-a89b-450559a30be9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1acaded5-2465-4512-9881-ce2e36f7ff12",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -69,18 +69,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5d50576d-a8c8-4540-9141-3821e313e14c",
+        "apim-request-id": "bd00d1c9-1696-40ba-888f-5f0ad4cc187e",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:14 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5cb3a6f1-9f0e-46f5-a594-fa156153ad56?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:57 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "201"
+        "x-envoy-upstream-service-time": "189",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5cb3a6f1-9f0e-46f5-a594-fa156153ad56?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -96,25 +97,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "c2cdbae6-f2b4-469b-846c-8fcb3f0a6d9d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4fd1b96f-af6a-4f59-8fbb-b0097d0f0da1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3b4ff0d-ff78-4e32-a252-15512cdb8253",
+        "apim-request-id": "6d22c35c-e6e7-4923-bdfc-72eeb0a1e59c",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5cb3a6f1-9f0e-46f5-a594-fa156153ad56",
-        "lastUpdatedDateTime": "2022-10-15T02:27:14Z",
-        "createdDateTime": "2022-10-15T02:27:14Z",
-        "expirationDateTime": "2022-10-16T02:27:14Z",
+        "jobId": "66a2b482-d4b4-4be5-b98c-7fb47f4afee6",
+        "lastUpdatedDateTime": "2022-10-24T05:18:57Z",
+        "createdDateTime": "2022-10-24T05:18:57Z",
+        "expirationDateTime": "2022-10-25T05:18:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -127,7 +129,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5cb3a6f1-9f0e-46f5-a594-fa156153ad56?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -143,25 +145,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7b11c680-b567-4bfc-b803-c9a6fd4cf74f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "917831ed-0595-41e5-bfa9-e85cfac5e06d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b691edbb-6933-4950-974f-d5182561d538",
+        "apim-request-id": "2186a669-b6cb-4312-b94d-0933c2a47163",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5cb3a6f1-9f0e-46f5-a594-fa156153ad56",
-        "lastUpdatedDateTime": "2022-10-15T02:27:14Z",
-        "createdDateTime": "2022-10-15T02:27:14Z",
-        "expirationDateTime": "2022-10-16T02:27:14Z",
+        "jobId": "66a2b482-d4b4-4be5-b98c-7fb47f4afee6",
+        "lastUpdatedDateTime": "2022-10-24T05:18:57Z",
+        "createdDateTime": "2022-10-24T05:18:57Z",
+        "expirationDateTime": "2022-10-25T05:18:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -174,7 +177,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5cb3a6f1-9f0e-46f5-a594-fa156153ad56?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -190,36 +193,37 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "5219e349-9461-4de5-a783-f72183f7d00f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "08b61fbd-8306-4cce-92f1-c652c94ffc69",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5b3b9605-0b2e-4d46-b8aa-addce1383ddb",
-        "Content-Length": "2870",
+        "apim-request-id": "7906b979-cf85-4b00-8fba-f4e81c1d64ee",
+        "Content-Length": "1953",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "291"
+        "x-envoy-upstream-service-time": "111",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5cb3a6f1-9f0e-46f5-a594-fa156153ad56",
-        "lastUpdatedDateTime": "2022-10-15T02:27:16Z",
-        "createdDateTime": "2022-10-15T02:27:14Z",
-        "expirationDateTime": "2022-10-16T02:27:14Z",
-        "status": "succeeded",
+        "jobId": "66a2b482-d4b4-4be5-b98c-7fb47f4afee6",
+        "lastUpdatedDateTime": "2022-10-24T05:18:59Z",
+        "createdDateTime": "2022-10-24T05:18:57Z",
+        "expirationDateTime": "2022-10-25T05:18:57Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.4408848Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.9215066Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -283,77 +287,8 @@
               }
             },
             {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.5192348Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "redactedText": ":)",
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":(",
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":P",
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":D",
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.6124252Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.4651572Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -421,7 +356,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5cb3a6f1-9f0e-46f5-a594-fa156153ad56?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -437,25 +372,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "528e9925-3500-40fc-883a-f8d196dcc021",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "58a3c72f-6832-4f65-8053-c8c0e2c5bfd3",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "872831a8-b471-4f8f-89db-4050e6f39d3d",
+        "apim-request-id": "3a49bf66-ea12-4588-bda1-b5df2d8d1295",
         "Content-Length": "2870",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "162"
+        "x-envoy-upstream-service-time": "236",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5cb3a6f1-9f0e-46f5-a594-fa156153ad56",
-        "lastUpdatedDateTime": "2022-10-15T02:27:16Z",
-        "createdDateTime": "2022-10-15T02:27:14Z",
-        "expirationDateTime": "2022-10-16T02:27:14Z",
+        "jobId": "66a2b482-d4b4-4be5-b98c-7fb47f4afee6",
+        "lastUpdatedDateTime": "2022-10-24T05:19:00Z",
+        "createdDateTime": "2022-10-24T05:18:57Z",
+        "expirationDateTime": "2022-10-25T05:18:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -466,7 +402,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.4408848Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.9215066Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -531,7 +467,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.5192348Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:00.0467951Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -600,7 +536,255 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:16.6124252Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.4651572Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66a2b482-d4b4-4be5-b98c-7fb47f4afee6?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "a6fb0819-e8b6-455c-87a8-99cc85b75f70",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ea331cc-c702-4681-9662-32926cb7e578",
+        "Content-Length": "2870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "66a2b482-d4b4-4be5-b98c-7fb47f4afee6",
+        "lastUpdatedDateTime": "2022-10-24T05:19:00Z",
+        "createdDateTime": "2022-10-24T05:18:57Z",
+        "expirationDateTime": "2022-10-25T05:18:57Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.9215066Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:00.0467951Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:18:59.4651572Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7c9ac470-6876-49da-ade9-d24b687ca570",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "048d8166-2266-4648-a76b-b8ce7b3302b8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -47,18 +47,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4ea3df23-d979-4cbf-a855-2160c9cbe6be",
+        "apim-request-id": "b4666416-796f-47de-99e1-23c749eb32e5",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:26:45 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/a8245b23-bb31-4529-93b0-c9a3b7307db6?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:18:34 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/35afc6af-27fc-4504-b7a4-62badc7763cb?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "89"
+        "x-envoy-upstream-service-time": "109",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a8245b23-bb31-4529-93b0-c9a3b7307db6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/35afc6af-27fc-4504-b7a4-62badc7763cb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -74,25 +75,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "713d7f48-8c3e-4d84-b346-9d00bdf1417e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "cb77af59-2585-4ff8-86ac-04e76b44bf80",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d9b9ee7c-a2c1-464b-90fd-510239650b05",
+        "apim-request-id": "96d91519-9dc0-4de3-8797-91ea2d55bb1b",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a8245b23-bb31-4529-93b0-c9a3b7307db6",
-        "lastUpdatedDateTime": "2022-10-15T02:26:46Z",
-        "createdDateTime": "2022-10-15T02:26:46Z",
-        "expirationDateTime": "2022-10-16T02:26:46Z",
+        "jobId": "35afc6af-27fc-4504-b7a4-62badc7763cb",
+        "lastUpdatedDateTime": "2022-10-24T05:18:34Z",
+        "createdDateTime": "2022-10-24T05:18:34Z",
+        "expirationDateTime": "2022-10-25T05:18:34Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -105,7 +107,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a8245b23-bb31-4529-93b0-c9a3b7307db6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/35afc6af-27fc-4504-b7a4-62badc7763cb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -121,25 +123,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "68b99e4c-7d9b-4033-800c-d5c9c5bd253c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1222721d-5388-484d-8e1c-9ab3f721cee9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9e59fea-b289-4f28-bc88-de579e79d650",
+        "apim-request-id": "1090f347-7960-4708-9ca6-d79e91d98f01",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a8245b23-bb31-4529-93b0-c9a3b7307db6",
-        "lastUpdatedDateTime": "2022-10-15T02:26:46Z",
-        "createdDateTime": "2022-10-15T02:26:46Z",
-        "expirationDateTime": "2022-10-16T02:26:46Z",
+        "jobId": "35afc6af-27fc-4504-b7a4-62badc7763cb",
+        "lastUpdatedDateTime": "2022-10-24T05:18:34Z",
+        "createdDateTime": "2022-10-24T05:18:34Z",
+        "expirationDateTime": "2022-10-25T05:18:34Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -152,7 +155,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a8245b23-bb31-4529-93b0-c9a3b7307db6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/35afc6af-27fc-4504-b7a4-62badc7763cb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -168,25 +171,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e0dc7e95-366a-4be1-9af5-90f54068adef",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "ba5e9ccd-b36d-43fd-af22-e7b0fc208239",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "980bd55d-a787-4b4d-9002-b8659114c06f",
-        "Content-Length": "843",
+        "apim-request-id": "1b247083-262c-4ccb-8df2-fc7de64cb6a2",
+        "Content-Length": "842",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "61"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a8245b23-bb31-4529-93b0-c9a3b7307db6",
-        "lastUpdatedDateTime": "2022-10-15T02:26:48Z",
-        "createdDateTime": "2022-10-15T02:26:46Z",
-        "expirationDateTime": "2022-10-16T02:26:46Z",
+        "jobId": "35afc6af-27fc-4504-b7a4-62badc7763cb",
+        "lastUpdatedDateTime": "2022-10-24T05:18:36Z",
+        "createdDateTime": "2022-10-24T05:18:34Z",
+        "expirationDateTime": "2022-10-25T05:18:34Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -198,7 +202,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:26:48.0258191Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:36.5577682Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -216,7 +220,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:26:48.0727103Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:36.738703Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -236,7 +240,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a8245b23-bb31-4529-93b0-c9a3b7307db6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/35afc6af-27fc-4504-b7a4-62badc7763cb?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -252,25 +256,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a839cb73-6a77-45f2-8fa5-8c0e3b1ea66b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "1dde15f6-152b-405b-917d-c1f691493f84",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "06f3ef7d-3dfa-452e-a298-b74d8db3c055",
-        "Content-Length": "843",
+        "apim-request-id": "b7be9ab3-b8f9-4088-b2f2-c46d343fb7cd",
+        "Content-Length": "842",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:26:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:18:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a8245b23-bb31-4529-93b0-c9a3b7307db6",
-        "lastUpdatedDateTime": "2022-10-15T02:26:48Z",
-        "createdDateTime": "2022-10-15T02:26:46Z",
-        "expirationDateTime": "2022-10-16T02:26:46Z",
+        "jobId": "35afc6af-27fc-4504-b7a4-62badc7763cb",
+        "lastUpdatedDateTime": "2022-10-24T05:18:36Z",
+        "createdDateTime": "2022-10-24T05:18:34Z",
+        "expirationDateTime": "2022-10-25T05:18:34Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -282,7 +287,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:26:48.0258191Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:36.5577682Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -300,7 +305,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:26:48.0727103Z",
+              "lastUpdateDateTime": "2022-10-24T05:18:36.738703Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "f5c20e52-66c0-457b-807d-7af97bdab338",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d30736be-fdce-4941-a27e-ec28ed250da4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -56,18 +56,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0ad9c389-9a8e-473a-a051-e366714a1f8d",
+        "apim-request-id": "245b3fe5-2e5b-4410-90dd-89b25fac0797",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:41 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:10 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/267da64b-9652-4a3f-9311-5d22a781045e?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "176"
+        "x-envoy-upstream-service-time": "176",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/267da64b-9652-4a3f-9311-5d22a781045e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -83,166 +84,39 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cf4e3c8c-1885-4fc0-9ffd-433614c1dcf0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5e671c26-1b0e-4536-a55f-0bb15015d1a9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff410e85-051b-4963-923c-3fb885d552e9",
-        "Content-Length": "283",
+        "apim-request-id": "d9d8b85b-71c7-4204-acb2-47eed6d219fc",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e71ad7a7-e93b-4e53-ba63-a8fa0cae1999",
-        "lastUpdatedDateTime": "2022-10-15T02:27:42Z",
-        "createdDateTime": "2022-10-15T02:27:42Z",
-        "expirationDateTime": "2022-10-16T02:27:42Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "936bfd06-e193-482c-80f3-d35f420b7207",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7d259475-aae5-45df-aa4b-f5fb665c076c",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "e71ad7a7-e93b-4e53-ba63-a8fa0cae1999",
-        "lastUpdatedDateTime": "2022-10-15T02:27:42Z",
-        "createdDateTime": "2022-10-15T02:27:42Z",
-        "expirationDateTime": "2022-10-16T02:27:42Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "0f3bb351-8b38-4a00-8e3c-a103002d2b49",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e2fbf29c-adc6-438b-b144-b17de055977b",
-        "Content-Length": "620",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:44 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
-      },
-      "ResponseBody": {
-        "jobId": "e71ad7a7-e93b-4e53-ba63-a8fa0cae1999",
-        "lastUpdatedDateTime": "2022-10-15T02:27:44Z",
-        "createdDateTime": "2022-10-15T02:27:42Z",
-        "expirationDateTime": "2022-10-16T02:27:42Z",
+        "jobId": "267da64b-9652-4a3f-9311-5d22a781045e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:11Z",
+        "createdDateTime": "2022-10-24T05:19:10Z",
+        "expirationDateTime": "2022-10-25T05:19:10Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.3630075Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "park"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "Espa\u00F1ol",
-                      "document"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [
-                      "\u306F\u5E78\u305B"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/267da64b-9652-4a3f-9311-5d22a781045e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -258,25 +132,74 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a47038c9-d8ee-4ca4-a76b-79c03bb55033",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8aa3f9a1-70ed-4670-a03e-86734689a468",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bd964a04-3ebc-428b-9cfd-f0542568df97",
-        "Content-Length": "1510",
+        "apim-request-id": "154de9e9-a21e-43f7-b3b2-aa0c663f7e23",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "150"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e71ad7a7-e93b-4e53-ba63-a8fa0cae1999",
-        "lastUpdatedDateTime": "2022-10-15T02:27:44Z",
-        "createdDateTime": "2022-10-15T02:27:42Z",
-        "expirationDateTime": "2022-10-16T02:27:42Z",
+        "jobId": "267da64b-9652-4a3f-9311-5d22a781045e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:11Z",
+        "createdDateTime": "2022-10-24T05:19:10Z",
+        "expirationDateTime": "2022-10-25T05:19:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/267da64b-9652-4a3f-9311-5d22a781045e?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "25fa93db-af07-4064-8cd9-ffe5304171a6",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "924b5c82-cd8b-4fe4-a41d-eafc8fff2237",
+        "Content-Length": "1510",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "173",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "267da64b-9652-4a3f-9311-5d22a781045e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:13Z",
+        "createdDateTime": "2022-10-24T05:19:10Z",
+        "expirationDateTime": "2022-10-25T05:19:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -287,7 +210,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.6403849Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:13.0852071Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -329,7 +252,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.5631587Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:13.1824541Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -358,7 +281,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.3630075Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:12.9685072Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -394,7 +317,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e71ad7a7-e93b-4e53-ba63-a8fa0cae1999?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/267da64b-9652-4a3f-9311-5d22a781045e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -410,25 +333,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "da5e1cb3-d246-441f-ae6c-cb6fd552492e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "333fd1de-99af-4cec-a52f-6c8e09534cfa",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a43c5f28-ca09-4b81-9ce1-4a2e6435f66c",
+        "apim-request-id": "8a27f227-fe6d-4f0e-ab4e-8dc70d654ff5",
         "Content-Length": "1510",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "164"
+        "x-envoy-upstream-service-time": "128",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e71ad7a7-e93b-4e53-ba63-a8fa0cae1999",
-        "lastUpdatedDateTime": "2022-10-15T02:27:44Z",
-        "createdDateTime": "2022-10-15T02:27:42Z",
-        "expirationDateTime": "2022-10-16T02:27:42Z",
+        "jobId": "267da64b-9652-4a3f-9311-5d22a781045e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:13Z",
+        "createdDateTime": "2022-10-24T05:19:10Z",
+        "expirationDateTime": "2022-10-25T05:19:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -439,7 +363,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.6403849Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:13.0852071Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -481,7 +405,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.5631587Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:13.1824541Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -510,7 +434,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:44.3630075Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:12.9685072Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9126f65e-e000-4128-8e34-48fa88e855cf",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2d31080b-3190-4d1c-a293-03b8009d0db5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2cf0334a-4e0f-4286-8144-6f7923f28d18",
+        "apim-request-id": "810c14e3-ca1e-4e63-8da1-0e54528ea134",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:17 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:02 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "150"
+        "x-envoy-upstream-service-time": "244",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ead8abc4-993c-4acf-89ea-9e33c1d51130",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "996e5dd8-ec8f-4f46-b857-29aa5f25195f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9c2ad52a-7b58-4806-89d8-c2814404dd07",
+        "apim-request-id": "dc4d3920-7cd3-4cf0-a55c-f148426c10bb",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:17Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
+        "jobId": "bd706844-6938-4b8f-8795-5df81ca04465",
+        "lastUpdatedDateTime": "2022-10-24T05:19:03Z",
+        "createdDateTime": "2022-10-24T05:19:02Z",
+        "expirationDateTime": "2022-10-25T05:19:02Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,25 +135,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b587a10a-48b7-4df1-a717-2b62ed5a2832",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "4d3d3fd7-81c7-4fef-bc27-0c780cad33f1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1734b2cb-6abb-4239-9d3a-b1ce5271a7a6",
+        "apim-request-id": "9f670a5c-f296-402d-88d6-f85c390315c3",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:17Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
+        "jobId": "bd706844-6938-4b8f-8795-5df81ca04465",
+        "lastUpdatedDateTime": "2022-10-24T05:19:03Z",
+        "createdDateTime": "2022-10-24T05:19:02Z",
+        "expirationDateTime": "2022-10-25T05:19:02Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,25 +183,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b9669f37-5cef-4863-a012-687df8699b7b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d936aa3e-c7f6-46b4-b818-cf103e107f2c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48ecd1c7-866a-417a-a257-d70160c7d0a6",
-        "Content-Length": "1105",
+        "apim-request-id": "e0462c11-3e3c-4352-acfe-0b911ea51ae2",
+        "Content-Length": "1113",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101"
+        "x-envoy-upstream-service-time": "131",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
+        "jobId": "bd706844-6938-4b8f-8795-5df81ca04465",
+        "lastUpdatedDateTime": "2022-10-24T05:19:05Z",
+        "createdDateTime": "2022-10-24T05:19:02Z",
+        "expirationDateTime": "2022-10-25T05:19:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -208,37 +212,51 @@
           "total": 3,
           "items": [
             {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:19:04.9428279Z",
               "status": "succeeded",
               "results": {
                 "documents": [
                   {
-                    "redactedText": "This was the best day of my life.",
                     "id": "0",
                     "entities": [],
                     "warnings": []
                   },
                   {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
                     "id": "1",
-                    "entities": [],
+                    "entities": [
+                      {
+                        "text": "hotel",
+                        "category": "Location",
+                        "offset": 19,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
                     "warnings": []
                   },
                   {
-                    "redactedText": "The restaurant was not as good as I hoped.",
                     "id": "2",
-                    "entities": [],
+                    "entities": [
+                      {
+                        "text": "restaurant",
+                        "category": "Location",
+                        "subcategory": "Structural",
+                        "offset": 4,
+                        "length": 10,
+                        "confidenceScore": 0.96
+                      }
+                    ],
                     "warnings": []
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-01-15"
+                "modelVersion": "2021-06-01"
               }
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:05.1972627Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -274,7 +292,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -290,575 +308,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "372483e1-c62c-40d3-8f02-80904b38abaa",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "66f089e8-2cd2-4183-86f2-409613d6a559",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b4b12a3-ef76-4850-b27c-07bc97e573da",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
-      },
-      "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "475bb519-6cec-435a-86bb-107bf72a70e9",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "405b439e-dd26-47a9-abc4-81500dbd7304",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
-      },
-      "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7990ecce-fda3-4b6b-b395-ada22f8b3c92",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b6ccd1b9-9c9b-4c5e-81b0-45dff9eb89fd",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "89"
-      },
-      "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4d62158a-a076-4368-8760-e133b6ffca54",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "824b677c-758a-4bc8-bd96-d5093787a30e",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:28 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
-      },
-      "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "edd3b66a-484d-4387-b6a8-400d4a2c3095",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d0003b0f-cf1d-4b7c-8b0a-9742673225ca",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:29 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99"
-      },
-      "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:19Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "12450556-4b81-4830-8e81-c75ec66ffaaa",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "077868f7-7a2d-43b6-8fd0-1f415f87bf89",
+        "apim-request-id": "d3902a16-c460-4a1d-b308-fcacf7ff7ced",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "130"
+        "x-envoy-upstream-service-time": "164",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:32Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
+        "jobId": "bd706844-6938-4b8f-8795-5df81ca04465",
+        "lastUpdatedDateTime": "2022-10-24T05:19:05Z",
+        "createdDateTime": "2022-10-24T05:19:02Z",
+        "expirationDateTime": "2022-10-25T05:19:02Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -869,7 +338,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:32.0916086Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:04.9428279Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -912,7 +381,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:05.8145433Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -941,7 +410,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:05.1972627Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -977,7 +446,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/35355ac7-e64f-4be0-ac5b-5789d5f88930?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/bd706844-6938-4b8f-8795-5df81ca04465?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -993,25 +462,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "16374bc5-86ab-4013-a2e9-7500f6bbe6c2",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5a193336-72e1-4d2b-a2d2-690c55c83ea0",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "663ec00d-1cba-4604-9e41-def529b46bc6",
+        "apim-request-id": "4c3434d1-b2be-4317-918b-37a4af5122ef",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "121",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "35355ac7-e64f-4be0-ac5b-5789d5f88930",
-        "lastUpdatedDateTime": "2022-10-15T02:27:32Z",
-        "createdDateTime": "2022-10-15T02:27:17Z",
-        "expirationDateTime": "2022-10-16T02:27:17Z",
+        "jobId": "bd706844-6938-4b8f-8795-5df81ca04465",
+        "lastUpdatedDateTime": "2022-10-24T05:19:05Z",
+        "createdDateTime": "2022-10-24T05:19:02Z",
+        "expirationDateTime": "2022-10-25T05:19:02Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1022,7 +492,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:32.0916086Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:04.9428279Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1065,7 +535,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.3896576Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:05.8145433Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1094,7 +564,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:19.4360617Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:05.1972627Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "32e5318f-1399-463c-81be-6dae3c377fb1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a37229a9-a58a-47d9-bf28-1ff1bab4ceed",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -59,18 +59,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a73e340e-0ce1-472f-977e-d214dca2fe87",
+        "apim-request-id": "b9d86675-b75f-4363-8625-aa238aee4bd2",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:27:32 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:07 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/0a9af275-8697-4c89-9385-7423e8a0599d?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "194"
+        "x-envoy-upstream-service-time": "158",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0a9af275-8697-4c89-9385-7423e8a0599d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -86,25 +87,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e2dc5181-fd35-4da4-a309-bc00e02b5fdc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "05d8fc73-f99d-47f2-a73d-c5b7d0580096",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e946758e-2ace-42dd-97c2-431f82b11565",
+        "apim-request-id": "e167f2a0-7aa7-4b66-8186-fcca1c2b939d",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:33Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
+        "jobId": "0a9af275-8697-4c89-9385-7423e8a0599d",
+        "lastUpdatedDateTime": "2022-10-24T05:19:08Z",
+        "createdDateTime": "2022-10-24T05:19:07Z",
+        "expirationDateTime": "2022-10-25T05:19:07Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -117,7 +119,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0a9af275-8697-4c89-9385-7423e8a0599d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -133,25 +135,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1a4f7251-7f9e-48c4-98c5-42543a9323d7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "76d84317-8f2e-46fa-9781-01c986783953",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "05208f5e-4bf7-498e-b3d0-342f23bd8949",
+        "apim-request-id": "beee6bd6-ec23-4fd8-b3cc-e9ac20e4587a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:33Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
+        "jobId": "0a9af275-8697-4c89-9385-7423e8a0599d",
+        "lastUpdatedDateTime": "2022-10-24T05:19:08Z",
+        "createdDateTime": "2022-10-24T05:19:07Z",
+        "expirationDateTime": "2022-10-25T05:19:07Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -164,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0a9af275-8697-4c89-9385-7423e8a0599d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -180,355 +183,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "19bce10c-1e6e-4cef-b90e-bfeb922b23a7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3b2f7ac7-4339-4569-9640-474c6d535b0e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6676b2ae-55aa-4486-8189-b61d412e562e",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "113"
-      },
-      "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:35Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:35.1817259Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:34.7759591Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cf7fcbf7-c912-434f-beda-397b10e2a2b7",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a91dbdb0-6bbe-48a8-ac7b-75e8d6d6b443",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "133"
-      },
-      "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:35Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:35.1817259Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:34.7759591Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d40d6b28-6ca6-4c6a-84fd-98e0403961f1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f57aa2c8-693d-4d05-a395-019d96aa13c9",
-        "Content-Length": "1105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
-      },
-      "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:35Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:35.1817259Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:34.7759591Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "best day",
-                      "life"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "hotel"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "restaurant"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b2260d75-2050-4688-9d5f-d737a7ba749b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "95073c2f-f37a-451b-987e-ab2c2a3844cb",
+        "apim-request-id": "5135c0c9-bae1-44b8-b392-4a2517491a9b",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "208"
+        "x-envoy-upstream-service-time": "147",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:40Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
+        "jobId": "0a9af275-8697-4c89-9385-7423e8a0599d",
+        "lastUpdatedDateTime": "2022-10-24T05:19:10Z",
+        "createdDateTime": "2022-10-24T05:19:07Z",
+        "expirationDateTime": "2022-10-25T05:19:07Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -539,7 +213,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:40.4376718Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:09.9828569Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -582,7 +256,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:35.1817259Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:10.0714901Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -611,7 +285,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:34.7759591Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:10.1626838Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -647,7 +321,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f3720ca2-784d-49c5-9cdc-012ae9a01975?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/0a9af275-8697-4c89-9385-7423e8a0599d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -663,25 +337,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e8950d0c-0f79-4132-992d-6fb38d35de4e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "0def7636-f544-48a9-bede-7ec17ea9fea9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a2be95a-0c8f-4eb3-8bc7-384e23982887",
+        "apim-request-id": "12487f7a-6d9b-42e1-acaa-db83082578dc",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:27:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "113"
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f3720ca2-784d-49c5-9cdc-012ae9a01975",
-        "lastUpdatedDateTime": "2022-10-15T02:27:40Z",
-        "createdDateTime": "2022-10-15T02:27:32Z",
-        "expirationDateTime": "2022-10-16T02:27:32Z",
+        "jobId": "0a9af275-8697-4c89-9385-7423e8a0599d",
+        "lastUpdatedDateTime": "2022-10-24T05:19:10Z",
+        "createdDateTime": "2022-10-24T05:19:07Z",
+        "expirationDateTime": "2022-10-25T05:19:07Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -692,7 +367,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:40.4376718Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:09.9828569Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -735,7 +410,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:35.1817259Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:10.0714901Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -764,7 +439,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:27:34.7759591Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:10.1626838Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "1b442d49-587a-4dea-aa88-e634acb8953f",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "239f4088-5fd8-4aa7-a8c5-022f3ddf38f9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -41,13 +41,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "e1343d8d-f047-4f92-a96c-d61fea983af1",
+        "apim-request-id": "91b878c0-284d-45cf-9fcc-f5f5b64c5772",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "3b4916ad-873a-493b-8086-4585c51643b0",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "31e42a84-91aa-4fb0-aa33-82b70e1fe84e",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -41,18 +41,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "22e95571-d04e-4d99-b94e-454d4e0e7602",
+        "apim-request-id": "d8e4d33d-1ce0-476b-be39-72ec5ac2fe4d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:37 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "x-envoy-upstream-service-time": "158",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -68,25 +69,122 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b9d2a27d-468d-4268-bc29-49235436d309",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "7457b871-410a-459c-af9f-6999f786c91a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "94c5224f-356a-4d33-bce3-3f15d12ca9bd",
-        "Content-Length": "280",
+        "apim-request-id": "917dea51-3c69-46ed-ab8d-b4952bbc68ea",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:10Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:37Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "0bebad45-1b93-490c-a65b-64ca41ff76ef",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "21c64c9c-5a8f-4f89-adc7-cbfdd00d521d",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:37Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US",
+        "Connection": "keep-alive",
+        "ocp-apim-subscription-key": "api_key",
+        "Referer": "http://localhost:9876/",
+        "sec-ch-ua": "",
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": "",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
+        "x-ms-client-request-id": "20d232bc-c7c1-417a-8b23-33354ae27249",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b536b319-e0a0-4780-becc-19ad88c02b64",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:19:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:38Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -99,7 +197,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -115,25 +213,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9b75626e-60b8-453f-a8bc-35ea9496e14c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "2a3d84ce-6992-46c8-b638-2986270438f9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "922397ff-fbb5-4632-a49e-bb3c971c144d",
+        "apim-request-id": "ccb4a659-8e7f-4f9e-a0c0-ee3fa42e0a0d",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:10Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:38Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -146,7 +245,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -162,119 +261,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "b8e89e57-a943-488b-9ece-0036e1623144",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a4a6b8ef-7852-4b84-8bdf-32d5037c3d5b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df2b834f-88b0-41d5-b69a-ed2f3aa4492f",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:10Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2bfacd3f-51f1-4667-8a74-04269f5546ba",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0d6e7417-dab6-4bec-a57b-a5192aa1f29f",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
-      },
-      "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:10Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Accept-Language": "en-US",
-        "Connection": "keep-alive",
-        "ocp-apim-subscription-key": "api_key",
-        "Referer": "http://localhost:9876/",
-        "sec-ch-ua": "",
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": "",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9a11a4b3-c08a-4d80-a3e3-702b289fa264",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "10b7beef-9eef-468b-a0bd-c18a0255cb30",
+        "apim-request-id": "8180618c-2093-4d5d-94f6-685337d29c5f",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:16Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:44Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -285,7 +291,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:16.4233784Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:44.0516138Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -310,7 +316,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/6bb11a6e-deda-49bd-8194-dda901ac7193?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1bde241a-6614-4334-a38a-d21df7b963d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -326,25 +332,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "cbefab5c-5532-43dd-836c-45758c671c35",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "925547e5-2e05-4d17-bbf0-c7bf65e54baa",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a637901e-7d35-487d-a756-ea43cb68929a",
+        "apim-request-id": "d9661150-0aa8-41f5-b796-4b00fdb43ae8",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "6bb11a6e-deda-49bd-8194-dda901ac7193",
-        "lastUpdatedDateTime": "2022-10-15T02:28:16Z",
-        "createdDateTime": "2022-10-15T02:28:10Z",
-        "expirationDateTime": "2022-10-16T02:28:10Z",
+        "jobId": "1bde241a-6614-4334-a38a-d21df7b963d0",
+        "lastUpdatedDateTime": "2022-10-24T05:19:44Z",
+        "createdDateTime": "2022-10-24T05:19:37Z",
+        "expirationDateTime": "2022-10-25T05:19:37Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -355,7 +362,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:16.4233784Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:44.0516138Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "59fce4e0-165f-4de2-8e1c-8949302c279b",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d7f78395-c274-40f3-b4bd-15a85e6db925",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -45,13 +45,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "e1a9eebd-f508-4154-93ad-a61ec90c3cfd",
+        "apim-request-id": "ad602ece-1c6b-415f-9eb3-78f90d4d1ec4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "57955f8c-faba-447c-a98f-1a00f9a4b85d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "6499d276-72c7-4164-8099-c10578a0655b",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,13 +43,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "0c74e2bd-027c-41b4-bc68-4e245b040318",
+        "apim-request-id": "5f8303b6-f0bd-42b9-a3ce-a9e4ef4e8ce7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "78444545-df3d-42c3-b420-4ae7dcf798c3",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "9a044b07-950c-4e81-b761-84a57d63eb7f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -2536,13 +2536,14 @@
       },
       "StatusCode": 413,
       "ResponseHeaders": {
-        "apim-request-id": "4f04da7c-0b10-4eb2-ac3d-d5f974b03ca7",
+        "apim-request-id": "41d59541-f924-4d1d-8d8a-3165bc8d5d51",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "376f367a-e39c-4b5b-bb04-655f519046b4",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "5e4892a0-988a-4a7f-bc27-aaf153b79df8",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -166,13 +166,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "95a6f466-f648-4232-9566-b885bec0b105",
+        "apim-request-id": "d8b27937-00bc-4196-828d-6468ef7408cb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "38a7e674-f4ff-40db-9c87-075f38ccde3e",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "d1cf4a58-9c98-4bfe-8f78-12386504ef8a",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6ce3460c-a678-4b64-8d4e-23e7f1ea4901",
+        "apim-request-id": "f8ec3d9a-ac05-4832-ae7c-f1adc2e45cad",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:16 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/3a17f883-3f22-40ff-aeff-d33b7d357a7e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:44 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/caac23eb-7f91-45de-97e7-244405f5cb35?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-envoy-upstream-service-time": "67",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3a17f883-3f22-40ff-aeff-d33b7d357a7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/caac23eb-7f91-45de-97e7-244405f5cb35?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,25 +71,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "88807065-dee3-4e79-b611-1e88ac8b3d6c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "58f5b337-0c29-4ffa-9eec-e396f0bce017",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c09e6df7-dabe-458c-856d-a63c1a3bc8ab",
+        "apim-request-id": "a48de19c-3b91-4cae-99a1-027f9390caf1",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3a17f883-3f22-40ff-aeff-d33b7d357a7e",
-        "lastUpdatedDateTime": "2022-10-15T02:28:16Z",
-        "createdDateTime": "2022-10-15T02:28:16Z",
-        "expirationDateTime": "2022-10-16T02:28:16Z",
+        "jobId": "caac23eb-7f91-45de-97e7-244405f5cb35",
+        "lastUpdatedDateTime": "2022-10-24T05:19:44Z",
+        "createdDateTime": "2022-10-24T05:19:44Z",
+        "expirationDateTime": "2022-10-25T05:19:44Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3a17f883-3f22-40ff-aeff-d33b7d357a7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/caac23eb-7f91-45de-97e7-244405f5cb35?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,25 +119,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "a9ffceb1-22c1-4d65-994d-7f90d6da753a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e57cbb32-f19c-4556-94c4-e2c1efb00dea",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bfe601bb-f2fd-40d6-82f7-8925debba17b",
+        "apim-request-id": "b9c16b80-cf92-4484-9e1a-41e152a96dc2",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3a17f883-3f22-40ff-aeff-d33b7d357a7e",
-        "lastUpdatedDateTime": "2022-10-15T02:28:16Z",
-        "createdDateTime": "2022-10-15T02:28:16Z",
-        "expirationDateTime": "2022-10-16T02:28:16Z",
+        "jobId": "caac23eb-7f91-45de-97e7-244405f5cb35",
+        "lastUpdatedDateTime": "2022-10-24T05:19:44Z",
+        "createdDateTime": "2022-10-24T05:19:44Z",
+        "expirationDateTime": "2022-10-25T05:19:44Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -148,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3a17f883-3f22-40ff-aeff-d33b7d357a7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/caac23eb-7f91-45de-97e7-244405f5cb35?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -164,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "af261e86-8c36-4136-8a16-5fa16f213d5d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "adec173b-5da1-4f17-ba9b-a7afad77cbf2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "70711abb-f60b-4b47-8e5a-b93c7b8b7021",
+        "apim-request-id": "53a68d4f-1ed1-41e1-afc0-3a088a15a715",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "87"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3a17f883-3f22-40ff-aeff-d33b7d357a7e",
-        "lastUpdatedDateTime": "2022-10-15T02:28:18Z",
-        "createdDateTime": "2022-10-15T02:28:16Z",
-        "expirationDateTime": "2022-10-16T02:28:16Z",
+        "jobId": "caac23eb-7f91-45de-97e7-244405f5cb35",
+        "lastUpdatedDateTime": "2022-10-24T05:19:46Z",
+        "createdDateTime": "2022-10-24T05:19:44Z",
+        "expirationDateTime": "2022-10-25T05:19:44Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +197,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:18.5520215Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:46.1718212Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -221,7 +225,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3a17f883-3f22-40ff-aeff-d33b7d357a7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/caac23eb-7f91-45de-97e7-244405f5cb35?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -237,25 +241,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9ac34d85-251b-4518-b1a9-4e553f239d26",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8be1f031-59f0-4dc1-af5a-b84104822331",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "62dab574-5850-4026-aa71-e092e317489d",
+        "apim-request-id": "2e1e75cc-603a-403a-9ab5-eb1f7a4b4358",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3a17f883-3f22-40ff-aeff-d33b7d357a7e",
-        "lastUpdatedDateTime": "2022-10-15T02:28:18Z",
-        "createdDateTime": "2022-10-15T02:28:16Z",
-        "expirationDateTime": "2022-10-16T02:28:16Z",
+        "jobId": "caac23eb-7f91-45de-97e7-244405f5cb35",
+        "lastUpdatedDateTime": "2022-10-24T05:19:46Z",
+        "createdDateTime": "2022-10-24T05:19:44Z",
+        "expirationDateTime": "2022-10-25T05:19:44Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -266,7 +271,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:18.5520215Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:46.1718212Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "4b8b65c8-fd85-43db-9d22-654da340144a",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "e1e366e1-c007-428c-bd4b-2469324304f4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "9977ca9e-0751-4410-9164-ba47c00a2c52",
+        "apim-request-id": "cdd5ec14-2ae6-4fc1-93ec-92f865a34984",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:21 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:49 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/2ca6833e-7523-4e3a-8796-f62b087a7f6e?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "x-envoy-upstream-service-time": "107",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2ca6833e-7523-4e3a-8796-f62b087a7f6e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,25 +71,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "2accfda6-cdd3-4869-8e86-33c1d5d2d421",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "8ae4f5c1-939c-4958-8ab6-387108e9c488",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "991df345-3835-4cef-875c-edb783e05c54",
+        "apim-request-id": "eacd21bb-c615-4449-a91b-24ebfdc1dc0a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa",
-        "lastUpdatedDateTime": "2022-10-15T02:28:21Z",
-        "createdDateTime": "2022-10-15T02:28:21Z",
-        "expirationDateTime": "2022-10-16T02:28:21Z",
+        "jobId": "2ca6833e-7523-4e3a-8796-f62b087a7f6e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:50Z",
+        "createdDateTime": "2022-10-24T05:19:49Z",
+        "expirationDateTime": "2022-10-25T05:19:49Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2ca6833e-7523-4e3a-8796-f62b087a7f6e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,25 +119,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "04ab5163-6166-40ad-8ee1-bcb3cdfe5a75",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "07968032-bac1-4391-92aa-caa2a6b49a16",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d528435-bc81-4011-94ab-62b7f35a81b8",
+        "apim-request-id": "73216ed9-61bc-4bbe-8185-3647ee9ca498",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa",
-        "lastUpdatedDateTime": "2022-10-15T02:28:21Z",
-        "createdDateTime": "2022-10-15T02:28:21Z",
-        "expirationDateTime": "2022-10-16T02:28:21Z",
+        "jobId": "2ca6833e-7523-4e3a-8796-f62b087a7f6e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:50Z",
+        "createdDateTime": "2022-10-24T05:19:49Z",
+        "expirationDateTime": "2022-10-25T05:19:49Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -148,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2ca6833e-7523-4e3a-8796-f62b087a7f6e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -164,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "d275ea81-57c9-4288-970c-10829c3ac244",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "293449ba-3520-41d3-adaf-b88f811f3a66",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7fbf5801-b330-48db-a050-856b435a36f3",
+        "apim-request-id": "c0a8eb55-01a1-46b8-8346-acd422d6a893",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "77"
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa",
-        "lastUpdatedDateTime": "2022-10-15T02:28:23Z",
-        "createdDateTime": "2022-10-15T02:28:21Z",
-        "expirationDateTime": "2022-10-16T02:28:21Z",
+        "jobId": "2ca6833e-7523-4e3a-8796-f62b087a7f6e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:51Z",
+        "createdDateTime": "2022-10-24T05:19:49Z",
+        "expirationDateTime": "2022-10-25T05:19:49Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +197,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:23.0052295Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:51.6322149Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -344,7 +348,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/2ca6833e-7523-4e3a-8796-f62b087a7f6e?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -360,25 +364,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "73cddb06-b277-4a8a-8333-d2e2e59c6145",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "72ae276f-c925-4bd5-913a-c4b5e89e4b1f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc9e6dc5-cc17-43d0-b104-da02dad8d5d9",
+        "apim-request-id": "7f1a9808-8de7-4b18-9cd4-13989c7b0c5c",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "8d30a6e1-c1c1-4994-bbd2-0c12cddc7baa",
-        "lastUpdatedDateTime": "2022-10-15T02:28:23Z",
-        "createdDateTime": "2022-10-15T02:28:21Z",
-        "expirationDateTime": "2022-10-16T02:28:21Z",
+        "jobId": "2ca6833e-7523-4e3a-8796-f62b087a7f6e",
+        "lastUpdatedDateTime": "2022-10-24T05:19:51Z",
+        "createdDateTime": "2022-10-24T05:19:49Z",
+        "expirationDateTime": "2022-10-25T05:19:49Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -389,7 +394,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:23.0052295Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:51.6322149Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
@@ -19,8 +19,8 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "10d0740b-a787-4f6b-8228-0d4ac45e6474",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "a0112217-6483-4e84-8596-49b64060c164",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": {
         "analysisInput": {
@@ -43,18 +43,19 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a2e00cda-e402-4437-b2b5-31b40e9a1a0a",
+        "apim-request-id": "ecf8aca4-a0e2-47ea-adbc-6d01a117b912",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:28:19 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/60a3d905-efb5-4b58-bc0c-c737ac502550?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:19:47 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/67ae66b9-372c-4a09-939c-a6fbe2296cb3?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
+        "x-envoy-upstream-service-time": "144",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/60a3d905-efb5-4b58-bc0c-c737ac502550?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/67ae66b9-372c-4a09-939c-a6fbe2296cb3?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -70,26 +71,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "eda7f1b2-1061-410c-a1a4-03515cfa805d",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "3a01e46c-4fb2-4ea5-aa4b-6678910708b2",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10a79a4a-c788-4484-802d-6cc84afcdb83",
-        "Content-Length": "280",
+        "apim-request-id": "d124c408-c35a-4a0f-b89f-9a9995bddbd0",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "60a3d905-efb5-4b58-bc0c-c737ac502550",
-        "lastUpdatedDateTime": "2022-10-15T02:28:19Z",
-        "createdDateTime": "2022-10-15T02:28:19Z",
-        "expirationDateTime": "2022-10-16T02:28:19Z",
-        "status": "running",
+        "jobId": "67ae66b9-372c-4a09-939c-a6fbe2296cb3",
+        "lastUpdatedDateTime": "2022-10-24T05:19:47Z",
+        "createdDateTime": "2022-10-24T05:19:46Z",
+        "expirationDateTime": "2022-10-25T05:19:46Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -101,7 +103,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/60a3d905-efb5-4b58-bc0c-c737ac502550?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/67ae66b9-372c-4a09-939c-a6fbe2296cb3?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -117,26 +119,27 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "79f231b1-bb1e-4b30-8149-01c48b6756da",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "71ab9b7f-0174-4bb5-a390-0447c82a50a1",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5e7fbfbf-48b6-42eb-9e24-1f8423252f30",
-        "Content-Length": "280",
+        "apim-request-id": "36b6fb21-a9bd-49ae-bc34-a661a5358d24",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "60a3d905-efb5-4b58-bc0c-c737ac502550",
-        "lastUpdatedDateTime": "2022-10-15T02:28:19Z",
-        "createdDateTime": "2022-10-15T02:28:19Z",
-        "expirationDateTime": "2022-10-16T02:28:19Z",
-        "status": "running",
+        "jobId": "67ae66b9-372c-4a09-939c-a6fbe2296cb3",
+        "lastUpdatedDateTime": "2022-10-24T05:19:47Z",
+        "createdDateTime": "2022-10-24T05:19:46Z",
+        "expirationDateTime": "2022-10-25T05:19:46Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -148,7 +151,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/60a3d905-efb5-4b58-bc0c-c737ac502550?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/67ae66b9-372c-4a09-939c-a6fbe2296cb3?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -164,25 +167,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "19379007-bd5e-4555-896c-5868e2fff951",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "30241949-f38f-4f3b-b15c-79e5c21ec56d",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5661f091-c464-43e2-bf2d-42f7cd3c96ec",
+        "apim-request-id": "8fdb3acb-1d65-4f30-b0f4-5b4ea5864ea0",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "60a3d905-efb5-4b58-bc0c-c737ac502550",
-        "lastUpdatedDateTime": "2022-10-15T02:28:20Z",
-        "createdDateTime": "2022-10-15T02:28:19Z",
-        "expirationDateTime": "2022-10-16T02:28:19Z",
+        "jobId": "67ae66b9-372c-4a09-939c-a6fbe2296cb3",
+        "lastUpdatedDateTime": "2022-10-24T05:19:48Z",
+        "createdDateTime": "2022-10-24T05:19:46Z",
+        "expirationDateTime": "2022-10-25T05:19:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +197,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:20.5838915Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:48.6613644Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -344,7 +348,7 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/60a3d905-efb5-4b58-bc0c-c737ac502550?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/67ae66b9-372c-4a09-939c-a6fbe2296cb3?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -360,25 +364,26 @@
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "6eec5026-9201-49ca-b994-1889c9572b8c",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 OS/Linuxx86_64"
+        "x-ms-client-request-id": "f5d1f535-c26e-4dc0-8645-26eb4688b41f",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "649cb169-5adb-446a-81b0-9bd5d2fb22b3",
+        "apim-request-id": "7c0fa601-d78d-45d3-a756-1b82eb76c22e",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:28:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:19:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "60a3d905-efb5-4b58-bc0c-c737ac502550",
-        "lastUpdatedDateTime": "2022-10-15T02:28:20Z",
-        "createdDateTime": "2022-10-15T02:28:19Z",
-        "expirationDateTime": "2022-10-16T02:28:19Z",
+        "jobId": "67ae66b9-372c-4a09-939c-a6fbe2296cb3",
+        "lastUpdatedDateTime": "2022-10-24T05:19:48Z",
+        "createdDateTime": "2022-10-24T05:19:46Z",
+        "expirationDateTime": "2022-10-25T05:19:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -389,7 +394,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:28:20.5838915Z",
+              "lastUpdateDateTime": "2022-10-24T05:19:48.6613644Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -8,10 +8,10 @@
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "687",
+        "Content-Length": "289",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f7f98a3c-f385-43c2-acc7-71a0d68405ac"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "af6ba75d-22ff-4c57-8984-3afe90e0304a"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -19,28 +19,13 @@
           "documents": [
             {
               "id": "1",
-              "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle",
-              "language": "en"
-            },
-            {
-              "id": "3",
               "text": "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
               "language": "en"
             },
             {
-              "id": "4",
-              "text": "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
-              "language": "es"
-            },
-            {
-              "id": "5",
-              "text": "La carretera estaba atascada. Hab\u00EDa mucho tr\u00E1fico el d\u00EDa de ayer.",
-              "language": "es"
+              "id": "2",
+              "text": "I didn\u0027t like the last book I read at all.",
+              "language": "en"
             }
           ]
         },
@@ -48,15 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e606e480-0eab-4874-bbc5-b06fcd9c9a0c",
-        "Content-Length": "1834",
+        "apim-request-id": "59b6096d-5ff6-4534-854e-b03766246785",
+        "Content-Length": "424",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:21:06 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
+        "Date": "Mon, 24 Oct 2022 05:12:03 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -64,82 +50,6 @@
           "documents": [
             {
               "id": "1",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 26,
-                      "length": 7,
-                      "confidenceScore": 0.21
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 65,
-                      "length": 12,
-                      "confidenceScore": 0.42
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "2",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 50,
-                      "length": 7,
-                      "confidenceScore": 0.2
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 90,
-                      "length": 12,
-                      "confidenceScore": 0.36
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "3",
               "entities": [
                 {
                   "bingId": "296617ab-4ddb-cc10-beba-56e0f42af76b",
@@ -161,29 +71,7 @@
               "warnings": []
             },
             {
-              "id": "4",
-              "entities": [
-                {
-                  "bingId": "9ae3e6ca-81ea-6fa1-ffa0-42e1d7890906",
-                  "name": "Monte Rainier",
-                  "matches": [
-                    {
-                      "text": "Monte Rainier",
-                      "offset": 29,
-                      "length": 13,
-                      "confidenceScore": 0.81
-                    }
-                  ],
-                  "language": "es",
-                  "id": "Monte Rainier",
-                  "url": "https://es.wikipedia.org/wiki/Monte_Rainier",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "5",
+              "id": "2",
               "entities": [],
               "warnings": []
             }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "551",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6ba0ab3c-52ae-482d-8f15-26e470a12807"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4f555887-22d6-4edf-8ccd-269942f4e636"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3edba080-be9f-41fb-9716-a3459b750303",
+        "apim-request-id": "9392694a-a7db-44c0-87a5-8c8a04ed7716",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:21:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:02 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "551",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b1a6b312-727c-4463-ae8e-f51864a7f2c8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8e4f1e9a-b011-4f6e-ada9-fb4a76ffd0b6"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3a30b092-aaad-44c4-a6d4-4db0771c11de",
+        "apim-request-id": "e8e6d603-f8cb-4187-ab5d-c9a1d7092e0b",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:21:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:02 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "770",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fe9dd4fc-988e-4173-a1ca-259c728cc8c9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8c53dd61-8130-43f6-9d23-064ee1e93f2f"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -53,13 +53,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "e1ce51da-8c69-42e1-a28a-4288c51e489b",
+        "apim-request-id": "1e6665d7-0d96-47ee-b3f1-4ddff487bd28",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "160",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f82d77f1-7cb4-498e-997e-286ed138fbd4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c2d1e305-4391-4cd7-9df5-b831b106a90c"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "827171f8-64ec-48d9-8ce8-6b5ac846adf6",
+        "apim-request-id": "54912c7d-99c5-42f1-baff-d2e859248657",
         "Content-Length": "408",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:03 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "691",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aae31258-6dcc-489c-bd2d-8d1b92e56c6d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1e36c269-57ae-4f89-b92e-00218fe80a5b"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83510ec5-e8bb-4674-b14f-d00c6e2f31d9",
+        "apim-request-id": "fb114480-5a44-4582-8f0a-02a7d01bc2ef",
         "Content-Length": "1462",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:20:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:55 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "555",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d82b91f5-f98a-4d9a-aeaf-bc9fbb9c50a0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bdd327c9-7a91-44d2-91d9-8dcd4975f1f4"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6b4ca5d1-c354-49a2-af12-56b644fa5b62",
+        "apim-request-id": "ad33928b-c510-4911-9afd-afa66b46f90c",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:55 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "555",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9727f824-74e1-44e0-b2df-54d988c9a085"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "409709d3-61f2-4adf-b8e8-c4c0d64a2176"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66967fc2-0332-4d7e-85c9-35bae8099cd2",
+        "apim-request-id": "ec469156-f69b-4811-82ad-76095063d412",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:54 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "770",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8a073555-eda3-4e72-8b84-20e3e3a280af"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9c764654-8619-4a54-9463-e006cedf1d63"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -53,13 +53,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f522809a-7dcc-43e0-bc40-54b417a6aa9d",
+        "apim-request-id": "e244c0c6-9288-483d-b3f9-c7ae95031ee3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "164",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "85fe7660-d91e-403d-8f32-daae2145c6e3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e37b78a7-5489-42f0-82d7-e114fbbbc905"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50d46d26-2769-426f-b46a-6e35fb9d03af",
+        "apim-request-id": "fffc365f-4ece-4daf-8d65-7f501899b9c2",
         "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:55 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "772",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f8954290-6a41-4011-88d6-b423ce0e9ea0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c08f1c2c-429c-41aa-b37a-0a85049e9f25"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf0296b7-e22d-446d-b236-2d5fa108ab63",
+        "apim-request-id": "459aafa6-2dfe-4ced-82c8-43508af9d723",
         "Content-Length": "524",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:21:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:57 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "557",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e32e3176-61dd-4b65-b4a7-67c497841b9d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f3262513-397d-4f1c-83e5-867a076293c1"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b88f8121-9359-454e-9700-bbc28ff63e2d",
+        "apim-request-id": "f12afd74-bee9-4862-b8a6-a933d9ebf4d3",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:57 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "557",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f92366c6-67e1-473a-aef8-75da1de28fc3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "166146f3-8dfd-4b8a-8d8a-4bac8e16e6aa"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "777faa7c-e7af-434c-ad45-3631691d48a9",
+        "apim-request-id": "f6fa47f9-c36f-4189-81a1-41cccc922afa",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:56 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "17",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "166",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f923e7e4-ddd0-4427-ac74-6e383194cf60"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b35ee7a0-f5c1-4cd5-a67e-6e4f0cb9e0f0"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04ff1246-8483-4c2d-94cb-63e5052f9337",
+        "apim-request-id": "78e70d12-ebac-4245-a840-669f3eae1ee8",
         "Content-Length": "704",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:59 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:57 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "126",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f6fe5dc0-8d6e-4487-b387-9538de75ff8e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8dd66b1a-7d56-4c9b-92c4-f8d86f7f6b9c"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a1aaaf1-77fd-40f8-923f-44bded578e43",
+        "apim-request-id": "29e1f2ea-6c97-4906-81a9-476beb75d2de",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:52 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "712",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1ec1b284-f0be-4da8-87d4-7042ab5046ed"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1b45e723-6f66-4106-a7d1-fd3c28290ac4"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -49,15 +49,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48c5d0fb-d911-4872-973a-3b6acf9eec49",
+        "apim-request-id": "a17245b5-db07-437d-849e-eab434835cad",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:54 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "567",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2486d51b-961f-4609-82f1-132aa1277d7e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b152f07a-647c-4812-93ca-2614879f7948"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "89cef551-933a-4041-95eb-d3fc2eff4c79",
+        "apim-request-id": "1cb99ba5-2536-4b12-bae0-f4f73c3d623e",
         "Content-Length": "517",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:52 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "800",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d51155d9-69b6-4504-9a17-103f3ee89f85"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6241ba7c-5462-4826-b673-416f6eef3848"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a6b6d237-89b4-4470-8e85-5b6a172ad546",
+        "apim-request-id": "da46373f-9476-4080-8cd2-e5533a82fe3c",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:53 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "162",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2038785c-a0bd-47f5-b318-0e222d717034"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f03e5367-181d-4227-bd41-5815846e9674"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5abb3b7e-1566-427b-bf13-488074047833",
+        "apim-request-id": "2be70599-ee7e-4fb5-8bbb-c374e75590ad",
         "Content-Length": "206",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:52 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "133",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "075527da-5973-4992-8b0f-6edc96a66a0e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5ff3b8bc-c7f3-4dbb-8d54-80960784cdd1"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3cbdb28b-bbe8-448f-9be1-075c9d46afbf",
+        "apim-request-id": "d4425390-3d48-4ce2-b8ea-ff5b9fe829f9",
         "Content-Length": "325",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:53 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "2",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "185",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "251d9dcb-683f-4d12-8f17-ab2e0747200c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3c3268ef-a09d-4f49-9c35-5cac09a2e686"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "142bc6f2-c4c2-40c3-b5b3-264b596c56d8",
+        "apim-request-id": "f692d7e6-4668-4004-a3a7-428b090a985c",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:01 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "200",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e568bd88-b702-4f04-bec3-03c633d5dadc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8d85ae89-0ee7-433e-a98e-631ba74c0b57"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -32,15 +32,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eecc21de-4e54-4ae4-8bca-b5594cab942e",
+        "apim-request-id": "dff04dea-9aea-46b6-a02b-ce6acb133e56",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:01 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "694",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "63ed0152-2931-4995-bec1-188faa90e354"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9a21ae93-e1ae-4a7b-aa80-82104fb88170"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "94cab973-1f7e-474a-a2bd-fd4d254ecf58",
+        "apim-request-id": "cb08da29-3b85-47c4-8885-32dbb5af69b6",
         "Content-Length": "1142",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:21:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:00 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "558",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fd624964-16ee-4453-8313-22a1a304491b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2740118c-e025-49c8-a60c-31e312cb9564"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "98fadaf2-e597-450b-8067-fe42f3272ada",
+        "apim-request-id": "bee7cc04-2174-4bff-b85f-0b3a83639549",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:21:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:58 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "558",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7ab08e43-4690-437d-a4cc-02fe0e3295d7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5bf32523-058c-4000-b210-a07cf6b0cc50"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "39e1ea3e-84b3-4357-a1c5-51b2c8f89553",
+        "apim-request-id": "386d1db9-4f22-4d9a-8dbf-62574b157829",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:21:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:58 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "159",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "daba07e6-cd7d-4631-9be0-e633e6e4e54f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "62cc5b99-851d-49d1-a229-3ffdba63b60d"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b7583d63-58b9-45d1-bcd1-250c539314cd",
+        "apim-request-id": "7e4ce91d-dfb5-4ef2-bff1-938a7fcb93eb",
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:58 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "158",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aeda0c1f-4ecb-40c0-8f98-10859f588133"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4099f489-d9f4-4fb2-8ffd-89dcc81ce149"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1bfb2013-67f4-4978-a274-640194d57119",
+        "apim-request-id": "382b9550-b3bd-4b34-b425-ae18838771cd",
         "Content-Length": "389",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:02 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -79,8 +80,8 @@
         "Connection": "keep-alive",
         "Content-Length": "200",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "09cbba33-1a5c-4523-8871-6e2cbb2084f3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "36914e61-9665-4f21-9c5a-927382ad170f"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -101,15 +102,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a2f8a4f7-d5f3-4b7d-948d-c0d69f1c18f1",
+        "apim-request-id": "96ee3d8e-4674-4a53-aff3-a51b5d25d865",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:02 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "167",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "34f25f5a-6f36-42b3-8bac-e4ad14aa6a58"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4de9a2ff-6ce5-4965-baf9-b5c8f7d9525a"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "32a29586-2908-4b23-81c1-00f0b1a22d40",
+        "apim-request-id": "9125d018-3915-4e2e-a0d0-ae7be67ceee6",
         "Content-Length": "450",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:00 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "555",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0838874b-a7f2-4504-b7ed-38c995e55427"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "03fec226-bed4-49c5-b54f-700fe155a715"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7801edc0-90a5-4efb-8811-98c127adbf38",
+        "apim-request-id": "5e5801c9-b391-4e65-946a-5cea181d0f42",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:48 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "555",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1bc1cef3-26d6-456e-b8a3-2a3d5266f3e2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a9f3184d-f9d5-43e3-b85f-4700cf516d63"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6b8e256f-a45a-45fe-999f-55ea4b0fbf8b",
+        "apim-request-id": "532045f1-83aa-4cc2-b00a-3ff91c0ddc1c",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:48 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "770",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "777e0010-acb3-49f1-aead-ffeea7d7a6e6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "85fd63e5-93b1-4929-9d0a-dbf39afccc30"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad3ca42a-546a-4f1e-bd07-ac1129ee131c",
+        "apim-request-id": "ce4dc606-1d20-4218-9a6b-9eeb29ca9b48",
         "Content-Length": "2343",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:50 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
@@ -1,0 +1,126 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "166",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8325ed9e-09db-4d1b-b234-fd87c566862e"
+      },
+      "RequestBody": {
+        "kind": "SentimentAnalysis",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "The food and service are not good",
+              "language": "en"
+            }
+          ]
+        },
+        "parameters": {
+          "opinionMining": true
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "514d331a-7d6d-4c12-ac61-ab9945b963e4",
+        "Content-Length": "954",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Mon, 24 Oct 2022 05:11:51 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "kind": "SentimentAnalysisResults",
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "sentiment": "negative",
+              "confidenceScores": {
+                "positive": 0.0,
+                "neutral": 0.0,
+                "negative": 1.0
+              },
+              "sentences": [
+                {
+                  "sentiment": "negative",
+                  "confidenceScores": {
+                    "positive": 0.0,
+                    "neutral": 0.0,
+                    "negative": 1.0
+                  },
+                  "offset": 0,
+                  "length": 33,
+                  "text": "The food and service are not good",
+                  "targets": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 4,
+                      "length": 4,
+                      "text": "food",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    },
+                    {
+                      "sentiment": "positive",
+                      "confidenceScores": {
+                        "positive": 1.0,
+                        "negative": 0.0
+                      },
+                      "offset": 13,
+                      "length": 7,
+                      "text": "service",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    }
+                  ],
+                  "assessments": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 29,
+                      "length": 4,
+                      "text": "good",
+                      "isNegated": true
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2022-10-01"
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "151",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d22568f3-dd31-4cb7-b8d4-019f9555998d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c3e60def-e28c-4754-8e68-5a9f8970cbd3"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb8abcce-bdb3-4db4-a817-7724900ec480",
+        "apim-request-id": "de4b2643-1200-4adc-ab7c-9b9668dc4300",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:51 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "207",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "062e891d-992c-4cab-b524-4e2dadd38810"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8d92fb7a-13a5-444c-a89f-6d258344a411"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d98bdfc-15c8-4d30-8114-3217465b9773",
+        "apim-request-id": "9ddccfea-098c-4c1b-91f0-3c2bd92ef4dc",
         "Content-Length": "1009",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:50 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "703",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fd4c8fb6-47f3-4849-a74d-d432b87d51d8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2b733cd6-d019-4002-995a-872416d8fd3f"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -60,15 +60,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7e4a98e8-f622-45f5-8eba-9f8da4648768",
+        "apim-request-id": "eaa95538-146c-4c24-8276-667d75f1d131",
         "Content-Length": "7828",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=7,CognitiveServices.TextAnalytics.TextRecords=7",
-        "Date": "Sat, 15 Oct 2022 02:20:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "592",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7500d1f0-c136-4f84-a627-14903c2704a4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b6fc0ea4-48bd-4fd1-a3f3-def3baf07477"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aaa0dc70-0fcf-497c-9855-161bf5c37208",
+        "apim-request-id": "36f75b97-0774-4a63-9803-5d78ab775293",
         "Content-Length": "1734",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "135",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "492a8f41-4def-4be9-a27a-364a85c1fbac"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "133924c4-bc6c-4d31-8507-3b88994bb12f"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be7037c0-bae8-4bd3-9442-48a693ebc0f9",
+        "apim-request-id": "97dcb987-11e3-4849-8bf8-ffd75eb06f63",
         "Content-Length": "699",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:49 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "170",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "266adbe9-50e7-4980-adc4-489e51d4b903"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "28e7869a-7651-4923-af8b-5d5951c38c6f"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "79c0d5f1-b9ae-4a7c-afab-9a14989c1392",
+        "apim-request-id": "6c1bb563-aac2-4f7d-ba04-7b7a10384d6b",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:05 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "171",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2f8d95a0-8fa1-4be8-bca5-8ec05196e095"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f6097f8b-aeb2-429b-a5de-21a0e28815ec"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "422724de-3ce0-40cf-b5cb-9ae16fdf1738",
+        "apim-request-id": "31c7916e-9fce-40a0-ae6a-a6a02e1f518a",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:07 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "170",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9f167de5-5630-48d2-a26d-21e991ec7bd5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cc325ff2-e392-430a-8ff1-c0efcee9f513"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99dd437e-ceec-4dd9-8280-c0ae4051a2b4",
+        "apim-request-id": "7e2cf995-a25a-4d88-a720-af1fc375a724",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:04 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "174",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fccd94fa-0fde-404b-83dd-6fb8a529ea46"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3d1ec8aa-dbb4-44a8-afa9-e03bb6c93ced"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4b55d6b1-bc64-4a64-875a-21f40e95b793",
+        "apim-request-id": "4b1d76ac-3f55-4826-8725-2b8419f7b7dc",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:04 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "191",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7d3a7486-ca09-44e3-9a5a-9a59d0ed28c3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "17bdd821-dd0e-4948-9c00-1f84cc0aeab4"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47e95db1-d229-4d96-b10b-136143688088",
+        "apim-request-id": "b5d12543-0eeb-468d-be41-7e4e09ad46c0",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:04 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "207",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6f0c8d39-720b-477c-a392-959f7fb0c3c0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a37b7624-6cdf-4127-bc2e-92d7a489c243"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61a6ca64-5fbd-4626-8903-de7c759fffa9",
+        "apim-request-id": "cc11a9ed-47fd-4fc0-b198-a159d8528b2e",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:05 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "172",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e028488e-d38f-4f74-8a8d-c28e60553a82"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "351f3191-5a59-45d7-89e0-fbefae48a6ce"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "52f678d0-432a-4a7e-aff8-ad4596f6e5e3",
+        "apim-request-id": "aa58cd02-92b0-44fa-9879-b8ded9184881",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:07 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "172",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e2c8fefc-6790-4eaa-b7c8-27d8f26bf2ab"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "84738f46-95b4-4b40-8203-df53ba158813"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d95b4a10-4476-4b9e-a334-52c9eb71a473",
+        "apim-request-id": "40f1dbed-ee1f-412a-89c7-223739738925",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:07 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "393",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "341c5dc7-35ec-4ad4-997d-a8e68e019d71"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fac9de62-d2f4-4066-8ade-914482028875"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4cee005-a8c5-496b-bdc6-d99089d66726",
+        "apim-request-id": "443b2fa5-4715-4c5a-984e-c99cb3167f98",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:08 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "x-envoy-upstream-service-time": "54",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "172",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "540d5666-6b3f-45a0-a0ef-c11643591550"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2a9d9119-0556-43d6-a473-d9af84f5ebb3"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aaf8bc39-e111-41c0-ad6f-423e9eba6904",
+        "apim-request-id": "f10f5d8a-b22d-4b64-918d-9582a0542988",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "173",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "37e7dfad-e007-44ee-84d5-a15dc52fd5c0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1b2bba86-c589-493a-a276-6c390636e790"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9bd25814-3564-48db-82b0-2aa19b70b1c7",
+        "apim-request-id": "2e01676b-eb54-459c-a2e7-561e25fe14ae",
         "Content-Length": "287",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:15 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "172",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "24f327a8-fb08-42f0-82ef-fd66ae990eae"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0c3b5caa-2591-4ba6-a90c-591223085869"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3089aa2d-3187-4dfc-b44c-e0db8769563b",
+        "apim-request-id": "70f7cda6-cc3f-4ac5-be5f-ebf290020206",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:13 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "176",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "22f9b15c-802f-44a5-b35a-8a0aaabbea93"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "abdf2f06-23c7-4907-a5ee-f5525f14bd1e"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc597278-69b4-42da-a212-186dedeea572",
+        "apim-request-id": "071a5dcc-4ddd-48e7-a753-ddd1ac9a9202",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:13 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "193",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "58d28d9a-5382-4676-b63d-00ee2673dc43"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d985f7e3-7836-4c4e-92b6-ad66a1149168"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "88fd961e-90d4-4c74-8d4b-d9ba08ab74ee",
+        "apim-request-id": "47a2a05a-8947-4b28-9417-d30abb284bdc",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e893d72c-ec83-4dfb-93c7-31baa4585d1b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c2c064e3-2ca6-42b0-992c-a549efa1633b"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab684af5-c651-43e6-9f3f-116bcb523e38",
+        "apim-request-id": "e3f6a1b0-6752-4de5-b401-5049a2d45fce",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:14 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "174",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a2c04062-2197-4194-bde7-4a0f24c904df"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dbada34c-2e96-423a-9baf-2199a19a1667"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d69ccb1c-2077-419e-8924-84f200827fa1",
+        "apim-request-id": "9b8c9f0e-d16c-4a0e-a00b-250df0721fa6",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:15 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "174",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0c1cf717-ed81-4d84-b57a-57b864c1932d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "edbc49a2-a6c3-4203-9cb6-149af95444a9"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dce68f2c-3637-47ee-9cf5-ae4a52b71422",
+        "apim-request-id": "3aad18ae-c621-42da-ac81-5dd8e817ca27",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:15 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "395",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2dee9e60-a634-44f1-863b-b9ee0b7c9a88"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3568d4b2-fe6b-4d66-8b2a-8796160a2c58"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "149684bb-3a8f-46cf-831f-3baf76efd63e",
+        "apim-request-id": "19fb6657-d83b-4347-a616-4c4d7c92b482",
         "Content-Length": "509",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:16 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "55"
+        "x-envoy-upstream-service-time": "51",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "173",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aacc894b-6dc5-40d3-b8b6-0115a0393813"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "12cf9fd9-b01c-4e4e-9203-dee15cd78551"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b32f6564-d33b-4dd5-bb74-197779e00656",
+        "apim-request-id": "53b4774c-cc7b-4a06-9f7d-3226134d5563",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:10 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "174",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "90a38fdc-953f-4eaa-8fc6-3e37ac2cff96"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ec272ffc-1000-47da-8060-f48795260793"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b21d0cf1-5848-4edb-883a-ab5c0c01cf9a",
+        "apim-request-id": "ccf23512-8cb0-482f-b5fa-383112848a77",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:10 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "173",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2b6df231-9743-4a9c-a3f6-858d10495c6f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "034b791e-3b9c-47fc-bfe1-3e35331e26d4"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dcd3c1c0-cd64-41ff-86d3-b100b03ddee7",
+        "apim-request-id": "29ccac13-51d8-40c3-a116-c6725c5aa925",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:08 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "177",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "85caffc3-8fd1-44d0-9921-07e651eadee9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6e138e3b-39f2-4e00-9f7d-e6512a712c03"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eda087c9-3bc2-4a51-b899-2f1e98be04e9",
+        "apim-request-id": "5a47d65d-1805-426b-a6bb-ce390f23936c",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:09 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "194",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c61dd2c4-ee22-45c5-a0ec-3428e499e872"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "35e4a565-d885-4505-8bc3-7a50e1aaa8a6"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ab838d1-d003-4308-b1c3-26d7150e2b95",
+        "apim-request-id": "00cc705a-a44c-41e3-b932-b186ec8e892a",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:09 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "210",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3fc0af4f-f8a1-40ae-9f68-dcf5f640d492"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "375f8748-8bf8-42da-a938-efbcd860b0ab"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d77cda44-a87f-4b12-aa23-d0919972eaac",
+        "apim-request-id": "0021c11c-0680-4b11-8ad4-45f891c2b568",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:09 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "175",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ad4cd79a-8067-45d7-9e37-c5bb9504a8d1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8f292d50-e50f-4b88-ab0f-c99dbf0b3ae3"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f41cbfb0-75e7-4e02-9c84-9ce08abea1bf",
+        "apim-request-id": "dbf490ef-932c-424f-927a-691e3d1a8ee6",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:11 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "175",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5e2794e4-b2a7-4d53-b8b9-f37d84a6f972"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "65c9e3a9-dbf9-4277-b02a-6008e67f8fd2"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "edeef1d5-8728-451d-929d-c4e60ad1fdd4",
+        "apim-request-id": "cde34962-e216-4a27-8559-7122ac5f0256",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:11 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "396",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5e840140-d0d6-4234-8fab-b92007f5e950"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fd56f056-916a-4ff4-89e8-ee06a2004da3"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "44b51d1b-25fd-4042-91bf-242c450d57d0",
+        "apim-request-id": "598b0f16-3671-46ca-977e-3fbe6ba720de",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:21:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:11 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-envoy-upstream-service-time": "67",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "480",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aaa88939-92a2-4a75-8d65-47a71c0d01fe"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "991363ee-aa10-4c24-861a-157a82cf31c2"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "14b979ac-c694-4522-9c52-fc4ed13368d6",
+        "apim-request-id": "16be4b2b-bf82-419e-82f4-d9c8b8b06280",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:34 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5fac2ac2-bc57-45d9-b313-74094aaf7f28?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:51 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "247"
+        "x-envoy-upstream-service-time": "79",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fac2ac2-bc57-45d9-b313-74094aaf7f28?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "01787227-4a34-47e4-b5ee-ab97997f3ecd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dd4b6a27-db46-4084-a5d8-0847f5720d59"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5f76a2e8-44b1-488e-b82b-c0e0177371e0",
+        "apim-request-id": "7a8fbd05-7bfb-49e2-856a-4c559bc67e0a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fac2ac2-bc57-45d9-b313-74094aaf7f28",
-        "lastUpdatedDateTime": "2022-10-15T02:23:35Z",
-        "createdDateTime": "2022-10-15T02:23:34Z",
-        "expirationDateTime": "2022-10-16T02:23:34Z",
+        "jobId": "b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be",
+        "lastUpdatedDateTime": "2022-10-24T05:14:52Z",
+        "createdDateTime": "2022-10-24T05:14:52Z",
+        "expirationDateTime": "2022-10-25T05:14:52Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fac2ac2-bc57-45d9-b313-74094aaf7f28?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "dcaf2f38-3486-4529-ba5f-dc3a58ff7836"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "72ee5a25-fe97-414e-9b1c-d478ebff961f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03a05e0e-15fd-48c3-affe-f94a0a3dc77e",
+        "apim-request-id": "457ca1ea-80c5-4fb1-8979-cb784f812a35",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fac2ac2-bc57-45d9-b313-74094aaf7f28",
-        "lastUpdatedDateTime": "2022-10-15T02:23:35Z",
-        "createdDateTime": "2022-10-15T02:23:34Z",
-        "expirationDateTime": "2022-10-16T02:23:34Z",
+        "jobId": "b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be",
+        "lastUpdatedDateTime": "2022-10-24T05:14:52Z",
+        "createdDateTime": "2022-10-24T05:14:52Z",
+        "expirationDateTime": "2022-10-25T05:14:52Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fac2ac2-bc57-45d9-b313-74094aaf7f28?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "06039edf-e61b-4ffb-9006-fc4be7e682d6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e0337fdb-963e-450e-b600-b012932bf2af"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4b88c22-25f0-4c91-b3c5-e88c6598212d",
+        "apim-request-id": "e0dc87dd-a2cd-46f3-a857-448d662ac59b",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fac2ac2-bc57-45d9-b313-74094aaf7f28",
-        "lastUpdatedDateTime": "2022-10-15T02:23:35Z",
-        "createdDateTime": "2022-10-15T02:23:34Z",
-        "expirationDateTime": "2022-10-16T02:23:34Z",
+        "jobId": "b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be",
+        "lastUpdatedDateTime": "2022-10-24T05:14:54Z",
+        "createdDateTime": "2022-10-24T05:14:52Z",
+        "expirationDateTime": "2022-10-25T05:14:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:35.5763179Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:54.0033194Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -291,32 +295,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fac2ac2-bc57-45d9-b313-74094aaf7f28?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "87ca09ed-1481-4870-9909-e2cc7a20f3b6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0fdef079-d6e0-4fc1-9dae-60db24a105a0"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb6dee1f-118f-48e3-a242-b1a71ce31f99",
+        "apim-request-id": "40adaaa7-b4a1-4217-a2a0-38cec9b18fdd",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fac2ac2-bc57-45d9-b313-74094aaf7f28",
-        "lastUpdatedDateTime": "2022-10-15T02:23:35Z",
-        "createdDateTime": "2022-10-15T02:23:34Z",
-        "expirationDateTime": "2022-10-16T02:23:34Z",
+        "jobId": "b6cbc779-cd26-4a6b-acc4-13c7e8a5a5be",
+        "lastUpdatedDateTime": "2022-10-24T05:14:54Z",
+        "createdDateTime": "2022-10-24T05:14:52Z",
+        "expirationDateTime": "2022-10-25T05:14:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -327,7 +332,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:35.5763179Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:54.0033194Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "487",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6488bd8b-c8e9-4496-9417-000e989975d1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "687f78d8-0cf8-4353-bb00-5f264168b1f1"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d211f386-c947-4bee-b31f-f3dcca345419",
+        "apim-request-id": "7cd65e64-8839-4a39-94af-2cefb1d0bb75",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:39 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/423c3c14-69db-4380-93d2-968861bef7d3?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:58 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/c8e796d8-6954-48cd-9189-2c04b873f678?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "106"
+        "x-envoy-upstream-service-time": "258",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/423c3c14-69db-4380-93d2-968861bef7d3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8e796d8-6954-48cd-9189-2c04b873f678?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c28ad0ae-73ed-42b6-8d6a-5de10d1e3d37"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c2d5d91d-cd6a-45c3-a15d-2d35c2fd1fc7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f722bf47-83bf-438c-a138-7349c2c93afb",
+        "apim-request-id": "f05f0aa2-e914-4b90-9494-7ae3d0cd0324",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "423c3c14-69db-4380-93d2-968861bef7d3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:40Z",
-        "createdDateTime": "2022-10-15T02:23:40Z",
-        "expirationDateTime": "2022-10-16T02:23:40Z",
+        "jobId": "c8e796d8-6954-48cd-9189-2c04b873f678",
+        "lastUpdatedDateTime": "2022-10-24T05:14:58Z",
+        "createdDateTime": "2022-10-24T05:14:58Z",
+        "expirationDateTime": "2022-10-25T05:14:58Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/423c3c14-69db-4380-93d2-968861bef7d3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8e796d8-6954-48cd-9189-2c04b873f678?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d5e3a373-7bc3-46b6-826b-c264f44a4989"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1e6c60ff-cbd7-4796-b67f-8f2c2a6433ea"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "511cde97-8906-4df4-b264-cb6be42c837a",
+        "apim-request-id": "1537510c-e0e7-46d0-9a32-958b76b861ad",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "423c3c14-69db-4380-93d2-968861bef7d3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:40Z",
-        "createdDateTime": "2022-10-15T02:23:40Z",
-        "expirationDateTime": "2022-10-16T02:23:40Z",
+        "jobId": "c8e796d8-6954-48cd-9189-2c04b873f678",
+        "lastUpdatedDateTime": "2022-10-24T05:14:58Z",
+        "createdDateTime": "2022-10-24T05:14:58Z",
+        "expirationDateTime": "2022-10-25T05:14:58Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/423c3c14-69db-4380-93d2-968861bef7d3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8e796d8-6954-48cd-9189-2c04b873f678?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "39d98092-d526-40d9-8945-4ad2d2adca98"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4ce2bb09-ea0f-4ea9-a8d8-2df282605f06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3b43b72-2bbf-42ab-b8cb-882c17419b4d",
+        "apim-request-id": "74fe79ce-a083-4cd1-9de0-474779ffa64e",
         "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "423c3c14-69db-4380-93d2-968861bef7d3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:41Z",
-        "createdDateTime": "2022-10-15T02:23:40Z",
-        "expirationDateTime": "2022-10-16T02:23:40Z",
+        "jobId": "c8e796d8-6954-48cd-9189-2c04b873f678",
+        "lastUpdatedDateTime": "2022-10-24T05:14:59Z",
+        "createdDateTime": "2022-10-24T05:14:58Z",
+        "expirationDateTime": "2022-10-25T05:14:58Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:41.0871924Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:59.0868932Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -178,32 +182,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/423c3c14-69db-4380-93d2-968861bef7d3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8e796d8-6954-48cd-9189-2c04b873f678?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c8261af4-cb08-4631-80ea-cbf3a378237b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9933700d-4fd2-41a8-8345-b43816f2bfce"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bfdc610c-9833-4193-a7ed-00f404027b79",
+        "apim-request-id": "c5695041-112c-43f0-8f70-d7bfb1cf1e66",
         "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "423c3c14-69db-4380-93d2-968861bef7d3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:41Z",
-        "createdDateTime": "2022-10-15T02:23:40Z",
-        "expirationDateTime": "2022-10-16T02:23:40Z",
+        "jobId": "c8e796d8-6954-48cd-9189-2c04b873f678",
+        "lastUpdatedDateTime": "2022-10-24T05:14:59Z",
+        "createdDateTime": "2022-10-24T05:14:58Z",
+        "expirationDateTime": "2022-10-25T05:14:58Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -214,7 +219,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:41.0871924Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:59.0868932Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "488",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "37373b60-b25a-4eb3-9657-a34f7afc3cfa"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "04f8b57a-bdc5-40fd-b652-fbdf324ccd8c"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "20445494-d867-4d59-8ca5-504b3d14b527",
+        "apim-request-id": "c6cc2efc-5a5e-4697-8677-421f3a692150",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:37 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/617c9fab-9092-4f5b-9b2f-93ddf25f98ff?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:55 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b47873e6-e472-49a1-bcb2-e3800041c6e5?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "172"
+        "x-envoy-upstream-service-time": "171",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/617c9fab-9092-4f5b-9b2f-93ddf25f98ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b47873e6-e472-49a1-bcb2-e3800041c6e5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "05b440da-a444-4026-a64e-1ae5fe1f7085"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dc55e5b2-3d39-409c-9a88-55276b2c0a6c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7da38767-5c2e-470d-916d-93a4dacbc3c8",
+        "apim-request-id": "6ff2118f-98a1-469f-8329-30dfa7abf00c",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "617c9fab-9092-4f5b-9b2f-93ddf25f98ff",
-        "lastUpdatedDateTime": "2022-10-15T02:23:37Z",
-        "createdDateTime": "2022-10-15T02:23:37Z",
-        "expirationDateTime": "2022-10-16T02:23:37Z",
+        "jobId": "b47873e6-e472-49a1-bcb2-e3800041c6e5",
+        "lastUpdatedDateTime": "2022-10-24T05:14:55Z",
+        "createdDateTime": "2022-10-24T05:14:55Z",
+        "expirationDateTime": "2022-10-25T05:14:55Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/617c9fab-9092-4f5b-9b2f-93ddf25f98ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b47873e6-e472-49a1-bcb2-e3800041c6e5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5bc51312-5f5f-47d8-b835-903ab337e162"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "baa44a95-ea22-449d-ab7a-a9c69b0c451c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc8d7c85-830f-4826-bbbd-19df132b7688",
+        "apim-request-id": "c8d1562c-e0f7-4a3d-8962-81d57f438495",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "617c9fab-9092-4f5b-9b2f-93ddf25f98ff",
-        "lastUpdatedDateTime": "2022-10-15T02:23:37Z",
-        "createdDateTime": "2022-10-15T02:23:37Z",
-        "expirationDateTime": "2022-10-16T02:23:37Z",
+        "jobId": "b47873e6-e472-49a1-bcb2-e3800041c6e5",
+        "lastUpdatedDateTime": "2022-10-24T05:14:55Z",
+        "createdDateTime": "2022-10-24T05:14:55Z",
+        "expirationDateTime": "2022-10-25T05:14:55Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/617c9fab-9092-4f5b-9b2f-93ddf25f98ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b47873e6-e472-49a1-bcb2-e3800041c6e5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d319844d-09b7-4621-a6d4-2ca19c7d68e2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9deddee5-0d91-4a07-a089-fd444fa8f7a5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7d40a633-d2c6-433d-b547-d13dec29e454",
+        "apim-request-id": "6e8c4a9a-0b15-4c71-91cb-ee5254692bbe",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "62",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "617c9fab-9092-4f5b-9b2f-93ddf25f98ff",
-        "lastUpdatedDateTime": "2022-10-15T02:23:38Z",
-        "createdDateTime": "2022-10-15T02:23:37Z",
-        "expirationDateTime": "2022-10-16T02:23:37Z",
+        "jobId": "b47873e6-e472-49a1-bcb2-e3800041c6e5",
+        "lastUpdatedDateTime": "2022-10-24T05:14:56Z",
+        "createdDateTime": "2022-10-24T05:14:55Z",
+        "expirationDateTime": "2022-10-25T05:14:55Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:38.1155912Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:56.0577609Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -183,32 +187,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/617c9fab-9092-4f5b-9b2f-93ddf25f98ff?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b47873e6-e472-49a1-bcb2-e3800041c6e5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4bf07ca9-b4bc-4964-8525-dc0e6b8205a3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2c752445-d985-4b12-913e-c09e9ca3619d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f41d4110-e1ce-4c1d-a9cd-055cf4d05c5a",
+        "apim-request-id": "4e83f4ee-3612-43c7-aea7-cb7df71460d7",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "617c9fab-9092-4f5b-9b2f-93ddf25f98ff",
-        "lastUpdatedDateTime": "2022-10-15T02:23:38Z",
-        "createdDateTime": "2022-10-15T02:23:37Z",
-        "expirationDateTime": "2022-10-16T02:23:37Z",
+        "jobId": "b47873e6-e472-49a1-bcb2-e3800041c6e5",
+        "lastUpdatedDateTime": "2022-10-24T05:14:56Z",
+        "createdDateTime": "2022-10-24T05:14:55Z",
+        "expirationDateTime": "2022-10-25T05:14:55Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -219,7 +224,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:38.1155912Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:56.0577609Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "336",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0d4718e2-8d3b-4d82-b403-024717b5e661"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3dc1d0e3-1a88-4cf2-8d18-242eb1a9fc9a"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5ac14bc9-6e60-4813-bbb6-430d9e582aaa",
+        "apim-request-id": "9022f808-81f7-43bf-965b-c89b3a77b6ab",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:11 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/3f6dbd72-8bb4-4312-b885-5b3fca00c6bb?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:24 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/90e5dccc-bcf4-4674-b3e3-cae9ed77093f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "118"
+        "x-envoy-upstream-service-time": "163",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f6dbd72-8bb4-4312-b885-5b3fca00c6bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90e5dccc-bcf4-4674-b3e3-cae9ed77093f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fb078903-0533-4583-b7d4-520d2fa7bfdb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d1f11540-623a-4002-a109-d2bc22d34e2a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b8b6a863-a1a0-4a2a-a3ec-e968a1f2a7d2",
+        "apim-request-id": "5ab09caf-811c-4314-9d90-ed1ba48ed03f",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3f6dbd72-8bb4-4312-b885-5b3fca00c6bb",
-        "lastUpdatedDateTime": "2022-10-15T02:23:11Z",
-        "createdDateTime": "2022-10-15T02:23:11Z",
-        "expirationDateTime": "2022-10-16T02:23:11Z",
+        "jobId": "90e5dccc-bcf4-4674-b3e3-cae9ed77093f",
+        "lastUpdatedDateTime": "2022-10-24T05:14:25Z",
+        "createdDateTime": "2022-10-24T05:14:25Z",
+        "expirationDateTime": "2022-10-25T05:14:25Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f6dbd72-8bb4-4312-b885-5b3fca00c6bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90e5dccc-bcf4-4674-b3e3-cae9ed77093f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "26a41c42-57e0-4ddc-bd55-9023d54c4def"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5dec375b-9905-4352-8927-4421bf869479"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7829b60d-3798-454a-a83a-aebf740f6c11",
+        "apim-request-id": "26343eab-8e88-4a40-805a-3ef4b4efb9da",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3f6dbd72-8bb4-4312-b885-5b3fca00c6bb",
-        "lastUpdatedDateTime": "2022-10-15T02:23:11Z",
-        "createdDateTime": "2022-10-15T02:23:11Z",
-        "expirationDateTime": "2022-10-16T02:23:11Z",
+        "jobId": "90e5dccc-bcf4-4674-b3e3-cae9ed77093f",
+        "lastUpdatedDateTime": "2022-10-24T05:14:25Z",
+        "createdDateTime": "2022-10-24T05:14:25Z",
+        "expirationDateTime": "2022-10-25T05:14:25Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,32 +129,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f6dbd72-8bb4-4312-b885-5b3fca00c6bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90e5dccc-bcf4-4674-b3e3-cae9ed77093f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4394ee3d-7efe-4d1e-b846-18597e5d961f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "656fbb08-b6cf-4d0f-ae55-329c4ac1a39f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d88fa8a-9779-45fc-873f-107136d0acf4",
+        "apim-request-id": "23b55d95-71ab-42cc-b3d0-b56cf563ee5f",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3f6dbd72-8bb4-4312-b885-5b3fca00c6bb",
-        "lastUpdatedDateTime": "2022-10-15T02:23:13Z",
-        "createdDateTime": "2022-10-15T02:23:11Z",
-        "expirationDateTime": "2022-10-16T02:23:11Z",
+        "jobId": "90e5dccc-bcf4-4674-b3e3-cae9ed77093f",
+        "lastUpdatedDateTime": "2022-10-24T05:14:27Z",
+        "createdDateTime": "2022-10-24T05:14:25Z",
+        "expirationDateTime": "2022-10-25T05:14:25Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:13.5656352Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:27.2517414Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -300,32 +304,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f6dbd72-8bb4-4312-b885-5b3fca00c6bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/90e5dccc-bcf4-4674-b3e3-cae9ed77093f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94bceed4-7501-4426-a81e-2a460f53a841"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6c3bc917-0297-4723-826e-bf68deeb8e3c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "348b0e0b-0ab0-4d3a-b96a-b21899e4932c",
+        "apim-request-id": "2de6d3cd-ae12-4565-b936-685ebb01c5f4",
         "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3f6dbd72-8bb4-4312-b885-5b3fca00c6bb",
-        "lastUpdatedDateTime": "2022-10-15T02:23:13Z",
-        "createdDateTime": "2022-10-15T02:23:11Z",
-        "expirationDateTime": "2022-10-16T02:23:11Z",
+        "jobId": "90e5dccc-bcf4-4674-b3e3-cae9ed77093f",
+        "lastUpdatedDateTime": "2022-10-24T05:14:27Z",
+        "createdDateTime": "2022-10-24T05:14:25Z",
+        "expirationDateTime": "2022-10-25T05:14:25Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -336,7 +341,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:13.5656352Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:27.2517414Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "284",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8f56002f-1e23-437c-af89-709d408cae1c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7b35cadd-42f1-4fa7-b4d2-077fd049ffc7"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ed1021a1-ead4-4930-93ef-cc6983861128",
+        "apim-request-id": "c410ac7d-b410-4cbf-b3ee-1d010b67f011",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:05 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/cb652cb7-1907-4185-a7fb-d2b0837ecaa9?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:12 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/66761f06-229a-42ac-8a63-58d722c6f22c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
+        "x-envoy-upstream-service-time": "115",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cb652cb7-1907-4185-a7fb-d2b0837ecaa9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66761f06-229a-42ac-8a63-58d722c6f22c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8b1d2aa8-274e-44be-81dd-71d5b0a0f12a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9724240b-51c8-4fe9-9b68-2794504b379b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "54ab3ca8-1e10-4d2a-8b8d-5bc74a435d16",
+        "apim-request-id": "2dfbd6b1-cdbc-4ad2-8ae7-3f9b64fc0aae",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cb652cb7-1907-4185-a7fb-d2b0837ecaa9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:05Z",
-        "createdDateTime": "2022-10-15T02:23:05Z",
-        "expirationDateTime": "2022-10-16T02:23:05Z",
+        "jobId": "66761f06-229a-42ac-8a63-58d722c6f22c",
+        "lastUpdatedDateTime": "2022-10-24T05:14:13Z",
+        "createdDateTime": "2022-10-24T05:14:13Z",
+        "expirationDateTime": "2022-10-25T05:14:13Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cb652cb7-1907-4185-a7fb-d2b0837ecaa9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66761f06-229a-42ac-8a63-58d722c6f22c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "08e3fd97-c199-49f2-806c-4a57c14f1a63"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9b6d870d-a163-49a0-82c4-971aa5eb480f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f440ad5-f9d1-40a4-8efc-a36ab56a90b9",
+        "apim-request-id": "53a9823b-50fb-48f4-9247-b43d15fb8107",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cb652cb7-1907-4185-a7fb-d2b0837ecaa9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:05Z",
-        "createdDateTime": "2022-10-15T02:23:05Z",
-        "expirationDateTime": "2022-10-16T02:23:05Z",
+        "jobId": "66761f06-229a-42ac-8a63-58d722c6f22c",
+        "lastUpdatedDateTime": "2022-10-24T05:14:13Z",
+        "createdDateTime": "2022-10-24T05:14:13Z",
+        "expirationDateTime": "2022-10-25T05:14:13Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,32 +129,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cb652cb7-1907-4185-a7fb-d2b0837ecaa9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66761f06-229a-42ac-8a63-58d722c6f22c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ea587002-0500-4675-9558-7d1b25876e1f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "04e9645f-c905-43d1-961a-0abf0653ec6a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4b8df2d-05b4-4c4b-895d-61a1861994e4",
+        "apim-request-id": "bd8bddd9-10fd-4f1b-a45a-39133bd3c863",
         "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cb652cb7-1907-4185-a7fb-d2b0837ecaa9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:07Z",
-        "createdDateTime": "2022-10-15T02:23:05Z",
-        "expirationDateTime": "2022-10-16T02:23:05Z",
+        "jobId": "66761f06-229a-42ac-8a63-58d722c6f22c",
+        "lastUpdatedDateTime": "2022-10-24T05:14:15Z",
+        "createdDateTime": "2022-10-24T05:14:13Z",
+        "expirationDateTime": "2022-10-25T05:14:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:07.5862822Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:15.4029046Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -230,32 +234,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/cb652cb7-1907-4185-a7fb-d2b0837ecaa9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/66761f06-229a-42ac-8a63-58d722c6f22c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ed2fb1ab-fef0-4e46-881c-6e146187addc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1b1d2a96-8bed-459f-a810-2ab1f75e30a8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b9aa67c-206f-408b-8d18-f51e0381d9f3",
+        "apim-request-id": "3656b41d-3796-49e7-8133-321dba175e5c",
         "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "cb652cb7-1907-4185-a7fb-d2b0837ecaa9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:07Z",
-        "createdDateTime": "2022-10-15T02:23:05Z",
-        "expirationDateTime": "2022-10-16T02:23:05Z",
+        "jobId": "66761f06-229a-42ac-8a63-58d722c6f22c",
+        "lastUpdatedDateTime": "2022-10-24T05:14:15Z",
+        "createdDateTime": "2022-10-24T05:14:13Z",
+        "expirationDateTime": "2022-10-25T05:14:13Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -266,7 +271,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:07.5862822Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:15.4029046Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "392",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bb8a6848-0b6b-4ce9-8189-4067bf507581"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "60cd8190-ca8c-419b-863d-87a3f1348b55"
       },
       "RequestBody": {
         "analysisInput": {
@@ -42,43 +42,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "de6216b7-0152-43ca-a636-3179e9b1edfc",
+        "apim-request-id": "45c38a84-8bc3-42a4-a73e-22669cce3c14",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:31 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/976a57bd-558e-44f6-aa37-f7250eefee09?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:49 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/77580059-74f1-4d5d-b4f3-aed4062427c1?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "137"
+        "x-envoy-upstream-service-time": "151",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/976a57bd-558e-44f6-aa37-f7250eefee09?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/77580059-74f1-4d5d-b4f3-aed4062427c1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "77e26569-ea2d-4603-9846-20573320c743"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "27281b4c-ff3f-4cd0-b9ae-f4451ab33fc7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6744cbc6-3ade-459f-a112-565e3c2d33a1",
+        "apim-request-id": "28b15eef-fc9a-4aea-944a-e433d339f804",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "976a57bd-558e-44f6-aa37-f7250eefee09",
-        "lastUpdatedDateTime": "2022-10-15T02:23:32Z",
-        "createdDateTime": "2022-10-15T02:23:31Z",
-        "expirationDateTime": "2022-10-16T02:23:31Z",
+        "jobId": "77580059-74f1-4d5d-b4f3-aed4062427c1",
+        "lastUpdatedDateTime": "2022-10-24T05:14:49Z",
+        "createdDateTime": "2022-10-24T05:14:49Z",
+        "expirationDateTime": "2022-10-25T05:14:49Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -91,33 +93,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/976a57bd-558e-44f6-aa37-f7250eefee09?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/77580059-74f1-4d5d-b4f3-aed4062427c1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0abd833f-0c6c-48cc-895a-4216b29cf3a2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "73995704-e85f-42fc-8934-2676de293088"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04135044-1fc5-45e9-8ec8-100881e6224b",
-        "Content-Length": "280",
+        "apim-request-id": "a90ce02b-654c-4754-914d-5d5818f5458b",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "13",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "976a57bd-558e-44f6-aa37-f7250eefee09",
-        "lastUpdatedDateTime": "2022-10-15T02:23:32Z",
-        "createdDateTime": "2022-10-15T02:23:31Z",
-        "expirationDateTime": "2022-10-16T02:23:31Z",
-        "status": "running",
+        "jobId": "77580059-74f1-4d5d-b4f3-aed4062427c1",
+        "lastUpdatedDateTime": "2022-10-24T05:14:49Z",
+        "createdDateTime": "2022-10-24T05:14:49Z",
+        "expirationDateTime": "2022-10-25T05:14:49Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -129,32 +132,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/976a57bd-558e-44f6-aa37-f7250eefee09?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/77580059-74f1-4d5d-b4f3-aed4062427c1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e0d883d2-4701-4308-a11e-82a8e16fcdd6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b9240ff2-015d-405b-973b-32692613206e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1430e8a3-b1b1-4339-ba34-b32d4e4b09ac",
+        "apim-request-id": "d12786c3-8ae8-4f6b-b9a6-8610146f2f90",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "x-envoy-upstream-service-time": "70",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "976a57bd-558e-44f6-aa37-f7250eefee09",
-        "lastUpdatedDateTime": "2022-10-15T02:23:33Z",
-        "createdDateTime": "2022-10-15T02:23:31Z",
-        "expirationDateTime": "2022-10-16T02:23:31Z",
+        "jobId": "77580059-74f1-4d5d-b4f3-aed4062427c1",
+        "lastUpdatedDateTime": "2022-10-24T05:14:51Z",
+        "createdDateTime": "2022-10-24T05:14:49Z",
+        "expirationDateTime": "2022-10-25T05:14:49Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -165,7 +169,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:33.8679479Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:51.3020097Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1282,32 +1286,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/976a57bd-558e-44f6-aa37-f7250eefee09?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/77580059-74f1-4d5d-b4f3-aed4062427c1?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e956a6e7-a3e6-401a-a4a8-f07bf8cc26a4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f148f905-2b62-4f4a-a1b8-d57037140225"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6d024997-7fcc-4aef-a02e-ead05a944162",
+        "apim-request-id": "5b61e110-3d97-4058-9fe4-3baacea52114",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:33 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
+        "x-envoy-upstream-service-time": "82",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "976a57bd-558e-44f6-aa37-f7250eefee09",
-        "lastUpdatedDateTime": "2022-10-15T02:23:33Z",
-        "createdDateTime": "2022-10-15T02:23:31Z",
-        "expirationDateTime": "2022-10-16T02:23:31Z",
+        "jobId": "77580059-74f1-4d5d-b4f3-aed4062427c1",
+        "lastUpdatedDateTime": "2022-10-24T05:14:51Z",
+        "createdDateTime": "2022-10-24T05:14:49Z",
+        "expirationDateTime": "2022-10-25T05:14:49Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1318,7 +1323,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:33.8679479Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:51.3020097Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "286",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f2907e0b-f64b-4141-ae03-a63ca302b55b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "36dbd5ee-4f5c-46ec-a117-6b107bc39e2d"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5ca643f7-0887-49f9-bde7-b83cec6c7eae",
+        "apim-request-id": "5bca285e-2a1c-497a-82fa-88d9a5f3fa4e",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:08 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5fcc9c61-bba7-4e74-b6a0-dd3073a21967?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:15 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "177"
+        "x-envoy-upstream-service-time": "119",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fcc9c61-bba7-4e74-b6a0-dd3073a21967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "05926d0a-b3db-40aa-aa1f-4a0e4404ac10"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5b6f4688-841a-4485-be7d-227323750475"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f3543a1-b91a-4515-a254-84210d5ea629",
+        "apim-request-id": "dc7cdbe9-623a-4032-bf07-045e09dffc75",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fcc9c61-bba7-4e74-b6a0-dd3073a21967",
-        "lastUpdatedDateTime": "2022-10-15T02:23:08Z",
-        "createdDateTime": "2022-10-15T02:23:08Z",
-        "expirationDateTime": "2022-10-16T02:23:08Z",
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:16Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fcc9c61-bba7-4e74-b6a0-dd3073a21967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f690ed52-4c15-49b9-9def-26a51e935afa"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ea012ea8-2980-44a1-bbda-cc2017226872"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "73863abe-516a-4fdf-9ef3-7511866989a7",
+        "apim-request-id": "4748e2ab-152f-424d-968f-ce85d8c69df6",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fcc9c61-bba7-4e74-b6a0-dd3073a21967",
-        "lastUpdatedDateTime": "2022-10-15T02:23:08Z",
-        "createdDateTime": "2022-10-15T02:23:08Z",
-        "expirationDateTime": "2022-10-16T02:23:08Z",
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:16Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,32 +129,150 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fcc9c61-bba7-4e74-b6a0-dd3073a21967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "587fabaf-9f1e-428f-a178-71c1e9c2f2f9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "31ef5576-8665-4ba7-8fe9-ff528c87ae5f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f82c9828-5267-47e4-bca3-2f134a112624",
+        "apim-request-id": "72ddd0ad-6512-4983-a753-cc8d22c3c2b2",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:16Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0c51a683-a582-48a6-9542-0d2cff492de8"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6f1737b4-7781-4206-962a-0d9e2eefa112",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:16Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "00d0d989-c44e-466b-a21f-c9c2ec5704bd"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3e7ef87b-a623-4eb0-ac90-57764dc4857c",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:16Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "be11681f-623d-446b-a99b-5509a25421cd"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cc71831f-3dc9-47c5-a7e8-320cf49a358f",
         "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fcc9c61-bba7-4e74-b6a0-dd3073a21967",
-        "lastUpdatedDateTime": "2022-10-15T02:23:10Z",
-        "createdDateTime": "2022-10-15T02:23:08Z",
-        "expirationDateTime": "2022-10-16T02:23:08Z",
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:22Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +283,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:10.5412178Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:22.6308693Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -194,32 +315,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fcc9c61-bba7-4e74-b6a0-dd3073a21967?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "44dbcd4c-0138-4573-bbd9-1fe1946f443f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3cf23239-1b14-4aab-9509-1285b106254c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8928d5a3-4581-4b9b-a9f5-ff740d58d194",
+        "apim-request-id": "a0a49907-5424-458a-a73d-f3ce151add59",
         "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "47",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5fcc9c61-bba7-4e74-b6a0-dd3073a21967",
-        "lastUpdatedDateTime": "2022-10-15T02:23:10Z",
-        "createdDateTime": "2022-10-15T02:23:08Z",
-        "expirationDateTime": "2022-10-16T02:23:08Z",
+        "jobId": "d8b8e5bf-4ab3-4f59-ad99-6e5b0befbdc7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:22Z",
+        "createdDateTime": "2022-10-24T05:14:16Z",
+        "expirationDateTime": "2022-10-25T05:14:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -230,7 +352,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:10.5412178Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:22.6308693Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "396",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fc6e15bb-4201-4ead-a0d4-e47c936dad32"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "019ad103-6fc8-4dc8-a466-910fe483f1d4"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,43 +44,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e8b0c00b-25dd-48b8-81d4-7ca5dba9063a",
+        "apim-request-id": "c4988fa5-6fe3-4db4-a5eb-66b46f9de982",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:14 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/ecc1261f-b8b0-437a-91a0-711bc6fa5617?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:27 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/572ca0dc-5e4f-4243-b78a-0be75691c2a0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "130"
+        "x-envoy-upstream-service-time": "186",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ecc1261f-b8b0-437a-91a0-711bc6fa5617?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/572ca0dc-5e4f-4243-b78a-0be75691c2a0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "33c58594-7c37-47b3-a0b0-3de42a2dbce6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5806e496-656f-47a6-a250-f7d7732f5723"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1bf03c08-f01c-437d-aa4b-a6c89b13f33b",
+        "apim-request-id": "7442db1d-a9fd-4d11-9cb9-0487df342f62",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ecc1261f-b8b0-437a-91a0-711bc6fa5617",
-        "lastUpdatedDateTime": "2022-10-15T02:23:14Z",
-        "createdDateTime": "2022-10-15T02:23:14Z",
-        "expirationDateTime": "2022-10-16T02:23:14Z",
+        "jobId": "572ca0dc-5e4f-4243-b78a-0be75691c2a0",
+        "lastUpdatedDateTime": "2022-10-24T05:14:28Z",
+        "createdDateTime": "2022-10-24T05:14:27Z",
+        "expirationDateTime": "2022-10-25T05:14:27Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -93,32 +95,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ecc1261f-b8b0-437a-91a0-711bc6fa5617?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/572ca0dc-5e4f-4243-b78a-0be75691c2a0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f1c246af-531d-4364-b9c0-d02ed5ab40a1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "25452417-0f97-46c6-8246-ec3da7b3e1fa"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc5a028c-7e0e-4bc9-92c1-6bc645860835",
+        "apim-request-id": "06ce55c8-8245-4a42-832f-0a7c866f91dc",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ecc1261f-b8b0-437a-91a0-711bc6fa5617",
-        "lastUpdatedDateTime": "2022-10-15T02:23:14Z",
-        "createdDateTime": "2022-10-15T02:23:14Z",
-        "expirationDateTime": "2022-10-16T02:23:14Z",
+        "jobId": "572ca0dc-5e4f-4243-b78a-0be75691c2a0",
+        "lastUpdatedDateTime": "2022-10-24T05:14:28Z",
+        "createdDateTime": "2022-10-24T05:14:27Z",
+        "expirationDateTime": "2022-10-25T05:14:27Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -131,32 +134,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ecc1261f-b8b0-437a-91a0-711bc6fa5617?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/572ca0dc-5e4f-4243-b78a-0be75691c2a0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6417cd04-1411-4b16-921f-225cbea640ae"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dd687acf-6e96-419b-a9dd-dffae8bf959d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f9808c9-9f03-418e-9cbc-50710ad03aa6",
+        "apim-request-id": "9b281501-0d25-4a33-bec2-fb9c114ab4a9",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "42"
+        "x-envoy-upstream-service-time": "50",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ecc1261f-b8b0-437a-91a0-711bc6fa5617",
-        "lastUpdatedDateTime": "2022-10-15T02:23:16Z",
-        "createdDateTime": "2022-10-15T02:23:14Z",
-        "expirationDateTime": "2022-10-16T02:23:14Z",
+        "jobId": "572ca0dc-5e4f-4243-b78a-0be75691c2a0",
+        "lastUpdatedDateTime": "2022-10-24T05:14:30Z",
+        "createdDateTime": "2022-10-24T05:14:27Z",
+        "expirationDateTime": "2022-10-25T05:14:27Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -167,7 +171,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:16.4852572Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:30.1332895Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -229,32 +233,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ecc1261f-b8b0-437a-91a0-711bc6fa5617?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/572ca0dc-5e4f-4243-b78a-0be75691c2a0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bdfa105f-3494-49a8-bf1d-28070e85fcdd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4d7b2ab6-5fa1-4574-9ac1-aba4a4e2d226"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1b769051-b186-41bf-a531-343385c3c999",
+        "apim-request-id": "91ecc133-923c-4cbb-801c-33cccdba6d19",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "49",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ecc1261f-b8b0-437a-91a0-711bc6fa5617",
-        "lastUpdatedDateTime": "2022-10-15T02:23:16Z",
-        "createdDateTime": "2022-10-15T02:23:14Z",
-        "expirationDateTime": "2022-10-16T02:23:14Z",
+        "jobId": "572ca0dc-5e4f-4243-b78a-0be75691c2a0",
+        "lastUpdatedDateTime": "2022-10-24T05:14:30Z",
+        "createdDateTime": "2022-10-24T05:14:27Z",
+        "expirationDateTime": "2022-10-25T05:14:27Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -265,7 +270,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:16.4852572Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:30.1332895Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "467",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "855300f1-3ab3-4f07-8442-f741520f1ce2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5cdeb13b-eeb9-48e1-bc29-49422cf02922"
       },
       "RequestBody": {
         "analysisInput": {
@@ -42,43 +42,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "80ef9ce5-1532-4d51-9898-b43619fe063a",
+        "apim-request-id": "80efbfa3-482d-4fb5-b448-9b4d9ead0387",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:16 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/1a561f93-84e1-44d1-a00d-df2f82b5c95d?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:30 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "165"
+        "x-envoy-upstream-service-time": "167",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a561f93-84e1-44d1-a00d-df2f82b5c95d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3eefeba9-ec97-40dd-8088-586c421604c0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "668c3a3d-2645-45ac-b95c-585818d1ef82"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a8d98d7-3188-420f-80f8-176676780488",
+        "apim-request-id": "07a46f2b-dacd-44e1-949a-6dd2b30916ce",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1a561f93-84e1-44d1-a00d-df2f82b5c95d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:17Z",
-        "createdDateTime": "2022-10-15T02:23:17Z",
-        "expirationDateTime": "2022-10-16T02:23:17Z",
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:30Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -91,32 +93,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a561f93-84e1-44d1-a00d-df2f82b5c95d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6ca413da-bf3a-4a47-918a-210ff500997c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "43813afc-55df-4720-a4e8-ff21357383bb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3d387c16-434c-4dbb-8a12-adb3e850ca33",
+        "apim-request-id": "9c9a9495-186d-4109-881d-246045e36f61",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:17 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1a561f93-84e1-44d1-a00d-df2f82b5c95d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:17Z",
-        "createdDateTime": "2022-10-15T02:23:17Z",
-        "expirationDateTime": "2022-10-16T02:23:17Z",
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:30Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -129,32 +132,189 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a561f93-84e1-44d1-a00d-df2f82b5c95d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "877b9e8f-ded5-430c-a4a0-ba8eb5fc57cb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4e9cf6a3-e7cb-495c-81a7-1390cc849361"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ce58d5a1-f765-4e05-a860-b3bec5058fbc",
+        "apim-request-id": "5fc807ca-37a3-40c7-addc-3e1db6529dd4",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:31Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "34b304ac-1966-477b-8fa4-a88f5d9004d4"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eb283665-18a5-4579-a905-b7d2273e53ef",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:31Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "760ccb57-53a2-4024-b017-74f56a9400d7"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "995e3480-cbe6-4f96-a312-796dda5d84e2",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:31Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "191acb6a-96af-44f1-8587-e6226aa97f0b"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a2ea515f-268d-4cf9-88fc-ba79b439a92f",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:39Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e396fa10-ecea-43d7-a236-32af4834a51f"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0c13e72c-5c23-4248-a2e3-cd1fcbf3b530",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1a561f93-84e1-44d1-a00d-df2f82b5c95d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:19Z",
-        "createdDateTime": "2022-10-15T02:23:17Z",
-        "expirationDateTime": "2022-10-16T02:23:17Z",
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:39Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -165,7 +325,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:19.1202123Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:39.1549445Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -199,32 +359,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a561f93-84e1-44d1-a00d-df2f82b5c95d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/24f87bb0-ea06-46a3-bf97-40381453d5a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b476e10c-7a8a-4750-911e-5e2fbf0a221f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d1ac5512-e97d-4d5f-aed4-1cc12bfef821"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1fb22a63-4075-4b1d-848a-4db47fa6cd30",
+        "apim-request-id": "056542fd-7c19-4284-8c66-6b70e1f34513",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "64",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1a561f93-84e1-44d1-a00d-df2f82b5c95d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:19Z",
-        "createdDateTime": "2022-10-15T02:23:17Z",
-        "expirationDateTime": "2022-10-16T02:23:17Z",
+        "jobId": "24f87bb0-ea06-46a3-bf97-40381453d5a7",
+        "lastUpdatedDateTime": "2022-10-24T05:14:39Z",
+        "createdDateTime": "2022-10-24T05:14:30Z",
+        "expirationDateTime": "2022-10-25T05:14:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -235,7 +396,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:19.1202123Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:39.1549445Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "439",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a0c0b5ac-df1c-439f-ac28-b510c2985464"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "06003598-fabb-4c91-8ed0-706bd0493427"
       },
       "RequestBody": {
         "analysisInput": {
@@ -40,43 +40,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1cd4dc1a-0c49-41cc-abdd-78902b20b724",
+        "apim-request-id": "c0b4c0de-8749-42ab-bbfe-745fbc0979ec",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:19 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/7ce6d5fe-1178-45be-9488-506e46b05673?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:41 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "148"
+        "x-envoy-upstream-service-time": "136",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7ce6d5fe-1178-45be-9488-506e46b05673?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e5cc03df-8271-4e47-9747-e6c4365dcfbc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "903facbc-7d00-41f7-a5a6-e23908ab99ce"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b1251d6-c624-48b4-baa4-9b460423d9f2",
+        "apim-request-id": "272b9f5b-6bfa-4955-b22e-b62fb9f1b50e",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7ce6d5fe-1178-45be-9488-506e46b05673",
-        "lastUpdatedDateTime": "2022-10-15T02:23:20Z",
-        "createdDateTime": "2022-10-15T02:23:20Z",
-        "expirationDateTime": "2022-10-16T02:23:20Z",
+        "jobId": "cf16ee74-09e7-4a57-83a2-6955afe76c69",
+        "lastUpdatedDateTime": "2022-10-24T05:14:41Z",
+        "createdDateTime": "2022-10-24T05:14:41Z",
+        "expirationDateTime": "2022-10-25T05:14:41Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -89,32 +91,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7ce6d5fe-1178-45be-9488-506e46b05673?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1e90a21d-be8c-4536-b0e3-791e45d3e78d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1fcc6550-3684-4985-bddd-1e98c87c4ddf"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f8564aa2-5b5e-416c-ae48-7082de468f23",
+        "apim-request-id": "e82c8ef8-ded3-4bdf-a615-d1ef35ce52a9",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7ce6d5fe-1178-45be-9488-506e46b05673",
-        "lastUpdatedDateTime": "2022-10-15T02:23:20Z",
-        "createdDateTime": "2022-10-15T02:23:20Z",
-        "expirationDateTime": "2022-10-16T02:23:20Z",
+        "jobId": "cf16ee74-09e7-4a57-83a2-6955afe76c69",
+        "lastUpdatedDateTime": "2022-10-24T05:14:41Z",
+        "createdDateTime": "2022-10-24T05:14:41Z",
+        "expirationDateTime": "2022-10-25T05:14:41Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -127,32 +130,72 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7ce6d5fe-1178-45be-9488-506e46b05673?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "728fc7ba-0bb9-4027-8d35-2d955f46ce37"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "baa8459b-4572-409d-bf93-75e48348a658"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "543e1ec6-edfe-437f-8cbe-2fb482403dfe",
+        "apim-request-id": "964c1721-77d4-4f38-ab89-d71f825e17ae",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cf16ee74-09e7-4a57-83a2-6955afe76c69",
+        "lastUpdatedDateTime": "2022-10-24T05:14:42Z",
+        "createdDateTime": "2022-10-24T05:14:41Z",
+        "expirationDateTime": "2022-10-25T05:14:41Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "868157c9-ed9e-41b5-9451-80adadcfb1e3"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5fc180a6-4e38-4b47-bd1b-cbfc6e5c6c2e",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7ce6d5fe-1178-45be-9488-506e46b05673",
-        "lastUpdatedDateTime": "2022-10-15T02:23:21Z",
-        "createdDateTime": "2022-10-15T02:23:20Z",
-        "expirationDateTime": "2022-10-16T02:23:20Z",
+        "jobId": "cf16ee74-09e7-4a57-83a2-6955afe76c69",
+        "lastUpdatedDateTime": "2022-10-24T05:14:44Z",
+        "createdDateTime": "2022-10-24T05:14:41Z",
+        "expirationDateTime": "2022-10-25T05:14:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -163,7 +206,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:21.7275713Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:44.1288262Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -240,32 +283,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/7ce6d5fe-1178-45be-9488-506e46b05673?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cf16ee74-09e7-4a57-83a2-6955afe76c69?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cceeff7e-d224-43e1-bc42-c36052f1f18f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "57f519b1-5054-49d5-b601-4633835186b1"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e74cdfcb-8207-40f2-bbdf-43ea12ad5e36",
+        "apim-request-id": "ab019a92-73a9-48af-9e8f-71ebdc9ffabb",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "42"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "7ce6d5fe-1178-45be-9488-506e46b05673",
-        "lastUpdatedDateTime": "2022-10-15T02:23:21Z",
-        "createdDateTime": "2022-10-15T02:23:20Z",
-        "expirationDateTime": "2022-10-16T02:23:20Z",
+        "jobId": "cf16ee74-09e7-4a57-83a2-6955afe76c69",
+        "lastUpdatedDateTime": "2022-10-24T05:14:44Z",
+        "createdDateTime": "2022-10-24T05:14:41Z",
+        "expirationDateTime": "2022-10-25T05:14:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -276,7 +320,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:21.7275713Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:44.1288262Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "739",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "302a5bde-d5be-416f-9f5a-9c7670955253"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "66b8333f-3ce8-46d8-8222-37c94f833576"
       },
       "RequestBody": {
         "analysisInput": {
@@ -65,43 +65,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "bc0c7126-beb9-48a0-8de0-8071596e9717",
+        "apim-request-id": "687deca4-6082-4c49-859d-2eb453483646",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:22 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:46 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/5fc89859-d8ae-41c9-8044-c410b6cc7614?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "222"
+        "x-envoy-upstream-service-time": "195",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fc89859-d8ae-41c9-8044-c410b6cc7614?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7a454474-2d83-45e1-84ec-96ce4676e67b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "287ffe9f-cb47-42a6-bcba-ea82d56bee8c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3a939c5f-07cb-43ad-a642-890de210e002",
+        "apim-request-id": "3fa19f24-a922-40da-b963-9596f64e2428",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:22 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:23Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
+        "jobId": "5fc89859-d8ae-41c9-8044-c410b6cc7614",
+        "lastUpdatedDateTime": "2022-10-24T05:14:46Z",
+        "createdDateTime": "2022-10-24T05:14:46Z",
+        "expirationDateTime": "2022-10-25T05:14:46Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -114,32 +116,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fc89859-d8ae-41c9-8044-c410b6cc7614?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "55a9232d-86a7-406a-a263-8e5443b627f2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b2af3cf3-9d33-4130-bbf9-65fe88ff7488"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b5cbdb9c-438d-4a3c-87dc-b0ecfd6f4734",
+        "apim-request-id": "63a41d40-0aa4-4bd7-8b6b-907c5944f457",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:22 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:23Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
+        "jobId": "5fc89859-d8ae-41c9-8044-c410b6cc7614",
+        "lastUpdatedDateTime": "2022-10-24T05:14:46Z",
+        "createdDateTime": "2022-10-24T05:14:46Z",
+        "expirationDateTime": "2022-10-25T05:14:46Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -152,146 +155,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fc89859-d8ae-41c9-8044-c410b6cc7614?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6a4dbf40-1f23-4ad5-994c-f225d36a285b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "abe10de7-ce3c-4e00-85d8-da08f793577e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a86c54e1-9767-4b40-8f1c-2fb65de08d9b",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
-      },
-      "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:23Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94390b8c-e85c-46c5-b4c8-1e75e57ae3e8"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0776ba49-3818-43de-8b09-8c175b3e2acd",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:23Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "923dbb00-31e1-4ee7-bdbb-486eb1e26534"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "960e7f0c-0148-4b88-b2f0-15aebd02e334",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:28 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:23Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9329b808-3ee1-43ac-94af-b0f7af7f61d8"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "394a2b2e-cafd-408a-a294-cac6508c7b38",
+        "apim-request-id": "cfc84f87-cf30-4cbe-a609-d513c0014d80",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "83"
+        "x-envoy-upstream-service-time": "92",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:30Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
+        "jobId": "5fc89859-d8ae-41c9-8044-c410b6cc7614",
+        "lastUpdatedDateTime": "2022-10-24T05:14:48Z",
+        "createdDateTime": "2022-10-24T05:14:46Z",
+        "expirationDateTime": "2022-10-25T05:14:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -302,7 +192,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:30.8550157Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:48.6370584Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -932,32 +822,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1ab2100b-3226-423f-a6ab-849661724ccd?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5fc89859-d8ae-41c9-8044-c410b6cc7614?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a6df6175-7bb9-4c09-8e89-d43bd9fd08b8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9947d593-5166-4a0a-834d-334a8a98bcae"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e1d8f662-0ab6-4e1e-9307-54f23c423386",
+        "apim-request-id": "faee242e-3b06-403c-9eb5-4ca93b47fe79",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "83"
+        "x-envoy-upstream-service-time": "79",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1ab2100b-3226-423f-a6ab-849661724ccd",
-        "lastUpdatedDateTime": "2022-10-15T02:23:30Z",
-        "createdDateTime": "2022-10-15T02:23:22Z",
-        "expirationDateTime": "2022-10-16T02:23:22Z",
+        "jobId": "5fc89859-d8ae-41c9-8044-c410b6cc7614",
+        "lastUpdatedDateTime": "2022-10-24T05:14:48Z",
+        "createdDateTime": "2022-10-24T05:14:46Z",
+        "expirationDateTime": "2022-10-25T05:14:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -968,7 +859,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:30.8550157Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:48.6370584Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "357",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "89b78bae-a05a-4a45-b9d9-46342f87cc00"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ffc80b2c-19c2-4c24-aa2c-d771ecacf263"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a86346ac-1e7b-423e-9a48-df1b81a328cf",
+        "apim-request-id": "0fb5e042-ae51-49b1-bb01-851929b3f60c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:50 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/e50f0efd-8d80-462a-be1f-f9e89ace8c51?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:06 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "166"
+        "x-envoy-upstream-service-time": "155",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e50f0efd-8d80-462a-be1f-f9e89ace8c51?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4962b868-3d0b-49bd-81c7-ad0cb4fafad6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b10e6d9f-eddb-4a44-95a0-2c3909248a24"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7fc7df77-bfd9-4944-a2f2-cd81070a0b11",
+        "apim-request-id": "de15999a-25b3-4ccc-848d-bc496b821c69",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e50f0efd-8d80-462a-be1f-f9e89ace8c51",
-        "lastUpdatedDateTime": "2022-10-15T02:23:51Z",
-        "createdDateTime": "2022-10-15T02:23:51Z",
-        "expirationDateTime": "2022-10-16T02:23:51Z",
+        "jobId": "c0d85152-b9cf-49e8-a56d-ac0687806391",
+        "lastUpdatedDateTime": "2022-10-24T05:15:07Z",
+        "createdDateTime": "2022-10-24T05:15:07Z",
+        "expirationDateTime": "2022-10-25T05:15:07Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -99,33 +101,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e50f0efd-8d80-462a-be1f-f9e89ace8c51?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "470a7c64-6781-4dac-ad30-1fa72e7762d1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0346280e-cf87-4b33-b285-0306a2494918"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20ebe69a-089a-478c-a238-45f614221eaa",
-        "Content-Length": "280",
+        "apim-request-id": "0777fb1c-1640-4c66-b461-6fe4c5574dab",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e50f0efd-8d80-462a-be1f-f9e89ace8c51",
-        "lastUpdatedDateTime": "2022-10-15T02:23:51Z",
-        "createdDateTime": "2022-10-15T02:23:51Z",
-        "expirationDateTime": "2022-10-16T02:23:51Z",
-        "status": "running",
+        "jobId": "c0d85152-b9cf-49e8-a56d-ac0687806391",
+        "lastUpdatedDateTime": "2022-10-24T05:15:07Z",
+        "createdDateTime": "2022-10-24T05:15:07Z",
+        "expirationDateTime": "2022-10-25T05:15:07Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -137,131 +140,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e50f0efd-8d80-462a-be1f-f9e89ace8c51?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c8c862a5-4e07-4558-aa22-c15a1cf7489d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c69d05b5-9654-47c1-9a32-2199473c9a22"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10cce59d-3c25-4df4-8238-11387a9338b4",
-        "Content-Length": "3107",
+        "apim-request-id": "dd03e722-1622-4ef2-a6b4-c94e20db61b2",
+        "Content-Length": "1381",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "117"
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e50f0efd-8d80-462a-be1f-f9e89ace8c51",
-        "lastUpdatedDateTime": "2022-10-15T02:23:53Z",
-        "createdDateTime": "2022-10-15T02:23:51Z",
-        "expirationDateTime": "2022-10-16T02:23:51Z",
-        "status": "succeeded",
+        "jobId": "c0d85152-b9cf-49e8-a56d-ac0687806391",
+        "lastUpdatedDateTime": "2022-10-24T05:15:09Z",
+        "createdDateTime": "2022-10-24T05:15:07Z",
+        "expirationDateTime": "2022-10-25T05:15:07Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 2,
           "total": 3,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:52.767139Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:53.2276279Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:53.457938Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:08.9146321Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -308,32 +224,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e50f0efd-8d80-462a-be1f-f9e89ace8c51?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4460dfa7-c0ba-4a04-8002-fbc9fe7b4b14"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "350d0c1f-1ffe-4782-8f5a-57e65871a8f8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f5e6f89-4d17-47b1-8d49-143f620f6de3",
-        "Content-Length": "3107",
+        "apim-request-id": "8e389147-c592-4f18-ab45-73cb63c81a22",
+        "Content-Length": "3109",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "124",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e50f0efd-8d80-462a-be1f-f9e89ace8c51",
-        "lastUpdatedDateTime": "2022-10-15T02:23:53Z",
-        "createdDateTime": "2022-10-15T02:23:51Z",
-        "expirationDateTime": "2022-10-16T02:23:51Z",
+        "jobId": "c0d85152-b9cf-49e8-a56d-ac0687806391",
+        "lastUpdatedDateTime": "2022-10-24T05:15:09Z",
+        "createdDateTime": "2022-10-24T05:15:07Z",
+        "expirationDateTime": "2022-10-25T05:15:07Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +261,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:52.767139Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:09.3251387Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -388,7 +305,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:53.2276279Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:09.3352663Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -432,7 +349,179 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:53.457938Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:08.9146321Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: de,en,es,fr,it,pt-BR,pt-PT,af,am,ar,as,az,be,bg,bn,br,bs,ca,cs,cy,da,el,eo,et,eu,fa,fi,fil,fy,ga,gd,gl,gu,ha,he,hi,hr,hu,hy,id,ja,jv,ka,kk,km,kn,ko,ku,ky,la,lo,lt,lv,mg,mk,ml,mn,mr,ms,my,ne,nl,no,om,or,pa,pl,ps,ro,ru,sa,sd,si,sk,sl,so,sq,sr,su,sv,sw,ta,te,th,tr,ug,uk,ur,uz,vi,xh,yi,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c0d85152-b9cf-49e8-a56d-ac0687806391?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6d3b025e-ddc0-4c0e-98cb-ed586078f89a"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d45173bc-6bbf-427a-bfcc-26ca11c25053",
+        "Content-Length": "3109",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "c0d85152-b9cf-49e8-a56d-ac0687806391",
+        "lastUpdatedDateTime": "2022-10-24T05:15:09Z",
+        "createdDateTime": "2022-10-24T05:15:07Z",
+        "expirationDateTime": "2022-10-25T05:15:07Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:09.3251387Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:09.3352663Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [],
+                "errors": [
+                  {
+                    "id": "1",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  },
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:08.9146321Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "296",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "19ce5611-cd43-42a0-8b94-d085565dd388"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dc713a36-f8fd-48b4-b931-e7609d679a61"
       },
       "RequestBody": {
         "analysisInput": {
@@ -40,43 +40,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "683831e8-db5e-47e3-a430-958a09e8c476",
+        "apim-request-id": "da1bb6d7-178f-4e8c-bd73-f88aef1d0cfb",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:35 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/152de7f9-d8e3-4cfa-829d-bc9f5b318456?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:48 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "162"
+        "x-envoy-upstream-service-time": "160",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/152de7f9-d8e3-4cfa-829d-bc9f5b318456?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b2afcc87-65ac-45d9-8145-546956cef3d5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "214c9766-4bfe-4905-a638-f39959786ca5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4e07e84-35a5-4b7c-9f63-cc4b4d753a54",
+        "apim-request-id": "5afb128a-6b34-4425-a8bb-db5223437840",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "18",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "152de7f9-d8e3-4cfa-829d-bc9f5b318456",
-        "lastUpdatedDateTime": "2022-10-15T02:24:35Z",
-        "createdDateTime": "2022-10-15T02:24:35Z",
-        "expirationDateTime": "2022-10-16T02:24:35Z",
+        "jobId": "fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:49Z",
+        "createdDateTime": "2022-10-24T05:15:48Z",
+        "expirationDateTime": "2022-10-25T05:15:48Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -89,32 +91,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/152de7f9-d8e3-4cfa-829d-bc9f5b318456?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7a12a1ec-e4df-4f6a-a66a-1bd3fdad7023"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ecd2efbf-91af-4e26-ac55-efc44a44211c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20630c42-7493-4929-a857-ae27ecf3b978",
+        "apim-request-id": "a6b603ce-bba6-4233-971b-2eb4fa2531e1",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "152de7f9-d8e3-4cfa-829d-bc9f5b318456",
-        "lastUpdatedDateTime": "2022-10-15T02:24:35Z",
-        "createdDateTime": "2022-10-15T02:24:35Z",
-        "expirationDateTime": "2022-10-16T02:24:35Z",
+        "jobId": "fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:49Z",
+        "createdDateTime": "2022-10-24T05:15:48Z",
+        "expirationDateTime": "2022-10-25T05:15:48Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -127,32 +130,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/152de7f9-d8e3-4cfa-829d-bc9f5b318456?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "523f4b68-21d3-4465-9e14-76e512d022cd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2eaf035f-a02b-4681-96ce-075fc3e0fabd"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "70dacb34-2450-4de4-b707-1f364ea11451",
+        "apim-request-id": "3b78b781-5f88-4a6e-b578-f448573c8918",
         "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "58"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "152de7f9-d8e3-4cfa-829d-bc9f5b318456",
-        "lastUpdatedDateTime": "2022-10-15T02:24:37Z",
-        "createdDateTime": "2022-10-15T02:24:35Z",
-        "expirationDateTime": "2022-10-16T02:24:35Z",
+        "jobId": "fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:50Z",
+        "createdDateTime": "2022-10-24T05:15:48Z",
+        "expirationDateTime": "2022-10-25T05:15:48Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -163,7 +167,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.0679727Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.8756081Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -185,7 +189,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.1006757Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.8879397Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -207,7 +211,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.5695973Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.4570126Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -232,32 +236,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/152de7f9-d8e3-4cfa-829d-bc9f5b318456?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "11816503-33df-490b-9c31-2603996cc212"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e4a9cca8-2080-4cdb-ba96-1564040d2f27"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e183922-f48e-4bb6-8db7-80020e9947ff",
+        "apim-request-id": "159cef2d-56df-4b3e-b82b-904f66682eeb",
         "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "59"
+        "x-envoy-upstream-service-time": "56",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "152de7f9-d8e3-4cfa-829d-bc9f5b318456",
-        "lastUpdatedDateTime": "2022-10-15T02:24:37Z",
-        "createdDateTime": "2022-10-15T02:24:35Z",
-        "expirationDateTime": "2022-10-16T02:24:35Z",
+        "jobId": "fdfac215-ed3e-4d53-b8c9-0ec70bea2b6c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:50Z",
+        "createdDateTime": "2022-10-24T05:15:48Z",
+        "expirationDateTime": "2022-10-25T05:15:48Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -268,7 +273,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.0679727Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.8756081Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -290,7 +295,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.1006757Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.8879397Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -312,7 +317,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:37.5695973Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:50.4570126Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "172",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5d138b24-c460-43c1-8c9b-aa733f34e553"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "125035bf-ed8c-4ac3-bf03-4747db3b67f3"
       },
       "RequestBody": {
         "displayName": "testJob",
@@ -33,43 +33,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8c497681-beab-4bb5-ae37-e23ece4ab4f8",
+        "apim-request-id": "07d95b56-28a7-4f66-9c16-ad6b18940612",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:00 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "106"
+        "x-envoy-upstream-service-time": "71",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c021a961-780c-4acf-bd85-bb3eeca548fe"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "758c7472-c625-45ad-8ead-e040b359b0f4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3c040f36-921a-4d1d-9c63-daa9098ff255",
+        "apim-request-id": "f186db17-6b83-4737-b721-e450dd13826b",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:46Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:00Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -83,32 +85,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ae9c72af-9972-4d2d-9267-264b72e76bfc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7326443d-be7b-4032-8e41-679f141d65a7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bf864768-c9d0-4976-981e-bb99e366fd35",
+        "apim-request-id": "9e313403-7a90-4ca4-913f-d6d9bb59e3b9",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:46Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:00Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "12fea8db-5853-43e0-9818-41b50bbd6b17"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2a76479c-f979-4402-ae16-74361d4c460a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4868950d-f8d9-4966-832c-15af4686e414",
+        "apim-request-id": "240a4f65-1fc0-49b2-be57-4ba176f725e2",
         "Content-Length": "304",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:47Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:00Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "running",
         "errors": [],
         "displayName": "testJob",
@@ -161,32 +165,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3a9fb791-5369-4283-a812-fe268834fdb6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0bbccd5e-2f19-458b-bb72-656d3b162751"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ba73ddd1-36d9-4bc7-a52c-04e0d80ca7f6",
+        "apim-request-id": "c51acce8-b523-43a6-8883-ae70e01ea9f8",
         "Content-Length": "304",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:47Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:00Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "running",
         "errors": [],
         "displayName": "testJob",
@@ -200,32 +205,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c75c9066-3dba-48a4-b4d9-5f1c15f0e99d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4fcd0f88-9a92-4284-80f0-5236a8a65f3d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "000ed554-2a7e-4c22-aef4-75205c83a572",
+        "apim-request-id": "59b55a2c-3ce9-48ae-9c71-71f1435c7ada",
         "Content-Length": "304",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:47Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:00Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "running",
         "errors": [],
         "displayName": "testJob",
@@ -239,71 +245,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa5d38e2-96f4-4cbe-b029-87436f436cf2?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1672b424-3e40-4b0f-ab35-21c99b62de4d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8a84d422-e5c5-4d43-9b9c-a72ad69d495f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a6acf34e-b45f-428c-865d-7f6ac163e94a",
-        "Content-Length": "304",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:54 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
-      },
-      "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:47Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "testJob",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2796e14a-e720-4d6d-92cd-6f0eb4fe98bb?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1d02895b-b7b4-4f01-a1bf-cbb72745375b"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1eb7ed08-5a59-4f15-8341-1502b551e782",
+        "apim-request-id": "ba0db453-c03a-4a0b-9484-3a7f642777b5",
         "Content-Length": "853",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "65",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2796e14a-e720-4d6d-92cd-6f0eb4fe98bb",
-        "lastUpdatedDateTime": "2022-10-15T02:24:55Z",
-        "createdDateTime": "2022-10-15T02:24:46Z",
-        "expirationDateTime": "2022-10-16T02:24:46Z",
+        "jobId": "fa5d38e2-96f4-4cbe-b029-87436f436cf2",
+        "lastUpdatedDateTime": "2022-10-24T05:16:08Z",
+        "createdDateTime": "2022-10-24T05:16:00Z",
+        "expirationDateTime": "2022-10-25T05:16:00Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "testJob",
@@ -315,7 +283,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:55.3444548Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:08.5925726Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "300",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2149b003-1138-4140-a8e0-934e4dff34e8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6064f8a6-1758-4aa5-bfe6-e6ab68616698"
       },
       "RequestBody": {
         "analysisInput": {
@@ -55,43 +55,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fc9bb91e-75a6-4acc-aad0-caf5d96cf004",
+        "apim-request-id": "2dbb8647-c86a-4a3e-8afc-de748237a6ba",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:15 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/39d55128-481e-4aa1-a632-e011049505a3?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:28 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "447"
+        "x-envoy-upstream-service-time": "222",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/39d55128-481e-4aa1-a632-e011049505a3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cc894024-6374-4051-8086-d772befe5770"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9da25e8b-4655-42f3-ad4b-6f78e5ece34b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1cf1cea1-287d-40f6-b673-2b1862639527",
+        "apim-request-id": "5b2a1da3-f310-4249-92c0-30707ff20c50",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "39d55128-481e-4aa1-a632-e011049505a3",
-        "lastUpdatedDateTime": "2022-10-15T02:24:15Z",
-        "createdDateTime": "2022-10-15T02:24:15Z",
-        "expirationDateTime": "2022-10-16T02:24:15Z",
+        "jobId": "9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6",
+        "lastUpdatedDateTime": "2022-10-24T05:15:28Z",
+        "createdDateTime": "2022-10-24T05:15:28Z",
+        "expirationDateTime": "2022-10-25T05:15:28Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -104,32 +106,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/39d55128-481e-4aa1-a632-e011049505a3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0492e0af-4f52-4c96-b52f-1e07dc7254fd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5783b2d1-6b05-4184-a993-2345b2fd0d61"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bf189afd-a551-4b7a-a86d-b0e47e90d3a8",
+        "apim-request-id": "6b5259c1-58a1-48dc-967d-1d96674ced9e",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "39d55128-481e-4aa1-a632-e011049505a3",
-        "lastUpdatedDateTime": "2022-10-15T02:24:15Z",
-        "createdDateTime": "2022-10-15T02:24:15Z",
-        "expirationDateTime": "2022-10-16T02:24:15Z",
+        "jobId": "9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6",
+        "lastUpdatedDateTime": "2022-10-24T05:15:28Z",
+        "createdDateTime": "2022-10-24T05:15:28Z",
+        "expirationDateTime": "2022-10-25T05:15:28Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -142,43 +145,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/39d55128-481e-4aa1-a632-e011049505a3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e430cf4b-7126-4b6d-85f9-c810ed022e4c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c526ecdf-a911-4bf6-9068-00495b3daad5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "30c39809-d91d-40da-a77a-a4ba519f122a",
-        "Content-Length": "1522",
+        "apim-request-id": "241c719f-8292-4cce-9339-39e7ab184514",
+        "Content-Length": "1132",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "172"
+        "x-envoy-upstream-service-time": "208",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "39d55128-481e-4aa1-a632-e011049505a3",
-        "lastUpdatedDateTime": "2022-10-15T02:24:17Z",
-        "createdDateTime": "2022-10-15T02:24:15Z",
-        "expirationDateTime": "2022-10-16T02:24:15Z",
-        "status": "succeeded",
+        "jobId": "9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6",
+        "lastUpdatedDateTime": "2022-10-24T05:15:31Z",
+        "createdDateTime": "2022-10-24T05:15:28Z",
+        "expirationDateTime": "2022-10-25T05:15:28Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.7423522Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:30.997656Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -214,7 +218,124 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.8437693Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:31.0440111Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "56",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "0",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "w",
+                    "id": "22",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "19",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "89699221-6641-43ec-983d-c9688b63e489"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c0290f2f-9fa5-496f-9f8b-2d5a5d8bc384",
+        "Content-Length": "1522",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "187",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6",
+        "lastUpdatedDateTime": "2022-10-24T05:15:31Z",
+        "createdDateTime": "2022-10-24T05:15:28Z",
+        "expirationDateTime": "2022-10-25T05:15:28Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:30.997656Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "56",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "0",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "22",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:31.0440111Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -255,7 +376,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.951567Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:31.9693936Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -294,32 +415,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/39d55128-481e-4aa1-a632-e011049505a3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a0657e9f-7e07-45a7-a1b3-0c5b297e49f9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "93362c81-64c5-487d-a7f8-f6e72a018b72"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "07fc042b-3109-469c-8264-6d6678be0255",
+        "apim-request-id": "3ad72031-8740-4b0d-8f98-00de46dc4ad1",
         "Content-Length": "1522",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "231"
+        "x-envoy-upstream-service-time": "185",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "39d55128-481e-4aa1-a632-e011049505a3",
-        "lastUpdatedDateTime": "2022-10-15T02:24:17Z",
-        "createdDateTime": "2022-10-15T02:24:15Z",
-        "expirationDateTime": "2022-10-16T02:24:15Z",
+        "jobId": "9b72c561-b0be-4d7a-9fd8-6e2c66b71fa6",
+        "lastUpdatedDateTime": "2022-10-24T05:15:31Z",
+        "createdDateTime": "2022-10-24T05:15:28Z",
+        "expirationDateTime": "2022-10-25T05:15:28Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -330,7 +452,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.7423522Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:30.997656Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -366,7 +488,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.8437693Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:31.0440111Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -407,7 +529,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:17.951567Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:31.9693936Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "307",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "19e7ff07-6abe-44be-94e6-adbb79020e5c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "03c70cc9-55c5-49a1-b899-b1783e7653f3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -55,43 +55,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7295ccde-8707-4d92-bffb-f770c1d78e5d",
+        "apim-request-id": "2994c35a-5273-4fe0-8d23-552633d655f8",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:53 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:11 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "209"
+        "x-envoy-upstream-service-time": "215",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "adb1e63c-10e8-442e-815f-6d6fffdf56b3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f2661c7c-9648-4379-a05f-911fc74d9cff"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "056f2058-5dba-4717-9c35-1c91b7c6cf08",
+        "apim-request-id": "0fd40dd9-cc19-4e84-a422-6216b26213c2",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:54Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:12Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -104,32 +106,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "88def527-c78d-497f-93fd-dbbf3d471e4d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "85f5c024-1253-4bf3-adb1-87dea35f85b5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "186eaf2c-eb13-4978-a041-eb9c9d1d0712",
+        "apim-request-id": "f89c467e-b299-4592-8c26-c569bb34daa8",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "11",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:54Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:12Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -142,220 +145,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "136bc5ee-db87-40bb-85f9-abdf760639d3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b654738d-7e06-4706-8c07-1e8833148748"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ddc5f4ca-997e-4187-ab89-36270f14a5bb",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:55 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:55Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "954b1a61-f221-4491-962b-8803a7744845"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4a954348-363c-4060-b00c-534a63bba578",
-        "Content-Length": "664",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:57 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
-      },
-      "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:56Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bc6fa78d-61dd-4a8a-9f7f-15bf86e47390"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "067c893a-fc7f-4152-b862-acee448677ca",
-        "Content-Length": "664",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:00 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "63"
-      },
-      "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:23:56Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 3,
-          "items": [
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "keyPhrases": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "keyPhrases": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "55cf805c-0bc0-4be9-b8e2-d8fe622eedad"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5f142cc4-f6a1-4c3a-8a31-42fbb58df50d",
+        "apim-request-id": "e9e14473-a5f7-44ef-8b8f-cf0c3705d853",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "222"
+        "x-envoy-upstream-service-time": "158",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:01Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -366,7 +182,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -447,7 +263,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -486,62 +302,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "64d49e3f-df5a-4059-9f0a-2608fadc1853"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "e44ebdf2-2a70-4243-8191-53861eb415fa",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:24:04 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "64d49e3f-df5a-4059-9f0a-2608fadc1853"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a708425c-19c9-43c3-a024-0b19fc70b6c4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "62fe73ef-aae8-403d-8ab3-43eb52b777fb",
+        "apim-request-id": "338dd7ce-7425-429b-85eb-6f36ee53cee8",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "115"
+        "x-envoy-upstream-service-time": "115",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:01Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -552,7 +339,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -633,7 +420,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -672,32 +459,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "64c067ed-4c70-4d2e-9311-c059b4e876df"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4cf20075-2bcc-43e0-b2d8-e7b82ced4e7b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7e93e224-eafa-488f-8e8e-f9ab08e1e986",
+        "apim-request-id": "993a1645-1bed-4064-a704-333eb6af7d60",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:07 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99"
+        "x-envoy-upstream-service-time": "125",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:01Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -708,7 +496,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -789,7 +577,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -828,32 +616,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "61eae311-9b45-46c5-970e-2e360610dd02"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "81acb48e-7238-444b-ad15-042f357ab392"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5b8213c1-ee4b-45e5-848a-55537d85df9c",
+        "apim-request-id": "88ba8578-6ecb-477d-bc25-390dc4e2557a",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "111"
+        "x-envoy-upstream-service-time": "143",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:01Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -864,7 +653,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -945,7 +734,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -984,32 +773,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "98ff1300-c9e0-4554-83f7-f6e70b9dba90"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "87ae923c-12fe-47a1-8c7e-6bedcfcdc7d6"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "54373fa4-8e43-4a46-b0e7-a5ed732e40ce",
+        "apim-request-id": "58ec5b07-dcb1-4bb2-8591-adbd04f1d706",
         "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "127"
+        "x-envoy-upstream-service-time": "125",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:01Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -1020,7 +810,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1101,7 +891,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1140,32 +930,190 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "84e14d30-c1c9-449d-9ca8-febd4d2af8d8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9f3616fb-8a69-4bd8-9e40-d897e6f2e090"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "986c6dd4-90ea-42ba-bdf1-cdcca5666b9f",
+        "apim-request-id": "1dd7a9df-7adc-4688-816d-ab22e252ccdd",
+        "Content-Length": "1556",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "238",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:14Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "70379788-3cbb-4d05-b707-c03169a0eb34"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ed82162-9985-4e8e-9c16-1debf21fb540",
         "Content-Length": "2043",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "163"
+        "x-envoy-upstream-service-time": "233",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:14Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:26Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1176,7 +1124,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1257,7 +1205,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:14.2402609Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:26.1339222Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1298,7 +1246,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1337,32 +1285,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d4b1563c-2ebe-456d-bba9-fa95690fdb6d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e72d8096-474b-4b55-a5ec-629c526e063c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6ee01196-454e-461a-8e06-b1007dd37186"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6b7f4c9b-e8f5-4611-88f5-d4bcc64e61f8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50810ae0-9ad9-4226-99d0-1572e8cbc418",
+        "apim-request-id": "87029a32-f8af-42c5-84b0-9f692a2bd5b1",
         "Content-Length": "2043",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:14 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183"
+        "x-envoy-upstream-service-time": "190",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d4b1563c-2ebe-456d-bba9-fa95690fdb6d",
-        "lastUpdatedDateTime": "2022-10-15T02:24:14Z",
-        "createdDateTime": "2022-10-15T02:23:54Z",
-        "expirationDateTime": "2022-10-16T02:23:54Z",
+        "jobId": "e72d8096-474b-4b55-a5ec-629c526e063c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:26Z",
+        "createdDateTime": "2022-10-24T05:15:12Z",
+        "expirationDateTime": "2022-10-25T05:15:12Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1373,7 +1322,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:01.9722055Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.5156384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1454,7 +1403,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:14.2402609Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:26.1339222Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1495,7 +1444,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:56.7376539Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:14.3628797Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "1389",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d209be5d-a24d-4f2e-b3b7-b55e99ff4a34"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "06039bdc-45d3-42c0-bf3d-098856781258"
       },
       "RequestBody": {
         "analysisInput": {
@@ -156,43 +156,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "19f93a4e-5dff-4a5c-9f91-b9a64f690f65",
+        "apim-request-id": "c5013c4b-330c-477e-a3b5-9d257a1e9efc",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:38 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:52 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "705"
+        "x-envoy-upstream-service-time": "754",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2ec7209e-cb3d-4aac-a3c1-6fa50bb3362e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d60aa1e1-02a0-480c-9449-56390702a6a7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b0a19da7-8083-4929-a042-0105f2ba0097",
+        "apim-request-id": "1f03b0e1-5cc2-47cb-aeb9-01ef1a53a9a4",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:39Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:52Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -205,70 +207,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "39a2d930-2008-40e3-aaf9-45f24ca02644"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0dd86e0f-2931-442d-886b-8d3d34381d70"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b29b4af-1861-4e15-9056-c3fedafd3dcb",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:39Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b32ebdc8-5f7f-468e-903c-b1d723cbe7a7"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "72a3b144-75ab-441e-83a8-d800e74d89aa",
+        "apim-request-id": "c762a332-4547-46b7-a900-c1bf05c3cc93",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:40Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:52Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -281,32 +246,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6f472794-9e49-4203-9ca9-9fcc9e000117"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "88484368-c6f5-41ca-88c9-83356e398ca7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "050d28dc-1030-4704-939c-7e42bca53096",
+        "apim-request-id": "014009bd-68fb-441c-8b5c-87e55ce56a56",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:43Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:52Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -319,32 +285,72 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3c824f8f-2328-495c-bef7-30f94d2649e5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fb6d478e-23db-4e2a-9a07-de0714b3d65a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "30d7a25c-b5e3-4561-92c1-5c8e1bdac6b5",
+        "apim-request-id": "9c46bf2a-d93a-4f0d-a0fa-5cbe34f5a765",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:55Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ae763ad4-9191-4203-9704-7a092fb3d981"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a5883fd4-ccc8-4abc-ab21-81a851284448",
         "Content-Length": "2666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "380"
+        "x-envoy-upstream-service-time": "474",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:44Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:58Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -355,7 +361,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:44.4911527Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:58.0146094Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -466,7 +472,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:43.2806543Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:57.2530446Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -617,36 +623,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?api-version=2022-05-01\u0026top=10",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?api-version=2022-05-01\u0026top=10",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "98fd5ad0-6775-4c04-a580-b5c257b2409b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ed9b4b72-15d3-43f2-95bc-3ec602357d84"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "52b24033-1257-4df3-ba49-e3fe337bc758",
+        "apim-request-id": "f14a3e18-b1be-477c-90ae-a736246fca0d",
         "Content-Length": "1717",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "205"
+        "x-envoy-upstream-service-time": "226",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:44Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:58Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -657,7 +664,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:44.4911527Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:58.0146094Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -718,7 +725,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:43.2806543Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:57.2530446Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -799,36 +806,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "65fd059e-dbed-409b-8698-e71081351f03"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ffd14df1-7f4b-4800-8daa-535699b702dc"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "da184f0d-1489-48ad-b2b6-bc619e427f88",
+        "apim-request-id": "9fae2d50-ef1f-4f95-927a-d2a7d4626074",
         "Content-Length": "1736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "200"
+        "x-envoy-upstream-service-time": "235",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:44Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:58Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -839,7 +847,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:44.4911527Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:58.0146094Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -900,7 +908,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:43.2806543Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:57.2530446Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -981,36 +989,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/878756bc-6b28-440b-871b-a925c1faeff0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/4bc062ce-5593-4735-bdd0-3c3ee6d254d0?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0988f362-e8f3-4882-83d8-87c9fefc608f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "81df1bb8-21e4-4f8a-93c2-94f8d306425e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ea0b43d2-7129-462e-8450-77167156a1b2",
+        "apim-request-id": "df8eff7b-ee09-4314-89db-d06bfaf2bca4",
         "Content-Length": "1404",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "175"
+        "x-envoy-upstream-service-time": "138",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "878756bc-6b28-440b-871b-a925c1faeff0",
-        "lastUpdatedDateTime": "2022-10-15T02:24:44Z",
-        "createdDateTime": "2022-10-15T02:24:38Z",
-        "expirationDateTime": "2022-10-16T02:24:38Z",
+        "jobId": "4bc062ce-5593-4735-bdd0-3c3ee6d254d0",
+        "lastUpdatedDateTime": "2022-10-24T05:15:58Z",
+        "createdDateTime": "2022-10-24T05:15:51Z",
+        "expirationDateTime": "2022-10-25T05:15:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1021,7 +1030,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:44.4911527Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:58.0146094Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1079,7 +1088,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:43.2806543Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:57.2530446Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "408",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0bc246e0-994c-43e7-9d81-28304344931f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ce6d2f26-8a8f-4e19-961d-5ad387f2dbcf"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,73 +51,123 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4a004d7b-1552-44b3-96ba-7f9c49ebf045",
+        "apim-request-id": "02672b9d-8f6b-4aba-9256-15e5b14a5c30",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:57 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:08 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "167"
+        "x-envoy-upstream-service-time": "175",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d60c9d06-57a7-46bc-9084-5032ea71ff58"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "8fc09ad2-d988-49ca-b7bc-c659238db87f",
-        "Content-Length": "85",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:24:57 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Rate limit is exceeded. Try again in 1 seconds."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d60c9d06-57a7-46bc-9084-5032ea71ff58"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "266a5e75-8446-4435-88b5-59b08adaba79"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "abb0e401-eeda-4452-beb7-8f057df6770f",
-        "Content-Length": "280",
+        "apim-request-id": "1c015947-41b0-4958-b5d2-5cedab8bbc40",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:24:58Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:09Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 4,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "35851546-86aa-44ec-a841-9f1181ffa4a2"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "77b79050-b23b-4f77-af0f-a47dcd4cafd7",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:09Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 4,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "58bcfc21-98ca-422d-bf6f-94759a4256ed"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8d4d46ab-3a79-4bb7-a566-db5002c754b5",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:09Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -130,119 +180,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "38edaa3b-687c-4792-a670-e4fe22acf3ea"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3c17a1f3-0601-4a60-a685-e08cf39ac625"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "71410786-9ecd-4ad1-b439-03f8896c7bc9",
-        "Content-Length": "280",
+        "apim-request-id": "930a71bc-36ca-4b0e-aea9-5f7be3b73635",
+        "Content-Length": "5790",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "x-envoy-upstream-service-time": "117",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:24:58Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:11Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 3,
           "failed": 0,
-          "inProgress": 4,
-          "total": 4,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "712eb687-6b1c-4f2b-969b-72c65a087d05"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5df89a2a-0562-434c-a7ca-70d62aeb077b",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:58 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:24:58Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 4,
-          "total": 4,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0a627af1-3693-4b48-9acc-ada567d53745"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b83967e5-ff68-4de8-8b2c-9561c270cd48",
-        "Content-Length": "6371",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:00 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "188"
-      },
-      "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:25:00Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 4,
-          "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 4,
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.450137Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.5494715Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -635,7 +610,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.4707173Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.7481309Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -687,48 +662,8 @@
               }
             },
             {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:00.4155139Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "******* does not suffer from high blood pressure.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Patient",
-                        "category": "PersonType",
-                        "offset": 0,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "daily",
-                        "category": "DateTime",
-                        "subcategory": "Set",
-                        "offset": 40,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.5904896Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.1814626Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -792,32 +727,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b5b919e3-fb25-4397-8ad7-3387dc21f09a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8652159b-cdc9-4e75-ac03-841d224541ee"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3cf5531d-ac38-44d3-806c-93bff7dec578",
-        "Content-Length": "6371",
+        "apim-request-id": "4eacb324-eef1-48ed-9c44-1bb60ee2714b",
+        "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "142"
+        "x-envoy-upstream-service-time": "122",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:25:00Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:11Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -828,7 +764,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.450137Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.5494715Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1221,7 +1157,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.4707173Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.7481309Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1274,7 +1210,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:00.4155139Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.9107024Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1314,7 +1250,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.5904896Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.1814626Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1378,32 +1314,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d6ea38fa-b94f-4a5b-b2e0-ce26f773312c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "51e0d84e-6051-49bc-86d0-ec99682dddb1"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eda552de-6243-4ea5-bfda-039a53a128db",
-        "Content-Length": "6371",
+        "apim-request-id": "a1fe3ecf-4fa1-44f0-809c-acb29efa3b52",
+        "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "120"
+        "x-envoy-upstream-service-time": "131",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:25:00Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:11Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1414,7 +1351,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.450137Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.5494715Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1807,7 +1744,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.4707173Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.7481309Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1860,7 +1797,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:00.4155139Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.9107024Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1900,7 +1837,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.5904896Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.1814626Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1964,32 +1901,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/532551de-b291-447c-b78f-eaa71cc1ea61?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "39795789-ca92-4004-8c11-95430bf3dc50"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3ed1eeba-bde9-44dc-a3f7-bbdbe7b8362f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7fd7dcc5-0057-4353-a5b3-388fa150255e",
-        "Content-Length": "6371",
+        "apim-request-id": "fcadcf88-eff4-4add-9eb3-b0b102ff4b29",
+        "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "137",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "532551de-b291-447c-b78f-eaa71cc1ea61",
-        "lastUpdatedDateTime": "2022-10-15T02:25:00Z",
-        "createdDateTime": "2022-10-15T02:24:57Z",
-        "expirationDateTime": "2022-10-16T02:24:57Z",
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:11Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -2000,7 +1938,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.450137Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.5494715Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2393,7 +2331,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.4707173Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.7481309Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2446,7 +2384,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:00.4155139Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.9107024Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2486,7 +2424,594 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:59.5904896Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.1814626Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.46,
+                      "neutral": 0.5,
+                      "negative": 0.05
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.46,
+                          "neutral": 0.5,
+                          "negative": 0.05
+                        },
+                        "offset": 0,
+                        "length": 49,
+                        "text": "Patient does not suffer from high blood pressure.",
+                        "targets": [],
+                        "assessments": []
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 46,
+                        "text": "Prescribed 100mg ibuprofen, taken twice daily.",
+                        "targets": [],
+                        "assessments": []
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edab58e0-0e0d-42e1-b953-a94132185eae?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0a52931e-72b0-4cb0-9338-45c03218ceec"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a980a0e6-0fd4-45a7-a64c-ce6f0a98b584",
+        "Content-Length": "6372",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "edab58e0-0e0d-42e1-b953-a94132185eae",
+        "lastUpdatedDateTime": "2022-10-24T05:16:11Z",
+        "createdDateTime": "2022-10-24T05:16:09Z",
+        "expirationDateTime": "2022-10-25T05:16:09Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 4,
+          "items": [
+            {
+              "kind": "HealthcareLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.5494715Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "offset": 29,
+                        "length": 19,
+                        "text": "high blood pressure",
+                        "category": "SymptomOrSign",
+                        "confidenceScore": 1.0,
+                        "assertion": {
+                          "certainty": "negative"
+                        },
+                        "name": "Hypertensive disease",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020538"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000023317"
+                          },
+                          {
+                            "dataSource": "BI",
+                            "id": "BI00001"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "1017493"
+                          },
+                          {
+                            "dataSource": "CCS",
+                            "id": "7.1"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000015800"
+                          },
+                          {
+                            "dataSource": "COSTAR",
+                            "id": "397"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "0571-5243"
+                          },
+                          {
+                            "dataSource": "CST",
+                            "id": "HYPERTENS"
+                          },
+                          {
+                            "dataSource": "DXP",
+                            "id": "U002034"
+                          },
+                          {
+                            "dataSource": "HPO",
+                            "id": "HP:0000822"
+                          },
+                          {
+                            "dataSource": "ICD10",
+                            "id": "I10-I15.9"
+                          },
+                          {
+                            "dataSource": "ICD10AM",
+                            "id": "I10-I15.9"
+                          },
+                          {
+                            "dataSource": "ICD10CM",
+                            "id": "I10"
+                          },
+                          {
+                            "dataSource": "ICD9CM",
+                            "id": "997.91"
+                          },
+                          {
+                            "dataSource": "ICPC2ICD10ENG",
+                            "id": "MTHU035456"
+                          },
+                          {
+                            "dataSource": "ICPC2P",
+                            "id": "K85004"
+                          },
+                          {
+                            "dataSource": "LCH",
+                            "id": "U002317"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh85063723"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LA14293-7"
+                          },
+                          {
+                            "dataSource": "MDR",
+                            "id": "10020772"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "33288"
+                          },
+                          {
+                            "dataSource": "MEDLINEPLUS",
+                            "id": "34"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D006973"
+                          },
+                          {
+                            "dataSource": "MTH",
+                            "id": "005"
+                          },
+                          {
+                            "dataSource": "MTHICD9",
+                            "id": "997.91"
+                          },
+                          {
+                            "dataSource": "NANDA-I",
+                            "id": "00905"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_CPTAC",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_CTCAE",
+                            "id": "E13785"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "1908"
+                          },
+                          {
+                            "dataSource": "NCI_GDC",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000458091"
+                          },
+                          {
+                            "dataSource": "NCI_NICHD",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NCI_caDSR",
+                            "id": "C3117"
+                          },
+                          {
+                            "dataSource": "NOC",
+                            "id": "060808"
+                          },
+                          {
+                            "dataSource": "OMIM",
+                            "id": "MTHU002068"
+                          },
+                          {
+                            "dataSource": "PCDS",
+                            "id": "PRB_11000.06"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000686951"
+                          },
+                          {
+                            "dataSource": "PSY",
+                            "id": "23830"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "XE0Ub"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "F-70700"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "D3-02000"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "38341003"
+                          },
+                          {
+                            "dataSource": "WHO",
+                            "id": "0210"
+                          }
+                        ]
+                      }
+                    ],
+                    "relations": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "offset": 11,
+                        "length": 5,
+                        "text": "100mg",
+                        "category": "Dosage",
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "offset": 17,
+                        "length": 9,
+                        "text": "ibuprofen",
+                        "category": "MedicationName",
+                        "confidenceScore": 1.0,
+                        "name": "ibuprofen",
+                        "links": [
+                          {
+                            "dataSource": "UMLS",
+                            "id": "C0020740"
+                          },
+                          {
+                            "dataSource": "AOD",
+                            "id": "0000019879"
+                          },
+                          {
+                            "dataSource": "ATC",
+                            "id": "M01AE01"
+                          },
+                          {
+                            "dataSource": "CCPSS",
+                            "id": "0046165"
+                          },
+                          {
+                            "dataSource": "CHV",
+                            "id": "0000006519"
+                          },
+                          {
+                            "dataSource": "CSP",
+                            "id": "2270-2077"
+                          },
+                          {
+                            "dataSource": "DRUGBANK",
+                            "id": "DB01050"
+                          },
+                          {
+                            "dataSource": "GS",
+                            "id": "1611"
+                          },
+                          {
+                            "dataSource": "LCH_NW",
+                            "id": "sh97005926"
+                          },
+                          {
+                            "dataSource": "LNC",
+                            "id": "LP16165-0"
+                          },
+                          {
+                            "dataSource": "MEDCIN",
+                            "id": "40458"
+                          },
+                          {
+                            "dataSource": "MMSL",
+                            "id": "d00015"
+                          },
+                          {
+                            "dataSource": "MSH",
+                            "id": "D007052"
+                          },
+                          {
+                            "dataSource": "MTHSPL",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_CTRP",
+                            "id": "C561"
+                          },
+                          {
+                            "dataSource": "NCI_DCP",
+                            "id": "00803"
+                          },
+                          {
+                            "dataSource": "NCI_DTP",
+                            "id": "NSC0256857"
+                          },
+                          {
+                            "dataSource": "NCI_FDA",
+                            "id": "WK2XYI10QM"
+                          },
+                          {
+                            "dataSource": "NCI_NCI-GLOSS",
+                            "id": "CDR0000613511"
+                          },
+                          {
+                            "dataSource": "NDDF",
+                            "id": "002377"
+                          },
+                          {
+                            "dataSource": "PDQ",
+                            "id": "CDR0000040475"
+                          },
+                          {
+                            "dataSource": "RCD",
+                            "id": "x02MO"
+                          },
+                          {
+                            "dataSource": "RXNORM",
+                            "id": "5640"
+                          },
+                          {
+                            "dataSource": "SNM",
+                            "id": "E-7772"
+                          },
+                          {
+                            "dataSource": "SNMI",
+                            "id": "C-603C0"
+                          },
+                          {
+                            "dataSource": "SNOMEDCT_US",
+                            "id": "387207008"
+                          },
+                          {
+                            "dataSource": "USP",
+                            "id": "m39860"
+                          },
+                          {
+                            "dataSource": "USPMG",
+                            "id": "MTHU000060"
+                          },
+                          {
+                            "dataSource": "VANDF",
+                            "id": "4017840"
+                          }
+                        ]
+                      },
+                      {
+                        "offset": 34,
+                        "length": 11,
+                        "text": "twice daily",
+                        "category": "Frequency",
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "relations": [
+                      {
+                        "relationType": "DosageOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/1/entities/0",
+                            "role": "Dosage"
+                          },
+                          {
+                            "ref": "#/results/documents/1/entities/1",
+                            "role": "Medication"
+                          }
+                        ]
+                      },
+                      {
+                        "relationType": "FrequencyOfMedication",
+                        "entities": [
+                          {
+                            "ref": "#/results/documents/1/entities/1",
+                            "role": "Medication"
+                          },
+                          {
+                            "ref": "#/results/documents/1/entities/2",
+                            "role": "Frequency"
+                          }
+                        ]
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-03-01"
+              }
+            },
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.7481309Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Patient",
+                        "category": "PersonType",
+                        "offset": 0,
+                        "length": 7,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "100mg",
+                        "category": "Quantity",
+                        "subcategory": "Dimension",
+                        "offset": 11,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "ibuprofen",
+                        "category": "Product",
+                        "offset": 17,
+                        "length": 9,
+                        "confidenceScore": 0.89
+                      },
+                      {
+                        "text": "daily",
+                        "category": "DateTime",
+                        "subcategory": "Set",
+                        "offset": 40,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.9107024Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "******* does not suffer from high blood pressure.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Patient",
+                        "category": "PersonType",
+                        "offset": 0,
+                        "length": 7,
+                        "confidenceScore": 0.94
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "daily",
+                        "category": "DateTime",
+                        "subcategory": "Set",
+                        "offset": 40,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "SentimentAnalysisLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:16:11.1814626Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "417",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3bca25dc-403d-4c50-a8e0-6afe473b557c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ec6318f4-1f00-40fd-a6f5-e445e99c4be8"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c3dcb1d6-7fc3-45e8-8798-c3005e095ea1",
+        "apim-request-id": "8cce1ff5-8c9e-40b2-9d20-524256c0d39f",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:45 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:04 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/a63d5347-2200-4483-9f59-a6ad9c3f11f7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "155"
+        "x-envoy-upstream-service-time": "233",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a63d5347-2200-4483-9f59-a6ad9c3f11f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c5bd3c80-05cc-4d41-8834-7aea1a2d310f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "eb55aa8e-f07b-445d-b72d-d1dd8ae349be"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5decb544-a248-4490-8ec0-4ff025d1c58b",
+        "apim-request-id": "e769c8c6-6d96-4af2-9532-2f7800cf8269",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "46cd092a-d25c-4506-8216-cdf08bbc33f3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:46Z",
-        "createdDateTime": "2022-10-15T02:23:46Z",
-        "expirationDateTime": "2022-10-16T02:23:46Z",
+        "jobId": "a63d5347-2200-4483-9f59-a6ad9c3f11f7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:04Z",
+        "createdDateTime": "2022-10-24T05:15:03Z",
+        "expirationDateTime": "2022-10-25T05:15:03Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -99,32 +101,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a63d5347-2200-4483-9f59-a6ad9c3f11f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0e501da1-1da2-4cd2-8810-c1b7c20cd088"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6d992857-0989-47db-bfac-4def0e629503"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae20f5fc-91cc-4f33-a088-4292d29da918",
+        "apim-request-id": "2977ae38-907c-42a1-89b1-e1e9562287aa",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "46cd092a-d25c-4506-8216-cdf08bbc33f3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:46Z",
-        "createdDateTime": "2022-10-15T02:23:46Z",
-        "expirationDateTime": "2022-10-16T02:23:46Z",
+        "jobId": "a63d5347-2200-4483-9f59-a6ad9c3f11f7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:04Z",
+        "createdDateTime": "2022-10-24T05:15:03Z",
+        "expirationDateTime": "2022-10-25T05:15:03Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -137,159 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a63d5347-2200-4483-9f59-a6ad9c3f11f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8863e787-ec04-4944-8c1d-8bcb58af657b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7bfece08-c191-4442-adf2-27d547d56cfb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91a4df20-6cf7-4ac7-8a6d-68a827b75752",
-        "Content-Length": "1949",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:47 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "87"
-      },
-      "ResponseBody": {
-        "jobId": "46cd092a-d25c-4506-8216-cdf08bbc33f3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:48Z",
-        "createdDateTime": "2022-10-15T02:23:46Z",
-        "expirationDateTime": "2022-10-16T02:23:46Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.0674352Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "3",
-                    "entities": [
-                      {
-                        "text": "restaurant",
-                        "category": "Location",
-                        "subcategory": "Structural",
-                        "offset": 4,
-                        "length": 10,
-                        "confidenceScore": 0.97
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ar,cs,da,fi,hu,nl,no,pl,ru,sv,tr,ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.1179595Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "The restaurant had really good food. I recommend you try it.",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "1",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code \u0027english\u0027. Supported languages: ja,ko,zh-Hans,de,en,es,fr,it,pt-BR,pt-PT. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9c2a0812-3299-4796-802b-0980f7fac07a"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b7fe99b5-9e88-4a6d-91cd-dadcc9cdbb16",
+        "apim-request-id": "44eddb8e-17d9-4704-b711-3e811fb6a6ce",
         "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "142"
+        "x-envoy-upstream-service-time": "131",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "46cd092a-d25c-4506-8216-cdf08bbc33f3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:48Z",
-        "createdDateTime": "2022-10-15T02:23:46Z",
-        "expirationDateTime": "2022-10-16T02:23:46Z",
+        "jobId": "a63d5347-2200-4483-9f59-a6ad9c3f11f7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:06Z",
+        "createdDateTime": "2022-10-24T05:15:03Z",
+        "expirationDateTime": "2022-10-25T05:15:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -300,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.0674352Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:06.2260976Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -348,7 +225,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.1179595Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:06.3045969Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -388,7 +265,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.4340669Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:05.8847903Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -433,32 +310,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/46cd092a-d25c-4506-8216-cdf08bbc33f3?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/a63d5347-2200-4483-9f59-a6ad9c3f11f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3478ee75-8c44-458e-a108-da62acf6e72f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cba6f0b7-817c-40fb-b9aa-22c03366df93"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2eddbd56-5b58-488e-b0d2-a1971984667c",
+        "apim-request-id": "d82a160a-2391-40b0-b4db-73205a5c86fe",
         "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "x-envoy-upstream-service-time": "165",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "46cd092a-d25c-4506-8216-cdf08bbc33f3",
-        "lastUpdatedDateTime": "2022-10-15T02:23:48Z",
-        "createdDateTime": "2022-10-15T02:23:46Z",
-        "expirationDateTime": "2022-10-16T02:23:46Z",
+        "jobId": "a63d5347-2200-4483-9f59-a6ad9c3f11f7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:06Z",
+        "createdDateTime": "2022-10-24T05:15:03Z",
+        "expirationDateTime": "2022-10-25T05:15:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -469,7 +347,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.0674352Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:06.2260976Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -517,7 +395,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.1179595Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:06.3045969Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -557,7 +435,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:48.4340669Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:05.8847903Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "376",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4b5727ea-5741-4784-903c-6e9c7b1a8edf"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d968daec-1e2d-4432-baa2-194f39bd36a1"
       },
       "RequestBody": {
         "analysisInput": {
@@ -60,43 +60,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "41e446af-3dd8-4589-9777-1fa45f4470c9",
+        "apim-request-id": "14f28711-ab0a-4cf6-9ee4-4336136091e7",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:19 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f99fa51e-2643-4e05-945d-ee50095763bc?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:34 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "210"
+        "x-envoy-upstream-service-time": "299",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f99fa51e-2643-4e05-945d-ee50095763bc?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a9105c17-955d-4179-be5d-b95a00c1ae68"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8f4e91c7-2e5a-4400-b864-07dd00d088ec"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be4240da-3f3f-4078-9810-9d398420043c",
+        "apim-request-id": "391c6ff5-93cd-4588-8695-6748f3b22f41",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f99fa51e-2643-4e05-945d-ee50095763bc",
-        "lastUpdatedDateTime": "2022-10-15T02:24:19Z",
-        "createdDateTime": "2022-10-15T02:24:18Z",
-        "expirationDateTime": "2022-10-16T02:24:18Z",
+        "jobId": "edb97043-c103-4501-ae7d-4b41684077d3",
+        "lastUpdatedDateTime": "2022-10-24T05:15:34Z",
+        "createdDateTime": "2022-10-24T05:15:34Z",
+        "expirationDateTime": "2022-10-25T05:15:34Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -109,33 +111,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f99fa51e-2643-4e05-945d-ee50095763bc?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "064dd86d-0354-4ced-9f9c-cb31f3e28819"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c154deef-5077-4863-8967-b3a45e478f06"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b27bced-f5af-420d-97de-65ed040295ce",
-        "Content-Length": "280",
+        "apim-request-id": "9eb2b293-c687-4d1b-aaf1-e21726c158e1",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f99fa51e-2643-4e05-945d-ee50095763bc",
-        "lastUpdatedDateTime": "2022-10-15T02:24:19Z",
-        "createdDateTime": "2022-10-15T02:24:18Z",
-        "expirationDateTime": "2022-10-16T02:24:18Z",
-        "status": "running",
+        "jobId": "edb97043-c103-4501-ae7d-4b41684077d3",
+        "lastUpdatedDateTime": "2022-10-24T05:15:34Z",
+        "createdDateTime": "2022-10-24T05:15:34Z",
+        "expirationDateTime": "2022-10-25T05:15:34Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -147,43 +150,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f99fa51e-2643-4e05-945d-ee50095763bc?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cb9751dc-680f-46d6-b793-e99d763a0198"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "30b023d1-d5c4-4f4b-b334-6a413584624a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b4dfcfb-c970-44de-b5a3-37b47c3d3ffd",
-        "Content-Length": "2870",
+        "apim-request-id": "c6acbf1f-12fc-4c9c-b95f-5bf6e07dff73",
+        "Content-Length": "1953",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "229"
+        "x-envoy-upstream-service-time": "155",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f99fa51e-2643-4e05-945d-ee50095763bc",
-        "lastUpdatedDateTime": "2022-10-15T02:24:21Z",
-        "createdDateTime": "2022-10-15T02:24:18Z",
-        "expirationDateTime": "2022-10-16T02:24:18Z",
-        "status": "succeeded",
+        "jobId": "edb97043-c103-4501-ae7d-4b41684077d3",
+        "lastUpdatedDateTime": "2022-10-24T05:15:36Z",
+        "createdDateTime": "2022-10-24T05:15:34Z",
+        "expirationDateTime": "2022-10-25T05:15:34Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:20.8572253Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.5155606Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -247,77 +251,8 @@
               }
             },
             {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:20.9314283Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "redactedText": ":)",
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":(",
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":P",
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": ":D",
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-01-15"
-              }
-            },
-            {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:21.0052592Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.2328299Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -385,32 +320,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f99fa51e-2643-4e05-945d-ee50095763bc?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fa155ee4-e8e8-4bb9-851f-e646427de9c8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "be62643a-8bdb-4657-9eda-403ba693bda6"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09ae39f8-9fd8-4630-9cdd-932d81e18140",
+        "apim-request-id": "248696aa-7aa3-4fec-9a87-a1f192f88b08",
         "Content-Length": "2870",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "153"
+        "x-envoy-upstream-service-time": "194",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f99fa51e-2643-4e05-945d-ee50095763bc",
-        "lastUpdatedDateTime": "2022-10-15T02:24:21Z",
-        "createdDateTime": "2022-10-15T02:24:18Z",
-        "expirationDateTime": "2022-10-16T02:24:18Z",
+        "jobId": "edb97043-c103-4501-ae7d-4b41684077d3",
+        "lastUpdatedDateTime": "2022-10-24T05:15:36Z",
+        "createdDateTime": "2022-10-24T05:15:34Z",
+        "expirationDateTime": "2022-10-25T05:15:34Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -421,7 +357,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:20.8572253Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.5155606Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -486,7 +422,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:20.9314283Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.6234972Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -555,7 +491,246 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:21.0052592Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.2328299Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/edb97043-c103-4501-ae7d-4b41684077d3?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f73c99fb-9b0d-4db2-9e27-a0b06d47d8b7"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "217c0531-bd72-4a41-81a4-76b5a00ea11e",
+        "Content-Length": "2870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "161",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "edb97043-c103-4501-ae7d-4b41684077d3",
+        "lastUpdatedDateTime": "2022-10-24T05:15:36Z",
+        "createdDateTime": "2022-10-24T05:15:34Z",
+        "expirationDateTime": "2022-10-25T05:15:34Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.5155606Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.6234972Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:15:36.2328299Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "240",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5d8c1dc8-269d-489e-9b4f-b47786f31cbf"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "70136f3d-2207-4697-9768-68d8edaa09eb"
       },
       "RequestBody": {
         "analysisInput": {
@@ -38,44 +38,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5f9cd680-eb72-413c-a596-66d4d0642bc3",
+        "apim-request-id": "6345eb37-7903-4997-b313-47d1e930cc4b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:43 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9bf4e61d-6d58-4d7b-b82e-e9174579c2a9?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:00 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/8089f33b-2e76-4fa5-bd19-dd5567269ea7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "168"
+        "x-envoy-upstream-service-time": "191",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9bf4e61d-6d58-4d7b-b82e-e9174579c2a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8089f33b-2e76-4fa5-bd19-dd5567269ea7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6c255baf-85ca-4f56-9922-bce87a556ca5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "45197bd0-5c37-4176-ae5f-be0cfa108a31"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d1effaa5-9121-4006-8b0d-deb0823f34ea",
-        "Content-Length": "280",
+        "apim-request-id": "906dba92-55e4-4458-88a5-d5d8e9c68b33",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9bf4e61d-6d58-4d7b-b82e-e9174579c2a9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:43Z",
-        "createdDateTime": "2022-10-15T02:23:43Z",
-        "expirationDateTime": "2022-10-16T02:23:43Z",
-        "status": "running",
+        "jobId": "8089f33b-2e76-4fa5-bd19-dd5567269ea7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:01Z",
+        "createdDateTime": "2022-10-24T05:15:01Z",
+        "expirationDateTime": "2022-10-25T05:15:01Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -87,33 +89,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9bf4e61d-6d58-4d7b-b82e-e9174579c2a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8089f33b-2e76-4fa5-bd19-dd5567269ea7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4d523661-5fe5-4b4f-b137-b76a18372d6b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "56933ce7-0636-4478-99a1-a9b8a5cdb247"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "039563cc-73fa-4966-8e6b-3151605b2f27",
-        "Content-Length": "280",
+        "apim-request-id": "f9738757-7660-4186-8842-8840eb41a1ef",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9bf4e61d-6d58-4d7b-b82e-e9174579c2a9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:43Z",
-        "createdDateTime": "2022-10-15T02:23:43Z",
-        "expirationDateTime": "2022-10-16T02:23:43Z",
-        "status": "running",
+        "jobId": "8089f33b-2e76-4fa5-bd19-dd5567269ea7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:01Z",
+        "createdDateTime": "2022-10-24T05:15:01Z",
+        "expirationDateTime": "2022-10-25T05:15:01Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -125,32 +128,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9bf4e61d-6d58-4d7b-b82e-e9174579c2a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8089f33b-2e76-4fa5-bd19-dd5567269ea7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cc881e13-e7db-4e1a-8227-7b757a3e058c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cd80b78b-9b4d-4739-b864-d0dc6f192f92"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "638147f8-1d54-4004-90d7-019e20c57614",
-        "Content-Length": "843",
+        "apim-request-id": "45806c0d-19b3-478e-952e-5c7cffb769f5",
+        "Content-Length": "842",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "47",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9bf4e61d-6d58-4d7b-b82e-e9174579c2a9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:45Z",
-        "createdDateTime": "2022-10-15T02:23:43Z",
-        "expirationDateTime": "2022-10-16T02:23:43Z",
+        "jobId": "8089f33b-2e76-4fa5-bd19-dd5567269ea7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:03Z",
+        "createdDateTime": "2022-10-24T05:15:01Z",
+        "expirationDateTime": "2022-10-25T05:15:01Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:23:44.9968266Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:03.2029162Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -180,7 +184,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:23:45.0077787Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:03.171384Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -200,32 +204,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9bf4e61d-6d58-4d7b-b82e-e9174579c2a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8089f33b-2e76-4fa5-bd19-dd5567269ea7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c9fe2434-7f75-4298-a112-b69cb5a73ead"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "49562074-7d61-4bd1-8086-7406698d6fcb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80eb07ef-8c0d-43fb-aac8-9e33b96362f8",
-        "Content-Length": "843",
+        "apim-request-id": "49ea5e5b-3d5c-40c4-9d3a-3509a20cc918",
+        "Content-Length": "842",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9bf4e61d-6d58-4d7b-b82e-e9174579c2a9",
-        "lastUpdatedDateTime": "2022-10-15T02:23:45Z",
-        "createdDateTime": "2022-10-15T02:23:43Z",
-        "expirationDateTime": "2022-10-16T02:23:43Z",
+        "jobId": "8089f33b-2e76-4fa5-bd19-dd5567269ea7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:03Z",
+        "createdDateTime": "2022-10-24T05:15:01Z",
+        "expirationDateTime": "2022-10-25T05:15:01Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -237,7 +242,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:23:44.9968266Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:03.2029162Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -255,7 +260,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:23:45.0077787Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:03.171384Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "320",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4c3b90ec-b072-4cfa-8e30-06bab4967fdb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "76b2db8d-5d72-494e-9da5-7656b96e1e46"
       },
       "RequestBody": {
         "analysisInput": {
@@ -47,43 +47,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3a5dc569-7c93-40a6-b00e-2a924266dcfd",
+        "apim-request-id": "0312223b-3f16-4adc-8ba5-25733dfd5cbd",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:30 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:45 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "160"
+        "x-envoy-upstream-service-time": "145",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bd45f85e-25b0-43f5-807b-4871c729d602"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c1ca6611-55cb-448b-a29c-b1587618d680"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a504add2-4df7-41f1-9e7a-621ba96ca383",
+        "apim-request-id": "bff59785-bb6f-48b6-bb7e-39b329764c72",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e9365249-ab03-4f61-8515-f4633ba862f2",
-        "lastUpdatedDateTime": "2022-10-15T02:24:30Z",
-        "createdDateTime": "2022-10-15T02:24:30Z",
-        "expirationDateTime": "2022-10-16T02:24:30Z",
+        "jobId": "9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:45Z",
+        "createdDateTime": "2022-10-24T05:15:45Z",
+        "expirationDateTime": "2022-10-25T05:15:45Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -96,32 +98,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "98689103-3228-4305-ac08-8326cfbbc5e1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f4a9902f-8a5f-40ee-a23b-07ed556c0f16"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5050be1e-16b9-49a6-a982-9e39e84acffd",
+        "apim-request-id": "2989c303-8782-4591-9ec1-e86141183199",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e9365249-ab03-4f61-8515-f4633ba862f2",
-        "lastUpdatedDateTime": "2022-10-15T02:24:30Z",
-        "createdDateTime": "2022-10-15T02:24:30Z",
-        "expirationDateTime": "2022-10-16T02:24:30Z",
+        "jobId": "9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:45Z",
+        "createdDateTime": "2022-10-24T05:15:45Z",
+        "expirationDateTime": "2022-10-25T05:15:45Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -134,146 +137,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0829a920-3f99-4d6e-b92d-840a74948dc2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8e237649-9784-4db7-8662-e7b77aeee80b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8037fc31-d320-4efe-9d0d-60d7a8791171",
-        "Content-Length": "1082",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:31 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
-      },
-      "ResponseBody": {
-        "jobId": "e9365249-ab03-4f61-8515-f4633ba862f2",
-        "lastUpdatedDateTime": "2022-10-15T02:24:32Z",
-        "createdDateTime": "2022-10-15T02:24:30Z",
-        "expirationDateTime": "2022-10-16T02:24:30Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.2243764Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "park",
-                        "category": "Location",
-                        "offset": 17,
-                        "length": 4,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "Espa\u00F1ol",
-                        "category": "Skill",
-                        "offset": 31,
-                        "length": 7,
-                        "confidenceScore": 0.94
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.5558656Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "park"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "keyPhrases": [
-                      "Espa\u00F1ol",
-                      "document"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "keyPhrases": [
-                      "\u306F\u5E78\u305B"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2022-10-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ecf7474d-4d65-46cc-aa5b-7ecddfaba907"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4cdb35df-22be-4640-b11f-825861d44f9f",
+        "apim-request-id": "c9b2da47-6c59-4421-891d-b3215ca05f32",
         "Content-Length": "1510",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "143"
+        "x-envoy-upstream-service-time": "163",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e9365249-ab03-4f61-8515-f4633ba862f2",
-        "lastUpdatedDateTime": "2022-10-15T02:24:33Z",
-        "createdDateTime": "2022-10-15T02:24:30Z",
-        "expirationDateTime": "2022-10-16T02:24:30Z",
+        "jobId": "9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:48Z",
+        "createdDateTime": "2022-10-24T05:15:45Z",
+        "expirationDateTime": "2022-10-25T05:15:45Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -284,7 +174,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.2243764Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:47.9993872Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -326,7 +216,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:33.2796426Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:48.0414275Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -355,7 +245,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.5558656Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:47.5829685Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -391,32 +281,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e9365249-ab03-4f61-8515-f4633ba862f2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94e49191-3858-4941-89c0-cc36317af255"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f2ff008b-a89a-4d60-b96c-f71810786f2f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ba99892-6ee2-4488-ae77-ff37aca2adfe",
+        "apim-request-id": "6d74bcf6-c374-4b17-87ea-c111317a6b68",
         "Content-Length": "1510",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "116"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e9365249-ab03-4f61-8515-f4633ba862f2",
-        "lastUpdatedDateTime": "2022-10-15T02:24:33Z",
-        "createdDateTime": "2022-10-15T02:24:30Z",
-        "expirationDateTime": "2022-10-16T02:24:30Z",
+        "jobId": "9b80cce2-d47e-44f6-a326-8d3ba8ba4f1c",
+        "lastUpdatedDateTime": "2022-10-24T05:15:48Z",
+        "createdDateTime": "2022-10-24T05:15:45Z",
+        "expirationDateTime": "2022-10-25T05:15:45Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -427,7 +318,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.2243764Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:47.9993872Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -469,7 +360,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:33.2796426Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:48.0414275Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -498,7 +389,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:32.5558656Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:47.5829685Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "429",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "088ab93b-a09c-4cf3-b0a3-98cf4fbad644"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1cc946da-27ae-40b7-b937-225999d19e02"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a55381e6-e30b-4076-8b0d-455929c39d1f",
+        "apim-request-id": "c7cf1c36-0a48-4b0f-a762-15caadf3bcf6",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:21 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/e2ded80c-7fe8-49cb-b538-ee7f14cb8a37?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:39 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/8f3077b7-5303-4712-be10-fbf435afc25d?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "218"
+        "x-envoy-upstream-service-time": "152",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2ded80c-7fe8-49cb-b538-ee7f14cb8a37?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8f3077b7-5303-4712-be10-fbf435afc25d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8088f2a8-fb42-4239-8367-13543be87fc0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6e24e1fd-7117-4bfe-a247-0d8eef549cac"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17607a26-5d38-4b2f-9565-fc9294cf99d4",
+        "apim-request-id": "95ae22bb-e34a-48ed-b5f0-0c2ebd9a0804",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e2ded80c-7fe8-49cb-b538-ee7f14cb8a37",
-        "lastUpdatedDateTime": "2022-10-15T02:24:22Z",
-        "createdDateTime": "2022-10-15T02:24:22Z",
-        "expirationDateTime": "2022-10-16T02:24:22Z",
+        "jobId": "8f3077b7-5303-4712-be10-fbf435afc25d",
+        "lastUpdatedDateTime": "2022-10-24T05:15:39Z",
+        "createdDateTime": "2022-10-24T05:15:39Z",
+        "expirationDateTime": "2022-10-25T05:15:39Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -99,32 +101,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2ded80c-7fe8-49cb-b538-ee7f14cb8a37?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8f3077b7-5303-4712-be10-fbf435afc25d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e9d03482-7905-4ac9-88ad-786fc5cbd762"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "38a92a31-6e7d-42f4-8cdf-37e714a2aa87"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dfd53104-5660-4ba5-8da3-0b2b3056df31",
+        "apim-request-id": "498f2ff3-1a90-4fdf-bedb-5c4e8f063d0f",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:22 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e2ded80c-7fe8-49cb-b538-ee7f14cb8a37",
-        "lastUpdatedDateTime": "2022-10-15T02:24:22Z",
-        "createdDateTime": "2022-10-15T02:24:22Z",
-        "expirationDateTime": "2022-10-16T02:24:22Z",
+        "jobId": "8f3077b7-5303-4712-be10-fbf435afc25d",
+        "lastUpdatedDateTime": "2022-10-24T05:15:39Z",
+        "createdDateTime": "2022-10-24T05:15:39Z",
+        "expirationDateTime": "2022-10-25T05:15:39Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -137,32 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2ded80c-7fe8-49cb-b538-ee7f14cb8a37?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8f3077b7-5303-4712-be10-fbf435afc25d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b82a990e-3bf3-47d2-b0d8-4513f3c6ec41"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "422294ba-4f3b-4486-b906-8456ccc4b048"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "92e1f92d-420d-4c2f-8093-2e945555f884",
+        "apim-request-id": "bf7755f2-2629-4eaa-93d5-dd55a891b3d3",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "167"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e2ded80c-7fe8-49cb-b538-ee7f14cb8a37",
-        "lastUpdatedDateTime": "2022-10-15T02:24:24Z",
-        "createdDateTime": "2022-10-15T02:24:22Z",
-        "expirationDateTime": "2022-10-16T02:24:22Z",
+        "jobId": "8f3077b7-5303-4712-be10-fbf435afc25d",
+        "lastUpdatedDateTime": "2022-10-24T05:15:41Z",
+        "createdDateTime": "2022-10-24T05:15:39Z",
+        "expirationDateTime": "2022-10-25T05:15:39Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -173,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:23.9354523Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.5164406Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -216,7 +220,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:24.0541819Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.6064422Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -245,7 +249,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:24.0463341Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.4246013Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -281,32 +285,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2ded80c-7fe8-49cb-b538-ee7f14cb8a37?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8f3077b7-5303-4712-be10-fbf435afc25d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2fc6a284-9af3-487e-a6bf-a74869c1d8b2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "72ce9ec1-7435-4dc1-8fbf-ece707a37b96"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "96df26c2-5811-40fb-93ac-fd654c181e73",
+        "apim-request-id": "685b86cc-f711-45e2-817b-29e79bd608e6",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:24 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "153"
+        "x-envoy-upstream-service-time": "169",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "e2ded80c-7fe8-49cb-b538-ee7f14cb8a37",
-        "lastUpdatedDateTime": "2022-10-15T02:24:24Z",
-        "createdDateTime": "2022-10-15T02:24:22Z",
-        "expirationDateTime": "2022-10-16T02:24:22Z",
+        "jobId": "8f3077b7-5303-4712-be10-fbf435afc25d",
+        "lastUpdatedDateTime": "2022-10-24T05:15:41Z",
+        "createdDateTime": "2022-10-24T05:15:39Z",
+        "expirationDateTime": "2022-10-25T05:15:39Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -317,7 +322,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:23.9354523Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.5164406Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -360,7 +365,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:24.0541819Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.6064422Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -389,7 +394,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:24.0463341Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:41.4246013Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "429",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4fac2c04-3fd5-4289-9e2b-7b3a55a162ae"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "35db5d0b-4ea3-4135-a1d6-a2ed0862e3af"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,230 +50,123 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d7e3539c-76d4-4588-b954-28e0b3c3c1c9",
+        "apim-request-id": "d71e6193-1941-49df-bb9f-bf2192f1daf8",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:24:24 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:15:42 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e2c0aade-4cc6-4abd-8950-d171ca09b6b7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "160"
+        "x-envoy-upstream-service-time": "189",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2c0aade-4cc6-4abd-8950-d171ca09b6b7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "19a93bb7-b784-41bf-9a94-5b2f5a39ca16"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9fca7510-1b63-45f6-ab7e-05f935436529"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f141bef4-3b92-4707-acf3-5c0f928dda50",
-        "Content-Length": "283",
+        "apim-request-id": "f1783da1-ad11-4298-aef8-e5ca59e98ee1",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:24 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "971dc631-8627-483e-8e53-c0a2b4e8c473",
-        "lastUpdatedDateTime": "2022-10-15T02:24:25Z",
-        "createdDateTime": "2022-10-15T02:24:25Z",
-        "expirationDateTime": "2022-10-16T02:24:25Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0945d4b5-e905-4f3f-8d22-d88e3a68794a"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "54a070aa-71ab-4ef2-a79e-3010fa51300e",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "971dc631-8627-483e-8e53-c0a2b4e8c473",
-        "lastUpdatedDateTime": "2022-10-15T02:24:25Z",
-        "createdDateTime": "2022-10-15T02:24:25Z",
-        "expirationDateTime": "2022-10-16T02:24:25Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Authorization": "Sanitized",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7fbf0472-cdb7-401a-850c-d37dea07bc3b"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a41c361b-1f60-47be-916d-23a0936dddad",
-        "Content-Length": "1260",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:27 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "84"
-      },
-      "ResponseBody": {
-        "jobId": "971dc631-8627-483e-8e53-c0a2b4e8c473",
-        "lastUpdatedDateTime": "2022-10-15T02:24:27Z",
-        "createdDateTime": "2022-10-15T02:24:25Z",
-        "expirationDateTime": "2022-10-16T02:24:25Z",
+        "jobId": "e2c0aade-4cc6-4abd-8950-d171ca09b6b7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:42Z",
+        "createdDateTime": "2022-10-24T05:15:42Z",
+        "expirationDateTime": "2022-10-25T05:15:42Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 2,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.046971Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "hotel",
-                        "category": "Location",
-                        "offset": 19,
-                        "length": 5,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "restaurant",
-                        "category": "Location",
-                        "subcategory": "Structural",
-                        "offset": 4,
-                        "length": 10,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.0357442Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "This was the best day of my life.",
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "I did not like the hotel we stayed at. It was too expensive.",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "The restaurant was not as good as I hoped.",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2c0aade-4cc6-4abd-8950-d171ca09b6b7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4804d75b-6f38-4832-9023-536e83e7a6f2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6f835c85-9e43-4d0b-b344-a7af3c5a4aa7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "815fe8cd-797e-47e5-9ed4-a700ae7360a1",
-        "Content-Length": "1601",
+        "apim-request-id": "26e7117c-451e-4517-823d-f34d647a2275",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "155"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "971dc631-8627-483e-8e53-c0a2b4e8c473",
-        "lastUpdatedDateTime": "2022-10-15T02:24:27Z",
-        "createdDateTime": "2022-10-15T02:24:25Z",
-        "expirationDateTime": "2022-10-16T02:24:25Z",
+        "jobId": "e2c0aade-4cc6-4abd-8950-d171ca09b6b7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:42Z",
+        "createdDateTime": "2022-10-24T05:15:42Z",
+        "expirationDateTime": "2022-10-25T05:15:42Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2c0aade-4cc6-4abd-8950-d171ca09b6b7?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0e42e1e4-afe9-4e4c-9bcd-5a46dd15cc43"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2a92afdf-1549-4165-8f05-68507d2e69d7",
+        "Content-Length": "1602",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:15:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "e2c0aade-4cc6-4abd-8950-d171ca09b6b7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:44Z",
+        "createdDateTime": "2022-10-24T05:15:42Z",
+        "expirationDateTime": "2022-10-25T05:15:42Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -284,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.046971Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.5725593Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -327,7 +220,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.0357442Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.6227999Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -356,7 +249,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.5434316Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.4258872Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -392,32 +285,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/971dc631-8627-483e-8e53-c0a2b4e8c473?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e2c0aade-4cc6-4abd-8950-d171ca09b6b7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cf32bf0e-6c90-4ebc-b272-ae3098ac7c0e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7df88004-a91c-48df-acf6-d3018c077766"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1cce5a5b-e139-4feb-ad4b-01109edc01f5",
-        "Content-Length": "1601",
+        "apim-request-id": "585cc8a4-877e-4289-8d3d-864362987126",
+        "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:24:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:15:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "971dc631-8627-483e-8e53-c0a2b4e8c473",
-        "lastUpdatedDateTime": "2022-10-15T02:24:27Z",
-        "createdDateTime": "2022-10-15T02:24:25Z",
-        "expirationDateTime": "2022-10-16T02:24:25Z",
+        "jobId": "e2c0aade-4cc6-4abd-8950-d171ca09b6b7",
+        "lastUpdatedDateTime": "2022-10-24T05:15:44Z",
+        "createdDateTime": "2022-10-24T05:15:42Z",
+        "expirationDateTime": "2022-10-25T05:15:42Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -428,7 +322,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.046971Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.5725593Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -471,7 +365,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.0357442Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.6227999Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -500,7 +394,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:24:27.5434316Z",
+              "lastUpdateDateTime": "2022-10-24T05:15:44.4258872Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "125",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a110a93b-7099-4dc4-9f7d-5c019cf97582"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "94bddd3a-8315-4026-bb11-dfa2122d2ddb"
       },
       "RequestBody": {
         "analysisInput": {
@@ -32,13 +32,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f481e4df-5fcb-4591-94e4-38b271cf7bb4",
+        "apim-request-id": "8e401ec6-62c9-43cd-9a70-702202a3f18b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "5239",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "55abbbb2-a0b8-4ebb-a662-a2c57255cbde"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "560ade7f-7e6b-48a2-a749-0a621014176f"
       },
       "RequestBody": {
         "analysisInput": {
@@ -32,43 +32,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "260e7516-6060-4f32-b4bb-43b6b06a6c3b",
+        "apim-request-id": "23eecb03-9475-4ff9-9c71-b24916b834f6",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:25:04 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:17 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "117"
+        "x-envoy-upstream-service-time": "151",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "20276452-a310-452b-91f8-020267f764af"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9407864b-f462-467e-ae39-e66554a36193"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "022535a4-46ef-447d-a6d7-791ef20fa504",
+        "apim-request-id": "aa73a545-b2a4-45d8-9e58-1b9636313852",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:04Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:17Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -81,32 +83,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e9c01180-2b38-43d2-9116-77243a9b0fe7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4eeb4ff0-294f-4d24-a01d-50b5bb3a0a16"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "51c68480-047d-4177-a7e8-978053a0671b",
+        "apim-request-id": "db723d4b-8681-45a8-8d3a-c1513534ab18",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:04Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:17Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -119,32 +122,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d78ef2e4-b582-446d-8d19-ec4ca3811e38"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "340fb0ba-a7ee-4699-9e57-afe1a93da411"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b1f99df2-18b0-4ce6-a707-dbc379e86e86",
+        "apim-request-id": "31d0da65-c8da-402b-aaae-92d4c45b9b4c",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:05Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:18Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -157,32 +161,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c27bf828-22f4-4436-80c1-b7cd374e5ad2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fc7dfd5d-5924-426a-9118-37c58f319cfa"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f89b7242-c2e6-4176-b9ff-4fdbb0ed335f",
+        "apim-request-id": "5b0d0513-38be-4a52-9e46-bb9ad56f22ed",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:08 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:05Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:18Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -195,32 +200,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4e6bdceb-a2ba-493d-b949-c550af2d2f1d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9efbeab5-af96-430b-8674-329f72f72d6d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d8e6851d-40b6-438a-9a44-710e0f7619ee",
+        "apim-request-id": "b2fb8e9c-4b7e-449e-a576-afd1267c3b14",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:10 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:05Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:18Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -233,32 +239,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f775e9db-cf15-4c4c-a433-55e5b55faa3b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d418c561-eab6-48b3-9c20-dafd1242b1a5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6ad1d40-0f75-47d4-a8ee-fb618235579a",
+        "apim-request-id": "a7e855ed-6a66-43a8-b532-c44717f3b2b1",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:12Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:24Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -269,7 +276,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:12.4809405Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:24.4081026Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -294,32 +301,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b90f3b8b-4d16-476a-b2f1-1c916b1f513d?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/47b3961d-7e45-45b4-9b08-ddcfda48fdde?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "342cc6ec-4cfa-419c-b23d-a9e84ea288d0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5a4e2f62-7fee-4854-9d87-b8e2553d02d2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "95847eea-8c35-4aa6-a314-851bdff6f38e",
+        "apim-request-id": "11b9e62b-4720-4da3-85a3-9ba4b71a0875",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b90f3b8b-4d16-476a-b2f1-1c916b1f513d",
-        "lastUpdatedDateTime": "2022-10-15T02:25:12Z",
-        "createdDateTime": "2022-10-15T02:25:04Z",
-        "expirationDateTime": "2022-10-16T02:25:04Z",
+        "jobId": "47b3961d-7e45-45b4-9b08-ddcfda48fdde",
+        "lastUpdatedDateTime": "2022-10-24T05:16:24Z",
+        "createdDateTime": "2022-10-24T05:16:17Z",
+        "expirationDateTime": "2022-10-25T05:16:17Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -330,7 +338,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:12.4809405Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:24.4081026Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "198",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0d395bea-5eb6-4589-97a0-18b298cf4afb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5cc51281-7a58-4909-b3bd-570815db061b"
       },
       "RequestBody": {
         "analysisInput": {
@@ -36,13 +36,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "93871157-3fbb-4241-a9a5-327c63f456b3",
+        "apim-request-id": "395428a7-78e4-4640-8ee0-d60beafefde8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "170",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2ee2bdcd-5ba0-4a30-87ca-898c9523e8f7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6aa2f3d2-9d93-454c-8834-0e7a47254f27"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,13 +34,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "00948224-e1c0-4c66-bb37-b0afaec28820",
+        "apim-request-id": "2fdcb926-aefb-4968-a5b7-2314b1763404",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "710471",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "609995d1-f40d-4db7-b4aa-4eefa92704be"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cb307bc8-c164-42d9-96d7-267135b8499e"
       },
       "RequestBody": {
         "analysisInput": {
@@ -2527,13 +2527,14 @@
       },
       "StatusCode": 413,
       "ResponseHeaders": {
-        "apim-request-id": "7b836d1b-59d0-42d9-928c-d9f2e6e7be31",
+        "apim-request-id": "3d89c499-bd76-45fe-9a6f-df982e0d7130",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "1345",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1e610823-e1ba-4e80-9471-65a2bb83e0be"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5b32d930-effb-4827-9534-56a19484187b"
       },
       "RequestBody": {
         "analysisInput": {
@@ -157,13 +157,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "c6135980-f264-498e-a142-d2eb9c40592e",
+        "apim-request-id": "2c385707-9f1f-46b6-b822-b578387f6449",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "222",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "09d8f412-12a1-4371-89fa-1959c5f04653"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2c99028b-39a6-426e-b8da-91dbb5f018f3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,43 +34,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "843983e9-f218-4c0c-8dbe-32186c715855",
+        "apim-request-id": "edfaa283-d750-4e52-99ef-a304ed966f91",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:25:13 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c2f0a386-a70d-482c-bb28-c91f3b4c7645?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:26 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "x-envoy-upstream-service-time": "146",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c2f0a386-a70d-482c-bb28-c91f3b4c7645?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c769d0a1-5659-461f-912c-2bf7dd33da37"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b5a3f292-83ae-4e26-8b37-5a54a8c94756"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bda6dc0-17a5-46ca-8de1-29750326880b",
+        "apim-request-id": "553d0cf0-e6d4-494f-83b4-e0dc5d26e459",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c2f0a386-a70d-482c-bb28-c91f3b4c7645",
-        "lastUpdatedDateTime": "2022-10-15T02:25:13Z",
-        "createdDateTime": "2022-10-15T02:25:13Z",
-        "expirationDateTime": "2022-10-16T02:25:13Z",
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:26Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -83,32 +85,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c2f0a386-a70d-482c-bb28-c91f3b4c7645?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "dc9702b6-2fef-4c1a-bc64-9aca32940626"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "72bd91ef-cd39-4452-8532-35c00edbfc88"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5e4d8239-e792-4087-bdb1-386b4ca90aab",
+        "apim-request-id": "919d95ce-0f10-45a5-a4d4-cb9a790d8808",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:13 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "9",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c2f0a386-a70d-482c-bb28-c91f3b4c7645",
-        "lastUpdatedDateTime": "2022-10-15T02:25:13Z",
-        "createdDateTime": "2022-10-15T02:25:13Z",
-        "expirationDateTime": "2022-10-16T02:25:13Z",
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:26Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -121,32 +124,150 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c2f0a386-a70d-482c-bb28-c91f3b4c7645?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "08f9227a-6aba-40ce-a6c7-bed28a8d44b2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7180f12e-487b-4d6e-bb47-576a85ebfb5a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a97c5e9c-de0f-4892-887d-a9d99357bbdc",
+        "apim-request-id": "b516cdef-251d-4ed4-8f28-3c64bf7ab6ed",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:27Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0e19a8e9-8f89-4621-a613-abede6f08015"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cddc70be-2c0f-4412-b8f5-8b6353ed4ac3",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:27Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4f37ede1-5308-4e8e-93d6-f6993bce7180"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "866a51b2-e0a9-4bb8-bd3b-9586da5e09fe",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:16:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:27Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6d6536fb-5b46-4884-a03d-0b1ae0b36375"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5668205b-8209-4654-a565-189671ff1ec8",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "41",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c2f0a386-a70d-482c-bb28-c91f3b4c7645",
-        "lastUpdatedDateTime": "2022-10-15T02:25:15Z",
-        "createdDateTime": "2022-10-15T02:25:13Z",
-        "expirationDateTime": "2022-10-16T02:25:13Z",
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:34Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +278,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:15.6325799Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:34.7005492Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -185,32 +306,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c2f0a386-a70d-482c-bb28-c91f3b4c7645?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/7466e231-5fb2-4c84-982b-b8dee331faa4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3ba6b829-2718-4327-8c76-f4f6965368af"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b61e101d-742a-40ae-af04-41e526428be6"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "62329181-9e03-420a-9abb-115b1149c979",
+        "apim-request-id": "38d28bd2-3b05-4b3c-bbd8-cc588b9241f2",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c2f0a386-a70d-482c-bb28-c91f3b4c7645",
-        "lastUpdatedDateTime": "2022-10-15T02:25:15Z",
-        "createdDateTime": "2022-10-15T02:25:13Z",
-        "expirationDateTime": "2022-10-16T02:25:13Z",
+        "jobId": "7466e231-5fb2-4c84-982b-b8dee331faa4",
+        "lastUpdatedDateTime": "2022-10-24T05:16:34Z",
+        "createdDateTime": "2022-10-24T05:16:26Z",
+        "expirationDateTime": "2022-10-25T05:16:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -221,7 +343,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:15.6325799Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:34.7005492Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "205",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "da90c687-2233-4a63-97ec-6c115ffd64be"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "aac63f3b-2f86-4a93-8295-f70d9f182617"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,43 +34,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "214566e4-8b58-4ae4-a98d-0030ac5013c2",
+        "apim-request-id": "b734c16e-c3a5-41a8-adbc-257ed4544bdc",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:25:19 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/2c473a4a-5857-40ef-a9a4-0a8a081a75e2?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:38 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/1a7ebe14-be98-4389-8e93-cb7480de5a38?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "174",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2c473a4a-5857-40ef-a9a4-0a8a081a75e2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a7ebe14-be98-4389-8e93-cb7480de5a38?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0ad65ef8-fbcf-4cfd-9a10-584c548909ee"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "746ca669-c86b-4b37-8919-f71a36db63f2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "642dde2c-b8c4-412d-aafd-d69b2921053a",
+        "apim-request-id": "5295c46f-7542-49a5-a32a-4d33065da12c",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2c473a4a-5857-40ef-a9a4-0a8a081a75e2",
-        "lastUpdatedDateTime": "2022-10-15T02:25:19Z",
-        "createdDateTime": "2022-10-15T02:25:19Z",
-        "expirationDateTime": "2022-10-16T02:25:19Z",
+        "jobId": "1a7ebe14-be98-4389-8e93-cb7480de5a38",
+        "lastUpdatedDateTime": "2022-10-24T05:16:38Z",
+        "createdDateTime": "2022-10-24T05:16:38Z",
+        "expirationDateTime": "2022-10-25T05:16:38Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -83,33 +85,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2c473a4a-5857-40ef-a9a4-0a8a081a75e2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a7ebe14-be98-4389-8e93-cb7480de5a38?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "15713ce4-b8d8-40cb-890b-d0c0f305b75b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "77c2cf38-ea14-4b33-89d3-692137e5ed4d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa30f15f-91ff-4217-ab8a-b1e0536930e7",
-        "Content-Length": "283",
+        "apim-request-id": "b0400bf3-a73d-4262-b49e-c3522466273d",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2c473a4a-5857-40ef-a9a4-0a8a081a75e2",
-        "lastUpdatedDateTime": "2022-10-15T02:25:19Z",
-        "createdDateTime": "2022-10-15T02:25:19Z",
-        "expirationDateTime": "2022-10-16T02:25:19Z",
-        "status": "notStarted",
+        "jobId": "1a7ebe14-be98-4389-8e93-cb7480de5a38",
+        "lastUpdatedDateTime": "2022-10-24T05:16:38Z",
+        "createdDateTime": "2022-10-24T05:16:38Z",
+        "expirationDateTime": "2022-10-25T05:16:38Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -121,32 +124,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2c473a4a-5857-40ef-a9a4-0a8a081a75e2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a7ebe14-be98-4389-8e93-cb7480de5a38?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4ede7cfc-79a7-48ba-b02b-c74c59c4ef53"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b46252c4-598f-432e-bd70-46ca8be431c3"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "19d1d7a3-814d-42e6-91b9-9c9ea31cade2",
+        "apim-request-id": "01779b9c-6b0f-43f1-9e82-b6eda90c1d77",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2c473a4a-5857-40ef-a9a4-0a8a081a75e2",
-        "lastUpdatedDateTime": "2022-10-15T02:25:20Z",
-        "createdDateTime": "2022-10-15T02:25:19Z",
-        "expirationDateTime": "2022-10-16T02:25:19Z",
+        "jobId": "1a7ebe14-be98-4389-8e93-cb7480de5a38",
+        "lastUpdatedDateTime": "2022-10-24T05:16:40Z",
+        "createdDateTime": "2022-10-24T05:16:38Z",
+        "expirationDateTime": "2022-10-25T05:16:38Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +161,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:20.6712081Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:40.3906146Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -308,32 +312,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/2c473a4a-5857-40ef-a9a4-0a8a081a75e2?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1a7ebe14-be98-4389-8e93-cb7480de5a38?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e258e55d-cf58-411b-9735-a3a0cb5dba63"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cb3182e3-bc6c-45d9-a66a-da2d5bedc45e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "95ef1fed-ea29-497a-ac34-d46e7e530fab",
+        "apim-request-id": "bf4c1643-e8f5-459d-8e4f-b8d31433031e",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "2c473a4a-5857-40ef-a9a4-0a8a081a75e2",
-        "lastUpdatedDateTime": "2022-10-15T02:25:20Z",
-        "createdDateTime": "2022-10-15T02:25:19Z",
-        "expirationDateTime": "2022-10-16T02:25:19Z",
+        "jobId": "1a7ebe14-be98-4389-8e93-cb7480de5a38",
+        "lastUpdatedDateTime": "2022-10-24T05:16:40Z",
+        "createdDateTime": "2022-10-24T05:16:38Z",
+        "expirationDateTime": "2022-10-25T05:16:38Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +349,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:20.6712081Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:40.3906146Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "202",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4bf9f745-bb75-418d-aadf-cf735b8d82ff"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1695313b-7365-4e26-86b6-3d223019d7e8"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,43 +34,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "868e9a1b-e836-4d15-abe4-52d6879a3254",
+        "apim-request-id": "77f48412-64e3-4065-8348-35345962c846",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:25:15 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/5a30103d-4154-4af6-897b-92cc137ebbe8?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:16:35 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/75265f11-98db-4411-a733-dce305fb192d?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "118"
+        "x-envoy-upstream-service-time": "91",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a30103d-4154-4af6-897b-92cc137ebbe8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/75265f11-98db-4411-a733-dce305fb192d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "92377ae6-d2aa-4905-a321-24d1dd5dc7af"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "009361a2-26f5-4f17-a0c2-0fe6cbef6855"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "608bfc05-aa8a-4a73-b3fd-5f037e9fa6b1",
+        "apim-request-id": "d56c6e4c-e0d5-41d1-9f1b-fd3bee758707",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5a30103d-4154-4af6-897b-92cc137ebbe8",
-        "lastUpdatedDateTime": "2022-10-15T02:25:16Z",
-        "createdDateTime": "2022-10-15T02:25:16Z",
-        "expirationDateTime": "2022-10-16T02:25:16Z",
+        "jobId": "75265f11-98db-4411-a733-dce305fb192d",
+        "lastUpdatedDateTime": "2022-10-24T05:16:35Z",
+        "createdDateTime": "2022-10-24T05:16:35Z",
+        "expirationDateTime": "2022-10-25T05:16:35Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -83,33 +85,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a30103d-4154-4af6-897b-92cc137ebbe8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/75265f11-98db-4411-a733-dce305fb192d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "af1ea10d-d6c8-4c19-9d75-58ced202905a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "71c285ea-5baa-4ebe-9470-54773e8286f5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4021581b-0b48-47bb-a72c-8c4861c9326b",
-        "Content-Length": "280",
+        "apim-request-id": "739bca8d-3612-41d4-843c-584b3f645a74",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:15 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5a30103d-4154-4af6-897b-92cc137ebbe8",
-        "lastUpdatedDateTime": "2022-10-15T02:25:16Z",
-        "createdDateTime": "2022-10-15T02:25:16Z",
-        "expirationDateTime": "2022-10-16T02:25:16Z",
-        "status": "running",
+        "jobId": "75265f11-98db-4411-a733-dce305fb192d",
+        "lastUpdatedDateTime": "2022-10-24T05:16:35Z",
+        "createdDateTime": "2022-10-24T05:16:35Z",
+        "expirationDateTime": "2022-10-25T05:16:35Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -121,32 +124,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a30103d-4154-4af6-897b-92cc137ebbe8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/75265f11-98db-4411-a733-dce305fb192d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "58d8b80d-8cf5-4887-b97c-9fc0f87d501a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d051d669-65ec-4749-8caf-a0730d730d58"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "08f6eec8-9675-43bb-a1ae-9b4ab13008ba",
+        "apim-request-id": "788ea2f2-3653-4643-801d-ef40ea84df14",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "98",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5a30103d-4154-4af6-897b-92cc137ebbe8",
-        "lastUpdatedDateTime": "2022-10-15T02:25:18Z",
-        "createdDateTime": "2022-10-15T02:25:16Z",
-        "expirationDateTime": "2022-10-16T02:25:16Z",
+        "jobId": "75265f11-98db-4411-a733-dce305fb192d",
+        "lastUpdatedDateTime": "2022-10-24T05:16:37Z",
+        "createdDateTime": "2022-10-24T05:16:35Z",
+        "expirationDateTime": "2022-10-25T05:16:35Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +161,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:18.3423188Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:37.6446648Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -308,32 +312,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/5a30103d-4154-4af6-897b-92cc137ebbe8?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/75265f11-98db-4411-a733-dce305fb192d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f982b20c-0f7f-44ea-9bbe-33da7d515535"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7119b103-d596-41bd-80dd-7a563edfa3a8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f9de34b-ca40-48d3-84df-73113e8dbc6b",
+        "apim-request-id": "7d9cc16c-c0d2-4483-add4-f7fe2bb1ee46",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:25:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "5a30103d-4154-4af6-897b-92cc137ebbe8",
-        "lastUpdatedDateTime": "2022-10-15T02:25:18Z",
-        "createdDateTime": "2022-10-15T02:25:16Z",
-        "expirationDateTime": "2022-10-16T02:25:16Z",
+        "jobId": "75265f11-98db-4411-a733-dce305fb192d",
+        "lastUpdatedDateTime": "2022-10-24T05:16:37Z",
+        "createdDateTime": "2022-10-24T05:16:35Z",
+        "expirationDateTime": "2022-10-25T05:16:35Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +349,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:25:18.3423188Z",
+              "lastUpdateDateTime": "2022-10-24T05:16:37.6446648Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/api_key_textanalysisclient_client_options/recording_service_version.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/api_key_textanalysisclient_client_options/recording_service_version.json
@@ -10,8 +10,8 @@
         "Content-Length": "249",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4c07f3b9-2d1a-44d9-80a1-5e890747e54e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "95c1df94-572a-486a-8441-79e68ffd776c"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -33,18 +33,19 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b523897c-3eb4-4770-899c-d1163d72f56a",
+        "apim-request-id": "e89e2357-257a-48c8-96bc-a41a1a2b0cd4",
         "Content-Length": "712",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Sat, 15 Oct 2022 02:25:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "warn-agent": "-",
         "warn-code": "299",
         "warn-text": "Microsoft Cognitive Services Language APIs version 2022-04-01-preview is retired and will be removed by Dec 1, 2022. The latest supported version is 2022-05-01. For more information please check http://aka.ms/language-api-versions.",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",
@@ -120,8 +121,8 @@
         "Content-Length": "249",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0c89de5b-7dad-442d-99d4-770abe64585b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3dd5caa3-243e-4ce9-9158-524ede240f78"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -143,15 +144,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9399840f-afc8-409a-89ac-fdfcde14e1bb",
+        "apim-request-id": "58052465-1bcb-4651-8ad5-acd50b64413c",
         "Content-Length": "712",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Sat, 15 Oct 2022 02:25:21 GMT",
+        "Date": "Mon, 24 Oct 2022 05:16:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -7,11 +7,11 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "687",
+        "Content-Length": "289",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c1d06cb6-6778-4b4e-9787-3279ac89f315"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7f616c98-53ee-48d5-b8a1-17c18bfdffce"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -19,28 +19,13 @@
           "documents": [
             {
               "id": "1",
-              "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle",
-              "language": "en"
-            },
-            {
-              "id": "3",
               "text": "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
               "language": "en"
             },
             {
-              "id": "4",
-              "text": "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
-              "language": "es"
-            },
-            {
-              "id": "5",
-              "text": "La carretera estaba atascada. Hab\u00EDa mucho tr\u00E1fico el d\u00EDa de ayer.",
-              "language": "es"
+              "id": "2",
+              "text": "I didn\u0027t like the last book I read at all.",
+              "language": "en"
             }
           ]
         },
@@ -48,15 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "07e6d365-daa3-4fa8-9184-887b668d3432",
-        "Content-Length": "1834",
+        "apim-request-id": "e1e613ca-cda0-4ce4-8732-452965351b54",
+        "Content-Length": "424",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",
@@ -64,82 +50,6 @@
           "documents": [
             {
               "id": "1",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 26,
-                      "length": 7,
-                      "confidenceScore": 0.21
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 65,
-                      "length": 12,
-                      "confidenceScore": 0.42
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "2",
-              "entities": [
-                {
-                  "bingId": "5fbba6b8-85e1-4d41-9444-d9055436e473",
-                  "name": "Seattle",
-                  "matches": [
-                    {
-                      "text": "Seattle",
-                      "offset": 50,
-                      "length": 7,
-                      "confidenceScore": 0.2
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Seattle",
-                  "url": "https://en.wikipedia.org/wiki/Seattle",
-                  "dataSource": "Wikipedia"
-                },
-                {
-                  "bingId": "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
-                  "name": "Space Needle",
-                  "matches": [
-                    {
-                      "text": "Space Needle",
-                      "offset": 90,
-                      "length": 12,
-                      "confidenceScore": 0.36
-                    }
-                  ],
-                  "language": "en",
-                  "id": "Space Needle",
-                  "url": "https://en.wikipedia.org/wiki/Space_Needle",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "3",
               "entities": [
                 {
                   "bingId": "296617ab-4ddb-cc10-beba-56e0f42af76b",
@@ -161,29 +71,7 @@
               "warnings": []
             },
             {
-              "id": "4",
-              "entities": [
-                {
-                  "bingId": "9ae3e6ca-81ea-6fa1-ffa0-42e1d7890906",
-                  "name": "Monte Rainier",
-                  "matches": [
-                    {
-                      "text": "Monte Rainier",
-                      "offset": 29,
-                      "length": 13,
-                      "confidenceScore": 0.81
-                    }
-                  ],
-                  "language": "es",
-                  "id": "Monte Rainier",
-                  "url": "https://es.wikipedia.org/wiki/Monte_Rainier",
-                  "dataSource": "Wikipedia"
-                }
-              ],
-              "warnings": []
-            },
-            {
-              "id": "5",
+              "id": "2",
               "entities": [],
               "warnings": []
             }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Content-Length": "551",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6a68dec7-e150-4f82-8e64-a842bfdaefce"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b0458038-aaf7-4b2b-b125-5198faf25ef6"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "14ef6634-47ab-4093-80be-9984d52b7fb4",
+        "apim-request-id": "fa0b2556-1a1c-44f9-95e7-5581415baa52",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "551",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "69957efa-4ae4-4b0e-af1f-8bd5a5d3d0fe"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bc2dcfb7-b9d3-47a2-930f-4b675a49be76"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b45b95f-63de-4f02-a7b7-9e80f267390e",
+        "apim-request-id": "2a8dd37f-2bd0-4e1c-aa71-043902c2a8bf",
         "Content-Length": "1525",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_client_throws_exception_for_too_many_inputs.json
@@ -10,8 +10,8 @@
         "Content-Length": "770",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1b9d7925-36ed-48c0-be71-c6351a43eda5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6d665d9f-a951-4f71-8a50-6cc1209dedf2"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -53,13 +53,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f397aaa8-f979-4913-9071-8b6c1e6c0666",
+        "apim-request-id": "7418dfb2-7e5a-4482-85cb-4a9eb40a3607",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entitylinking/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "160",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "db1a11f4-ac6a-4ba8-a240-8b1c30676dec"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "4114926b-bb4f-4b7f-b55e-a7d33017d896"
       },
       "RequestBody": {
         "kind": "EntityLinking",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3b0ec533-54d5-4dbe-803e-f155f1239e6a",
+        "apim-request-id": "003d838b-530b-41ae-a0e3-f6a283b7d278",
         "Content-Length": "408",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "2",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityLinkingResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Content-Length": "691",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b425389b-7608-4176-9c88-6f915dba4b28"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "01eb2593-2c47-48d3-8928-a2f26f07f989"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6d5fc93d-8546-4f5a-a496-a68bbcbe10e7",
+        "apim-request-id": "ea047a04-ba10-4907-8886-f447d68653cc",
         "Content-Length": "1462",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "46",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Content-Length": "555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a630aaf2-470e-40fd-9d89-cbd915b848f6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7717549c-db51-4cc4-a176-8eef91c55393"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a84d252d-f018-4bb2-b5e4-912358ad3b9b",
+        "apim-request-id": "ba278427-7e68-4663-81b1-77d9a180f45b",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "696ff0b6-7571-4141-91ff-ba6a1b79d32f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d02d3cda-9679-4ff3-8e7c-3d9fe802c549"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26c7cd36-4048-4795-abc2-3ed369c7566e",
+        "apim-request-id": "713d571e-6b73-4dca-8c3e-7d7b8e06af23",
         "Content-Length": "1221",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_client_throws_exception_for_too_many_inputs.json
@@ -10,8 +10,8 @@
         "Content-Length": "770",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "788f344b-6baa-4e05-a466-ffa41f9b11b4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dabbf497-7693-4d1a-a446-a5eab899166d"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -53,13 +53,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "67afcd72-8981-49a5-b464-8c973467f51a",
+        "apim-request-id": "350b3f87-ec4f-49fc-8259-adb2e9b73077",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_entityrecognition/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "164",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a916fb62-5145-44f9-ae00-454d77010587"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "049c2597-4f0b-4ea6-90ef-51bc361e3bfe"
       },
       "RequestBody": {
         "kind": "EntityRecognition",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b5989e7c-5a55-47a0-a498-ff0166a26945",
+        "apim-request-id": "fb8e24ae-4dd4-4f6a-80c7-98f58f4342aa",
         "Content-Length": "480",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "EntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Content-Length": "772",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cd529a22-c64d-4cbb-ab7c-7f2862b8831d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "686020b7-ee65-49a3-81e4-8d3d0f9dab72"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9fbfdca5-7771-4c75-9656-dbc9c158cd83",
+        "apim-request-id": "0706633f-95ff-434f-a4ba-3b499ca48786",
         "Content-Length": "524",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "16",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Content-Length": "557",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8c21a351-de7c-4fd7-8445-cd5a2de21331"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c096161c-e118-4dc4-8d21-0151ef0209fc"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d6f3738-18fc-43c5-bf2b-0dcb65936264",
+        "apim-request-id": "8ba6b13b-addb-454b-bc18-635e29bb73ad",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "15",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "557",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "14ede43c-8046-4e22-8146-c59b3cff97e2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "aa01ea22-6dd2-402b-b3e3-38a93b6cede0"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ffb2256b-3c48-4e7f-9761-222ee5b2f15e",
+        "apim-request-id": "f2466b90-ea8c-41ed-a6d7-c99412e694da",
         "Content-Length": "375",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "17",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_keyphraseextraction/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "166",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "084f5dc6-4512-417b-a326-f337293641af"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fd374b0c-b9fb-47aa-a5be-426319a2c55b"
       },
       "RequestBody": {
         "kind": "KeyPhraseExtraction",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d3ac282-58fa-429d-9993-098cf0173bd5",
+        "apim-request-id": "811a7695-aac6-42f3-921c-c87fa668093a",
         "Content-Length": "704",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "KeyPhraseExtractionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_a_countryhint.json
@@ -10,8 +10,8 @@
         "Content-Length": "126",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "01f9beb0-6018-46cc-88df-9b7d077b1cfc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6b53e8af-0702-48fd-8fbd-546e8a7617ca"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "061c2d90-81c3-477b-92b8-abe1e114416c",
+        "apim-request-id": "8e5333f9-d55c-4649-a9c8-15dfd43dcdfd",
         "Content-Length": "204",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_mixedcountry_detectlanguageinput.json
@@ -10,8 +10,8 @@
         "Content-Length": "712",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "38388c81-528f-456d-8515-4b30933ab630"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "59985069-78a0-45e9-b523-38b60cb6236b"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -49,15 +49,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5022634f-9ad8-4a99-ba44-c0c682951438",
+        "apim-request-id": "da4703e6-b64c-4772-9972-b80884a2d866",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_no_countryhint.json
@@ -10,8 +10,8 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "76ca5351-899a-4065-b6bb-a6fcd995da4d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ad5b2d89-b7a0-4f71-8d97-fa31ca10e0e2"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50307619-a595-4d7f-9253-d46827a99aac",
+        "apim-request-id": "e828744e-0ae5-4ddf-9860-cfb14feadfd6",
         "Content-Length": "517",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
@@ -10,8 +10,8 @@
         "Content-Length": "800",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a8a62fda-e0a1-4ed3-9089-f17488a0074a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "26c000d9-d6da-4c1d-9bb6-413dd7ce44aa"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99a43a9c-4984-4b30-b09a-a856b6ae3ff5",
+        "apim-request-id": "24698eb3-0309-4f6a-b9bf-bfe981a68553",
         "Content-Length": "726",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_client_accepts_none_country_hint_with_string_input.json
@@ -10,8 +10,8 @@
         "Content-Length": "162",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5725a6ab-732e-4709-bc3a-fef8c4b7b92a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c26732ac-490e-414b-98ef-12819d7c1cfc"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d2ff6aab-4162-4765-a5cf-dc25da8dae41",
+        "apim-request-id": "af2bfced-ea58-416b-b1b0-72662cf2f930",
         "Content-Length": "206",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_languagedetection/recording_service_errors_on_invalid_country_hint.json
@@ -10,8 +10,8 @@
         "Content-Length": "133",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cc261346-ad17-47cb-8ce9-5e05ce8c239b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0becec60-6025-4d7c-83cb-bbdd618f1fdc"
       },
       "RequestBody": {
         "kind": "LanguageDetection",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d577f3cd-c6a4-4ff6-b309-c9cb35810573",
+        "apim-request-id": "91e7371f-2bbc-4b75-bc10-1681c70b3de3",
         "Content-Length": "325",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:43 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:41 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "LanguageDetectionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_domain_filter.json
@@ -10,8 +10,8 @@
         "Content-Length": "185",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "08e653d1-9560-47eb-a801-535961f3ec53"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d7171024-b974-4ea3-aebf-e77e7913c862"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9656c24a-9076-4f80-9eb9-df86e0636671",
+        "apim-request-id": "33780710-343f-4be1-bc4d-af1571c48d7d",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "49"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_accepts_pii_categories.json
@@ -10,8 +10,8 @@
         "Content-Length": "200",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "443e3ea6-c3bc-4b72-8357-ccd03f0acdcd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "06c986df-a671-4d38-af1d-4d8f1bce95bd"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -32,15 +32,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "23531b6a-0340-479f-bb74-22c087e5315c",
+        "apim-request-id": "cd2af4a5-dbe3-4d45-9ba3-1a65d047ed59",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_mixedlanguage_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Content-Length": "694",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6727bb19-79a2-41d8-8028-073c287d1765"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "66ec1cfe-cf74-4bbb-8f51-c2c1822848cf"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8626ff7a-7c26-4b87-8d8a-80db0b3cd533",
+        "apim-request-id": "835b0ada-55eb-4361-8d2c-2b29ec86b866",
         "Content-Length": "1142",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=5,CognitiveServices.TextAnalytics.TextRecords=5",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_a_language_specified.json
@@ -10,8 +10,8 @@
         "Content-Length": "558",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e417e386-d5db-431f-9765-59a5abcbaf03"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f5386f6f-d34a-4a34-8caf-6f27295b376a"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a22f3389-f966-4146-896c-9b0a7a618185",
+        "apim-request-id": "2c05e881-9336-4ec6-920e-f702c3df714b",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "558",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2fc74c77-772b-47f3-ac43-5c823ce22c21"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cb9b951e-dea4-4379-a276-b774abd1ba07"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "402f4129-9427-4324-a385-07ac35f123f4",
+        "apim-request-id": "0a726af9-f3b2-4c2c-bc24-eff8c4120f72",
         "Content-Length": "883",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_client_correctly_reports_recognition_of_piilike_pattern.json
@@ -10,8 +10,8 @@
         "Content-Length": "159",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "42bffc10-d40a-4cca-8fb6-680954e9f48e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "46468d19-98dd-4914-835d-b2afa833d0c6"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e9c9c633-20c4-4d2b-83bd-6e82d3fbf619",
+        "apim-request-id": "287b6ed6-6a68-4659-b4b7-a481e32532b7",
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "42",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_output_pii_categories_are_accepted_as_input.json
@@ -10,8 +10,8 @@
         "Content-Length": "158",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9c933f80-82f0-492b-93dc-4b350eab36be"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bbb1aa24-4b32-4872-800a-a9e9b419116f"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,15 +28,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1dcf68d5-e474-4a8a-afa0-ceee3d85bea4",
+        "apim-request-id": "37439672-e5e5-4e9a-ba55-e31dcb2e9c62",
         "Content-Length": "389",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",
@@ -79,8 +80,8 @@
         "Content-Length": "200",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d3753b5a-b296-4119-9413-ab296bb6ea10"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2c2831f3-d031-47f3-ab96-906cd0185f45"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -101,15 +102,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55cfb01a-d47f-4661-b950-1ad4286e2638",
+        "apim-request-id": "8db033ab-a7da-4f2b-95aa-3d9c25dcb880",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_piientityrecognition/recording_service_errors_on_unsupported_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "167",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d19914ce-8f42-47c1-8eaf-e99b1ba96ad9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "161792d0-5c48-42f6-afad-68f6606d75e9"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "105c75f7-ffc8-4a2e-bca9-a773f859e9a3",
+        "apim-request-id": "66cac6cf-0969-4a60-b279-f2f92a01daf3",
         "Content-Length": "450",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:42 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_and_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "947d2213-7206-476e-8a7b-da0bec42141c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "773d2e29-d0ab-4bf3-aab1-50ac2c17c0cc"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3e3e210-a6f5-4f4e-a1ce-c817cc13c195",
+        "apim-request-id": "8b55555b-5ec8-4021-92ec-62152e9ae230",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_string_with_no_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "087c9992-4a33-499f-9d5e-45a6ff7b18a0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "543ed2cd-5b5c-4a38-985f-df03c6d64ee2"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -43,15 +43,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f40606a6-812b-427a-a561-9cda360f93b6",
+        "apim-request-id": "d8e27db2-dcc4-4441-a001-edb39990c87f",
         "Content-Length": "1572",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "x-envoy-upstream-service-time": "37",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_accepts_textdocumentinput.json
@@ -10,8 +10,8 @@
         "Content-Length": "770",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5a6f577a-346d-48f9-8e08-e3bdeac37c22"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cf0c2613-cde2-4230-861d-4a77c3309304"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -53,15 +53,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a669a469-76b0-475c-a205-f7b5d937d147",
+        "apim-request-id": "73f89bd8-74e0-486b-a25e-c0d63557b08a",
         "Content-Length": "2343",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6,CognitiveServices.TextAnalytics.TextRecords=6",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "37",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_negative_mined_assessments.json
@@ -1,0 +1,126 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://endpoint/language/:analyze-text?api-version=2022-05-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "166",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a69980e1-8828-4963-a1b1-1ca79a0ef85b"
+      },
+      "RequestBody": {
+        "kind": "SentimentAnalysis",
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "The food and service are not good",
+              "language": "en"
+            }
+          ]
+        },
+        "parameters": {
+          "opinionMining": true
+        }
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c05e8a0a-3578-4d3c-8a2d-dcef0faba010",
+        "Content-Length": "954",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "kind": "SentimentAnalysisResults",
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "sentiment": "negative",
+              "confidenceScores": {
+                "positive": 0.0,
+                "neutral": 0.0,
+                "negative": 1.0
+              },
+              "sentences": [
+                {
+                  "sentiment": "negative",
+                  "confidenceScores": {
+                    "positive": 0.0,
+                    "neutral": 0.0,
+                    "negative": 1.0
+                  },
+                  "offset": 0,
+                  "length": 33,
+                  "text": "The food and service are not good",
+                  "targets": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 4,
+                      "length": 4,
+                      "text": "food",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    },
+                    {
+                      "sentiment": "positive",
+                      "confidenceScores": {
+                        "positive": 1.0,
+                        "negative": 0.0
+                      },
+                      "offset": 13,
+                      "length": 7,
+                      "text": "service",
+                      "relations": [
+                        {
+                          "relationType": "assessment",
+                          "ref": "#/documents/0/sentences/0/assessments/0"
+                        }
+                      ]
+                    }
+                  ],
+                  "assessments": [
+                    {
+                      "sentiment": "negative",
+                      "confidenceScores": {
+                        "positive": 0.0,
+                        "negative": 1.0
+                      },
+                      "offset": 29,
+                      "length": 4,
+                      "text": "good",
+                      "isNegated": true
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2022-10-01"
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_no_mined_assessments.json
@@ -10,8 +10,8 @@
         "Content-Length": "151",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "062a468b-be75-4a83-af74-3da904cebfbd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d49a4618-3537-40f7-b613-5e6a037feba6"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a8a02338-6eaa-4263-9cc6-71b1560f761a",
+        "apim-request-id": "13697098-fe18-4e77-87b3-6d8079eddd44",
         "Content-Length": "403",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "19",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_client_gets_positive_mined_assessments.json
@@ -10,8 +10,8 @@
         "Content-Length": "207",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e4d7b514-1810-478d-9879-f92c743ed352"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "01492fd1-11a1-440e-bdfb-de5943062973"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "82dc717c-66ea-4247-82aa-4ac2e3a1c56c",
+        "apim-request-id": "ee19c745-48a4-4451-90eb-56fd7d2b37c3",
         "Content-Length": "1009",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_has_a_bug_when_referencing_assessments_in_doc_6_or_greater.json
@@ -10,8 +10,8 @@
         "Content-Length": "703",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c11a0797-5317-4843-9f2c-5cfdd6de5bf2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a02dc09e-9971-4d73-bceb-76d7e9c146eb"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -60,15 +60,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9bd41ca7-b721-4303-8563-e319cdc0e64b",
+        "apim-request-id": "dddf8115-fd72-414a-a7d1-16cb4f8e56a6",
         "Content-Length": "7828",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=7,CognitiveServices.TextAnalytics.TextRecords=7",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_an_error_for_an_empty_document.json
@@ -10,8 +10,8 @@
         "Content-Length": "592",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fec84218-c91e-4ec6-8fc8-52c987374dfe"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "01bf02c8-26ba-45a4-8c63-4de299a94fc1"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -48,15 +48,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a2fb0df-0cd7-4efe-8b60-9c9aad39f76e",
+        "apim-request-id": "8cd5836b-d665-456d-a35f-f69f512b1e9d",
         "Content-Length": "1734",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_sentimentanalysis/recording_service_returns_error_for_invalid_language.json
@@ -10,8 +10,8 @@
         "Content-Length": "135",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1c667194-4696-45d4-8f83-1d613d0bdbc8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c602d300-a389-46a3-8d11-2bff4f7bea06"
       },
       "RequestBody": {
         "kind": "SentimentAnalysis",
@@ -28,14 +28,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "190e8cec-1bc9-43e3-b82b-943a84e589db",
+        "apim-request-id": "3243ccc5-83f0-4107-bbba-f1865a92929b",
         "Content-Length": "699",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:20:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "x-envoy-upstream-service-time": "3",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "SentimentAnalysisResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "170",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "55f607d6-2c0c-4410-96d0-5e233fcd5e78"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "07efdfb3-a0d0-417a-b974-b607049fc538"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "14adefb5-8d2a-448a-be2e-4def5bcf37fb",
+        "apim-request-id": "5bfe54c3-43a1-4e8c-b7da-867d834986f8",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "171",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c8805908-d870-4b7d-a5a8-cbbcb978d9c1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "10aa36c5-6daa-4b49-87e5-dbe636585fa7"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "510c078b-333c-464e-aa1f-0af1f3abac6d",
+        "apim-request-id": "67b23a64-ffee-467d-be30-32570e65365b",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "170",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "eb08eb72-0ac9-42fb-a367-adfcb5d9e7dd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2bb6fc10-5d90-47c8-981f-bddabf50ca23"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc72564c-ed38-4611-a047-f93ef2acae36",
+        "apim-request-id": "4f108b1e-23fa-43a6-a33f-f97030bb28cf",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "174",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4c96c033-67e3-40fd-bf40-e6884e70189c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0dbc2668-6659-4cda-bea5-90391eaa7174"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa1afbe5-470a-422d-b838-1bdd78b67405",
+        "apim-request-id": "5bb567a7-7f8c-4bf9-888d-787f1a5a0b0c",
         "Content-Length": "291",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "21f7a61c-b8dd-4545-8b6c-a681bccd664b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "797cd225-7817-4499-8136-7c55d6ad9031"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5fefc54d-0246-433e-bce9-515ae2ade8eb",
+        "apim-request-id": "307bf07f-0995-45d3-94e4-90430d2d6de9",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:43 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "207",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cd230703-b52a-4f64-9b6c-044669efdc1e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "40c67dc3-e054-4ac9-9045-a018dfebe28e"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7d1a47a4-66c7-477c-b662-78e26927fd4e",
+        "apim-request-id": "a09ead98-fb44-4ed7-b860-5e1c9fe99068",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "172",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "de28c291-93fb-415f-8ae8-437330c8d930"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b77667ab-cec6-4bcd-9491-d7817720346b"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "43a9f23b-abe4-4cbd-b284-f8ad4add752c",
+        "apim-request-id": "2be15962-028a-47a0-851d-ce2b8fc4779e",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "172",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "83d4aedb-0f23-4fdd-8b39-08740a6c1ea7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dde7b383-40f0-4f82-9a94-1a0f0ec3ade1"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1fc879d8-7be5-42f8-b880-7b2563752711",
+        "apim-request-id": "092fd31b-f49c-4eac-bf58-2db2cabf2b3f",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_default_encoding_utf16codeunit/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Content-Length": "393",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cc6b439f-16bb-4dbb-abe2-710deb83d267"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "15d15534-3aa9-46d9-9817-ffae1e3efc9b"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c280adde-fc20-4b0f-be5a-6f7f9b31cc5f",
+        "apim-request-id": "d1eba25a-4803-4c9c-81b4-aadc8311a7e8",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "58"
+        "x-envoy-upstream-service-time": "59",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "172",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "53ad9f20-ea8c-4015-b108-24b783a30b09"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "859c4260-6451-430d-b70f-28c9b931c1a2"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ca35af9-baa5-4013-b30e-e278fc0b9549",
+        "apim-request-id": "9653257a-6625-4d5f-85f9-26c88443517a",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "173",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d3a33c70-af9b-41aa-94b6-12827bc54dad"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8b1b3d80-c79a-4000-a316-7b1c89c44099"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03ffbf7e-8954-4f40-a35b-338981ab893a",
+        "apim-request-id": "4c04ea6a-d29c-41ec-9dda-1406f69056ef",
         "Content-Length": "287",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "172",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e1e0db22-a7b4-4d38-a8c4-c2953c0e271c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ed9de690-57e8-4af9-961f-5dd52c5566f2"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "29e6db86-8911-45fa-8768-8dfc780416f3",
+        "apim-request-id": "b834e393-84d0-407d-93f3-d20fe75dc26e",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "176",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "db11962f-d31a-4ab6-adf3-18eb67218234"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9b7b1de8-60f5-4f1f-80d8-2637aa30a42e"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a88712ad-ae9d-4c56-b346-9174ddd0d2ee",
+        "apim-request-id": "2cf3f790-fa95-4e2e-8ee9-16a2f7b26558",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "193",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ce1db87f-3c42-4064-b05c-5625ec71b66e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "80385878-a6ab-47ae-b282-0ed75361dcfa"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7279a6f0-1c3d-467d-b461-2fadb63382d5",
+        "apim-request-id": "91bd13a2-1f0f-494e-b214-3203fa1beace",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "209",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "313717e1-34cc-457d-ad6d-288fc065322c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bd2266dd-d494-431f-8b5c-44886f452b0e"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "adaeeb63-c4b7-4aa1-9f23-d5df9f5c8257",
+        "apim-request-id": "83161ba6-8746-4f97-84d3-82dc2954822e",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "174",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f0812f92-ab91-46c1-8aba-b85263424317"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "90e93687-ba47-46b7-ac07-d1093425ed1b"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be0d3c75-3100-4df5-a824-deae14e30fef",
+        "apim-request-id": "2c438d3a-3b36-4697-b8d4-2eed73134cf8",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "174",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d712609f-17cd-4c70-babe-1651b5d1a028"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "05685455-31d5-42ec-98b8-d0bcea56abb7"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6dcfe776-cdcf-4606-936e-2a3eb9b94635",
+        "apim-request-id": "884d514e-9fab-4388-a139-f8c16ef0e42b",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Content-Length": "395",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0350a889-3d73-4bd0-afa7-0d46f2062ee7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "70e0a4de-13df-4b59-b4ea-ca90f640315d"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "952a6d07-31ba-4b34-b085-f7c3b96fbe76",
+        "apim-request-id": "72763bc0-0606-42ee-8bc8-a3214a3d4901",
         "Content-Length": "509",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:47 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
+        "x-envoy-upstream-service-time": "60",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "173",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a396495f-dbc2-482c-b70e-5ed4bdb817d9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c2adaa88-1b62-4aa7-9223-57fd11539df0"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b6dd17a-2dbf-40ae-a615-4020a82dadc8",
+        "apim-request-id": "b02502a1-be74-4210-bf85-250cdf04e23e",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_diacritics_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "174",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "529868ec-f895-4bda-955e-b5a58c09d343"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ca2f8859-bd7f-47f9-9379-88d8016cb67f"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "061f1fc5-3ae0-4dcf-a903-5934f4466340",
+        "apim-request-id": "8a52ea3d-814f-4db7-919c-5c8786fc3b4f",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "173",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1d2bd520-5002-4192-8f38-a5481639fe34"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a7a837f0-ad9c-4fa5-a67a-1d94a212bcc2"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5896632c-d005-43a7-87dc-8536728e28f0",
+        "apim-request-id": "7440c146-7d54-4906-9d73-f8a1ecb71b48",
         "Content-Length": "286",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "177",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b976b02b-5014-4614-8bdb-aeb305eec386"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "79b686a8-283c-4f6a-90df-db868b2f2414"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4eb0e4e1-4976-45ae-b294-041039a9ce66",
+        "apim-request-id": "722266f4-9c3d-4d99-8d63-3c3abf9d25b5",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "194",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f929a9b9-53d8-4db1-ba13-7e0a4cac95c6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2f83fc76-8001-4bd7-97a1-552f75ea9dec"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b757e3d-d5b6-4a67-b2aa-1d810287e147",
+        "apim-request-id": "f113945a-da90-41fd-97f2-aa7446286ca3",
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "210",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "40cb167d-d205-4b21-9bab-7183140c5430"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "259bae40-9db8-49c8-a503-6e669e71a6c5"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00346c2e-c6b0-45a6-9cef-70818b1e0068",
+        "apim-request-id": "89739b3c-ad51-4ffe-9462-e4386a8d833b",
         "Content-Length": "324",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:45 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "29",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfc.json
@@ -10,8 +10,8 @@
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "20b37114-7c5f-4e8d-9fa1-5bc6e7ecb7ac"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "33f781c1-0df5-4632-ac40-294db368d774"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "57169e06-0d09-44a3-a2e6-9ca4f50cd006",
+        "apim-request-id": "3e1234db-821d-4b11-80d9-1244628e3f21",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_korean_nfd.json
@@ -10,8 +10,8 @@
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "060c373a-9657-4b66-8a27-ad5ad17b7463"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9fd443b8-cd7e-456f-be06-5757955ca480"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a0e747b-2ae7-44e5-90f8-9cc65ae183f9",
+        "apim-request-id": "6602caa4-d710-4bc7-a4c4-bd9178be434d",
         "Content-Length": "288",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "26",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_unicodecodepoint/recording_zalgo.json
@@ -10,8 +10,8 @@
         "Content-Length": "396",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "01b74a24-fcdc-4093-860d-6641953b3c4a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e4276083-0e66-4b60-a8f2-e6d5631ab505"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26613968-f9f8-4019-9a35-717a6ef6fd11",
+        "apim-request-id": "d94f0f6f-d260-40e6-ad38-960031d8d521",
         "Content-Length": "511",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Sat, 15 Oct 2022 02:20:47 GMT",
+        "Date": "Mon, 24 Oct 2022 05:11:46 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
+        "x-envoy-upstream-service-time": "57",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "kind": "PiiEntityRecognitionResults",

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_entity_recognition.json
@@ -10,8 +10,8 @@
         "Content-Length": "480",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9ba32009-deb4-4fee-9809-c5e6770235d3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a744a50c-fffa-4757-a8d7-7377939e41d6"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a1ab65e7-a4e0-41e2-8121-ba27c7f985b4",
+        "apim-request-id": "3f7e63ab-885d-4c18-bffd-7d65b4c7933b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:51 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/a629a122-9969-469e-89d2-c35bac4af65a?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:38 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/6fc07711-c207-4b78-b2c2-e5a60154912a?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "152"
+        "x-envoy-upstream-service-time": "247",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a629a122-9969-469e-89d2-c35bac4af65a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6fc07711-c207-4b78-b2c2-e5a60154912a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7b53e193-50c7-40ae-b0d2-e5a7f117ee80"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2d8f2d38-eaca-40ad-a897-2a272992b4af"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fc52bf9f-da1c-45fa-bdc3-319e5e52ca57",
+        "apim-request-id": "504cf31b-9dd3-4d42-bc04-91500fe4a623",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a629a122-9969-469e-89d2-c35bac4af65a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:52Z",
-        "createdDateTime": "2022-10-15T02:21:52Z",
-        "expirationDateTime": "2022-10-16T02:21:52Z",
+        "jobId": "6fc07711-c207-4b78-b2c2-e5a60154912a",
+        "lastUpdatedDateTime": "2022-10-24T05:12:38Z",
+        "createdDateTime": "2022-10-24T05:12:38Z",
+        "expirationDateTime": "2022-10-25T05:12:38Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a629a122-9969-469e-89d2-c35bac4af65a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6fc07711-c207-4b78-b2c2-e5a60154912a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "23821829-7878-45d8-ae81-2c9b9b560737"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1a06f59c-d049-4e44-90ec-a70a1689f1d3"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c79b358c-e165-4508-9352-fe65beea0e9e",
+        "apim-request-id": "97618de9-9781-4f4c-a6f8-b90b506c3ab9",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a629a122-9969-469e-89d2-c35bac4af65a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:52Z",
-        "createdDateTime": "2022-10-15T02:21:52Z",
-        "expirationDateTime": "2022-10-16T02:21:52Z",
+        "jobId": "6fc07711-c207-4b78-b2c2-e5a60154912a",
+        "lastUpdatedDateTime": "2022-10-24T05:12:38Z",
+        "createdDateTime": "2022-10-24T05:12:38Z",
+        "expirationDateTime": "2022-10-25T05:12:38Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a629a122-9969-469e-89d2-c35bac4af65a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6fc07711-c207-4b78-b2c2-e5a60154912a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c28374ed-71ce-46b0-acf3-db8fe47eb1ee"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "52381fc4-0f18-4f7b-9868-ed23d8eeb614"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4a431ca-274f-42de-8017-b52820ee6b38",
+        "apim-request-id": "f5b366e6-4d45-47d8-bcf8-6dcae03efc7c",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "39",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a629a122-9969-469e-89d2-c35bac4af65a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:52Z",
-        "createdDateTime": "2022-10-15T02:21:52Z",
-        "expirationDateTime": "2022-10-16T02:21:52Z",
+        "jobId": "6fc07711-c207-4b78-b2c2-e5a60154912a",
+        "lastUpdatedDateTime": "2022-10-24T05:12:39Z",
+        "createdDateTime": "2022-10-24T05:12:38Z",
+        "expirationDateTime": "2022-10-25T05:12:38Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:52.4833255Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:39.8345508Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -291,32 +295,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a629a122-9969-469e-89d2-c35bac4af65a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/6fc07711-c207-4b78-b2c2-e5a60154912a?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "be7cd411-a450-4465-ab39-fa889935c3cb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fe50fc86-c2b6-4800-8066-e510f89a2c17"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dea93bd6-15c2-41d8-9f53-5c0e88c33925",
+        "apim-request-id": "d5416027-eb76-4363-bab0-df5ecbc65749",
         "Content-Length": "1970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a629a122-9969-469e-89d2-c35bac4af65a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:52Z",
-        "createdDateTime": "2022-10-15T02:21:52Z",
-        "expirationDateTime": "2022-10-16T02:21:52Z",
+        "jobId": "6fc07711-c207-4b78-b2c2-e5a60154912a",
+        "lastUpdatedDateTime": "2022-10-24T05:12:39Z",
+        "createdDateTime": "2022-10-24T05:12:38Z",
+        "expirationDateTime": "2022-10-25T05:12:38Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -327,7 +332,7 @@
           "items": [
             {
               "kind": "CustomEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:52.4833255Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:39.8345508Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_multi_label_classification_action.json
@@ -10,8 +10,8 @@
         "Content-Length": "487",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8df77078-f7cb-4e65-b548-0393667f902e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dd43023d-ca14-4766-8143-2df940601364"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7aa01eee-7d98-4f35-9083-4ac4b91a3292",
+        "apim-request-id": "d263e5e7-a7ba-4a40-9d39-6d225420bc92",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:56 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c91ce5ef-d7f0-450c-bc13-b7f1819a833a?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:43 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/9d9df6bb-d23a-41b1-9b6d-a02f613364c5?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76"
+        "x-envoy-upstream-service-time": "177",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c91ce5ef-d7f0-450c-bc13-b7f1819a833a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d9df6bb-d23a-41b1-9b6d-a02f613364c5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "56f62682-e70b-4bd9-995d-bf1b31ed16d8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3a9d8b30-37bd-4fbd-b408-26364c1180e8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "809e97d5-d83b-4fdb-ae61-deb9b667ee54",
+        "apim-request-id": "58fa1fee-154a-4b9b-bede-a0e3c7a2572a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c91ce5ef-d7f0-450c-bc13-b7f1819a833a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:57Z",
-        "createdDateTime": "2022-10-15T02:21:57Z",
-        "expirationDateTime": "2022-10-16T02:21:57Z",
+        "jobId": "9d9df6bb-d23a-41b1-9b6d-a02f613364c5",
+        "lastUpdatedDateTime": "2022-10-24T05:12:43Z",
+        "createdDateTime": "2022-10-24T05:12:43Z",
+        "expirationDateTime": "2022-10-25T05:12:43Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c91ce5ef-d7f0-450c-bc13-b7f1819a833a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d9df6bb-d23a-41b1-9b6d-a02f613364c5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9a9b0c6d-cafb-4634-b3f7-4617067269dd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "55d957a6-1c99-4f17-8317-dedaa98f3fce"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a57c677-9585-4bf9-b3c2-149d3da1f5d0",
+        "apim-request-id": "48af6e54-7496-40c3-b099-7b1de494db74",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c91ce5ef-d7f0-450c-bc13-b7f1819a833a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:57Z",
-        "createdDateTime": "2022-10-15T02:21:57Z",
-        "expirationDateTime": "2022-10-16T02:21:57Z",
+        "jobId": "9d9df6bb-d23a-41b1-9b6d-a02f613364c5",
+        "lastUpdatedDateTime": "2022-10-24T05:12:43Z",
+        "createdDateTime": "2022-10-24T05:12:43Z",
+        "expirationDateTime": "2022-10-25T05:12:43Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c91ce5ef-d7f0-450c-bc13-b7f1819a833a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d9df6bb-d23a-41b1-9b6d-a02f613364c5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5784ff96-c66a-46ca-acbe-598236951fff"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "44dd29a2-aed9-4693-9d09-9dbcbf048709"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f07e68a-3b41-4af2-9fe0-ff45029d9df5",
-        "Content-Length": "534",
+        "apim-request-id": "b5cc5f4f-297b-4c79-8a77-8e27fe1dc783",
+        "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c91ce5ef-d7f0-450c-bc13-b7f1819a833a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:57Z",
-        "createdDateTime": "2022-10-15T02:21:57Z",
-        "expirationDateTime": "2022-10-16T02:21:57Z",
+        "jobId": "9d9df6bb-d23a-41b1-9b6d-a02f613364c5",
+        "lastUpdatedDateTime": "2022-10-24T05:12:44Z",
+        "createdDateTime": "2022-10-24T05:12:43Z",
+        "expirationDateTime": "2022-10-25T05:12:43Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:57.559634Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:44.3905466Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -178,32 +182,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c91ce5ef-d7f0-450c-bc13-b7f1819a833a?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/9d9df6bb-d23a-41b1-9b6d-a02f613364c5?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2d9c0a8b-ce29-4d4a-be40-ff2ba211160d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "22672d53-0d67-473e-a009-8fc8fa6074ba"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa45d273-5fcd-420e-83fa-b1df74dad326",
-        "Content-Length": "534",
+        "apim-request-id": "fb30bdb9-b592-419e-aa76-350379787887",
+        "Content-Length": "535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "24",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c91ce5ef-d7f0-450c-bc13-b7f1819a833a",
-        "lastUpdatedDateTime": "2022-10-15T02:21:57Z",
-        "createdDateTime": "2022-10-15T02:21:57Z",
-        "expirationDateTime": "2022-10-16T02:21:57Z",
+        "jobId": "9d9df6bb-d23a-41b1-9b6d-a02f613364c5",
+        "lastUpdatedDateTime": "2022-10-24T05:12:44Z",
+        "createdDateTime": "2022-10-24T05:12:43Z",
+        "expirationDateTime": "2022-10-25T05:12:43Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -214,7 +219,7 @@
           "items": [
             {
               "kind": "CustomMultiLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:57.559634Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:44.3905466Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_custom/recording_single_label_classification_action.json
@@ -10,8 +10,8 @@
         "Content-Length": "488",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d3637a60-855b-4217-a509-aab97b3b9462"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a8d3a51a-7454-4443-8c20-318377af406f"
       },
       "RequestBody": {
         "analysisInput": {
@@ -35,43 +35,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "03afe482-5ed0-461b-b5ec-ef74fabf42e7",
+        "apim-request-id": "ec3ceadc-47c1-45cf-a05b-c29db22c422e",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:54 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/d2836830-967f-4554-96e4-bc860b1492c6?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:41 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e75c4ba2-40c8-4293-b656-8cb6b218fc70?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "250"
+        "x-envoy-upstream-service-time": "398",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d2836830-967f-4554-96e4-bc860b1492c6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e75c4ba2-40c8-4293-b656-8cb6b218fc70?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8ea592ca-693d-4766-b044-c3ab663e3f13"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cfff994b-5625-4050-bfbf-769932892cec"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c598170-4d15-4ed3-a1f2-53c314cb6e75",
+        "apim-request-id": "b57a9959-4e94-4908-ba2e-2418767d0684",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2836830-967f-4554-96e4-bc860b1492c6",
-        "lastUpdatedDateTime": "2022-10-15T02:21:54Z",
-        "createdDateTime": "2022-10-15T02:21:54Z",
-        "expirationDateTime": "2022-10-16T02:21:54Z",
+        "jobId": "e75c4ba2-40c8-4293-b656-8cb6b218fc70",
+        "lastUpdatedDateTime": "2022-10-24T05:12:41Z",
+        "createdDateTime": "2022-10-24T05:12:41Z",
+        "expirationDateTime": "2022-10-25T05:12:41Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -84,32 +86,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d2836830-967f-4554-96e4-bc860b1492c6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e75c4ba2-40c8-4293-b656-8cb6b218fc70?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "139b2d5e-33dd-4b0c-b59f-a92f1e3d4fed"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "18be1fb3-88df-4ac6-aa82-c25269e1d94e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "76f53a8e-8260-4ceb-9c52-c4d37dae0c1d",
+        "apim-request-id": "c8086797-1f3b-479f-b58a-52680a6c0d70",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:54 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2836830-967f-4554-96e4-bc860b1492c6",
-        "lastUpdatedDateTime": "2022-10-15T02:21:54Z",
-        "createdDateTime": "2022-10-15T02:21:54Z",
-        "expirationDateTime": "2022-10-16T02:21:54Z",
+        "jobId": "e75c4ba2-40c8-4293-b656-8cb6b218fc70",
+        "lastUpdatedDateTime": "2022-10-24T05:12:41Z",
+        "createdDateTime": "2022-10-24T05:12:41Z",
+        "expirationDateTime": "2022-10-25T05:12:41Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d2836830-967f-4554-96e4-bc860b1492c6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e75c4ba2-40c8-4293-b656-8cb6b218fc70?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f65c4707-f831-48ec-9e4d-f44c5080a6e1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0e031e57-08ee-413d-bbcf-345f9feecf04"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ddb0a12-465e-4029-ba0d-46241593dd70",
+        "apim-request-id": "844356a3-fa5c-4cc4-9ed7-3904d9a89ae2",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2836830-967f-4554-96e4-bc860b1492c6",
-        "lastUpdatedDateTime": "2022-10-15T02:21:55Z",
-        "createdDateTime": "2022-10-15T02:21:54Z",
-        "expirationDateTime": "2022-10-16T02:21:54Z",
+        "jobId": "e75c4ba2-40c8-4293-b656-8cb6b218fc70",
+        "lastUpdatedDateTime": "2022-10-24T05:12:42Z",
+        "createdDateTime": "2022-10-24T05:12:41Z",
+        "expirationDateTime": "2022-10-25T05:12:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -158,7 +162,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:55.3848947Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:42.6985094Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -183,32 +187,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/d2836830-967f-4554-96e4-bc860b1492c6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e75c4ba2-40c8-4293-b656-8cb6b218fc70?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "79b42f36-7a3b-4797-be4d-21c9c58b0ac4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "db5ced53-8d99-4d98-adc9-49130c34cc60"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "afd8faba-1702-44aa-b3bb-1700c71da322",
+        "apim-request-id": "820cd0cf-96ec-45e6-b297-af846f857e27",
         "Content-Length": "582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:56 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "d2836830-967f-4554-96e4-bc860b1492c6",
-        "lastUpdatedDateTime": "2022-10-15T02:21:55Z",
-        "createdDateTime": "2022-10-15T02:21:54Z",
-        "expirationDateTime": "2022-10-16T02:21:54Z",
+        "jobId": "e75c4ba2-40c8-4293-b656-8cb6b218fc70",
+        "lastUpdatedDateTime": "2022-10-24T05:12:42Z",
+        "createdDateTime": "2022-10-24T05:12:41Z",
+        "expirationDateTime": "2022-10-25T05:12:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -219,7 +224,7 @@
           "items": [
             {
               "kind": "CustomSingleLabelClassificationLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:55.3848947Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:42.6985094Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_linking.json
@@ -10,8 +10,8 @@
         "Content-Length": "336",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2452ea87-4f77-45cc-8ed6-7b71f8885285"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "98f287ff-6b5d-4af9-8ff6-42d63ec3917d"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f009667e-fbd8-4c50-92b7-9eb0229ac7c6",
+        "apim-request-id": "bee066f6-9ace-4f1b-a580-ea92e0dabc6b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:30 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/dd2a33cd-e556-4834-9b1e-a8ff505d1934?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:21 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/68003b3a-756a-4a1b-a65b-cc033b377f80?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
+        "x-envoy-upstream-service-time": "139",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dd2a33cd-e556-4834-9b1e-a8ff505d1934?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/68003b3a-756a-4a1b-a65b-cc033b377f80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c5fb8a6a-7fcb-4114-8af9-22c7dda8ab95"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "abd9462a-fbaa-4740-8290-3e565b9e49bf"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00d96016-ef25-46b6-8eff-b91012bec944",
+        "apim-request-id": "efcc865e-7d1f-47a4-a158-6a637116ab62",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dd2a33cd-e556-4834-9b1e-a8ff505d1934",
-        "lastUpdatedDateTime": "2022-10-15T02:21:30Z",
-        "createdDateTime": "2022-10-15T02:21:30Z",
-        "expirationDateTime": "2022-10-16T02:21:30Z",
+        "jobId": "68003b3a-756a-4a1b-a65b-cc033b377f80",
+        "lastUpdatedDateTime": "2022-10-24T05:12:21Z",
+        "createdDateTime": "2022-10-24T05:12:21Z",
+        "expirationDateTime": "2022-10-25T05:12:21Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dd2a33cd-e556-4834-9b1e-a8ff505d1934?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/68003b3a-756a-4a1b-a65b-cc033b377f80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "951d5690-73e8-4630-a764-4ce198d30d2a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "02f9189c-b1e4-41ff-b5a8-c4fc35a39406"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf712d75-06ce-4b68-8a8b-0e66c9444122",
+        "apim-request-id": "fbdcd767-abd7-43c0-8d03-d64325f89715",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dd2a33cd-e556-4834-9b1e-a8ff505d1934",
-        "lastUpdatedDateTime": "2022-10-15T02:21:30Z",
-        "createdDateTime": "2022-10-15T02:21:30Z",
-        "expirationDateTime": "2022-10-16T02:21:30Z",
+        "jobId": "68003b3a-756a-4a1b-a65b-cc033b377f80",
+        "lastUpdatedDateTime": "2022-10-24T05:12:21Z",
+        "createdDateTime": "2022-10-24T05:12:21Z",
+        "expirationDateTime": "2022-10-25T05:12:21Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,32 +129,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dd2a33cd-e556-4834-9b1e-a8ff505d1934?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/68003b3a-756a-4a1b-a65b-cc033b377f80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4821b9d1-0ec9-469c-8075-95398e0dba45"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1cd5d22f-6cfc-40fd-ac11-8164c84308f8"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c7f2d929-161b-42cc-91f4-d2f393dc3e16",
-        "Content-Length": "2433",
+        "apim-request-id": "c04d1649-f9f6-4bc0-81a0-3f410116d828",
+        "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "59"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dd2a33cd-e556-4834-9b1e-a8ff505d1934",
-        "lastUpdatedDateTime": "2022-10-15T02:21:32Z",
-        "createdDateTime": "2022-10-15T02:21:30Z",
-        "expirationDateTime": "2022-10-16T02:21:30Z",
+        "jobId": "68003b3a-756a-4a1b-a65b-cc033b377f80",
+        "lastUpdatedDateTime": "2022-10-24T05:12:23Z",
+        "createdDateTime": "2022-10-24T05:12:21Z",
+        "expirationDateTime": "2022-10-25T05:12:21Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:32.651857Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:23.7062546Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -300,32 +304,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dd2a33cd-e556-4834-9b1e-a8ff505d1934?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/68003b3a-756a-4a1b-a65b-cc033b377f80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b0a95a7e-f7de-48a2-ac23-388d1af270b8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1e38767a-d969-448e-8ed7-e46393ee6688"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12f636cb-9add-4070-978c-15477c24583e",
-        "Content-Length": "2433",
+        "apim-request-id": "aa1da759-ef0e-47f2-9671-b15d84d587bb",
+        "Content-Length": "2434",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dd2a33cd-e556-4834-9b1e-a8ff505d1934",
-        "lastUpdatedDateTime": "2022-10-15T02:21:32Z",
-        "createdDateTime": "2022-10-15T02:21:30Z",
-        "expirationDateTime": "2022-10-16T02:21:30Z",
+        "jobId": "68003b3a-756a-4a1b-a65b-cc033b377f80",
+        "lastUpdatedDateTime": "2022-10-24T05:12:23Z",
+        "createdDateTime": "2022-10-24T05:12:21Z",
+        "expirationDateTime": "2022-10-25T05:12:21Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -336,7 +341,7 @@
           "items": [
             {
               "kind": "EntityLinkingLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:32.651857Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:23.7062546Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_entity_recognition.json
@@ -10,8 +10,8 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cb8d790b-110c-43e5-b1f5-fd53b3468862"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7fe75a7e-85b7-477b-8736-7fce936462d3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ce248191-9046-4089-bebb-e64195391588",
+        "apim-request-id": "8ff06127-3db7-47b1-8143-f32dc04f284c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:19 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:16 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/62a3deca-5b5a-4a20-8ca8-c7d1b01be869?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "152"
+        "x-envoy-upstream-service-time": "146",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/62a3deca-5b5a-4a20-8ca8-c7d1b01be869?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aa39c052-6be0-448c-b6ac-b1a179e8e77e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e1bb4c85-f37d-454a-a230-b50238888d43"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6fcba95a-1f8d-44bf-95f1-e1088baf2a0e",
+        "apim-request-id": "f8b75b2f-0828-47b6-a539-d47828721d9c",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "127",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:19Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
+        "jobId": "62a3deca-5b5a-4a20-8ca8-c7d1b01be869",
+        "lastUpdatedDateTime": "2022-10-24T05:12:16Z",
+        "createdDateTime": "2022-10-24T05:12:16Z",
+        "expirationDateTime": "2022-10-25T05:12:16Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/62a3deca-5b5a-4a20-8ca8-c7d1b01be869?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0050204a-4219-4ca9-9ef4-4180ffa450f9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a28c1194-8541-497e-a0f8-b7328b4c7c87"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5013d971-c288-4f90-be86-fee2bc3bc5a1",
+        "apim-request-id": "1667659b-a0ec-4d90-916c-77665ea108c7",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:19 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:19Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
+        "jobId": "62a3deca-5b5a-4a20-8ca8-c7d1b01be869",
+        "lastUpdatedDateTime": "2022-10-24T05:12:16Z",
+        "createdDateTime": "2022-10-24T05:12:16Z",
+        "expirationDateTime": "2022-10-25T05:12:16Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,146 +129,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/62a3deca-5b5a-4a20-8ca8-c7d1b01be869?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e936aefd-c0e1-41b7-b8bc-8f674f9aaa46"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f7edeae7-0515-41e3-88cd-062780e002b5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c2f59f4e-fd61-4bd7-bfc2-dd932e0f2e5b",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:20Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b03eaa3f-c536-48e6-8082-520c77c3b701"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fa0e2014-95ab-47c9-964c-480ed8f915db",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:20Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9f1babd8-ff99-4276-b1ce-c81feeb43bd8"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "502f18b2-a84b-4c77-a4da-f40439c39b51",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:20Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "adfa2620-c101-4584-ad71-7ef500b0c723"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9a7a8104-49e0-46ad-8c97-37ba7a967538",
+        "apim-request-id": "35af4929-3e9b-4f20-b72d-91923b43ce5e",
         "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "63",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:27Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
+        "jobId": "62a3deca-5b5a-4a20-8ca8-c7d1b01be869",
+        "lastUpdatedDateTime": "2022-10-24T05:12:18Z",
+        "createdDateTime": "2022-10-24T05:12:16Z",
+        "expirationDateTime": "2022-10-25T05:12:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -276,7 +166,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:27.5007832Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:18.4942579Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -344,32 +234,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/98cb02c7-6d12-44c8-be8c-1ba6af3f1d04?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/62a3deca-5b5a-4a20-8ca8-c7d1b01be869?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b6989f3c-cca6-4127-8aac-d79e948ea748"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c1a326c4-34f5-4999-800d-e17572f2883a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6331919f-7815-47dd-8b7f-61beb58fb781",
+        "apim-request-id": "ae419670-7dbf-4908-8c54-eddd26f82e96",
         "Content-Length": "1070",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "98cb02c7-6d12-44c8-be8c-1ba6af3f1d04",
-        "lastUpdatedDateTime": "2022-10-15T02:21:27Z",
-        "createdDateTime": "2022-10-15T02:21:19Z",
-        "expirationDateTime": "2022-10-16T02:21:19Z",
+        "jobId": "62a3deca-5b5a-4a20-8ca8-c7d1b01be869",
+        "lastUpdatedDateTime": "2022-10-24T05:12:18Z",
+        "createdDateTime": "2022-10-24T05:12:16Z",
+        "expirationDateTime": "2022-10-25T05:12:16Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -380,7 +271,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:27.5007832Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:18.4942579Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_healthcare.json
@@ -10,8 +10,8 @@
         "Content-Length": "392",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "67403102-579d-40b4-99a2-dfd93ad3ec81"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ae821bc4-1cd8-470a-9432-46eff99a0fa3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -42,43 +42,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a6b07c71-eae9-4c13-b9dd-ca6b00d28494",
+        "apim-request-id": "e4e6dcac-270e-4165-9f51-9e6961265672",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:49 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/239b346c-9010-4ef4-836f-ae96479e2505?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:33 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
+        "x-envoy-upstream-service-time": "163",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/239b346c-9010-4ef4-836f-ae96479e2505?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d0b18bfb-fdbe-4b66-9778-361ca81d9235"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2a4ce7b8-426b-425d-b285-b4449cd54739"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1425eb9f-a105-4919-aa60-28b62d9ae3e0",
+        "apim-request-id": "44c96083-68d4-4420-bdab-fa26aaedd1ae",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "239b346c-9010-4ef4-836f-ae96479e2505",
-        "lastUpdatedDateTime": "2022-10-15T02:21:49Z",
-        "createdDateTime": "2022-10-15T02:21:49Z",
-        "expirationDateTime": "2022-10-16T02:21:49Z",
+        "jobId": "ac585850-dc82-4cd6-826a-59c8483a5683",
+        "lastUpdatedDateTime": "2022-10-24T05:12:34Z",
+        "createdDateTime": "2022-10-24T05:12:34Z",
+        "expirationDateTime": "2022-10-25T05:12:34Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -91,32 +93,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/239b346c-9010-4ef4-836f-ae96479e2505?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2addb0f4-b05f-4676-9b5c-c95381af83ab"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "be786cd4-7c9e-4a6a-bd9a-9b2d39e6bc17"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8ba15245-e614-42bf-ad6e-972fb90d206c",
+        "apim-request-id": "57c4c8d0-2a02-4a7a-bb71-ae8e9dfe1e00",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "239b346c-9010-4ef4-836f-ae96479e2505",
-        "lastUpdatedDateTime": "2022-10-15T02:21:49Z",
-        "createdDateTime": "2022-10-15T02:21:49Z",
-        "expirationDateTime": "2022-10-16T02:21:49Z",
+        "jobId": "ac585850-dc82-4cd6-826a-59c8483a5683",
+        "lastUpdatedDateTime": "2022-10-24T05:12:34Z",
+        "createdDateTime": "2022-10-24T05:12:34Z",
+        "expirationDateTime": "2022-10-25T05:12:34Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -129,32 +132,72 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/239b346c-9010-4ef4-836f-ae96479e2505?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d73a0b05-4952-4811-9bf0-058023d6a631"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f47c585c-2430-4b02-98e7-2aeb7dc6351c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc997617-dbee-450b-b121-0d80ddbb521e",
+        "apim-request-id": "1c0d3e6c-2b17-400e-8635-8fa36fdfb2ff",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:12:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "ac585850-dc82-4cd6-826a-59c8483a5683",
+        "lastUpdatedDateTime": "2022-10-24T05:12:34Z",
+        "createdDateTime": "2022-10-24T05:12:34Z",
+        "expirationDateTime": "2022-10-25T05:12:34Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2d70409f-28b9-4a7a-9274-a8d31b5215c6"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "38816493-8723-4fd0-9b86-a1a0e417d74d",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "48"
+        "x-envoy-upstream-service-time": "93",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "239b346c-9010-4ef4-836f-ae96479e2505",
-        "lastUpdatedDateTime": "2022-10-15T02:21:51Z",
-        "createdDateTime": "2022-10-15T02:21:49Z",
-        "expirationDateTime": "2022-10-16T02:21:49Z",
+        "jobId": "ac585850-dc82-4cd6-826a-59c8483a5683",
+        "lastUpdatedDateTime": "2022-10-24T05:12:37Z",
+        "createdDateTime": "2022-10-24T05:12:34Z",
+        "expirationDateTime": "2022-10-25T05:12:34Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -165,7 +208,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:51.5710585Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:37.3095646Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1282,32 +1325,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/239b346c-9010-4ef4-836f-ae96479e2505?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/ac585850-dc82-4cd6-826a-59c8483a5683?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3a6ed349-4666-4958-804a-2bd68d72e6eb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bac88df0-82b8-4ff1-b161-d9aed1661d35"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f1ab6c26-e9e8-41aa-8f5a-a1c5fe040f19",
+        "apim-request-id": "9720199d-8fcc-43e9-85a8-54688c72495b",
         "Content-Length": "11361",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76"
+        "x-envoy-upstream-service-time": "58",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "239b346c-9010-4ef4-836f-ae96479e2505",
-        "lastUpdatedDateTime": "2022-10-15T02:21:51Z",
-        "createdDateTime": "2022-10-15T02:21:49Z",
-        "expirationDateTime": "2022-10-16T02:21:49Z",
+        "jobId": "ac585850-dc82-4cd6-826a-59c8483a5683",
+        "lastUpdatedDateTime": "2022-10-24T05:12:37Z",
+        "createdDateTime": "2022-10-24T05:12:34Z",
+        "expirationDateTime": "2022-10-25T05:12:34Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1318,7 +1362,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:51.5710585Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:37.3095646Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_key_phrase_extraction.json
@@ -10,8 +10,8 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "62dcb862-fa74-4096-a065-8b67dd094702"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "82131318-38be-4519-a573-e46f354b2256"
       },
       "RequestBody": {
         "analysisInput": {
@@ -39,43 +39,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0de4ccf9-8c3b-43c4-ae22-12741bcb8b40",
+        "apim-request-id": "4fe126d3-f8e3-4c99-9b6f-2d0b96705553",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:28 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/a5d5374c-b1f5-4652-a1a9-30b921be7bf4?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:19 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/46d09e24-4493-492e-aa5c-1d48b33440a7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "176"
+        "x-envoy-upstream-service-time": "142",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a5d5374c-b1f5-4652-a1a9-30b921be7bf4?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d09e24-4493-492e-aa5c-1d48b33440a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2d80a24c-e4af-4632-b209-b4b37ca5ff78"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9b8b7393-3ce3-462a-883e-7b74dac067a9"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "297a414b-2a64-4d33-a8b0-0f6245a15611",
+        "apim-request-id": "f057d57b-c10c-4155-ae91-aa88d8a332db",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a5d5374c-b1f5-4652-a1a9-30b921be7bf4",
-        "lastUpdatedDateTime": "2022-10-15T02:21:28Z",
-        "createdDateTime": "2022-10-15T02:21:28Z",
-        "expirationDateTime": "2022-10-16T02:21:28Z",
+        "jobId": "46d09e24-4493-492e-aa5c-1d48b33440a7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:19Z",
+        "createdDateTime": "2022-10-24T05:12:19Z",
+        "expirationDateTime": "2022-10-25T05:12:19Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -88,32 +90,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a5d5374c-b1f5-4652-a1a9-30b921be7bf4?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d09e24-4493-492e-aa5c-1d48b33440a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "62fa35fb-781b-4cff-b0bd-ae010c4a1fee"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6ec38196-6091-4a64-9754-991da8f14326"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6b4258b-cf2a-480c-a0ca-7bb16a4499a8",
+        "apim-request-id": "7d911261-a7c3-40cd-acd3-efc11cb57f7a",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a5d5374c-b1f5-4652-a1a9-30b921be7bf4",
-        "lastUpdatedDateTime": "2022-10-15T02:21:28Z",
-        "createdDateTime": "2022-10-15T02:21:28Z",
-        "expirationDateTime": "2022-10-16T02:21:28Z",
+        "jobId": "46d09e24-4493-492e-aa5c-1d48b33440a7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:19Z",
+        "createdDateTime": "2022-10-24T05:12:19Z",
+        "expirationDateTime": "2022-10-25T05:12:19Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -126,32 +129,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a5d5374c-b1f5-4652-a1a9-30b921be7bf4?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d09e24-4493-492e-aa5c-1d48b33440a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8a33b2ae-793c-43b5-a156-ad1114c7caec"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0a17db83-60f4-4794-9ba3-9cb2a39eb68c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0f8c844c-1e16-49f5-b6cb-df64e2aa7654",
-        "Content-Length": "616",
+        "apim-request-id": "76d8e94a-c14d-4530-abf1-9e8034b3de53",
+        "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "38",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a5d5374c-b1f5-4652-a1a9-30b921be7bf4",
-        "lastUpdatedDateTime": "2022-10-15T02:21:30Z",
-        "createdDateTime": "2022-10-15T02:21:28Z",
-        "expirationDateTime": "2022-10-16T02:21:28Z",
+        "jobId": "46d09e24-4493-492e-aa5c-1d48b33440a7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:21Z",
+        "createdDateTime": "2022-10-24T05:12:19Z",
+        "expirationDateTime": "2022-10-25T05:12:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:30.209077Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:21.0489615Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -194,32 +198,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/a5d5374c-b1f5-4652-a1a9-30b921be7bf4?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d09e24-4493-492e-aa5c-1d48b33440a7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "23baa5c2-b112-4201-a39a-3b54afd6500a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c7d8d879-80e7-4f00-9af3-febccf72c097"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b7e045ed-f6f0-4842-8f8f-acb482e9b51c",
-        "Content-Length": "616",
+        "apim-request-id": "6b51a9f4-1176-4b00-8132-c289b3765335",
+        "Content-Length": "617",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:30 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "a5d5374c-b1f5-4652-a1a9-30b921be7bf4",
-        "lastUpdatedDateTime": "2022-10-15T02:21:30Z",
-        "createdDateTime": "2022-10-15T02:21:28Z",
-        "expirationDateTime": "2022-10-16T02:21:28Z",
+        "jobId": "46d09e24-4493-492e-aa5c-1d48b33440a7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:21Z",
+        "createdDateTime": "2022-10-24T05:12:19Z",
+        "expirationDateTime": "2022-10-25T05:12:19Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -230,7 +235,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:30.209077Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:21.0489615Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition.json
@@ -10,8 +10,8 @@
         "Content-Length": "396",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "91e47cd6-4c12-40cf-bf83-350b8688e7f1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2ad08580-88de-43d8-825b-4fe94f8ae832"
       },
       "RequestBody": {
         "analysisInput": {
@@ -44,43 +44,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fde58dc7-fac8-4134-8011-a7a5a8dc9174",
+        "apim-request-id": "e706b09e-0eae-441e-9ef2-2a1786c44597",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:32 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/06127fd6-b281-4279-a3c7-dc3d32322299?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:23 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/1fc0c410-00d1-4416-a69e-a47e572ca31f?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "102"
+        "x-envoy-upstream-service-time": "191",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/06127fd6-b281-4279-a3c7-dc3d32322299?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1fc0c410-00d1-4416-a69e-a47e572ca31f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e2dcbb72-3aa0-42b8-a7d8-bb66902a2493"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0e839612-e673-4ce1-9009-8934bad0cd99"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27829b38-b153-4e03-99ef-8990d670c784",
+        "apim-request-id": "ca77ed78-2d94-44f5-a4e4-e84645116468",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "06127fd6-b281-4279-a3c7-dc3d32322299",
-        "lastUpdatedDateTime": "2022-10-15T02:21:33Z",
-        "createdDateTime": "2022-10-15T02:21:33Z",
-        "expirationDateTime": "2022-10-16T02:21:33Z",
+        "jobId": "1fc0c410-00d1-4416-a69e-a47e572ca31f",
+        "lastUpdatedDateTime": "2022-10-24T05:12:24Z",
+        "createdDateTime": "2022-10-24T05:12:23Z",
+        "expirationDateTime": "2022-10-25T05:12:23Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -93,32 +95,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/06127fd6-b281-4279-a3c7-dc3d32322299?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1fc0c410-00d1-4416-a69e-a47e572ca31f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5d9a538b-2fbb-4dca-bb96-7cdafc59341a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3120ba1e-1639-4d7c-9403-e2fd22c64ecf"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3e65a33-635b-4298-ad92-07b7120a1402",
+        "apim-request-id": "cb7bcb38-ee1a-4b67-9bc2-6803e46cd40a",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "06127fd6-b281-4279-a3c7-dc3d32322299",
-        "lastUpdatedDateTime": "2022-10-15T02:21:33Z",
-        "createdDateTime": "2022-10-15T02:21:33Z",
-        "expirationDateTime": "2022-10-16T02:21:33Z",
+        "jobId": "1fc0c410-00d1-4416-a69e-a47e572ca31f",
+        "lastUpdatedDateTime": "2022-10-24T05:12:24Z",
+        "createdDateTime": "2022-10-24T05:12:23Z",
+        "expirationDateTime": "2022-10-25T05:12:23Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,32 +134,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/06127fd6-b281-4279-a3c7-dc3d32322299?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1fc0c410-00d1-4416-a69e-a47e572ca31f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "40a09099-545a-4c96-bbad-6e9ff5f774f1"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b3cfac74-5c6c-4332-8799-1c41a714fd38"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55bed486-70e2-4b42-af16-325880610abc",
+        "apim-request-id": "9796cb66-e472-4bd9-b6ea-44fba10b06e5",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "55"
+        "x-envoy-upstream-service-time": "117",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "06127fd6-b281-4279-a3c7-dc3d32322299",
-        "lastUpdatedDateTime": "2022-10-15T02:21:34Z",
-        "createdDateTime": "2022-10-15T02:21:33Z",
-        "expirationDateTime": "2022-10-16T02:21:33Z",
+        "jobId": "1fc0c410-00d1-4416-a69e-a47e572ca31f",
+        "lastUpdatedDateTime": "2022-10-24T05:12:25Z",
+        "createdDateTime": "2022-10-24T05:12:23Z",
+        "expirationDateTime": "2022-10-25T05:12:23Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -167,7 +171,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:34.8181991Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:25.8140618Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -229,32 +233,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/06127fd6-b281-4279-a3c7-dc3d32322299?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/1fc0c410-00d1-4416-a69e-a47e572ca31f?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94b429c2-0d56-481f-92aa-d1a6b67b2846"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "18c42cdb-d930-4ab2-b576-0edde312c3df"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "185629c5-f87d-4123-a819-622217d3bd60",
+        "apim-request-id": "8f07004a-9dc1-477f-b31d-cea2dc2c39dc",
         "Content-Length": "1198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "06127fd6-b281-4279-a3c7-dc3d32322299",
-        "lastUpdatedDateTime": "2022-10-15T02:21:34Z",
-        "createdDateTime": "2022-10-15T02:21:33Z",
-        "expirationDateTime": "2022-10-16T02:21:33Z",
+        "jobId": "1fc0c410-00d1-4416-a69e-a47e572ca31f",
+        "lastUpdatedDateTime": "2022-10-24T05:12:25Z",
+        "createdDateTime": "2022-10-24T05:12:23Z",
+        "expirationDateTime": "2022-10-25T05:12:23Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -265,7 +270,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:34.8181991Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:25.8140618Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_filtered_categories.json
@@ -10,8 +10,8 @@
         "Content-Length": "467",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "80359c84-9712-472f-831d-c04d4abd3132"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a024d7aa-fc62-4be8-8c04-c0b2667d1603"
       },
       "RequestBody": {
         "analysisInput": {
@@ -42,43 +42,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "43c56bb8-bf2f-4d8b-9b58-995764ff2b6f",
+        "apim-request-id": "ed49f5ae-a8fe-4e38-978a-53b2e383e87b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:35 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c30a423c-2f73-43d2-9e21-62e997e1fae7?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:26 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/e40eef8f-f013-4379-a52a-4d3bf989c8f7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "137"
+        "x-envoy-upstream-service-time": "133",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c30a423c-2f73-43d2-9e21-62e997e1fae7?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e40eef8f-f013-4379-a52a-4d3bf989c8f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0ce412b0-51cf-420c-8145-edc26322b971"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "43ac146a-5b2b-4ad7-930c-c40573c0240e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0dc43ade-a9d1-46c6-86fe-cb7adf9ab7a7",
+        "apim-request-id": "90292b78-5780-40ec-915c-9f30f6ad22bb",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c30a423c-2f73-43d2-9e21-62e997e1fae7",
-        "lastUpdatedDateTime": "2022-10-15T02:21:35Z",
-        "createdDateTime": "2022-10-15T02:21:35Z",
-        "expirationDateTime": "2022-10-16T02:21:35Z",
+        "jobId": "e40eef8f-f013-4379-a52a-4d3bf989c8f7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:26Z",
+        "createdDateTime": "2022-10-24T05:12:26Z",
+        "expirationDateTime": "2022-10-25T05:12:26Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -91,32 +93,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c30a423c-2f73-43d2-9e21-62e997e1fae7?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e40eef8f-f013-4379-a52a-4d3bf989c8f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "86f09c2a-27fb-4471-b0b5-c9101ae16dab"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f1db3e7f-b5ea-4add-98d8-d70f02d87a90"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2456f73a-ff5d-4c16-a602-8284ba512e3f",
+        "apim-request-id": "d60febd1-47ee-43ee-826d-fb097bf13c43",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:35 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c30a423c-2f73-43d2-9e21-62e997e1fae7",
-        "lastUpdatedDateTime": "2022-10-15T02:21:35Z",
-        "createdDateTime": "2022-10-15T02:21:35Z",
-        "expirationDateTime": "2022-10-16T02:21:35Z",
+        "jobId": "e40eef8f-f013-4379-a52a-4d3bf989c8f7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:26Z",
+        "createdDateTime": "2022-10-24T05:12:26Z",
+        "expirationDateTime": "2022-10-25T05:12:26Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -129,32 +132,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c30a423c-2f73-43d2-9e21-62e997e1fae7?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e40eef8f-f013-4379-a52a-4d3bf989c8f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fd9798de-5b53-421a-805f-f1492305e000"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "216437d5-c9ce-46ae-a0fd-a81e9909ba4e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a108f012-1292-4b5d-9450-fbfe0d021d05",
+        "apim-request-id": "a6c78c49-e42e-4cc6-9542-13ee8c30cf5a",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c30a423c-2f73-43d2-9e21-62e997e1fae7",
-        "lastUpdatedDateTime": "2022-10-15T02:21:37Z",
-        "createdDateTime": "2022-10-15T02:21:35Z",
-        "expirationDateTime": "2022-10-16T02:21:35Z",
+        "jobId": "e40eef8f-f013-4379-a52a-4d3bf989c8f7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:28Z",
+        "createdDateTime": "2022-10-24T05:12:26Z",
+        "expirationDateTime": "2022-10-25T05:12:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -165,7 +169,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:37.7693475Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:28.3923245Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -199,32 +203,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c30a423c-2f73-43d2-9e21-62e997e1fae7?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/e40eef8f-f013-4379-a52a-4d3bf989c8f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a416f0c7-d0f6-41cc-963a-daaa9eb2ff1d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "11caf816-c155-4968-9897-6c8d4b1a67a3"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "576713c1-ca0a-4681-b52e-aca408da6525",
+        "apim-request-id": "8c97569d-c8b0-4736-8c45-6461f09c1b92",
         "Content-Length": "917",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:37 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "35",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c30a423c-2f73-43d2-9e21-62e997e1fae7",
-        "lastUpdatedDateTime": "2022-10-15T02:21:37Z",
-        "createdDateTime": "2022-10-15T02:21:35Z",
-        "expirationDateTime": "2022-10-16T02:21:35Z",
+        "jobId": "e40eef8f-f013-4379-a52a-4d3bf989c8f7",
+        "lastUpdatedDateTime": "2022-10-24T05:12:28Z",
+        "createdDateTime": "2022-10-24T05:12:26Z",
+        "expirationDateTime": "2022-10-25T05:12:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -235,7 +240,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:37.7693475Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:28.3923245Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_pii_entity_recognition_with_phi_domain.json
@@ -10,8 +10,8 @@
         "Content-Length": "439",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "87642a03-8006-4262-b39e-21980aff8fff"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c458332a-ba7d-4a0b-8b10-734edc7dd120"
       },
       "RequestBody": {
         "analysisInput": {
@@ -40,119 +40,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1ebce0ae-de9d-4278-82d4-db763cd65d11",
+        "apim-request-id": "1960ecbc-acab-4970-a4c3-83f061dc266d",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:38 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:28 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/8ca9235d-36ac-4ca3-af6f-438854089d3c?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "150"
+        "x-envoy-upstream-service-time": "87",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ca9235d-36ac-4ca3-af6f-438854089d3c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "216fcfa6-abc7-46a9-8b6d-2a616a724a26"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2cd15161-3335-4af7-b7a3-57eddb4d3196"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f58f35d8-4afb-4cd7-bdf1-01eca07393d9",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:38Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bfdefc19-cc43-4204-bddd-55e02fb66550"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a3ab4fe5-c1e1-4807-a636-7436b0161046",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:38Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0d02c006-79d9-42db-ac60-292e7fde33f6"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "eb791044-2025-4f5f-ae77-54b330869490",
+        "apim-request-id": "6ec131a2-b2f3-4e47-a1fc-26e661a289e2",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:38Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
+        "jobId": "8ca9235d-36ac-4ca3-af6f-438854089d3c",
+        "lastUpdatedDateTime": "2022-10-24T05:12:29Z",
+        "createdDateTime": "2022-10-24T05:12:29Z",
+        "expirationDateTime": "2022-10-25T05:12:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -165,32 +91,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ca9235d-36ac-4ca3-af6f-438854089d3c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8d5d7e6e-f672-42d1-a03c-7fcd3fadefdd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b8697821-909c-4ed2-81c6-83213b4d2a5b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4b69976-fb9e-460f-bdba-b0362e7f73e5",
+        "apim-request-id": "82e94c24-a88b-4b61-bcba-8c0b3e211d64",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:41 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:38Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
+        "jobId": "8ca9235d-36ac-4ca3-af6f-438854089d3c",
+        "lastUpdatedDateTime": "2022-10-24T05:12:29Z",
+        "createdDateTime": "2022-10-24T05:12:29Z",
+        "expirationDateTime": "2022-10-25T05:12:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,70 +130,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ca9235d-36ac-4ca3-af6f-438854089d3c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fbe9b975-fdf5-444e-adb0-d0c16e0dd7b2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "65f1af81-8b5d-4f8e-baa9-dc245049fbb2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1277d8b3-4649-4a61-bad6-4a5047a58b7d",
-        "Content-Length": "280",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:38Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "eec5dce5-6929-4e42-8785-8120bdde9a74"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "95d5efe4-c066-4ac6-a276-1580f6708bb1",
+        "apim-request-id": "11cb448c-2b38-4db9-abf3-27d8ae439d3e",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:45Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
+        "jobId": "8ca9235d-36ac-4ca3-af6f-438854089d3c",
+        "lastUpdatedDateTime": "2022-10-24T05:12:30Z",
+        "createdDateTime": "2022-10-24T05:12:29Z",
+        "expirationDateTime": "2022-10-25T05:12:29Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -277,7 +167,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:45.9277531Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:30.8733184Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -354,32 +244,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/257dd205-6de1-4d9d-a368-2bb8a0d7d6f5?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8ca9235d-36ac-4ca3-af6f-438854089d3c?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9613f61f-c0ac-4347-8e44-b33688a69b52"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fd324f3f-e1b9-4be4-9bb9-0a7b8496d9f4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8c091c14-746f-4f17-9695-8f323d2fbb77",
+        "apim-request-id": "0da5ae69-ccbe-42ec-a5d1-e840fb556c65",
         "Content-Length": "1496",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:45 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "257dd205-6de1-4d9d-a368-2bb8a0d7d6f5",
-        "lastUpdatedDateTime": "2022-10-15T02:21:45Z",
-        "createdDateTime": "2022-10-15T02:21:38Z",
-        "expirationDateTime": "2022-10-16T02:21:38Z",
+        "jobId": "8ca9235d-36ac-4ca3-af6f-438854089d3c",
+        "lastUpdatedDateTime": "2022-10-24T05:12:30Z",
+        "createdDateTime": "2022-10-24T05:12:29Z",
+        "expirationDateTime": "2022-10-25T05:12:29Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -390,7 +281,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:45.9277531Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:30.8733184Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_actions_prebuilt/recording_sentiment_analysis_with_opinion_mining.json
@@ -10,8 +10,8 @@
         "Content-Length": "739",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ed43ea85-3601-432e-856c-609f2277764e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c3f6b1a6-91f4-4170-a83d-175f828f6387"
       },
       "RequestBody": {
         "analysisInput": {
@@ -65,43 +65,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e859f03a-1005-434f-8d4e-69f4273037ef",
+        "apim-request-id": "7acce392-dbfd-49e0-9aa4-57ae16e14bcd",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:46 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/08c25568-d729-4fcd-be40-92b2211025a9?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:31 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/5963d15b-82a6-4763-9623-b20f7a77af37?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "x-envoy-upstream-service-time": "253",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/08c25568-d729-4fcd-be40-92b2211025a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5963d15b-82a6-4763-9623-b20f7a77af37?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ac06ef44-ee91-4fab-91de-48cdb9b18d52"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "92eb6dec-4949-465d-8fbe-e05bcc9bfa45"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "57fd8dd5-ffa0-4e48-968d-ace22728aa4f",
+        "apim-request-id": "d896098e-6609-4007-82cb-d946c823f88e",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "08c25568-d729-4fcd-be40-92b2211025a9",
-        "lastUpdatedDateTime": "2022-10-15T02:21:46Z",
-        "createdDateTime": "2022-10-15T02:21:46Z",
-        "expirationDateTime": "2022-10-16T02:21:46Z",
+        "jobId": "5963d15b-82a6-4763-9623-b20f7a77af37",
+        "lastUpdatedDateTime": "2022-10-24T05:12:31Z",
+        "createdDateTime": "2022-10-24T05:12:31Z",
+        "expirationDateTime": "2022-10-25T05:12:31Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -114,33 +116,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/08c25568-d729-4fcd-be40-92b2211025a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5963d15b-82a6-4763-9623-b20f7a77af37?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3cd792cb-b542-4129-b9dd-b1368831478a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5acfd809-1604-48b1-b33c-19662e344011"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6b9fa11-4444-4a1a-996d-01725b8544e9",
-        "Content-Length": "280",
+        "apim-request-id": "13554dc6-7883-4c88-9d7f-9c18b45418bd",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "08c25568-d729-4fcd-be40-92b2211025a9",
-        "lastUpdatedDateTime": "2022-10-15T02:21:46Z",
-        "createdDateTime": "2022-10-15T02:21:46Z",
-        "expirationDateTime": "2022-10-16T02:21:46Z",
-        "status": "running",
+        "jobId": "5963d15b-82a6-4763-9623-b20f7a77af37",
+        "lastUpdatedDateTime": "2022-10-24T05:12:31Z",
+        "createdDateTime": "2022-10-24T05:12:31Z",
+        "expirationDateTime": "2022-10-25T05:12:31Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -152,32 +155,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/08c25568-d729-4fcd-be40-92b2211025a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5963d15b-82a6-4763-9623-b20f7a77af37?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "68fe4cb5-d31b-40ca-8524-05d1b2c6e9cd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "85108f1a-7f0b-468f-a85f-f9014bdcb52f"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7742c770-7c35-4a1b-86de-20273f1db028",
+        "apim-request-id": "43b20a4e-1f7f-40f1-8f6a-bd1c2dbb6161",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "111",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "08c25568-d729-4fcd-be40-92b2211025a9",
-        "lastUpdatedDateTime": "2022-10-15T02:21:49Z",
-        "createdDateTime": "2022-10-15T02:21:46Z",
-        "expirationDateTime": "2022-10-16T02:21:46Z",
+        "jobId": "5963d15b-82a6-4763-9623-b20f7a77af37",
+        "lastUpdatedDateTime": "2022-10-24T05:12:33Z",
+        "createdDateTime": "2022-10-24T05:12:31Z",
+        "expirationDateTime": "2022-10-25T05:12:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -188,7 +192,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:49.1147886Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:33.6046486Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -818,32 +822,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/08c25568-d729-4fcd-be40-92b2211025a9?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5963d15b-82a6-4763-9623-b20f7a77af37?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9c56b896-2a40-46a5-8437-2ed441844846"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5a835e8e-5a66-486e-8eff-29a958e856fe"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ed8715f-a6aa-4b1b-84f1-8261ff4c53df",
+        "apim-request-id": "12a0f95f-8197-4cfb-83b8-a3a9a94b116a",
         "Content-Length": "8186",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:49 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "80",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "08c25568-d729-4fcd-be40-92b2211025a9",
-        "lastUpdatedDateTime": "2022-10-15T02:21:49Z",
-        "createdDateTime": "2022-10-15T02:21:46Z",
-        "expirationDateTime": "2022-10-16T02:21:46Z",
+        "jobId": "5963d15b-82a6-4763-9623-b20f7a77af37",
+        "lastUpdatedDateTime": "2022-10-24T05:12:33Z",
+        "createdDateTime": "2022-10-24T05:12:31Z",
+        "expirationDateTime": "2022-10-25T05:12:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -854,7 +859,7 @@
           "items": [
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:21:49.1147886Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:33.6046486Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_all_documents_with_errors_and_multiple_actions.json
@@ -10,8 +10,8 @@
         "Content-Length": "357",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2cd07e3e-91fe-4993-ae7d-489f5a1187a7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "41083a9d-99cb-475d-8910-5f0c5cb1391b"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f57e365f-c554-4c75-b9ee-601486e73f62",
+        "apim-request-id": "b5e3eed6-f096-40bc-a530-a034fcb86aef",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:04 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:51 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/5ebf49e4-e8c8-4401-8325-332bd652df60?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "163"
+        "x-envoy-upstream-service-time": "154",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5ebf49e4-e8c8-4401-8325-332bd652df60?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d05c08aa-0a5c-4d6c-91a6-84d856918276"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "830c328e-7f6b-4ea4-9836-37c8df5a65da"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a3dc016-0117-4095-9915-4f99a196dcf6",
+        "apim-request-id": "faadc8e8-3776-4584-b15b-831d5727c67c",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0",
-        "lastUpdatedDateTime": "2022-10-15T02:22:04Z",
-        "createdDateTime": "2022-10-15T02:22:04Z",
-        "expirationDateTime": "2022-10-16T02:22:04Z",
+        "jobId": "5ebf49e4-e8c8-4401-8325-332bd652df60",
+        "lastUpdatedDateTime": "2022-10-24T05:12:51Z",
+        "createdDateTime": "2022-10-24T05:12:51Z",
+        "expirationDateTime": "2022-10-25T05:12:51Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -99,33 +101,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5ebf49e4-e8c8-4401-8325-332bd652df60?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "227fb64b-a822-48ce-b599-f5a300e6d668"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "60fd612f-5067-408c-b928-9424654e3552"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8222015-3ad9-462f-b093-7f8637cd6393",
-        "Content-Length": "280",
+        "apim-request-id": "2edc23a4-3f55-495d-b6bd-3c7ce247ee7f",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:04 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0",
-        "lastUpdatedDateTime": "2022-10-15T02:22:04Z",
-        "createdDateTime": "2022-10-15T02:22:04Z",
-        "expirationDateTime": "2022-10-16T02:22:04Z",
-        "status": "running",
+        "jobId": "5ebf49e4-e8c8-4401-8325-332bd652df60",
+        "lastUpdatedDateTime": "2022-10-24T05:12:51Z",
+        "createdDateTime": "2022-10-24T05:12:51Z",
+        "expirationDateTime": "2022-10-25T05:12:51Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -137,32 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5ebf49e4-e8c8-4401-8325-332bd652df60?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "df877084-11b6-490e-8c99-7b72144d8ae3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d626468b-ea84-4697-8258-6412a00c668e"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c6d4107-22b2-41f0-aff3-359ac74c0478",
+        "apim-request-id": "89bc0a55-703c-4eac-9361-d0c253c90f93",
         "Content-Length": "3109",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "116"
+        "x-envoy-upstream-service-time": "193",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0",
-        "lastUpdatedDateTime": "2022-10-15T02:22:06Z",
-        "createdDateTime": "2022-10-15T02:22:04Z",
-        "expirationDateTime": "2022-10-16T02:22:04Z",
+        "jobId": "5ebf49e4-e8c8-4401-8325-332bd652df60",
+        "lastUpdatedDateTime": "2022-10-24T05:12:53Z",
+        "createdDateTime": "2022-10-24T05:12:51Z",
+        "expirationDateTime": "2022-10-25T05:12:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -173,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.3338297Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.4888488Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -217,7 +221,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.3434662Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.4618435Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -261,7 +265,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.5760092Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.2838804Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -308,32 +312,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/5ebf49e4-e8c8-4401-8325-332bd652df60?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c4b8c220-c530-40ac-8c6f-838bf764a76a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ee041986-eb2a-4f41-86dc-4fd82d244b81"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "beced860-75b1-4885-bdb5-c3c5c2fc38da",
+        "apim-request-id": "47f507ac-2936-491b-b427-9ff8f0b331fe",
         "Content-Length": "3109",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "176"
+        "x-envoy-upstream-service-time": "128",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f40eb89e-a0fd-4ed9-93ad-3c202cf3f4f0",
-        "lastUpdatedDateTime": "2022-10-15T02:22:06Z",
-        "createdDateTime": "2022-10-15T02:22:04Z",
-        "expirationDateTime": "2022-10-16T02:22:04Z",
+        "jobId": "5ebf49e4-e8c8-4401-8325-332bd652df60",
+        "lastUpdatedDateTime": "2022-10-24T05:12:53Z",
+        "createdDateTime": "2022-10-24T05:12:51Z",
+        "expirationDateTime": "2022-10-25T05:12:51Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +349,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.3338297Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.4888488Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -388,7 +393,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.3434662Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.4618435Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -432,7 +437,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:06.5760092Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:53.2838804Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_invalid_language_hint.json
@@ -10,8 +10,8 @@
         "Content-Length": "296",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94575fc2-70d3-4d68-83e9-2e1980be2a55"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ea016863-ec94-41f3-bf54-64a423e9e41f"
       },
       "RequestBody": {
         "analysisInput": {
@@ -40,43 +40,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4e7fc7f4-e0f9-425c-ad4e-6330d0aa0dd5",
+        "apim-request-id": "61121f42-2255-4f36-92ad-c2a50a54fe23",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:29 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/dba59985-d83a-44a1-9efc-11a45a078cc6?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:28 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/919c81e8-be96-4ede-b8bc-54aa3a260dea?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "x-envoy-upstream-service-time": "180",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dba59985-d83a-44a1-9efc-11a45a078cc6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/919c81e8-be96-4ede-b8bc-54aa3a260dea?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2082aa28-1a42-4418-b839-0e61fa0035d8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "80678d01-7652-4322-b61f-0928c552b71d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dd14f7ed-af7a-411a-b45e-ed7163fa69a2",
+        "apim-request-id": "d8128dd4-9a2f-4d62-bae7-3bc8a91c9aa9",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dba59985-d83a-44a1-9efc-11a45a078cc6",
-        "lastUpdatedDateTime": "2022-10-15T02:22:29Z",
-        "createdDateTime": "2022-10-15T02:22:29Z",
-        "expirationDateTime": "2022-10-16T02:22:29Z",
+        "jobId": "919c81e8-be96-4ede-b8bc-54aa3a260dea",
+        "lastUpdatedDateTime": "2022-10-24T05:13:28Z",
+        "createdDateTime": "2022-10-24T05:13:28Z",
+        "expirationDateTime": "2022-10-25T05:13:28Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -89,32 +91,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dba59985-d83a-44a1-9efc-11a45a078cc6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/919c81e8-be96-4ede-b8bc-54aa3a260dea?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a2606d57-aa8a-427f-beec-4f3da8973359"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "718c7ab2-2ad0-4a19-a437-12bddf55fb48"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61661635-cca9-406e-9778-6da602f8aa27",
+        "apim-request-id": "929b00fe-5b47-4ed1-993f-1dafbcae1b28",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:29 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dba59985-d83a-44a1-9efc-11a45a078cc6",
-        "lastUpdatedDateTime": "2022-10-15T02:22:29Z",
-        "createdDateTime": "2022-10-15T02:22:29Z",
-        "expirationDateTime": "2022-10-16T02:22:29Z",
+        "jobId": "919c81e8-be96-4ede-b8bc-54aa3a260dea",
+        "lastUpdatedDateTime": "2022-10-24T05:13:28Z",
+        "createdDateTime": "2022-10-24T05:13:28Z",
+        "expirationDateTime": "2022-10-25T05:13:28Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -127,32 +130,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dba59985-d83a-44a1-9efc-11a45a078cc6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/919c81e8-be96-4ede-b8bc-54aa3a260dea?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "91085b73-69f1-42e3-9ec2-0bbcbd74698a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "20b31eba-52bb-4472-b0f8-04659e021efe"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "087c6646-22f5-4142-ba98-c506595281f6",
-        "Content-Length": "2144",
+        "apim-request-id": "b4aed4c3-4111-4632-8f08-7061ba747b1d",
+        "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "x-envoy-upstream-service-time": "64",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dba59985-d83a-44a1-9efc-11a45a078cc6",
-        "lastUpdatedDateTime": "2022-10-15T02:22:31Z",
-        "createdDateTime": "2022-10-15T02:22:29Z",
-        "expirationDateTime": "2022-10-16T02:22:29Z",
+        "jobId": "919c81e8-be96-4ede-b8bc-54aa3a260dea",
+        "lastUpdatedDateTime": "2022-10-24T05:13:30Z",
+        "createdDateTime": "2022-10-24T05:13:28Z",
+        "expirationDateTime": "2022-10-25T05:13:28Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -163,7 +167,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.424829Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.6223858Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -185,7 +189,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.4173097Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.6038242Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -207,7 +211,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.066755Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.1034574Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -232,32 +236,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/dba59985-d83a-44a1-9efc-11a45a078cc6?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/919c81e8-be96-4ede-b8bc-54aa3a260dea?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "28915c28-5e59-444c-aed8-969464897a63"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1b886550-7bd4-4183-b433-625bf38782e0"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f810559-392d-4631-a846-81c7d07ccdf9",
-        "Content-Length": "2144",
+        "apim-request-id": "8324131a-7b57-4d6a-a4ee-00088d31b1a9",
+        "Content-Length": "2146",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:31 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "53"
+        "x-envoy-upstream-service-time": "68",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "dba59985-d83a-44a1-9efc-11a45a078cc6",
-        "lastUpdatedDateTime": "2022-10-15T02:22:31Z",
-        "createdDateTime": "2022-10-15T02:22:29Z",
-        "expirationDateTime": "2022-10-16T02:22:29Z",
+        "jobId": "919c81e8-be96-4ede-b8bc-54aa3a260dea",
+        "lastUpdatedDateTime": "2022-10-24T05:13:30Z",
+        "createdDateTime": "2022-10-24T05:13:28Z",
+        "expirationDateTime": "2022-10-25T05:13:28Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -268,7 +273,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.424829Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.6223858Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -290,7 +295,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.4173097Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.6038242Z",
               "status": "succeeded",
               "results": {
                 "documents": [],
@@ -312,7 +317,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:31.066755Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:30.1034574Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_operation_metadata.json
@@ -10,8 +10,8 @@
         "Content-Length": "172",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9b83afd8-76ca-428e-bb0a-55233301c967"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d3f642fc-daee-479e-bbed-01b042433f0a"
       },
       "RequestBody": {
         "displayName": "testJob",
@@ -33,43 +33,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "74c81213-5e13-4597-b85f-c1be2cc2bb9b",
+        "apim-request-id": "c9cd4401-da7d-4f9d-bc28-5d65ac62a119",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/b88f626f-b9c9-426d-b2ed-05675ddedbec?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:43 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/3f164c6f-b2a2-4e83-88ff-a88b688bb958?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "278"
+        "x-envoy-upstream-service-time": "102",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b88f626f-b9c9-426d-b2ed-05675ddedbec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f164c6f-b2a2-4e83-88ff-a88b688bb958?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9712b1a3-2d71-4f1b-88e6-d3ef2f32738c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "22cd3487-f219-46df-99ee-68cabc7f116a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2161ca28-e2dc-45e8-a4c5-e0d7c7658b68",
+        "apim-request-id": "196af0dd-6069-4f3e-8799-482e6edf0ea2",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b88f626f-b9c9-426d-b2ed-05675ddedbec",
-        "lastUpdatedDateTime": "2022-10-15T02:22:40Z",
-        "createdDateTime": "2022-10-15T02:22:40Z",
-        "expirationDateTime": "2022-10-16T02:22:40Z",
+        "jobId": "3f164c6f-b2a2-4e83-88ff-a88b688bb958",
+        "lastUpdatedDateTime": "2022-10-24T05:13:44Z",
+        "createdDateTime": "2022-10-24T05:13:44Z",
+        "expirationDateTime": "2022-10-25T05:13:44Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -83,32 +85,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b88f626f-b9c9-426d-b2ed-05675ddedbec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f164c6f-b2a2-4e83-88ff-a88b688bb958?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a82f901c-042c-409c-a8ba-425926a48664"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "07dbe166-c311-42a2-9671-f4d99b269e20"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c0d2c725-50a5-47f9-ab2b-fefbc1c7f103",
+        "apim-request-id": "4c5980b6-a103-4dc2-9fae-ebf0073d08bd",
         "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "14",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b88f626f-b9c9-426d-b2ed-05675ddedbec",
-        "lastUpdatedDateTime": "2022-10-15T02:22:40Z",
-        "createdDateTime": "2022-10-15T02:22:40Z",
-        "expirationDateTime": "2022-10-16T02:22:40Z",
+        "jobId": "3f164c6f-b2a2-4e83-88ff-a88b688bb958",
+        "lastUpdatedDateTime": "2022-10-24T05:13:44Z",
+        "createdDateTime": "2022-10-24T05:13:44Z",
+        "expirationDateTime": "2022-10-25T05:13:44Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "testJob",
@@ -122,32 +125,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/b88f626f-b9c9-426d-b2ed-05675ddedbec?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3f164c6f-b2a2-4e83-88ff-a88b688bb958?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7fc90469-270c-4a86-837a-43c2951f6a0f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "aea2dd3c-0cf2-46f2-a225-e9213b55beab"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f212627-9791-4657-97c8-489a5f181ac7",
+        "apim-request-id": "b13e59a4-5c97-485d-bad2-8b8d6263e651",
         "Content-Length": "853",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "27",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "b88f626f-b9c9-426d-b2ed-05675ddedbec",
-        "lastUpdatedDateTime": "2022-10-15T02:22:42Z",
-        "createdDateTime": "2022-10-15T02:22:40Z",
-        "expirationDateTime": "2022-10-16T02:22:40Z",
+        "jobId": "3f164c6f-b2a2-4e83-88ff-a88b688bb958",
+        "lastUpdatedDateTime": "2022-10-24T05:13:46Z",
+        "createdDateTime": "2022-10-24T05:13:44Z",
+        "expirationDateTime": "2022-10-25T05:13:44Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "testJob",
@@ -159,7 +163,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:42.1510272Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:46.1369242Z",
               "status": "succeeded",
               "results": {
                 "documents": [],

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_out_of_order_input_ids_with_multiple_actions.json
@@ -10,8 +10,8 @@
         "Content-Length": "300",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cacacbfb-ac2a-4a7b-9230-d4104fb6a873"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ad19ff4b-4347-484f-b55e-d40f43416345"
       },
       "RequestBody": {
         "analysisInput": {
@@ -55,194 +55,123 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "69551993-4084-4cfc-9ebc-35054b3711e8",
+        "apim-request-id": "1845c9e9-7117-43a5-9a7f-4f305b7f66b5",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:12 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:03 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/c3667053-8cac-4fc3-b1c3-28747aabd1e4?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "223"
+        "x-envoy-upstream-service-time": "229",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c3667053-8cac-4fc3-b1c3-28747aabd1e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "140bc997-10fe-4c7e-a109-b71d846f7253"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "47c947f6-5fb1-46b6-aa81-70552a75b272"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d716954f-5170-4ff8-bbdd-d64bc3c236e5",
-        "Content-Length": "283",
+        "apim-request-id": "104f2707-4205-4e06-9db4-9b7fd49c2b70",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:12 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f80e1d8a-ec7f-41fe-81a4-3811859d0a70",
-        "lastUpdatedDateTime": "2022-10-15T02:22:12Z",
-        "createdDateTime": "2022-10-15T02:22:12Z",
-        "expirationDateTime": "2022-10-16T02:22:12Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "72768e95-f9a0-435f-a52d-7a9b72298e66"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "676c3add-0ea3-49e0-bc07-4611227233de",
-        "Content-Length": "283",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "f80e1d8a-ec7f-41fe-81a4-3811859d0a70",
-        "lastUpdatedDateTime": "2022-10-15T02:22:12Z",
-        "createdDateTime": "2022-10-15T02:22:12Z",
-        "expirationDateTime": "2022-10-16T02:22:12Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "44a23014-969a-4e35-abf2-1f897af81301"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b15ae34b-27ff-4cb7-8c64-8e3d267ab218",
-        "Content-Length": "655",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:14 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "64"
-      },
-      "ResponseBody": {
-        "jobId": "f80e1d8a-ec7f-41fe-81a4-3811859d0a70",
-        "lastUpdatedDateTime": "2022-10-15T02:22:14Z",
-        "createdDateTime": "2022-10-15T02:22:12Z",
-        "expirationDateTime": "2022-10-16T02:22:12Z",
+        "jobId": "c3667053-8cac-4fc3-b1c3-28747aabd1e4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:03Z",
+        "createdDateTime": "2022-10-24T05:13:03Z",
+        "expirationDateTime": "2022-10-25T05:13:03Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.1462971Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "56",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "0",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "22",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "19",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ]
+          "items": []
         }
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c3667053-8cac-4fc3-b1c3-28747aabd1e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3ec2c1c8-cb51-4e44-86ba-b1c5d83bf563"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fe74b230-8dea-4d0d-9d10-49df2737d295"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0e6a41d7-e4eb-46db-bea0-f110d37292bb",
-        "Content-Length": "1522",
+        "apim-request-id": "ea2d60a2-b0d9-4c40-a1b5-239725b475a8",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "143"
+        "x-envoy-upstream-service-time": "4",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f80e1d8a-ec7f-41fe-81a4-3811859d0a70",
-        "lastUpdatedDateTime": "2022-10-15T02:22:14Z",
-        "createdDateTime": "2022-10-15T02:22:12Z",
-        "expirationDateTime": "2022-10-16T02:22:12Z",
+        "jobId": "c3667053-8cac-4fc3-b1c3-28747aabd1e4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:03Z",
+        "createdDateTime": "2022-10-24T05:13:03Z",
+        "expirationDateTime": "2022-10-25T05:13:03Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c3667053-8cac-4fc3-b1c3-28747aabd1e4?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9c754f7c-4cab-43e5-a38f-be5ba8e22a26"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "48b7946c-b16d-451c-8d6c-7a905e03b5ac",
+        "Content-Length": "1522",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "301",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "c3667053-8cac-4fc3-b1c3-28747aabd1e4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:05Z",
+        "createdDateTime": "2022-10-24T05:13:03Z",
+        "expirationDateTime": "2022-10-25T05:13:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -253,7 +182,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.1462971Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.6297145Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -289,7 +218,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.859133Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.7584164Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -330,7 +259,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.6737445Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.534622Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -369,32 +298,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f80e1d8a-ec7f-41fe-81a4-3811859d0a70?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/c3667053-8cac-4fc3-b1c3-28747aabd1e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "668c1b97-35fa-4f10-b4fa-c68a6c744e6a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "10184f7d-2788-42b1-b5d3-883044cd69c6"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "96c6b8fb-fce4-4d9f-a597-8d5ab835cf38",
+        "apim-request-id": "0dcec10c-0571-4c36-a71d-69f3dc1435fd",
         "Content-Length": "1522",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:16 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "178"
+        "x-envoy-upstream-service-time": "169",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f80e1d8a-ec7f-41fe-81a4-3811859d0a70",
-        "lastUpdatedDateTime": "2022-10-15T02:22:14Z",
-        "createdDateTime": "2022-10-15T02:22:12Z",
-        "expirationDateTime": "2022-10-16T02:22:12Z",
+        "jobId": "c3667053-8cac-4fc3-b1c3-28747aabd1e4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:05Z",
+        "createdDateTime": "2022-10-24T05:13:03Z",
+        "expirationDateTime": "2022-10-25T05:13:03Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -405,7 +335,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.1462971Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.6297145Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -441,7 +371,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.859133Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.7584164Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -482,7 +412,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:14.6737445Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:05.534622Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_output_order_is_same_as_the_inputs_one_with_multiple_actions.json
@@ -10,8 +10,8 @@
         "Content-Length": "307",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "739ea557-d262-4179-8da3-fc494a769c77"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c3510959-a3f2-40b1-baca-f3c79467c42c"
       },
       "RequestBody": {
         "analysisInput": {
@@ -55,43 +55,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2834c35b-fd4d-4199-8b3d-066b6226086a",
+        "apim-request-id": "db0cb790-48f1-4a14-9587-20ebac304626",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:06 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:53 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "251"
+        "x-envoy-upstream-service-time": "193",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b36d7258-8f5c-4b6a-bbe1-6e5793e8a64c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b2cac599-1c10-4edd-9cc6-727145d4e00b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "51abb725-944f-45b1-ad71-f2973c26d98c",
+        "apim-request-id": "0f5c9e95-8e16-4712-82d7-f995967fdd41",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9617eae4-9f23-489e-86f7-b5b58bd0e234",
-        "lastUpdatedDateTime": "2022-10-15T02:22:07Z",
-        "createdDateTime": "2022-10-15T02:22:07Z",
-        "expirationDateTime": "2022-10-16T02:22:07Z",
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:12:54Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -104,33 +106,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7254a80e-17ea-4ceb-9ba8-9612e2d0805f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "404c1bea-f579-4cd4-8ce9-2faeb9e631a9"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3f1092a-425e-49b9-b45e-48f42fc2912c",
-        "Content-Length": "283",
+        "apim-request-id": "87a70c39-5e35-4099-93c7-24e09c4c2b7c",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:06 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9617eae4-9f23-489e-86f7-b5b58bd0e234",
-        "lastUpdatedDateTime": "2022-10-15T02:22:07Z",
-        "createdDateTime": "2022-10-15T02:22:07Z",
-        "expirationDateTime": "2022-10-16T02:22:07Z",
-        "status": "notStarted",
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:12:54Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -142,32 +145,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aa23bed4-580d-478e-920c-5dbfd3609b93"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "07676d90-965d-4fed-a042-eb566e6fb252"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf44ed45-019d-4467-8260-40db31846eae",
-        "Content-Length": "1656",
+        "apim-request-id": "b5c2cb34-088d-4125-8aeb-201fb4d12025",
+        "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:09 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "140",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9617eae4-9f23-489e-86f7-b5b58bd0e234",
-        "lastUpdatedDateTime": "2022-10-15T02:22:09Z",
-        "createdDateTime": "2022-10-15T02:22:07Z",
-        "expirationDateTime": "2022-10-16T02:22:07Z",
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:12:56Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -178,7 +182,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.0201123Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.0312452Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -255,213 +259,11 @@
                 ],
                 "errors": [],
                 "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.1229071Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "one",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "two",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "three",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "four",
-                    "id": "4",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "five",
-                    "id": "5",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "433e4cc0-459c-447a-a736-7c2c508443a0"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4369102d-8553-4274-a601-f6c5aacd743c",
-        "Content-Length": "2043",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "156"
-      },
-      "ResponseBody": {
-        "jobId": "9617eae4-9f23-489e-86f7-b5b58bd0e234",
-        "lastUpdatedDateTime": "2022-10-15T02:22:09Z",
-        "createdDateTime": "2022-10-15T02:22:07Z",
-        "expirationDateTime": "2022-10-16T02:22:07Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 0,
-          "total": 3,
-          "items": [
-            {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.0201123Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "one",
-                        "category": "Quantity",
-                        "subcategory": "Number",
-                        "offset": 0,
-                        "length": 3,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "two",
-                        "category": "Quantity",
-                        "subcategory": "Number",
-                        "offset": 0,
-                        "length": 3,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "entities": [
-                      {
-                        "text": "three",
-                        "category": "Quantity",
-                        "subcategory": "Number",
-                        "offset": 0,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "entities": [
-                      {
-                        "text": "four",
-                        "category": "Quantity",
-                        "subcategory": "Number",
-                        "offset": 0,
-                        "length": 4,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "5",
-                    "entities": [
-                      {
-                        "text": "five",
-                        "category": "Quantity",
-                        "subcategory": "Number",
-                        "offset": 0,
-                        "length": 4,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
-              "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.1229071Z",
-              "status": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "one",
-                    "id": "1",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "two",
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "three",
-                    "id": "3",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "four",
-                    "id": "4",
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "five",
-                    "id": "5",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
               }
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.5908129Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.1839219Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -500,32 +302,347 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9617eae4-9f23-489e-86f7-b5b58bd0e234?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1e284c16-89a0-4fd6-b3e0-bccd592d92e6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "dc8a5a39-4754-464c-908b-df6af0d0c4f2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "989ef874-433f-4a8e-9ea4-f35e2c0e8c43",
-        "Content-Length": "2043",
+        "apim-request-id": "f38b134a-1abd-4d5c-939d-df92b1793b28",
+        "Content-Length": "1556",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:11 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "213"
+        "x-envoy-upstream-service-time": "199",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9617eae4-9f23-489e-86f7-b5b58bd0e234",
-        "lastUpdatedDateTime": "2022-10-15T02:22:09Z",
-        "createdDateTime": "2022-10-15T02:22:07Z",
-        "expirationDateTime": "2022-10-16T02:22:07Z",
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:12:56Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.0312452Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.1839219Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fa3118a8-4ac8-42b4-aa37-7a6d7111efb1"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0ecc3eab-ea59-4a6a-959a-dde2172bec4e",
+        "Content-Length": "1556",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "136",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:12:56Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.0312452Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.1839219Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d048afde-3b5c-4d6b-8e4b-9ada51ca1d9b"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ce35ef37-4d7d-41dc-a181-4fb757c6aa82",
+        "Content-Length": "2043",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "195",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:13:02Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -536,7 +653,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.0201123Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.0312452Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -617,7 +734,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.1229071Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:02.1750035Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -658,7 +775,205 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:09.5908129Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.1839219Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/569c138a-0fc8-457d-83c3-0e52d60754dd?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e4cda089-0653-4508-be7f-50bacdcb6d90"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7c46a833-a585-46b5-b3f2-44c7885d5f0e",
+        "Content-Length": "2043",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "569c138a-0fc8-457d-83c3-0e52d60754dd",
+        "lastUpdatedDateTime": "2022-10-24T05:13:02Z",
+        "createdDateTime": "2022-10-24T05:12:54Z",
+        "expirationDateTime": "2022-10-25T05:12:54Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.0312452Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "one",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "two",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 3,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "text": "three",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "entities": [
+                      {
+                        "text": "four",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "entities": [
+                      {
+                        "text": "five",
+                        "category": "Quantity",
+                        "subcategory": "Number",
+                        "offset": 0,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:02.1750035Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "one",
+                    "id": "1",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "two",
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "three",
+                    "id": "3",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "four",
+                    "id": "4",
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "five",
+                    "id": "5",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:12:56.1839219Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_paged_results_with_custom_page_size.json
@@ -10,8 +10,8 @@
         "Content-Length": "1389",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "94e99c57-2840-4ce1-bd42-14c261cbb200"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5e35b8a9-5331-4567-865d-40b4eed89b4e"
       },
       "RequestBody": {
         "analysisInput": {
@@ -156,43 +156,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fbba21ec-f301-4f16-b8b0-67f5296243bc",
+        "apim-request-id": "16a831c6-6df2-41bb-ac71-41cfa6167b48",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:32 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:31 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "798"
+        "x-envoy-upstream-service-time": "795",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "eb104111-8d33-422a-9be9-569def90ca94"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b17f8358-3a8a-491b-8130-28b7e6592d94"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f495fc02-dce0-4a6b-841d-1ed5eab8a3c3",
+        "apim-request-id": "aebd1957-21a7-4835-97ad-eef414a23807",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:32Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:31Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -205,32 +207,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ee815fcb-48e9-4fcd-9107-2496e13c8019"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e8f1df39-5aa0-4ac0-b516-38fe6df9ddcc"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a3ca616f-f414-4474-a863-c2fa17235d4b",
+        "apim-request-id": "2ec25c9f-eb27-4759-88cb-33ee1ef63b63",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:32 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "226",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:32Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:31Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -243,32 +246,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2ae87b78-9e17-4dc1-9fd1-680a8b4bdf97"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "180b73ad-69ae-4aaa-9d51-92b0c15a3e13"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4513249f-565f-40a6-842a-f4629c4166ae",
+        "apim-request-id": "74189589-45ab-4592-a502-75a946bb3d3e",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:34 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:33Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:32Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -281,32 +285,72 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a877a344-6f99-4c59-971e-24acbaad534f"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "555037a8-cf17-46c2-b4b3-43e1ca5adacb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "22fe7db2-319d-4369-8f46-3b139aa0939a",
-        "Content-Length": "1696",
+        "apim-request-id": "8f54b463-66ff-4e48-8d7d-99f37427193a",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:36 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:36Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:35Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c99674ef-3a40-44bc-9389-4d952de2d39c"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "235b9527-aac0-4d2f-9a2f-bad5250c30f1",
+        "Content-Length": "1696",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "259",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:37Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -317,7 +361,7 @@
           "items": [
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:36.2919924Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -468,36 +512,229 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "8b1b5578-784f-4d9d-8d9d-442d6292ccf9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f8bccef2-81b1-44ae-8205-66603c5f5684"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f13ea6ac-a785-4a62-9ff6-c8917e458db6",
+        "apim-request-id": "19d4594e-2b9a-49b2-9233-f57c840082f5",
+        "Content-Length": "1696",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "262",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:37Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "items": [
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
+              "status": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "5",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "6",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "7",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "8",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "9",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "10",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "11",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "12",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "13",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "14",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "15",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "16",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "17",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "18",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "19",
+                    "keyPhrases": [
+                      "random text"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        },
+        "nextLink": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0bd08682-f7e2-43e9-a752-27b7e5eea1c5"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "951a863c-9aea-49af-943b-69afdcecd67c",
         "Content-Length": "2666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:38 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "384"
+        "x-envoy-upstream-service-time": "534",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:38Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:41Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -508,7 +745,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:38.5252835Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:41.9688732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -619,7 +856,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:36.2919924Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -770,36 +1007,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?api-version=2022-05-01\u0026top=10",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?api-version=2022-05-01\u0026top=10",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2ef92433-814e-45bd-8081-e8e14c5b9382"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "78a2f37f-2a4e-4ae1-b0b5-3513841cbf8a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc05ead1-db82-4da2-978b-3d8740beb6ca",
+        "apim-request-id": "99fbd757-2b05-4c02-9a3e-09ad5e067421",
         "Content-Length": "1717",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "354"
+        "x-envoy-upstream-service-time": "218",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:38Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:41Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -810,7 +1048,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:38.5252835Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:41.9688732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -871,7 +1109,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:36.2919924Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -952,36 +1190,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=10\u0026skip=10\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bc396cb3-40fc-41dd-a6ae-7577aa038768"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fe3a09d8-5cdd-47e6-adb9-becdcba845e9"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1081635-4867-4bba-8972-1e9c28ab763b",
+        "apim-request-id": "f348277f-eb6d-4dc6-beda-c39aa2800e48",
         "Content-Length": "1736",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "199"
+        "x-envoy-upstream-service-time": "206",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:38Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:41Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -992,7 +1231,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:38.5252835Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:41.9688732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1053,7 +1292,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:36.2919924Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1134,36 +1373,37 @@
             }
           ]
         },
-        "nextLink": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
+        "nextLink": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01"
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/696bdf95-3910-479b-bdcb-226ce821ec2d?showStats=False\u0026top=5\u0026skip=20\u0026api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6d64eb2d-0779-40d6-b40e-2a217a01c41b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b5c56f46-b6d2-4430-9b03-02aec9d9cbc2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9968b774-9e53-4bcb-8a14-3b774a7d1b79",
+        "apim-request-id": "a048ce69-eab6-412b-b912-0b3172d2c3e5",
         "Content-Length": "1404",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:39 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "131"
+        "x-envoy-upstream-service-time": "130",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "76b0f3b3-bebd-41fe-ae1f-8d9f0a9cc57b",
-        "lastUpdatedDateTime": "2022-10-15T02:22:38Z",
-        "createdDateTime": "2022-10-15T02:22:32Z",
-        "expirationDateTime": "2022-10-16T02:22:32Z",
+        "jobId": "696bdf95-3910-479b-bdcb-226ce821ec2d",
+        "lastUpdatedDateTime": "2022-10-24T05:13:41Z",
+        "createdDateTime": "2022-10-24T05:13:30Z",
+        "expirationDateTime": "2022-10-25T05:13:30Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1174,7 +1414,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:38.5252835Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:41.9688732Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1232,7 +1472,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:36.2919924Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:37.0712561Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_rehydrated_polling.json
@@ -10,8 +10,8 @@
         "Content-Length": "408",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "11425358-dcce-4be1-9610-003de85aa9ad"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3447e968-bad4-45f8-9d00-30469e9f89d0"
       },
       "RequestBody": {
         "analysisInput": {
@@ -51,43 +51,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "944e2483-22b3-4731-9681-ebc7f2693ebd",
+        "apim-request-id": "502ea6e2-f3d2-4101-8daa-5e2b6b086267",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:42 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:46 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "196"
+        "x-envoy-upstream-service-time": "172",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "851e0bfa-92d9-4fa5-9e09-89f909334880"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "269f7442-7b29-418c-82b5-11ecee84c764"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47b73b35-5afc-4df1-b8a8-ebd5dc6a28e4",
+        "apim-request-id": "8bf79cb1-f6bd-4e2e-9e64-0514d808028e",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:43Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:46Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -100,33 +102,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a8fe272c-c7cd-44df-8395-ab283372a965"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "479aaef1-1fa4-46b9-9044-0fb991f75994"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a9976332-244c-4232-b52c-01c80a49834b",
-        "Content-Length": "283",
+        "apim-request-id": "cba8e0fe-6129-40a0-a25c-f62ded2d288e",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "10",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:43Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
-        "status": "notStarted",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:47Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -138,33 +141,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9fc47eff-8ff9-4a9e-81e8-1b81458822f2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "75f7a713-7f65-4e9b-aa86-d2b6eb7fcb26"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d80f98e2-20fe-450a-98d7-162b74df329e",
-        "Content-Length": "283",
+        "apim-request-id": "97d84bd1-ae14-4817-8ad8-838770cd0390",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:42 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:43Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
-        "status": "notStarted",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:47Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -176,32 +180,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "76091771-ea57-4079-850b-81a77f5ec8cb"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b0e3ed91-0292-4ff9-9f42-63d17579afe1"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60842b0e-8961-4ff4-b589-3a5c97a70376",
-        "Content-Length": "4953",
+        "apim-request-id": "45ca32ed-6deb-47b2-ad01-e047e0df5b6d",
+        "Content-Length": "4889",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:44 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
+        "x-envoy-upstream-service-time": "118",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:44Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:48Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -212,7 +217,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -604,12 +609,13 @@
               }
             },
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
                   {
+                    "redactedText": "******* does not suffer from high blood pressure.",
                     "id": "0",
                     "entities": [
                       {
@@ -617,29 +623,15 @@
                         "category": "PersonType",
                         "offset": 0,
                         "length": 7,
-                        "confidenceScore": 0.99
+                        "confidenceScore": 0.94
                       }
                     ],
                     "warnings": []
                   },
                   {
+                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
                     "id": "1",
                     "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
                       {
                         "text": "daily",
                         "category": "DateTime",
@@ -653,7 +645,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-06-01"
+                "modelVersion": "2021-01-15"
               }
             }
           ]
@@ -661,32 +653,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "269194e5-3096-4fb5-bc10-f0a7c7afb88a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1833ca5e-3473-4dac-94ac-6e4a119dca0d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ea70848-f9a1-48c4-8a21-c93e47d1ceb7",
-        "Content-Length": "4953",
+        "apim-request-id": "6b592e5d-dd82-4f4f-8490-24fabc488489",
+        "Content-Length": "4889",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:46 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "115"
+        "x-envoy-upstream-service-time": "79",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:44Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:48Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -697,7 +690,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1089,12 +1082,13 @@
               }
             },
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
                   {
+                    "redactedText": "******* does not suffer from high blood pressure.",
                     "id": "0",
                     "entities": [
                       {
@@ -1102,29 +1096,15 @@
                         "category": "PersonType",
                         "offset": 0,
                         "length": 7,
-                        "confidenceScore": 0.99
+                        "confidenceScore": 0.94
                       }
                     ],
                     "warnings": []
                   },
                   {
+                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
                     "id": "1",
                     "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
                       {
                         "text": "daily",
                         "category": "DateTime",
@@ -1138,7 +1118,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-06-01"
+                "modelVersion": "2021-01-15"
               }
             }
           ]
@@ -1146,32 +1126,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "e21b6ed0-175a-42ea-9f4c-0b350c4839ff"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "5b82f536-c1f4-4608-b741-f037b961c8a4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ada33cd8-28a1-417d-8e54-3e0fd1a56b15",
-        "Content-Length": "4953",
+        "apim-request-id": "b01f03c0-c505-4a53-8ec8-b4ce30429536",
+        "Content-Length": "4889",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:48 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "71"
+        "x-envoy-upstream-service-time": "69",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:49Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:53Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -1182,7 +1163,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -1574,12 +1555,13 @@
               }
             },
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
                   {
+                    "redactedText": "******* does not suffer from high blood pressure.",
                     "id": "0",
                     "entities": [
                       {
@@ -1587,29 +1569,15 @@
                         "category": "PersonType",
                         "offset": 0,
                         "length": 7,
-                        "confidenceScore": 0.99
+                        "confidenceScore": 0.94
                       }
                     ],
                     "warnings": []
                   },
                   {
+                    "redactedText": "Prescribed 100mg ibuprofen, taken twice *****.",
                     "id": "1",
                     "entities": [
-                      {
-                        "text": "100mg",
-                        "category": "Quantity",
-                        "subcategory": "Dimension",
-                        "offset": 11,
-                        "length": 5,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "ibuprofen",
-                        "category": "Product",
-                        "offset": 17,
-                        "length": 9,
-                        "confidenceScore": 0.89
-                      },
                       {
                         "text": "daily",
                         "category": "DateTime",
@@ -1623,7 +1591,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-06-01"
+                "modelVersion": "2021-01-15"
               }
             }
           ]
@@ -1631,32 +1599,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1ef7030f-e811-4127-91f8-22c160c2cc51"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "88e7a5c8-eff5-4e27-aa46-a2a8401a4d99"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "382290d7-c114-474b-a5f0-cef2730e59be",
+        "apim-request-id": "e2b98819-3058-4d12-b9b7-92b2255a3351",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:50 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "125"
+        "x-envoy-upstream-service-time": "145",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:50Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:54Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1667,7 +1636,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2060,7 +2029,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.8109106Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2113,7 +2082,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:50.8654638Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2153,7 +2122,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:49.7740607Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.4251974Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2217,32 +2186,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "355d2c51-7c41-4649-90a9-554573833a5b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "220bd00e-18a2-47b3-bfe7-161cae90f524"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a2dff67-051a-4339-abf7-6d89c9486cf4",
+        "apim-request-id": "041d8b98-ddad-4291-9aca-6c9f1a3c588c",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "127"
+        "x-envoy-upstream-service-time": "121",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:50Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:54Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -2253,7 +2223,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2646,7 +2616,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.8109106Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2699,7 +2669,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:50.8654638Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2739,7 +2709,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:49.7740607Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.4251974Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -2803,32 +2773,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c705bf7b-ac3a-4a82-9d0f-ec168adaf540"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "cd564d54-1573-4ecf-91ad-b1b9ec2bb138"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ef7bc84a-1eda-4ceb-82b6-f37894973a7d",
+        "apim-request-id": "ff954391-8ed8-4663-9d62-e850b62fe4b6",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "123"
+        "x-envoy-upstream-service-time": "138",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:50Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:54Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -2839,7 +2810,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3232,7 +3203,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.8109106Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3285,7 +3256,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:50.8654638Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3325,7 +3296,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:49.7740607Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.4251974Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3389,32 +3360,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/c8967da8-dd39-4697-9af0-c9f63da6f367?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/aed764c9-6232-4922-83c4-d881162e5bd6?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a4e0dd85-2ebe-418e-b9de-b295b24bfb82"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "ef633089-1d3a-4213-a42f-dbf3f999ef7b"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f36850bf-c197-45b1-af31-715a2c31c524",
+        "apim-request-id": "f2767de7-9fe9-45cd-aec9-afce5f0ff1e6",
         "Content-Length": "6372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "147"
+        "x-envoy-upstream-service-time": "122",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "c8967da8-dd39-4697-9af0-c9f63da6f367",
-        "lastUpdatedDateTime": "2022-10-15T02:22:50Z",
-        "createdDateTime": "2022-10-15T02:22:42Z",
-        "expirationDateTime": "2022-10-16T02:22:42Z",
+        "jobId": "aed764c9-6232-4922-83c4-d881162e5bd6",
+        "lastUpdatedDateTime": "2022-10-24T05:13:54Z",
+        "createdDateTime": "2022-10-24T05:13:46Z",
+        "expirationDateTime": "2022-10-25T05:13:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -3425,7 +3397,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7249554Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.5267582Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3818,7 +3790,7 @@
             },
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:44.7999645Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.8109106Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3871,7 +3843,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:50.8654638Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:48.8047193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -3911,7 +3883,7 @@
             },
             {
               "kind": "SentimentAnalysisLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:49.7740607Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:54.4251974Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_some_documents_with_errors_and_multiple_actions.json
@@ -10,8 +10,8 @@
         "Content-Length": "417",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "16497ecd-77f9-46a4-9963-8c1b004210e9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0bff6519-6f6e-4dfc-ab2a-2360416f58e3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,44 +50,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8c197a5c-d67f-48fa-b96f-13bf4305c41b",
+        "apim-request-id": "40ce267b-3c45-4458-ab8b-0d1444974f3b",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:01 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/4482d88b-f8e5-478d-a0d7-5e32d401b515?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:48 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/fa2778f9-8beb-4e11-ac78-6ba1726105e4?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "157"
+        "x-envoy-upstream-service-time": "174",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4482d88b-f8e5-478d-a0d7-5e32d401b515?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa2778f9-8beb-4e11-ac78-6ba1726105e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "665c0c43-eb51-454f-af85-1eed7678cfe4"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "142d458c-78ca-4679-98fa-184e03e596a2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "76cc40a8-eb12-4da8-83e0-2749fc973d26",
-        "Content-Length": "280",
+        "apim-request-id": "4e11d5df-3623-47e8-ad0d-5fe7cb4e9af3",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4482d88b-f8e5-478d-a0d7-5e32d401b515",
-        "lastUpdatedDateTime": "2022-10-15T02:22:02Z",
-        "createdDateTime": "2022-10-15T02:22:01Z",
-        "expirationDateTime": "2022-10-16T02:22:01Z",
-        "status": "running",
+        "jobId": "fa2778f9-8beb-4e11-ac78-6ba1726105e4",
+        "lastUpdatedDateTime": "2022-10-24T05:12:48Z",
+        "createdDateTime": "2022-10-24T05:12:48Z",
+        "expirationDateTime": "2022-10-25T05:12:48Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -99,33 +101,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4482d88b-f8e5-478d-a0d7-5e32d401b515?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa2778f9-8beb-4e11-ac78-6ba1726105e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "16cb9278-cb5d-4063-9ea4-73b9e711f603"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "07daa0b1-5292-4ed1-8e85-9c0492fb81d2"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "863af5ca-556d-460b-8327-47790426bf5a",
-        "Content-Length": "280",
+        "apim-request-id": "e29a474b-7b70-47c1-b90f-5d8772c432dc",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4482d88b-f8e5-478d-a0d7-5e32d401b515",
-        "lastUpdatedDateTime": "2022-10-15T02:22:02Z",
-        "createdDateTime": "2022-10-15T02:22:01Z",
-        "expirationDateTime": "2022-10-16T02:22:01Z",
-        "status": "running",
+        "jobId": "fa2778f9-8beb-4e11-ac78-6ba1726105e4",
+        "lastUpdatedDateTime": "2022-10-24T05:12:48Z",
+        "createdDateTime": "2022-10-24T05:12:48Z",
+        "expirationDateTime": "2022-10-25T05:12:48Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -137,32 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4482d88b-f8e5-478d-a0d7-5e32d401b515?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa2778f9-8beb-4e11-ac78-6ba1726105e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6b96321c-fd1b-46bd-991b-166ff084a847"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "61c815e3-d043-4c81-87a9-da5ff57b6f75"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "418c5d9d-fab2-4dff-9198-67044c4033f7",
+        "apim-request-id": "6eff0256-8495-492f-a470-5fbcf3e638c3",
         "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "147"
+        "x-envoy-upstream-service-time": "112",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4482d88b-f8e5-478d-a0d7-5e32d401b515",
-        "lastUpdatedDateTime": "2022-10-15T02:22:03Z",
-        "createdDateTime": "2022-10-15T02:22:01Z",
-        "expirationDateTime": "2022-10-16T02:22:01Z",
+        "jobId": "fa2778f9-8beb-4e11-ac78-6ba1726105e4",
+        "lastUpdatedDateTime": "2022-10-24T05:12:50Z",
+        "createdDateTime": "2022-10-24T05:12:48Z",
+        "expirationDateTime": "2022-10-25T05:12:48Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -173,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.9360587Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.5604352Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -221,7 +225,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.9480657Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.8669793Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -261,7 +265,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.5961093Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.4854423Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -306,32 +310,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/4482d88b-f8e5-478d-a0d7-5e32d401b515?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/fa2778f9-8beb-4e11-ac78-6ba1726105e4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "862c4916-1e3f-45d8-bfe8-22b54cd22063"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "85b3f57e-5839-4062-b95e-b030ca583d8a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66aaf9a7-c79c-4a5a-a4f1-8eccca339bf3",
+        "apim-request-id": "316b9915-d16d-46d0-91ae-da5f496a7f50",
         "Content-Length": "2954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:03 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
+        "x-envoy-upstream-service-time": "156",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "4482d88b-f8e5-478d-a0d7-5e32d401b515",
-        "lastUpdatedDateTime": "2022-10-15T02:22:03Z",
-        "createdDateTime": "2022-10-15T02:22:01Z",
-        "expirationDateTime": "2022-10-16T02:22:01Z",
+        "jobId": "fa2778f9-8beb-4e11-ac78-6ba1726105e4",
+        "lastUpdatedDateTime": "2022-10-24T05:12:50Z",
+        "createdDateTime": "2022-10-24T05:12:48Z",
+        "expirationDateTime": "2022-10-25T05:12:48Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -342,7 +347,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.9360587Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.5604352Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -390,7 +395,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.9480657Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.8669793Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -430,7 +435,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:03.5961093Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:50.4854423Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_statistics.json
@@ -10,8 +10,8 @@
         "Content-Length": "376",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "0772adb6-8468-455c-a6ac-45e6b6cfb0e0"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "87ef70f1-15a8-47f2-bda6-fbc6c73a68e1"
       },
       "RequestBody": {
         "analysisInput": {
@@ -60,73 +60,123 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cfbb4496-cffd-465d-9e4c-985f519fc7f9",
+        "apim-request-id": "c0749280-5202-4036-b2b4-b44719253b64",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:17 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:06 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "218"
+        "x-envoy-upstream-service-time": "198",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ed55beb8-bb83-4900-91e2-aa2dc15e1866"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "e77ce58d-cc6c-48c5-98fd-9094d0229623",
-        "Content-Length": "337",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:22:17 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the Get analysis status and results Operation under Microsoft Cognitive Language Service have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01\u0026showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ed55beb8-bb83-4900-91e2-aa2dc15e1866"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a071eaca-c7de-4283-9bc7-0ef63cd18cbd"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8b1da5f5-4f47-42d4-b0e0-64baaf81ceb0",
-        "Content-Length": "280",
+        "apim-request-id": "40c4732c-cc19-4a2d-b79a-2757563d17c8",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9dbbd84e-f95a-4027-bc19-1eed587a203d",
-        "lastUpdatedDateTime": "2022-10-15T02:22:17Z",
-        "createdDateTime": "2022-10-15T02:22:17Z",
-        "expirationDateTime": "2022-10-16T02:22:17Z",
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:06Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "872f16c3-8b67-4b5f-98c4-3310da5e3cd2"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b43b9eaa-8c61-41c8-8d82-679bf9bbb991",
+        "Content-Length": "283",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:06Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "notStarted",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 3,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "53a2d70d-c3cd-4fb3-b3a6-b714e0ec8cb6"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "109d5308-3d12-4005-a394-019f79fa60dc",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:08Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -139,146 +189,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4032d4ed-beda-4cf0-a060-3fa5fccfbe64"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a52b6883-b4c9-4725-85f8-8f3143d7a1bc"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66ddbe56-3f66-44d2-8777-d4b9a8dfd618",
-        "Content-Length": "280",
+        "apim-request-id": "4359ada3-0fdf-4752-8b93-e857a341227d",
+        "Content-Length": "2036",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:18 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "183",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9dbbd84e-f95a-4027-bc19-1eed587a203d",
-        "lastUpdatedDateTime": "2022-10-15T02:22:17Z",
-        "createdDateTime": "2022-10-15T02:22:17Z",
-        "expirationDateTime": "2022-10-16T02:22:17Z",
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:09Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 3,
-          "total": 3,
-          "items": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01\u0026showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "efb3fb0a-90b6-4326-85e3-e7f3e8fdd9a5"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "95518b05-94ec-4cbd-bc90-ac54fc0d131f",
-        "Content-Length": "2869",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:20 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "240"
-      },
-      "ResponseBody": {
-        "jobId": "9dbbd84e-f95a-4027-bc19-1eed587a203d",
-        "lastUpdatedDateTime": "2022-10-15T02:22:19Z",
-        "createdDateTime": "2022-10-15T02:22:17Z",
-        "expirationDateTime": "2022-10-16T02:22:17Z",
-        "status": "succeeded",
-        "errors": [],
-        "tasks": {
-          "completed": 3,
-          "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:18.889577Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:19.0150817Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -347,7 +295,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:19.0316047Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -415,108 +363,44 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/9dbbd84e-f95a-4027-bc19-1eed587a203d?api-version=2022-05-01\u0026showStats=true",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "22cf0dfb-e207-474a-863a-779bd6c1b314"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9225f7ed-5975-41bc-a712-6bb92c9b2358"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b792c351-b392-4acb-a154-354b9e704cef",
-        "Content-Length": "2869",
+        "apim-request-id": "20574052-275b-4c49-bd82-3f939fce532c",
+        "Content-Length": "2036",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:20 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "172"
+        "x-envoy-upstream-service-time": "130",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "9dbbd84e-f95a-4027-bc19-1eed587a203d",
-        "lastUpdatedDateTime": "2022-10-15T02:22:19Z",
-        "createdDateTime": "2022-10-15T02:22:17Z",
-        "expirationDateTime": "2022-10-16T02:22:17Z",
-        "status": "succeeded",
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:09Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 3,
           "items": [
             {
-              "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:18.889577Z",
-              "status": "succeeded",
-              "results": {
-                "statistics": {
-                  "documentsCount": 5,
-                  "validDocumentsCount": 4,
-                  "erroneousDocumentsCount": 1,
-                  "transactionsCount": 4
-                },
-                "documents": [
-                  {
-                    "id": "0",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "3",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  },
-                  {
-                    "id": "4",
-                    "statistics": {
-                      "charactersCount": 2,
-                      "transactionsCount": 1
-                    },
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Document in request.",
-                      "innererror": {
-                        "code": "InvalidDocument",
-                        "message": "Document text is empty."
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            },
-            {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:19.0150817Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
               "status": "succeeded",
               "results": {
                 "statistics": {
@@ -585,7 +469,833 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:19.0316047Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "eebe9e7c-b11d-4cc0-b75c-ae8e6dc65ea9"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "48750269-88ba-43bb-a297-8e1b5274f9e4",
+        "Content-Length": "2036",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "122",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:09Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "12a6fae0-f33b-4065-9d07-c5fe5ef20439"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bc8e7e28-48df-4c4b-b0bb-5618707c43fc",
+        "Content-Length": "2036",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:09Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 3,
+          "items": [
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "bec7ad83-dd94-482d-9b15-bc8fe4623a07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "060dda36-b8d0-42a2-9426-2d982592b300",
+        "Content-Length": "2870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "213",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:17Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:17.7264205Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "keyPhrases": [],
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2022-10-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/cc56b988-fcc8-4a58-989b-e73e4fd3b999?api-version=2022-05-01\u0026showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "f8a1a67e-f595-4ace-91e9-a6d2e6be9057"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7dbcb9fa-af29-446b-9278-89427646d16e",
+        "Content-Length": "2870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:13:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "207",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "cc56b988-fcc8-4a58-989b-e73e4fd3b999",
+        "lastUpdatedDateTime": "2022-10-24T05:13:17Z",
+        "createdDateTime": "2022-10-24T05:13:06Z",
+        "expirationDateTime": "2022-10-25T05:13:06Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 3,
+          "items": [
+            {
+              "kind": "EntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:17.7264205Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            },
+            {
+              "kind": "PiiEntityRecognitionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:08.7493972Z",
+              "status": "succeeded",
+              "results": {
+                "statistics": {
+                  "documentsCount": 5,
+                  "validDocumentsCount": 4,
+                  "erroneousDocumentsCount": 1,
+                  "transactionsCount": 4
+                },
+                "documents": [
+                  {
+                    "redactedText": ":)",
+                    "id": "0",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":(",
+                    "id": "1",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":P",
+                    "id": "3",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": ":D",
+                    "id": "4",
+                    "statistics": {
+                      "charactersCount": 2,
+                      "transactionsCount": 1
+                    },
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Document in request.",
+                      "innererror": {
+                        "code": "InvalidDocument",
+                        "message": "Document text is empty."
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-01-15"
+              }
+            },
+            {
+              "kind": "KeyPhraseExtractionLROResults",
+              "lastUpdateDateTime": "2022-10-24T05:13:09.5297601Z",
               "status": "succeeded",
               "results": {
                 "statistics": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_unique_multiple_actions_per_type_are_allowed.json
@@ -10,8 +10,8 @@
         "Content-Length": "240",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c98f8e91-ee3c-47b9-aee7-335911eadd1a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a1875cc0-cd0e-48d4-8e33-18ca85771c59"
       },
       "RequestBody": {
         "analysisInput": {
@@ -38,44 +38,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "81dbdd46-c8b4-48e9-813b-e81979bc0747",
+        "apim-request-id": "120c2e47-ec54-4c3c-850a-ff467d42502c",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:21:58 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f7530863-e6f9-48b4-b997-4d782e85dc7e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:12:46 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/3eeb5643-b534-45d5-a221-55771cc57b28?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "121"
+        "x-envoy-upstream-service-time": "137",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f7530863-e6f9-48b4-b997-4d782e85dc7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3eeb5643-b534-45d5-a221-55771cc57b28?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4f0fac09-80fa-42e5-bea4-d2fff246748e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "fb5c4076-7072-4f92-b7ce-35dce8bb7856"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ef7168f-c4f8-4c6a-87a5-8b7998456aff",
-        "Content-Length": "280",
+        "apim-request-id": "5e31a8ac-a3ec-45c5-99b5-bf3ce9fa8fe2",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f7530863-e6f9-48b4-b997-4d782e85dc7e",
-        "lastUpdatedDateTime": "2022-10-15T02:21:59Z",
-        "createdDateTime": "2022-10-15T02:21:59Z",
-        "expirationDateTime": "2022-10-16T02:21:59Z",
-        "status": "running",
+        "jobId": "3eeb5643-b534-45d5-a221-55771cc57b28",
+        "lastUpdatedDateTime": "2022-10-24T05:12:46Z",
+        "createdDateTime": "2022-10-24T05:12:46Z",
+        "expirationDateTime": "2022-10-25T05:12:46Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -87,33 +89,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f7530863-e6f9-48b4-b997-4d782e85dc7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3eeb5643-b534-45d5-a221-55771cc57b28?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2594bb9f-6db0-4864-908b-883aff26786c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b7f3b8ba-1e7a-4535-95df-01a03d3309e5"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f0946833-827f-4856-9765-338ffef0324a",
-        "Content-Length": "280",
+        "apim-request-id": "e7706816-c53d-49f2-b113-a7140c2d41f7",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:21:58 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f7530863-e6f9-48b4-b997-4d782e85dc7e",
-        "lastUpdatedDateTime": "2022-10-15T02:21:59Z",
-        "createdDateTime": "2022-10-15T02:21:59Z",
-        "expirationDateTime": "2022-10-16T02:21:59Z",
-        "status": "running",
+        "jobId": "3eeb5643-b534-45d5-a221-55771cc57b28",
+        "lastUpdatedDateTime": "2022-10-24T05:12:46Z",
+        "createdDateTime": "2022-10-24T05:12:46Z",
+        "expirationDateTime": "2022-10-25T05:12:46Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -125,32 +128,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f7530863-e6f9-48b4-b997-4d782e85dc7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3eeb5643-b534-45d5-a221-55771cc57b28?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ed0f9a01-0af2-404d-b0e5-be8a6c4c4b18"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6c873d41-b252-4673-8725-31894120a9bb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a67d755e-92c6-4a8f-8b66-ee23e4171263",
+        "apim-request-id": "b1a763ed-0164-42e1-8c77-3b80e39f4607",
         "Content-Length": "843",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f7530863-e6f9-48b4-b997-4d782e85dc7e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:00Z",
-        "createdDateTime": "2022-10-15T02:21:59Z",
-        "expirationDateTime": "2022-10-16T02:21:59Z",
+        "jobId": "3eeb5643-b534-45d5-a221-55771cc57b28",
+        "lastUpdatedDateTime": "2022-10-24T05:12:48Z",
+        "createdDateTime": "2022-10-24T05:12:46Z",
+        "expirationDateTime": "2022-10-25T05:12:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -162,7 +166,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:22:00.8778561Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:48.4079802Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -180,7 +184,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:22:00.8863997Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:48.2938193Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -200,32 +204,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f7530863-e6f9-48b4-b997-4d782e85dc7e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/3eeb5643-b534-45d5-a221-55771cc57b28?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "097b4169-5abb-40af-93bb-4d1960aec05b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a075b50a-d126-4f80-88ab-4552c563af27"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb2d8823-fac0-4cf7-a233-7243de07960d",
+        "apim-request-id": "7097b0bd-6cd4-45a7-a498-51f0da1b47c2",
         "Content-Length": "843",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:01 GMT",
+        "Date": "Mon, 24 Oct 2022 05:12:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "45",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f7530863-e6f9-48b4-b997-4d782e85dc7e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:00Z",
-        "createdDateTime": "2022-10-15T02:21:59Z",
-        "expirationDateTime": "2022-10-16T02:21:59Z",
+        "jobId": "3eeb5643-b534-45d5-a221-55771cc57b28",
+        "lastUpdatedDateTime": "2022-10-24T05:12:48Z",
+        "createdDateTime": "2022-10-24T05:12:46Z",
+        "expirationDateTime": "2022-10-25T05:12:46Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -237,7 +242,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action1",
-              "lastUpdateDateTime": "2022-10-15T02:22:00.8778561Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:48.4079802Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -255,7 +260,7 @@
             {
               "kind": "PiiEntityRecognitionLROResults",
               "taskName": "action2",
-              "lastUpdateDateTime": "2022-10-15T02:22:00.8863997Z",
+              "lastUpdateDateTime": "2022-10-24T05:12:48.2938193Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_input_with_a_language_hint.json
@@ -10,8 +10,8 @@
         "Content-Length": "320",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ae1328d3-fe3e-44e9-93d0-85f8df91e7be"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "80a30542-42e7-4379-9bd8-7f360ec0ad78"
       },
       "RequestBody": {
         "analysisInput": {
@@ -47,44 +47,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c7b36fbb-3774-40fe-8429-e3148dac5866",
+        "apim-request-id": "6a2eca4e-02d7-4c11-9867-6501d77b8693",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:26 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/276a3206-5a58-4b48-a919-ccb95acef36e?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:25 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/46d66489-ae95-48bd-af71-cbb2a56529f4?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "156"
+        "x-envoy-upstream-service-time": "161",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/276a3206-5a58-4b48-a919-ccb95acef36e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d66489-ae95-48bd-af71-cbb2a56529f4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "92223e3a-34a7-4744-a19d-7fa2ce83873b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "acd2992c-e176-4a05-8380-5b278c590dc0"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dd10badb-b5ee-4fa7-b014-28208683813b",
-        "Content-Length": "280",
+        "apim-request-id": "29a33f4b-ef19-4565-8819-db769ce59f02",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "276a3206-5a58-4b48-a919-ccb95acef36e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:26Z",
-        "createdDateTime": "2022-10-15T02:22:26Z",
-        "expirationDateTime": "2022-10-16T02:22:26Z",
-        "status": "running",
+        "jobId": "46d66489-ae95-48bd-af71-cbb2a56529f4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:25Z",
+        "createdDateTime": "2022-10-24T05:13:25Z",
+        "expirationDateTime": "2022-10-25T05:13:25Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -96,33 +98,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/276a3206-5a58-4b48-a919-ccb95acef36e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d66489-ae95-48bd-af71-cbb2a56529f4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b4aabc48-32ff-4b26-98ba-a93934e3ccea"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "34139913-cc2b-490b-ab21-9095e467f7d7"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fb67748e-2b98-42ed-bb59-fc2b5a087374",
-        "Content-Length": "280",
+        "apim-request-id": "8a421a0c-8967-452a-97d6-fae2382d2613",
+        "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "276a3206-5a58-4b48-a919-ccb95acef36e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:26Z",
-        "createdDateTime": "2022-10-15T02:22:26Z",
-        "expirationDateTime": "2022-10-16T02:22:26Z",
-        "status": "running",
+        "jobId": "46d66489-ae95-48bd-af71-cbb2a56529f4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:25Z",
+        "createdDateTime": "2022-10-24T05:13:25Z",
+        "expirationDateTime": "2022-10-25T05:13:25Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -134,32 +137,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/276a3206-5a58-4b48-a919-ccb95acef36e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d66489-ae95-48bd-af71-cbb2a56529f4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b5ec4760-36b8-48f2-a830-ef47e22428e2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "02b97924-2a58-4567-93d0-e5e23c2d06b1"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6bac3322-cab7-4213-9ef2-e07a60f06621",
-        "Content-Length": "1510",
+        "apim-request-id": "dfbf8ecc-ff35-41cb-83d4-9d8e65b1eeab",
+        "Content-Length": "1509",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "x-envoy-upstream-service-time": "184",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "276a3206-5a58-4b48-a919-ccb95acef36e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:28Z",
-        "createdDateTime": "2022-10-15T02:22:26Z",
-        "expirationDateTime": "2022-10-16T02:22:26Z",
+        "jobId": "46d66489-ae95-48bd-af71-cbb2a56529f4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:27Z",
+        "createdDateTime": "2022-10-24T05:13:25Z",
+        "expirationDateTime": "2022-10-25T05:13:25Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -170,7 +174,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.4915282Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.7935025Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -212,7 +216,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.5489764Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.808204Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -241,7 +245,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.7006437Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.5118761Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -277,32 +281,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/276a3206-5a58-4b48-a919-ccb95acef36e?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/46d66489-ae95-48bd-af71-cbb2a56529f4?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b3bef25b-1e0c-4da1-9161-403fe21d606e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e6f5f456-8b1b-4832-9cc2-ee457f14337c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7eccf6d4-29fb-4cb3-87e9-eb78b10ca02a",
-        "Content-Length": "1510",
+        "apim-request-id": "abfb8eee-fb8c-439b-bc7c-0abd3b680c4a",
+        "Content-Length": "1509",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:28 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "108"
+        "x-envoy-upstream-service-time": "143",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "276a3206-5a58-4b48-a919-ccb95acef36e",
-        "lastUpdatedDateTime": "2022-10-15T02:22:28Z",
-        "createdDateTime": "2022-10-15T02:22:26Z",
-        "expirationDateTime": "2022-10-16T02:22:26Z",
+        "jobId": "46d66489-ae95-48bd-af71-cbb2a56529f4",
+        "lastUpdatedDateTime": "2022-10-24T05:13:27Z",
+        "createdDateTime": "2022-10-24T05:13:25Z",
+        "expirationDateTime": "2022-10-25T05:13:25Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -313,7 +318,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.4915282Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.7935025Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -355,7 +360,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.5489764Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.808204Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -384,7 +389,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:28.7006437Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:27.5118761Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_language_hint.json
@@ -10,8 +10,8 @@
         "Content-Length": "429",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a8626ca5-034a-468d-8ee5-6874c904514b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "31aa46af-29a1-4518-add5-5433d8888878"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2e533e0c-b0f5-478b-8d1d-cea56cd0604c",
+        "apim-request-id": "3f38aab3-0046-4ab4-879c-dd89c7bf3eec",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:20 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/3bef172e-62cb-454f-87af-e5f59d4e14b1?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:19 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/b5c4be5f-306d-43f8-9a22-3d068e9e38f7?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "165"
+        "x-envoy-upstream-service-time": "178",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3bef172e-62cb-454f-87af-e5f59d4e14b1?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b5c4be5f-306d-43f8-9a22-3d068e9e38f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "fbd57a64-6e39-474b-a8bf-b276bd0a7a9b"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "c5f2960d-82fd-4e8d-84f7-8bfab0c3a801"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "05f2bb66-b07e-4c10-a9a9-b642efa379a1",
+        "apim-request-id": "76fca2dc-d9f7-4c2d-95b5-2dfc18f00119",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:20 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3bef172e-62cb-454f-87af-e5f59d4e14b1",
-        "lastUpdatedDateTime": "2022-10-15T02:22:21Z",
-        "createdDateTime": "2022-10-15T02:22:21Z",
-        "expirationDateTime": "2022-10-16T02:22:21Z",
+        "jobId": "b5c4be5f-306d-43f8-9a22-3d068e9e38f7",
+        "lastUpdatedDateTime": "2022-10-24T05:13:20Z",
+        "createdDateTime": "2022-10-24T05:13:20Z",
+        "expirationDateTime": "2022-10-25T05:13:20Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -99,32 +101,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3bef172e-62cb-454f-87af-e5f59d4e14b1?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b5c4be5f-306d-43f8-9a22-3d068e9e38f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "dd47aff4-e195-4f51-a69d-615ff057b688"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "9920bfab-8bce-4e66-96a9-09fdf13512cc"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1a400b3b-e4b7-425f-92d8-a5f1b8f96b57",
+        "apim-request-id": "fb6b7eec-19c4-4c20-8fac-0a1639ab5471",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:20 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3bef172e-62cb-454f-87af-e5f59d4e14b1",
-        "lastUpdatedDateTime": "2022-10-15T02:22:21Z",
-        "createdDateTime": "2022-10-15T02:22:21Z",
-        "expirationDateTime": "2022-10-16T02:22:21Z",
+        "jobId": "b5c4be5f-306d-43f8-9a22-3d068e9e38f7",
+        "lastUpdatedDateTime": "2022-10-24T05:13:20Z",
+        "createdDateTime": "2022-10-24T05:13:20Z",
+        "expirationDateTime": "2022-10-25T05:13:20Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -137,32 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3bef172e-62cb-454f-87af-e5f59d4e14b1?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b5c4be5f-306d-43f8-9a22-3d068e9e38f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "dcf6a4d3-7def-4ddf-91fb-5655c9937f97"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "60685078-92b9-44cb-9ca3-886c1ff03861"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "171658ca-b8ce-468b-a3ce-7510c3d098d3",
+        "apim-request-id": "18b6d74a-f71f-49f0-96dc-ceb577c0bc2f",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "123"
+        "x-envoy-upstream-service-time": "152",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3bef172e-62cb-454f-87af-e5f59d4e14b1",
-        "lastUpdatedDateTime": "2022-10-15T02:22:23Z",
-        "createdDateTime": "2022-10-15T02:22:21Z",
-        "expirationDateTime": "2022-10-16T02:22:21Z",
+        "jobId": "b5c4be5f-306d-43f8-9a22-3d068e9e38f7",
+        "lastUpdatedDateTime": "2022-10-24T05:13:22Z",
+        "createdDateTime": "2022-10-24T05:13:20Z",
+        "expirationDateTime": "2022-10-25T05:13:20Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -173,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:23.0846512Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.0659704Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -216,7 +220,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:23.2101157Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.1466902Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -245,7 +249,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:22.7116293Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.1332346Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -281,32 +285,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/3bef172e-62cb-454f-87af-e5f59d4e14b1?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/b5c4be5f-306d-43f8-9a22-3d068e9e38f7?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1b45cf71-54f6-42c1-8449-ae4e2d4b9c50"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b8f1afe1-a4c5-449a-a2e0-9e2a938c17cc"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "15e2e8a9-0cd6-43a8-9863-36cee3d502db",
+        "apim-request-id": "40584a5a-2302-490b-8406-ee36f9f55e44",
         "Content-Length": "1602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "214"
+        "x-envoy-upstream-service-time": "178",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "3bef172e-62cb-454f-87af-e5f59d4e14b1",
-        "lastUpdatedDateTime": "2022-10-15T02:22:23Z",
-        "createdDateTime": "2022-10-15T02:22:21Z",
-        "expirationDateTime": "2022-10-16T02:22:21Z",
+        "jobId": "b5c4be5f-306d-43f8-9a22-3d068e9e38f7",
+        "lastUpdatedDateTime": "2022-10-24T05:13:22Z",
+        "createdDateTime": "2022-10-24T05:13:20Z",
+        "expirationDateTime": "2022-10-25T05:13:20Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -317,7 +322,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:23.0846512Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.0659704Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -360,7 +365,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:23.2101157Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.1466902Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -389,7 +394,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:22.7116293Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:22.1332346Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior/recording_whole_batch_with_no_language_hint.json
@@ -10,8 +10,8 @@
         "Content-Length": "429",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7e3b1327-d000-457a-a05b-8a6577ceb719"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7c5feb21-f72a-4423-876b-086165308b19"
       },
       "RequestBody": {
         "analysisInput": {
@@ -50,43 +50,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "9d4b7e7b-2051-4092-953a-2e7392649fbf",
+        "apim-request-id": "ad079749-c1ad-4590-9d7b-605ea6ef6e5a",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:23 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/edca3526-83e1-4dcf-9181-577d96c74f13?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:23 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/db3de8a9-774b-4e66-b7a3-d2bbc2086087?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "x-envoy-upstream-service-time": "208",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/edca3526-83e1-4dcf-9181-577d96c74f13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/db3de8a9-774b-4e66-b7a3-d2bbc2086087?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1f3b8cd2-634c-4796-bc0a-bb0b39ae0b34"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7a18d11a-7305-4d8f-a507-68df4e9e78ca"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f06f141-1987-4a44-9519-5752a92519ce",
+        "apim-request-id": "5c0dec67-3e2b-4ed0-903c-8cc30ae2b710",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "edca3526-83e1-4dcf-9181-577d96c74f13",
-        "lastUpdatedDateTime": "2022-10-15T02:22:24Z",
-        "createdDateTime": "2022-10-15T02:22:23Z",
-        "expirationDateTime": "2022-10-16T02:22:23Z",
+        "jobId": "db3de8a9-774b-4e66-b7a3-d2bbc2086087",
+        "lastUpdatedDateTime": "2022-10-24T05:13:23Z",
+        "createdDateTime": "2022-10-24T05:13:22Z",
+        "expirationDateTime": "2022-10-25T05:13:22Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -99,33 +101,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/edca3526-83e1-4dcf-9181-577d96c74f13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/db3de8a9-774b-4e66-b7a3-d2bbc2086087?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6ae7e55d-3365-494e-9460-7068f4ea31c3"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "eb8f4001-ecec-48c7-bd2d-316a5226c991"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2024b32b-d0e4-48fe-9eb4-220bf64bb300",
-        "Content-Length": "283",
+        "apim-request-id": "7c35ab6e-4d52-47ad-a353-cf943d3bce5f",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:23 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "edca3526-83e1-4dcf-9181-577d96c74f13",
-        "lastUpdatedDateTime": "2022-10-15T02:22:24Z",
-        "createdDateTime": "2022-10-15T02:22:23Z",
-        "expirationDateTime": "2022-10-16T02:22:23Z",
-        "status": "notStarted",
+        "jobId": "db3de8a9-774b-4e66-b7a3-d2bbc2086087",
+        "lastUpdatedDateTime": "2022-10-24T05:13:23Z",
+        "createdDateTime": "2022-10-24T05:13:22Z",
+        "expirationDateTime": "2022-10-25T05:13:22Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -137,32 +140,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/edca3526-83e1-4dcf-9181-577d96c74f13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/db3de8a9-774b-4e66-b7a3-d2bbc2086087?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3cfdd6f9-60cb-4538-860f-dffedc7e9102"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "610da0ad-6c29-4793-b44f-dc0d36a3b915"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e233072b-4cda-4cf2-b4a1-310439f3956e",
-        "Content-Length": "1602",
+        "apim-request-id": "88bfd862-4b4e-4386-9a66-1714e7ef290c",
+        "Content-Length": "1601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "133"
+        "x-envoy-upstream-service-time": "128",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "edca3526-83e1-4dcf-9181-577d96c74f13",
-        "lastUpdatedDateTime": "2022-10-15T02:22:26Z",
-        "createdDateTime": "2022-10-15T02:22:23Z",
-        "expirationDateTime": "2022-10-16T02:22:23Z",
+        "jobId": "db3de8a9-774b-4e66-b7a3-d2bbc2086087",
+        "lastUpdatedDateTime": "2022-10-24T05:13:25Z",
+        "createdDateTime": "2022-10-24T05:13:22Z",
+        "expirationDateTime": "2022-10-25T05:13:22Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -173,7 +177,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:26.1875801Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:25.0907815Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -216,7 +220,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:26.1970097Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:25.1361726Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -245,7 +249,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:25.9479054Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:24.684537Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -281,32 +285,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/edca3526-83e1-4dcf-9181-577d96c74f13?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/db3de8a9-774b-4e66-b7a3-d2bbc2086087?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ea30da09-cb91-424c-8019-8ba0fa650891"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d95e9990-aeef-4268-8cdc-5607f6a6f9f9"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "85b8f7c2-2174-4902-8188-107fcd9bc27d",
-        "Content-Length": "1602",
+        "apim-request-id": "7f356cfd-650c-4ee5-95a1-1f84877be591",
+        "Content-Length": "1601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:26 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "166"
+        "x-envoy-upstream-service-time": "211",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "edca3526-83e1-4dcf-9181-577d96c74f13",
-        "lastUpdatedDateTime": "2022-10-15T02:22:26Z",
-        "createdDateTime": "2022-10-15T02:22:23Z",
-        "expirationDateTime": "2022-10-16T02:22:23Z",
+        "jobId": "db3de8a9-774b-4e66-b7a3-d2bbc2086087",
+        "lastUpdatedDateTime": "2022-10-24T05:13:25Z",
+        "createdDateTime": "2022-10-24T05:13:22Z",
+        "expirationDateTime": "2022-10-25T05:13:22Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -317,7 +322,7 @@
           "items": [
             {
               "kind": "EntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:26.1875801Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:25.0907815Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -360,7 +365,7 @@
             },
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:26.1970097Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:25.1361726Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -389,7 +394,7 @@
             },
             {
               "kind": "KeyPhraseExtractionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:25.9479054Z",
+              "lastUpdateDateTime": "2022-10-24T05:13:24.684537Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_bad_request_empty_string.json
@@ -10,8 +10,8 @@
         "Content-Length": "125",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "65889f94-1715-4485-b358-1c8bf324afcd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6c8930dc-f2d5-43c5-92e3-8f07dc9cc21c"
       },
       "RequestBody": {
         "analysisInput": {
@@ -32,13 +32,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "5e71f009-1702-4684-9a52-b08fd3c66865",
+        "apim-request-id": "91d4c0df-36a6-4f80-b46f-88c3a15a24de",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_big_document_causes_a_warning.json
@@ -10,8 +10,8 @@
         "Content-Length": "5239",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1926b8ac-625f-4cb4-9a8b-1258c734f34c"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d27c73ee-0886-4387-9449-51b6da75caec"
       },
       "RequestBody": {
         "analysisInput": {
@@ -32,43 +32,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "321c1134-3d3f-440c-81ca-7c667b3e781d",
+        "apim-request-id": "1cfb3a1f-3a7b-42e3-aaab-6ce50e093e14",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:53 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:13:56 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
+        "x-envoy-upstream-service-time": "89",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "58953a30-02b3-43f7-a6f2-151e862ee1c5"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "711991f3-b2e2-49b5-967d-e013c73723cf"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6ed4255-5e48-4f03-bc34-fe0dca6d1ee5",
+        "apim-request-id": "4aa2bc69-079f-4091-8476-2b9fc8360f66",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1daa7843-f91b-4e9f-9661-a53e31f6de7f",
-        "lastUpdatedDateTime": "2022-10-15T02:22:54Z",
-        "createdDateTime": "2022-10-15T02:22:53Z",
-        "expirationDateTime": "2022-10-16T02:22:53Z",
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:13:57Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -81,32 +83,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4eed180f-6553-40a4-9e24-ef927afc2183"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d82291fd-5e09-4c12-b242-70146cbcb18d"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d2dbd8e8-5a31-4782-a655-5bfedb5205fa",
+        "apim-request-id": "e17b1c31-7fb6-4576-86ef-197520e7f735",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1daa7843-f91b-4e9f-9661-a53e31f6de7f",
-        "lastUpdatedDateTime": "2022-10-15T02:22:54Z",
-        "createdDateTime": "2022-10-15T02:22:53Z",
-        "expirationDateTime": "2022-10-16T02:22:53Z",
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:13:57Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -119,32 +122,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2c5f3a64-d87c-4584-9ef7-540bae4418d8"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "57369392-4206-4f5e-baaf-3a33168ca218"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "002962f4-e3d8-4670-b19b-f49f3f7e0160",
+        "apim-request-id": "45e730e5-2dab-4fb4-a7ff-5c146b0d3c76",
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:55 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1daa7843-f91b-4e9f-9661-a53e31f6de7f",
-        "lastUpdatedDateTime": "2022-10-15T02:22:54Z",
-        "createdDateTime": "2022-10-15T02:22:53Z",
-        "expirationDateTime": "2022-10-16T02:22:53Z",
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:13:57Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -157,32 +161,111 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c04ab9d4-7600-4f29-8106-f6fb68af79db"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2695d4f4-6fd8-4a9a-92b2-6d858b564808"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "107d1b73-d070-4ce0-b47e-6e4d248d62be",
-        "Content-Length": "654",
+        "apim-request-id": "8f5c8885-a32d-48a9-8cd1-98fb49017bf0",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1daa7843-f91b-4e9f-9661-a53e31f6de7f",
-        "lastUpdatedDateTime": "2022-10-15T02:22:57Z",
-        "createdDateTime": "2022-10-15T02:22:53Z",
-        "expirationDateTime": "2022-10-16T02:22:53Z",
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:13:57Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6ce7e4b0-f8fd-4b41-a634-e5b4d1be656e"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5f4de8cd-b77d-4d29-8ae8-aad2bd2f2618",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:13:57Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1,
+          "items": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Ocp-Apim-Subscription-Key": "api_key",
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "8aefc79f-93f5-4e46-b5c0-7298d64cc7e3"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b84618bd-b5c7-4ccf-a78a-b875fb4e8f89",
+        "Content-Length": "654",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 24 Oct 2022 05:14:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "25",
+        "x-ms-region": "West US 2"
+      },
+      "ResponseBody": {
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:14:03Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -193,7 +276,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:57.9803159Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:03.5853655Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -218,32 +301,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/1daa7843-f91b-4e9f-9661-a53e31f6de7f?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/f03cf496-3509-427d-90cd-8e445fcce404?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "d84da3a1-2a34-4dce-a113-0c6053cee4c6"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "87163985-cf65-4b01-b4f5-cca13b08eaf9"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab63477f-ae5b-41b7-a27d-e183f693549c",
+        "apim-request-id": "dd81ce28-8e34-4ded-9d8a-908096eb0973",
         "Content-Length": "654",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "1daa7843-f91b-4e9f-9661-a53e31f6de7f",
-        "lastUpdatedDateTime": "2022-10-15T02:22:57Z",
-        "createdDateTime": "2022-10-15T02:22:53Z",
-        "expirationDateTime": "2022-10-16T02:22:53Z",
+        "jobId": "f03cf496-3509-427d-90cd-8e445fcce404",
+        "lastUpdatedDateTime": "2022-10-24T05:14:03Z",
+        "createdDateTime": "2022-10-24T05:13:57Z",
+        "expirationDateTime": "2022-10-25T05:13:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -254,7 +338,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:22:57.9803159Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:03.5853655Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_duplicate_actions_of_the_same_type_are_disallowed.json
@@ -10,8 +10,8 @@
         "Content-Length": "198",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "13a8a151-b309-4273-b632-5fc068a3660e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e665ba22-9e49-46c8-99d0-c4a424a300f9"
       },
       "RequestBody": {
         "analysisInput": {
@@ -36,13 +36,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "f65e6566-832b-425c-b205-18d20fdd0667",
+        "apim-request-id": "d5608916-069c-49c3-bb12-4b026c503194",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_malformed_action.json
@@ -10,8 +10,8 @@
         "Content-Length": "170",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1a33e121-48f5-4bd7-a7c2-4f1d5d9bb216"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2473a09a-911a-4416-aee6-2b8060e122ea"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,13 +34,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "df68207c-da12-4266-afd5-c0939ad3725b",
+        "apim-request-id": "fab87748-66f3-459d-b131-58f2c646e95e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_payload_too_large.json
@@ -10,8 +10,8 @@
         "Content-Length": "710471",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "04f7b324-f192-4efd-bef2-564f2e1169dc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "3bd9cfa8-4757-493c-a066-7b452af27f1c"
       },
       "RequestBody": {
         "analysisInput": {
@@ -2527,13 +2527,14 @@
       },
       "StatusCode": 413,
       "ResponseHeaders": {
-        "apim-request-id": "3af9d6b3-012f-469e-84e3-14c0fa46954e",
+        "apim-request-id": "c1b3569b-1f98-4155-b8f6-c6a89ee9640a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:53 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "20",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_errors_and_warnings/recording_too_many_documents.json
@@ -10,181 +10,8 @@
         "Content-Length": "1345",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5bf5edb5-ae02-4485-a0a2-f34547f971c9"
-      },
-      "RequestBody": {
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "0",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "1",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "3",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "4",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "5",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "6",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "7",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "8",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "9",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "10",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "11",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "12",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "13",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "14",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "15",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "16",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "17",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "18",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "19",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "20",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "21",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "22",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "23",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "24",
-              "text": "random text",
-              "language": "en"
-            },
-            {
-              "id": "25",
-              "text": "random text",
-              "language": "en"
-            }
-          ]
-        },
-        "tasks": [
-          {
-            "kind": "Healthcare",
-            "parameters": {}
-          }
-        ]
-      },
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "721c190d-39a7-40db-965d-c0d72a773cf0",
-        "Content-Length": "330",
-        "Content-Type": "application/json",
-        "Date": "Sat, 15 Oct 2022 02:22:51 GMT",
-        "policy-id": "ResourceRateLimitBy1s",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the Submit text analysis job Operation under Microsoft Cognitive Language Service have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs?api-version=2022-05-01",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip,deflate",
-        "Connection": "keep-alive",
-        "Content-Length": "1345",
-        "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5bf5edb5-ae02-4485-a0a2-f34547f971c9"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "38f68814-3786-48a9-9736-69a379325495"
       },
       "RequestBody": {
         "analysisInput": {
@@ -330,13 +157,14 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "95c10acf-5f25-43ed-ac26-cc90a3bddcee",
+        "apim-request-id": "d6090bb0-c3b8-433e-9d98-0c6908c9bafe",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:52 GMT",
+        "Date": "Mon, 24 Oct 2022 05:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "5",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
         "error": {

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "de52455f-8257-4c4d-bf74-39813a97c6e7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "0b8abfc3-b8b9-4ca8-807e-44b993a564e3"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,43 +34,45 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "39536d91-6f3e-4b82-b8b9-756b88c1598e",
+        "apim-request-id": "88b47c9b-9181-4920-9b0d-c98815d6b9fe",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:22:57 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/f1730818-3957-4614-a0b0-e3e06c0392df?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:05 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/95943764-9a44-4fab-9cbc-4d2312e0e0fa?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "91"
+        "x-envoy-upstream-service-time": "135",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f1730818-3957-4614-a0b0-e3e06c0392df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/95943764-9a44-4fab-9cbc-4d2312e0e0fa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "48e67cd9-0c29-4591-b031-4200e0b18abe"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "60124e4e-2613-49f4-be54-6df6863bdf0a"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b6ae66b-c73f-4906-9ccf-0ac01a553fca",
+        "apim-request-id": "6e65275c-cb15-404e-8841-df0939d0f987",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "8",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f1730818-3957-4614-a0b0-e3e06c0392df",
-        "lastUpdatedDateTime": "2022-10-15T02:22:58Z",
-        "createdDateTime": "2022-10-15T02:22:58Z",
-        "expirationDateTime": "2022-10-16T02:22:58Z",
+        "jobId": "95943764-9a44-4fab-9cbc-4d2312e0e0fa",
+        "lastUpdatedDateTime": "2022-10-24T05:14:05Z",
+        "createdDateTime": "2022-10-24T05:14:05Z",
+        "expirationDateTime": "2022-10-25T05:14:05Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -83,32 +85,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f1730818-3957-4614-a0b0-e3e06c0392df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/95943764-9a44-4fab-9cbc-4d2312e0e0fa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7cd041ae-a22b-4dd9-bdf1-ebaeca28ac1d"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "e2e5deff-a95c-409c-b78b-e84624537c9c"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aaa8f568-210d-473d-a891-8175929e594f",
+        "apim-request-id": "904f0ad6-527b-4309-8fc5-1598ec533532",
         "Content-Length": "283",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:22:57 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f1730818-3957-4614-a0b0-e3e06c0392df",
-        "lastUpdatedDateTime": "2022-10-15T02:22:58Z",
-        "createdDateTime": "2022-10-15T02:22:58Z",
-        "expirationDateTime": "2022-10-16T02:22:58Z",
+        "jobId": "95943764-9a44-4fab-9cbc-4d2312e0e0fa",
+        "lastUpdatedDateTime": "2022-10-24T05:14:05Z",
+        "createdDateTime": "2022-10-24T05:14:05Z",
+        "expirationDateTime": "2022-10-25T05:14:05Z",
         "status": "notStarted",
         "errors": [],
         "tasks": {
@@ -121,32 +124,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f1730818-3957-4614-a0b0-e3e06c0392df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/95943764-9a44-4fab-9cbc-4d2312e0e0fa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "191cd331-c16c-4885-a947-6e08d36bb53a"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "708c5c66-9bc1-44bc-91ac-6889cd6e0cb1"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c23ab32-2000-4b3f-80a4-c39beac6157f",
+        "apim-request-id": "be7fcb27-a0e1-4ba8-a61d-efd8610e9947",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "x-envoy-upstream-service-time": "40",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f1730818-3957-4614-a0b0-e3e06c0392df",
-        "lastUpdatedDateTime": "2022-10-15T02:23:00Z",
-        "createdDateTime": "2022-10-15T02:22:58Z",
-        "expirationDateTime": "2022-10-16T02:22:58Z",
+        "jobId": "95943764-9a44-4fab-9cbc-4d2312e0e0fa",
+        "lastUpdatedDateTime": "2022-10-24T05:14:07Z",
+        "createdDateTime": "2022-10-24T05:14:05Z",
+        "expirationDateTime": "2022-10-25T05:14:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +161,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:00.2349592Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:07.3485675Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -185,32 +189,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/f1730818-3957-4614-a0b0-e3e06c0392df?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/95943764-9a44-4fab-9cbc-4d2312e0e0fa?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "595f91c3-1089-4a19-be21-87b64d6487c7"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "6755bf74-f77a-499c-a3bc-70dbdefa96a4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0842da7-cfba-4d34-8304-3075dac54868",
+        "apim-request-id": "a380efd0-b53a-4161-8f97-2ff0530b64fe",
         "Content-Length": "682",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "f1730818-3957-4614-a0b0-e3e06c0392df",
-        "lastUpdatedDateTime": "2022-10-15T02:23:00Z",
-        "createdDateTime": "2022-10-15T02:22:58Z",
-        "expirationDateTime": "2022-10-16T02:22:58Z",
+        "jobId": "95943764-9a44-4fab-9cbc-4d2312e0e0fa",
+        "lastUpdatedDateTime": "2022-10-24T05:14:07Z",
+        "createdDateTime": "2022-10-24T05:14:05Z",
+        "expirationDateTime": "2022-10-25T05:14:05Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -221,7 +226,7 @@
           "items": [
             {
               "kind": "PiiEntityRecognitionLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:00.2349592Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:07.3485675Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_unicodecodepoint.json
@@ -10,8 +10,8 @@
         "Content-Length": "205",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f186852b-ecf0-4a09-9844-2b11a307e176"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "49b7b708-618e-410e-9622-42c6c058b680"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,44 +34,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a8709168-6952-42cb-ae72-7682284aea7e",
+        "apim-request-id": "6465a741-87ea-488b-803c-da6b93ec5792",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:02 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/ad8d6b1e-794b-496d-b29b-b4bbfe820e49?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:10 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/8616cf41-63d1-40fe-bc59-b1fa4e323d80?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "85"
+        "x-envoy-upstream-service-time": "176",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ad8d6b1e-794b-496d-b29b-b4bbfe820e49?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8616cf41-63d1-40fe-bc59-b1fa4e323d80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "edd5d5ee-326d-477c-abaf-4fcb4c1c0382"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "7e21f5c2-66e6-4b71-94a0-507a822723cf"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d08e4d26-f1e7-42c6-807f-9ddb71a788fa",
-        "Content-Length": "283",
+        "apim-request-id": "43fe151d-9851-4009-8aa3-69e7b862b6fe",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ad8d6b1e-794b-496d-b29b-b4bbfe820e49",
-        "lastUpdatedDateTime": "2022-10-15T02:23:03Z",
-        "createdDateTime": "2022-10-15T02:23:03Z",
-        "expirationDateTime": "2022-10-16T02:23:03Z",
-        "status": "notStarted",
+        "jobId": "8616cf41-63d1-40fe-bc59-b1fa4e323d80",
+        "lastUpdatedDateTime": "2022-10-24T05:14:10Z",
+        "createdDateTime": "2022-10-24T05:14:10Z",
+        "expirationDateTime": "2022-10-25T05:14:10Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -83,33 +85,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ad8d6b1e-794b-496d-b29b-b4bbfe820e49?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8616cf41-63d1-40fe-bc59-b1fa4e323d80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c6da2f0b-5488-424b-b2b0-87394df1cafc"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b76ed13f-522c-41e7-b824-1a968e7a4118"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ddcc4ec2-2362-4dd9-8f0c-99495c9e3c0a",
-        "Content-Length": "283",
+        "apim-request-id": "e711f3b3-d4c7-4e2b-a29e-de624bb04856",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "6",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ad8d6b1e-794b-496d-b29b-b4bbfe820e49",
-        "lastUpdatedDateTime": "2022-10-15T02:23:03Z",
-        "createdDateTime": "2022-10-15T02:23:03Z",
-        "expirationDateTime": "2022-10-16T02:23:03Z",
-        "status": "notStarted",
+        "jobId": "8616cf41-63d1-40fe-bc59-b1fa4e323d80",
+        "lastUpdatedDateTime": "2022-10-24T05:14:10Z",
+        "createdDateTime": "2022-10-24T05:14:10Z",
+        "expirationDateTime": "2022-10-25T05:14:10Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -121,32 +124,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ad8d6b1e-794b-496d-b29b-b4bbfe820e49?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8616cf41-63d1-40fe-bc59-b1fa4e323d80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6a9e435f-d1e4-4979-bc8c-5579aa57ca2e"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b7b8496c-2c8c-42db-ab09-34f99dd6ea08"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "32ceb06d-a2f1-4fd5-b55e-7ff3ba774838",
+        "apim-request-id": "7cea5a0c-5b65-4d98-a139-6c0c8df3b085",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ad8d6b1e-794b-496d-b29b-b4bbfe820e49",
-        "lastUpdatedDateTime": "2022-10-15T02:23:04Z",
-        "createdDateTime": "2022-10-15T02:23:03Z",
-        "expirationDateTime": "2022-10-16T02:23:03Z",
+        "jobId": "8616cf41-63d1-40fe-bc59-b1fa4e323d80",
+        "lastUpdatedDateTime": "2022-10-24T05:14:11Z",
+        "createdDateTime": "2022-10-24T05:14:10Z",
+        "expirationDateTime": "2022-10-25T05:14:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +161,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:04.8832895Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:11.9746054Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -308,32 +312,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/ad8d6b1e-794b-496d-b29b-b4bbfe820e49?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/8616cf41-63d1-40fe-bc59-b1fa4e323d80?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a5106cec-66cb-405a-832d-41b3d4f10cbd"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "2be6a7e1-21dd-4a54-9f87-43dc9eb695f4"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc6d7fa5-196c-494b-888a-0bc7ea1cbbdf",
+        "apim-request-id": "647e1f51-bd36-4b2d-ae6a-357dd93324b1",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:05 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "28",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "ad8d6b1e-794b-496d-b29b-b4bbfe820e49",
-        "lastUpdatedDateTime": "2022-10-15T02:23:04Z",
-        "createdDateTime": "2022-10-15T02:23:03Z",
-        "expirationDateTime": "2022-10-16T02:23:03Z",
+        "jobId": "8616cf41-63d1-40fe-bc59-b1fa4e323d80",
+        "lastUpdatedDateTime": "2022-10-24T05:14:11Z",
+        "createdDateTime": "2022-10-24T05:14:10Z",
+        "expirationDateTime": "2022-10-25T05:14:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +349,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:04.8832895Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:11.9746054Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyzebatch_general_behavior_stringindextype/recording_family_emoji_wit_skin_tone_modifier_with_utf16codeunit.json
@@ -10,8 +10,8 @@
         "Content-Length": "202",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "7629e3bc-a816-4dbe-b8b0-c252296555db"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "1f726050-73c9-438f-80bd-e3343967f1da"
       },
       "RequestBody": {
         "analysisInput": {
@@ -34,44 +34,46 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "06dfd1bb-8e1b-4c49-815d-e674b7d71db1",
+        "apim-request-id": "4262e971-b716-4fd7-83d1-c5b7f47f80eb",
         "Content-Length": "0",
-        "Date": "Sat, 15 Oct 2022 02:23:00 GMT",
-        "operation-location": "https://endpoint/language/analyze-text/jobs/182e9f89-5675-45f5-96ff-155825ddf63b?api-version=2022-05-01",
+        "Date": "Mon, 24 Oct 2022 05:14:07 GMT",
+        "operation-location": "https://endpoint/language/analyze-text/jobs/027e0f35-af61-4e07-b163-bf7406688370?api-version=2022-05-01",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "82"
+        "x-envoy-upstream-service-time": "147",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/182e9f89-5675-45f5-96ff-155825ddf63b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/027e0f35-af61-4e07-b163-bf7406688370?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "646319a4-3d98-4f20-a368-27ee76a27e17"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d998fad8-8d71-432e-a80c-6dd06fea14ca"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a208a8ef-b6db-4722-a8b4-1df0a1a79e61",
-        "Content-Length": "283",
+        "apim-request-id": "04cb44f8-b439-447e-9573-a13d75d98ded",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "30",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "182e9f89-5675-45f5-96ff-155825ddf63b",
-        "lastUpdatedDateTime": "2022-10-15T02:23:00Z",
-        "createdDateTime": "2022-10-15T02:23:00Z",
-        "expirationDateTime": "2022-10-16T02:23:00Z",
-        "status": "notStarted",
+        "jobId": "027e0f35-af61-4e07-b163-bf7406688370",
+        "lastUpdatedDateTime": "2022-10-24T05:14:08Z",
+        "createdDateTime": "2022-10-24T05:14:07Z",
+        "expirationDateTime": "2022-10-25T05:14:07Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -83,33 +85,34 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/182e9f89-5675-45f5-96ff-155825ddf63b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/027e0f35-af61-4e07-b163-bf7406688370?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "59eb8406-2950-4667-9a1e-47a59b0d3713"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "d8c68bc8-d70e-415c-b965-b592820c0d62"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "11ac075a-f14d-46dd-9d74-164d7eceacbe",
-        "Content-Length": "283",
+        "apim-request-id": "b0ead659-5beb-4799-85bd-828302ca8dd2",
+        "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:00 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "7",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "182e9f89-5675-45f5-96ff-155825ddf63b",
-        "lastUpdatedDateTime": "2022-10-15T02:23:00Z",
-        "createdDateTime": "2022-10-15T02:23:00Z",
-        "expirationDateTime": "2022-10-16T02:23:00Z",
-        "status": "notStarted",
+        "jobId": "027e0f35-af61-4e07-b163-bf7406688370",
+        "lastUpdatedDateTime": "2022-10-24T05:14:08Z",
+        "createdDateTime": "2022-10-24T05:14:07Z",
+        "expirationDateTime": "2022-10-25T05:14:07Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -121,32 +124,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/182e9f89-5675-45f5-96ff-155825ddf63b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/027e0f35-af61-4e07-b163-bf7406688370?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ffec38ef-ef76-4167-b74d-53012c853050"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "29dc8301-ac66-4323-835d-cdf13f7be4eb"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10dc5eb9-5359-4993-a9b7-8113d14a5e6b",
+        "apim-request-id": "a5be2eb9-8ef5-490e-a714-cf9e531a9b23",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "23",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "182e9f89-5675-45f5-96ff-155825ddf63b",
-        "lastUpdatedDateTime": "2022-10-15T02:23:02Z",
-        "createdDateTime": "2022-10-15T02:23:00Z",
-        "expirationDateTime": "2022-10-16T02:23:00Z",
+        "jobId": "027e0f35-af61-4e07-b163-bf7406688370",
+        "lastUpdatedDateTime": "2022-10-24T05:14:09Z",
+        "createdDateTime": "2022-10-24T05:14:07Z",
+        "expirationDateTime": "2022-10-25T05:14:07Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -157,7 +161,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:02.4821625Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:09.6197315Z",
               "status": "succeeded",
               "results": {
                 "documents": [
@@ -308,32 +312,33 @@
       }
     },
     {
-      "RequestUri": "https://endpoint/language/analyze-text/jobs/182e9f89-5675-45f5-96ff-155825ddf63b?api-version=2022-05-01",
+      "RequestUri": "https://endpoint/language/analyze-text/jobs/027e0f35-af61-4e07-b163-bf7406688370?api-version=2022-05-01",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.9.3 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c91acce7-3f0c-4610-9a13-3dce224dc0a2"
+        "User-Agent": "azsdk-js-ai-language-text/1.0.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a85ed888-f2bb-4e2b-94a4-649497a78902"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8a09ac76-7391-41e2-95fe-e61ef843690c",
+        "apim-request-id": "ddbc54cf-8f1c-4b8f-97dd-886e9768e845",
         "Content-Length": "1788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Oct 2022 02:23:02 GMT",
+        "Date": "Mon, 24 Oct 2022 05:14:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "West US 2"
       },
       "ResponseBody": {
-        "jobId": "182e9f89-5675-45f5-96ff-155825ddf63b",
-        "lastUpdatedDateTime": "2022-10-15T02:23:02Z",
-        "createdDateTime": "2022-10-15T02:23:00Z",
-        "expirationDateTime": "2022-10-16T02:23:00Z",
+        "jobId": "027e0f35-af61-4e07-b163-bf7406688370",
+        "lastUpdatedDateTime": "2022-10-24T05:14:09Z",
+        "createdDateTime": "2022-10-24T05:14:07Z",
+        "expirationDateTime": "2022-10-25T05:14:07Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -344,7 +349,7 @@
           "items": [
             {
               "kind": "HealthcareLROResults",
-              "lastUpdateDateTime": "2022-10-15T02:23:02.4821625Z",
+              "lastUpdateDateTime": "2022-10-24T05:14:09.6197315Z",
               "status": "succeeded",
               "results": {
                 "documents": [

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -7,18 +7,49 @@ import {
   KnownPiiEntityDomain,
   KnownStringIndexType,
   KnownTextAnalysisErrorCode,
-  LanguageDetectionInput,
-  Opinion,
-  SentenceSentiment,
   TextAnalysisClient,
-  TextDocumentInput,
 } from "../../src";
 import { AuthMethod, createClient, startRecorder } from "./utils/recordedClient";
 import { Context, Suite } from "mocha";
 import { assert, matrix } from "@azure/test-utils";
-import { assertAllSuccess, assertRestError, getSuccRes, isSuccess } from "./utils/resultHelper";
+import { assertActionResults, assertRestError } from "./utils/resultHelper";
 import { checkEntityTextOffset, checkOffsetAndLength } from "./utils/stringIndexTypeHelpers";
 import { Recorder } from "@azure-tools/test-recorder";
+import {
+  expectation30,
+  expectation31,
+  expectation32,
+  expectation33,
+  expectation34,
+  expectation35,
+  expectation36,
+  expectation37,
+  expectation38,
+  expectation39,
+  expectation40,
+  expectation41,
+  expectation42,
+  expectation43,
+  expectation44,
+  expectation45,
+  expectation46,
+  expectation47,
+  expectation48,
+  expectation49,
+  expectation50,
+  expectation51,
+  expectation52,
+  expectation53,
+  expectation54,
+  expectation55,
+  expectation56,
+  expectation57,
+  expectation58,
+  expectation59,
+  expectation60,
+  expectation61,
+  expectation62,
+} from "./expectations";
 
 const testDataEn = [
   "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
@@ -59,42 +90,39 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
     describe("analyze", function () {
       describe("#SentimentAnalysis", function () {
         it("client throws on empty list", async function () {
-          return assert.isRejected(
+          await assert.isRejected(
             client.analyze(AnalyzeActionNames.SentimentAnalysis, []),
             /non-empty array/
           );
         });
 
         it("client accepts string[] and language", async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.SentimentAnalysis,
-            testDataEn,
-            "en"
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, testDataEn, "en"),
+            expectation30
           );
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
         });
 
         it("client accepts string[] with no language", async function () {
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, testDataEn),
+            expectation30
+          );
         });
 
         it("service returns error for invalid language", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.SentimentAnalysis,
-            ["Hello world!"],
-            "notalanguage"
+          assertActionResults(
+            await client.analyze(
+              AnalyzeActionNames.SentimentAnalysis,
+              ["Hello world!"],
+              "notalanguage"
+            ),
+            expectation31
           );
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service.");
-          }
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.UnsupportedLanguageCode);
         });
 
         it("service has a bug when referencing assessments in doc #6 or greater", async function () {
-          const documents = [
+          const docs = [
             "The food was unacceptable",
             "The rooms were beautiful. The AC was good and quiet.",
             "The breakfast was good, but the toilet was smelly.",
@@ -103,360 +131,204 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
             "The toilet smelled.",
           ];
-          const results = await client.analyze(
-            AnalyzeActionNames.SentimentAnalysis,
-            documents,
-            "en",
-            {
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, docs, "en", {
               includeOpinionMining: true,
-            }
+            }),
+            expectation32
           );
-          const result1 = getSuccRes(results[0]);
-          const result6 = getSuccRes(results[5]);
-          const result7 = getSuccRes(results[6]);
-          const Assessment1 = result1.sentences[0].opinions[0].assessments[0];
-          const Assessment2 = result6.sentences[0].opinions[0].assessments[0];
-          assert.notDeepEqual(Assessment1, Assessment2);
-
-          const listAllAssessments = (acc: string[], sentence: SentenceSentiment): string[] =>
-            acc.concat(
-              sentence.opinions.reduce(
-                (assessments: string[], opinion: Opinion) =>
-                  assessments.concat(opinion.assessments.map((assessment) => assessment.text)),
-                []
-              )
-            );
-          const allAssessments1 = result1.sentences.reduce(listAllAssessments, []);
-          assert.deepEqual(allAssessments1, ["unacceptable"]);
-          const allAssessments2 = result6.sentences.reduce(listAllAssessments, []);
-          assert.deepEqual(allAssessments2, ["Nice", "old", "dirty"]);
-          const allAssessments7 = result7.sentences.reduce(listAllAssessments, []);
-          assert.deepEqual(allAssessments7, ["smelled"]);
         });
 
         it("service returns an error for an empty document", async function () {
           const data = [...testDataEn];
           data.splice(1, 0, "");
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, data);
-          const errorResult = results[1];
-          if (errorResult.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-          assert.equal(
-            results.filter((result) => result.error === undefined).length,
-            testDataEn.length
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, data),
+            expectation33
           );
-          assert.equal(errorResult.error.code, KnownTextAnalysisErrorCode.InvalidDocument);
         });
 
         it("client accepts TextDocumentInput[]", async function () {
-          const enInputs = testDataEn.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              language: "en",
-              text,
-            })
-          );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              language: "es",
-              text,
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, allInputs);
-          assert.equal(results.length, testDataEn.length + testDataEs.length);
-          assertAllSuccess(results);
-          results.map((result) =>
-            getSuccRes(result).sentences.map((sentence) => assert.isEmpty(sentence.opinions))
+          const enDocs = testDataEn.map((text) => ({
+            id: getId(),
+            language: "en",
+            text,
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            language: "es",
+            text,
+          }));
+          const docs = enDocs.concat(esDocs);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, docs),
+            expectation34
           );
         });
 
         it("client gets positive mined assessments", async function () {
-          const documents = [
-            {
-              text: "It has a sleek premium aluminum design that makes it beautiful to look at.",
-              id: "0",
-              language: "en",
-            },
+          const docs = [
+            "It has a sleek premium aluminum design that makes it beautiful to look at.",
           ];
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, documents, {
-            includeOpinionMining: true,
-          });
-          assert.equal(results.length, 1);
-          assertAllSuccess(results);
-          const documentSentiment = getSuccRes(results[0]);
-          documentSentiment.sentences.map((sentence) =>
-            sentence.opinions.map((opinion) => {
-              const Target = opinion.target;
-              assert.equal(Target.text, "design");
-              assert.equal(Target.sentiment, "positive");
-              assert.isAtLeast(Target.confidenceScores.positive, 0);
-              assert.isAtLeast(Target.confidenceScores.negative, 0);
-              assert.equal(Target.offset, 32);
-              assert.equal(Target.length, 6);
-              assert.equal(Target.text.length, Target.length);
-
-              const sleekAssessment = opinion.assessments[0];
-              assert.equal(sleekAssessment.text, "sleek");
-              assert.equal(sleekAssessment.sentiment, "positive");
-              assert.isAtLeast(sleekAssessment.confidenceScores.positive, 0);
-              assert.isAtLeast(sleekAssessment.confidenceScores.negative, 0);
-              assert.isFalse(sleekAssessment.isNegated);
-              assert.equal(sleekAssessment.offset, 9);
-              assert.equal(sleekAssessment.length, 5);
-              assert.equal(sleekAssessment.text.length, sleekAssessment.length);
-
-              const beautifulAssessment = opinion.assessments[1];
-              assert.equal(beautifulAssessment.text, "beautiful");
-              assert.equal(beautifulAssessment.sentiment, "positive");
-              assert.isAtLeast(beautifulAssessment.confidenceScores.positive, 0);
-              assert.isAtLeast(beautifulAssessment.confidenceScores.negative, 0);
-              assert.isFalse(beautifulAssessment.isNegated);
-              assert.equal(beautifulAssessment.offset, 53);
-              assert.equal(beautifulAssessment.length, 9);
-              assert.equal(beautifulAssessment.text.length, beautifulAssessment.length);
-            })
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, docs, "en", {
+              includeOpinionMining: true,
+            }),
+            expectation35
           );
         });
 
-        /** TODO, unskip when the service fix the bug */
-        it.skip("client gets negative mined assessments", async function () {
-          const documents = [
-            {
-              text: "The food and service are not good",
-              id: "0",
-              language: "en",
-            },
-          ];
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, documents, {
-            includeOpinionMining: true,
-          });
-          assert.equal(results.length, 1);
-          assertAllSuccess(results);
-          const documentSentiment = getSuccRes(results[0]);
-          documentSentiment.sentences.map((sentence) => {
-            const foodTarget = sentence.opinions[0].target;
-            assert.equal(foodTarget.text, "food");
-            assert.equal(foodTarget.sentiment, "negative");
-
-            const foodTargetPositiveScore = foodTarget.confidenceScores.positive;
-            const foodTargetNegativeScore = foodTarget.confidenceScores.negative;
-
-            assert.isAtLeast(foodTargetPositiveScore, 0);
-            assert.isAtLeast(foodTargetNegativeScore, 0);
-            assert.equal(foodTargetPositiveScore + foodTargetNegativeScore, 1);
-
-            const serviceTarget = sentence.opinions[1].target;
-            assert.equal(serviceTarget.text, "service");
-            assert.equal(serviceTarget.sentiment, "negative");
-
-            const serviceTargetPositiveScore = serviceTarget.confidenceScores.positive;
-            const serviceTargetNegativeScore = serviceTarget.confidenceScores.negative;
-
-            assert.isAtLeast(serviceTargetPositiveScore, 0);
-            assert.isAtLeast(serviceTargetNegativeScore, 0);
-            assert.equal(serviceTargetPositiveScore + serviceTargetNegativeScore, 1);
-
-            const foodAssessment = sentence.opinions[0].assessments[0];
-            const serviceAssessment = sentence.opinions[1].assessments[0];
-
-            assert.deepEqual(foodAssessment, serviceAssessment);
-
-            assert.equal(foodAssessment.text, "good");
-            assert.equal(foodAssessment.sentiment, "negative");
-
-            const foodAssessmentPositiveScore = foodAssessment.confidenceScores.positive;
-            const foodAssessmentNegativeScore = foodAssessment.confidenceScores.negative;
-
-            assert.isAtLeast(foodAssessmentPositiveScore, 0);
-            assert.isAtLeast(foodAssessmentNegativeScore, 0);
-            assert.equal(foodAssessmentPositiveScore + foodAssessmentNegativeScore, 1);
-            assert.isTrue(foodAssessment.isNegated);
-          });
+        it("client gets negative mined assessments", async function () {
+          const docs = ["The food and service are not good"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, docs, "en", {
+              includeOpinionMining: true,
+            }),
+            expectation36
+          );
         });
 
         it("client gets no mined assessments", async function () {
-          const documents = [
-            {
-              text: "today is a hot day",
-              id: "0",
-              language: "en",
-            },
-          ];
-          const results = await client.analyze(AnalyzeActionNames.SentimentAnalysis, documents, {
-            includeOpinionMining: true,
-          });
-          assert.equal(results.length, 1);
-          assertAllSuccess(results);
-          const documentSentiment = getSuccRes(results[0]);
-          assert.isEmpty(documentSentiment.sentences[0].opinions);
+          const docs = ["today is a hot day"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.SentimentAnalysis, docs, "en", {
+              includeOpinionMining: true,
+            }),
+            expectation37
+          );
         });
       });
 
       describe("#LanguageDetection", function () {
         it("client throws on empty list", async function () {
-          return assert.isRejected(
+          await assert.isRejected(
             client.analyze(AnalyzeActionNames.LanguageDetection, []),
             /non-empty array/
           );
         });
 
         it("client accepts no countryHint", async function () {
-          const results = await client.analyze(AnalyzeActionNames.LanguageDetection, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, testDataEn),
+            expectation38
+          );
         });
 
         it("client accepts a countryHint", async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.LanguageDetection,
-            ["impossible"],
-            "fr"
+          const docs = ["impossible"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, docs, "fr"),
+            expectation39
           );
-          assert.equal(results.length, 1);
-          assertAllSuccess(results);
         });
 
         it('client accepts "none" country hint with string[] input', async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.LanguageDetection,
-            ["I use Azure Functions to develop my service."],
-            "none"
+          const docs = ["I use Azure Functions to develop my service."];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, docs, "none"),
+            expectation40
           );
-          assert.equal(results.length, 1);
-          assertAllSuccess(results);
-          const result = getSuccRes(results[0]);
-          assert.equal(result.primaryLanguage.iso6391Name, "en");
         });
 
         it('client accepts "none" country hint with DetectLanguageInput[] input', async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.LanguageDetection,
-            testDataEn.concat(testDataEs).map(
-              (input): LanguageDetectionInput => ({
-                id: getId(),
-                countryHint: "none",
-                text: input,
-              })
-            )
+          const docs = testDataEn.concat(testDataEs).map((input) => ({
+            id: getId(),
+            countryHint: "none",
+            text: input,
+          }));
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, docs),
+            expectation41
           );
-          assertAllSuccess(results);
         });
 
         it("service errors on invalid country hint", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.LanguageDetection,
-            ["hello"],
-            "invalidcountry"
+          const docs = ["hello"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, docs, "invalidcountry"),
+            expectation42
           );
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.InvalidCountryHint);
         });
 
         it("client accepts mixed-country DetectLanguageInput[]", async function () {
-          const enInputs = testDataEn.map(
-            (text): LanguageDetectionInput => ({
-              id: getId(),
-              text,
-            })
+          const enDocs = testDataEn.map((text) => ({
+            id: getId(),
+            text,
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            countryHint: "mx",
+            text,
+          }));
+          const docs = enDocs.concat(esDocs);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.LanguageDetection, docs),
+            expectation43
           );
-          const esInputs = testDataEs.map(
-            (text): LanguageDetectionInput => ({
-              id: getId(),
-              countryHint: "mx",
-              text,
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-
-          const results = await client.analyze(AnalyzeActionNames.LanguageDetection, allInputs);
-          assert.equal(results.length, testDataEn.length + testDataEs.length);
-          assertAllSuccess(results);
         });
       });
 
       describe("#EntityRecognition", function () {
         it("client throws on empty list", async function () {
-          return assert.isRejected(
+          await assert.isRejected(
             client.analyze(AnalyzeActionNames.EntityRecognition, []),
             /non-empty array/
           );
         });
 
         it("client accepts string[] with no language", async function () {
-          const results = await client.analyze(AnalyzeActionNames.EntityRecognition, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityRecognition, testDataEn),
+            expectation44
+          );
         });
 
         it("client accepts string[] with a language specified", async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.EntityRecognition,
-            testDataEn,
-            "en"
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityRecognition, testDataEn, "en"),
+            expectation45
           );
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
         });
 
         it("service errors on unsupported language", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.EntityRecognition,
-            ["This is some text, but it doesn't matter."],
-            "notalanguage"
+          const docs = ["This is some text, but it doesn't matter."];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityRecognition, docs, "notalanguage"),
+            expectation46
           );
-
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.UnsupportedLanguageCode);
         });
 
         it("client accepts mixed-language TextDocumentInput[]", async function () {
-          const enInputs = testDataEn.slice(0, -1).map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
+          const enDocs = testDataEn.slice(0, -1).map((text) => ({
+            id: getId(),
+            text,
+            language: "en",
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            text,
+            language: "es",
+          }));
+          const docs = enDocs.concat(esDocs);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityRecognition, docs),
+            expectation47
           );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-
-          const results = await client.analyze(AnalyzeActionNames.EntityRecognition, allInputs);
-          assert.equal(results.length, testDataEn.length - 1 + testDataEs.length);
-          assertAllSuccess(results);
         });
 
         it("client throws exception for too many inputs", async function () {
-          const enInputs = testDataEn.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
-          );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-          await assertRestError(client.analyze(AnalyzeActionNames.EntityRecognition, allInputs), {
+          const enDocs = testDataEn.map((text) => ({
+            id: getId(),
+            text,
+            language: "en",
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            text,
+            language: "es",
+          }));
+          const docs = enDocs.concat(esDocs);
+          await assertRestError(client.analyze(AnalyzeActionNames.EntityRecognition, docs), {
             code: KnownTextAnalysisErrorCode.InvalidDocumentBatch,
             statusCode: 400,
             messagePattern: /Max 5 records are permitted/,
@@ -466,205 +338,141 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
 
       describe("#KeyPhraseExtraction", function () {
         it("client throws on empty list", async function () {
-          return assert.isRejected(
+          await assert.isRejected(
             client.analyze(AnalyzeActionNames.KeyPhraseExtraction, []),
             /non-empty array/
           );
         });
 
         it("client accepts string[] with no language", async function () {
-          const results = await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, testDataEn),
+            expectation48
+          );
         });
 
         it("client accepts string[] with a language specified", async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.KeyPhraseExtraction,
-            testDataEn,
-            "en"
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, testDataEn, "en"),
+            expectation49
           );
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
         });
 
         it("service errors on unsupported language", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.KeyPhraseExtraction,
-            ["This is some text, but it doesn't matter."],
-            "notalanguage"
+          const docs = ["This is some text, but it doesn't matter."];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, docs, "notalanguage"),
+            expectation50
           );
-
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.UnsupportedLanguageCode);
         });
 
         it("client accepts mixed-language TextDocumentInput[]", async function () {
-          const enInputs = testDataEn.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
+          const enDocs = testDataEn.map((text) => ({
+            id: getId(),
+            text,
+            language: "en",
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            text,
+            language: "es",
+          }));
+          const docs = enDocs.concat(esDocs);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, docs),
+            expectation51
           );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-
-          const results = await client.analyze(AnalyzeActionNames.KeyPhraseExtraction, allInputs);
-          assert.equal(results.length, testDataEn.length + testDataEs.length);
-          assertAllSuccess(results);
         });
       });
 
       describe("#PiiEntityRecognition", function () {
         it("client throws on empty list", async function () {
-          return assert.isRejected(client.analyze(AnalyzeActionNames.PiiEntityRecognition, []));
+          await assert.isRejected(client.analyze(AnalyzeActionNames.PiiEntityRecognition, []));
         });
 
         it("client accepts string[] with no language", async function () {
-          const results = await client.analyze(AnalyzeActionNames.PiiEntityRecognition, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, testDataEn),
+            expectation52
+          );
         });
 
         it("client accepts string[] with a language specified", async function () {
-          const results = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            testDataEn,
-            "en"
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, testDataEn, "en"),
+            expectation53
           );
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
         });
 
         it("client correctly reports recognition of PII-like pattern", async function () {
           // 078-05-1120 is an invalid social security number due to its use in advertising
           // throughout the late 1930s
-          const fakeSSNDocument = "Your Social Security Number is 859-98-0987.";
-          const [result] = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            [fakeSSNDocument],
-            "en"
+          const docs = ["Your Social Security Number is 859-98-0987."];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs),
+            expectation54
           );
-          assert.equal(getSuccRes(result).entities.length, 1);
         });
 
         it("service errors on unsupported language", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            ["This is some text, but it doesn't matter."],
-            "notalanguage"
+          const docs = ["This is some text, but it doesn't matter."];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs, "notalanguage"),
+            expectation55
           );
-
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.UnsupportedLanguageCode);
         });
 
         it("client accepts mixed-language TextDocumentInput[]", async function () {
           const sliceSize = 3;
-          const enInputs = testDataEn.slice(0, sliceSize).map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
+          const enDocs = testDataEn.slice(0, sliceSize).map((text) => ({
+            id: getId(),
+            text,
+            language: "en",
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            text,
+            language: "es",
+          }));
+          const docs = enDocs.concat(esDocs);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs),
+            expectation56
           );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
-
-          const results = await client.analyze(AnalyzeActionNames.PiiEntityRecognition, allInputs);
-          assert.equal(results.length, sliceSize + testDataEs.length);
-          // TA NER public preview currently supports only english
-          assert.ok(results.slice(0, sliceSize).every(isSuccess));
         });
 
         it("accepts domain filter", async function () {
-          const response = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            [
-              {
-                id: "0",
-                text: "I work at Microsoft and my phone number is 333-333-3333",
-                language: "en",
-              },
-            ],
-            { domainFilter: KnownPiiEntityDomain.Phi }
-          );
-          const result = getSuccRes(response[0]);
-          assert.equal(result.entities.length, 2);
-          assert.equal(result.entities[0].text, "Microsoft");
-          assert.equal(result.entities[0].category, "Organization");
-          assert.equal(result.entities[1].text, "333-333-3333");
-          assert.equal(result.entities[1].category, "PhoneNumber");
-          assert.equal(
-            result.redactedText,
-            "I work at ********* and my phone number is ************"
+          const docs = ["I work at Microsoft and my phone number is 333-333-3333"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs, "en", {
+              domainFilter: KnownPiiEntityDomain.Phi,
+            }),
+            expectation57
           );
         });
 
         it("accepts pii categories", async function () {
-          const response = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            [
-              {
-                id: "0",
-                text: "Patient name is Joe and SSN is 859-98-0987",
-                language: "en",
-              },
-            ],
-            { categoriesFilter: [KnownPiiEntityCategory.USSocialSecurityNumber] }
+          const docs = ["Patient name is Joe and SSN is 859-98-0987"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs, "en", {
+              categoriesFilter: [KnownPiiEntityCategory.USSocialSecurityNumber],
+            }),
+            expectation58
           );
-          const result = getSuccRes(response[0]);
-          assert.equal(result.entities.length, 1);
-          assert.equal(result.entities[0].text, "859-98-0987");
-          assert.equal(result.entities[0].category, KnownPiiEntityCategory.USSocialSecurityNumber);
-          assert.equal(result.redactedText, "Patient name is Joe and SSN is ***********");
         });
 
         it("output pii categories are accepted as input", async function () {
-          const response1 = await client.analyze(AnalyzeActionNames.PiiEntityRecognition, [
-            {
-              id: "0",
-              text: "Patient name is Joe and SSN is 859-98-0987",
-              language: "en",
-            },
-          ]);
-          const result1 = getSuccRes(response1[0]);
-          const entity2 = result1.entities[1];
-          const response2 = await client.analyze(
-            AnalyzeActionNames.PiiEntityRecognition,
-            [
-              {
-                id: "0",
-                text: "Patient name is Joe and SSN is 859-98-0987",
-                language: "en",
-              },
-            ],
-            { categoriesFilter: [entity2.category] }
+          const docs = ["Patient name is Joe and SSN is 859-98-0987"];
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs),
+            expectation59
           );
-          const result2 = getSuccRes(response2[0]);
-          assert.equal(result2.entities.length, 1);
-          assert.equal(result2.entities[0].text, entity2.text);
-          assert.equal(result2.entities[0].category, entity2.category);
-          assert.equal(result2.redactedText, "Patient name is Joe and SSN is ***********");
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.PiiEntityRecognition, docs, "en", {
+              categoriesFilter: [expectation59[0].entities[1].category],
+            }),
+            expectation58
+          );
         });
       });
 
@@ -677,71 +485,63 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
         });
 
         it("client accepts string[] with no language", async function () {
-          const results = await client.analyze(AnalyzeActionNames.EntityLinking, testDataEn);
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityLinking, testDataEn),
+            expectation60
+          );
         });
 
         it("client accepts string[] with a language specified", async function () {
-          const results = await client.analyze(AnalyzeActionNames.EntityLinking, testDataEn, "en");
-          assert.equal(results.length, testDataEn.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityLinking, testDataEn, "en"),
+            expectation60
+          );
         });
 
         it("service errors on unsupported language", async function () {
-          const [result] = await client.analyze(
-            AnalyzeActionNames.EntityLinking,
-            ["This is some text, but it doesn't matter."],
-            "notalanguage"
+          assertActionResults(
+            await client.analyze(
+              AnalyzeActionNames.EntityLinking,
+              ["This is some text, but it doesn't matter."],
+              "notalanguage"
+            ),
+            expectation61
           );
-
-          if (result.error === undefined) {
-            assert.fail("Expected an error from the service");
-          }
-
-          assert.equal(result.error.code, KnownTextAnalysisErrorCode.UnsupportedLanguageCode);
         });
 
         it("client accepts mixed-language TextDocumentInput[]", async function () {
-          const enInputs = testDataEn.slice(0, -1).map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
-          );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
+          const enDocs = testDataEn.slice(2).map((text) => ({
+            id: getId(),
+            language: "en",
+            text,
+          }));
+          const esDocs = testDataEs.slice(2).map((text) => ({
+            id: getId(),
+            language: "es",
+            text,
+          }));
+          const docs = enDocs.concat(esDocs);
 
-          const results = await client.analyze(AnalyzeActionNames.EntityLinking, allInputs);
-          assert.equal(results.length, testDataEn.length - 1 + testDataEs.length);
-          assertAllSuccess(results);
+          assertActionResults(
+            await client.analyze(AnalyzeActionNames.EntityLinking, docs),
+            expectation62
+          );
         });
 
         it("client throws exception for too many inputs", async function () {
-          const enInputs = testDataEn.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "en",
-            })
-          );
-          const esInputs = testDataEs.map(
-            (text): TextDocumentInput => ({
-              id: getId(),
-              text,
-              language: "es",
-            })
-          );
-          const allInputs = enInputs.concat(esInputs);
+          const enDocs = testDataEn.map((text) => ({
+            id: getId(),
+            language: "en",
+            text,
+          }));
+          const esDocs = testDataEs.map((text) => ({
+            id: getId(),
+            language: "es",
+            text,
+          }));
+          const docs = enDocs.concat(esDocs);
 
-          await assertRestError(client.analyze(AnalyzeActionNames.EntityRecognition, allInputs), {
+          await assertRestError(client.analyze(AnalyzeActionNames.EntityRecognition, docs), {
             code: KnownTextAnalysisErrorCode.InvalidDocumentBatch,
             statusCode: 400,
             messagePattern: /Max 5 records are permitted/,

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -13,7 +13,7 @@ import { AuthMethod, createClient, startRecorder } from "./utils/recordedClient"
 import { Context, Suite } from "mocha";
 import { Recorder, assertEnvironmentVariable, isPlaybackMode } from "@azure-tools/test-recorder";
 import { assert, matrix } from "@azure/test-utils";
-import { assertActionResults, assertRestError } from "./utils/resultHelper";
+import { assertActionsResults, assertRestError } from "./utils/resultHelper";
 import {
   expectation1,
   expectation10,
@@ -96,7 +96,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               }
             );
 
-            await assertActionResults(await poller.pollUntilDone(), expectation3);
+            await assertActionsResults(await poller.pollUntilDone(), expectation3);
           });
 
           it("key phrase extraction", async function () {
@@ -124,7 +124,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation5);
+            await assertActionsResults(await poller.pollUntilDone(), expectation5);
           });
 
           it("entity linking", async function () {
@@ -145,7 +145,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation6);
+            await assertActionsResults(await poller.pollUntilDone(), expectation6);
           });
 
           it("pii entity recognition", async function () {
@@ -167,7 +167,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation7);
+            await assertActionsResults(await poller.pollUntilDone(), expectation7);
           });
 
           it("pii entity recognition with filtered categories", async function () {
@@ -189,7 +189,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation8);
+            await assertActionsResults(await poller.pollUntilDone(), expectation8);
           });
 
           it("pii entity recognition with phi domain", async function () {
@@ -211,7 +211,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation24);
+            await assertActionsResults(await poller.pollUntilDone(), expectation24);
           });
 
           it("sentiment analysis with opinion mining", async function () {
@@ -238,7 +238,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation9);
+            await assertActionsResults(await poller.pollUntilDone(), expectation9);
           });
 
           it("healthcare", async function () {
@@ -259,7 +259,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation20);
+            await assertActionsResults(await poller.pollUntilDone(), expectation20);
           });
         });
 
@@ -286,7 +286,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation1);
+            await assertActionsResults(await poller.pollUntilDone(), expectation1);
           });
 
           it("single label classification action", async function () {
@@ -311,7 +311,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation2);
+            await assertActionsResults(await poller.pollUntilDone(), expectation2);
           });
 
           it("multi label classification action", async function () {
@@ -336,7 +336,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation4);
+            await assertActionsResults(await poller.pollUntilDone(), expectation4);
           });
         });
       });
@@ -488,7 +488,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation21, FIXME1);
+            await assertActionsResults(await poller.pollUntilDone(), expectation21, FIXME1);
           });
         });
 
@@ -511,7 +511,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation19);
+          await assertActionsResults(await poller.pollUntilDone(), expectation19);
         });
 
         it("some documents with errors and multiple actions", async function () {
@@ -545,7 +545,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation10, FIXME1);
+          await assertActionsResults(await poller.pollUntilDone(), expectation10, FIXME1);
         });
 
         it("all documents with errors and multiple actions", async function () {
@@ -579,7 +579,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation11);
+          await assertActionsResults(await poller.pollUntilDone(), expectation11);
         });
 
         it("output order is same as the input's one with multiple actions", async function () {
@@ -607,7 +607,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation12);
+          await assertActionsResults(await poller.pollUntilDone(), expectation12);
         });
 
         it("out of order input IDs with multiple actions", async function () {
@@ -635,7 +635,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation13);
+          await assertActionsResults(await poller.pollUntilDone(), expectation13);
         });
 
         it("statistics", async function () {
@@ -705,7 +705,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation14);
+          await assertActionsResults(await poller.pollUntilDone(), expectation14);
         });
 
         it("whole batch with no language hint", async function () {
@@ -732,7 +732,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation14);
+          await assertActionsResults(await poller.pollUntilDone(), expectation14);
         });
 
         it("whole batch input with a language hint", async function () {
@@ -758,7 +758,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation15);
+          await assertActionsResults(await poller.pollUntilDone(), expectation15);
         });
 
         it("invalid language hint", async function () {
@@ -781,7 +781,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation16);
+          await assertActionsResults(await poller.pollUntilDone(), expectation16);
         });
 
         it("paged results with custom page size", async function () {
@@ -803,7 +803,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               updateIntervalInMs: pollingInterval,
             }
           );
-          await assertActionResults(await poller.pollUntilDone(), expectation17, {
+          await assertActionsResults(await poller.pollUntilDone(), expectation17, {
             maxPageSize: 10,
           });
         });
@@ -919,8 +919,8 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           const rehydratedPoller = await client.restoreAnalyzeBatchPoller(serializedState, {
             updateIntervalInMs: pollingInterval,
           });
-          await assertActionResults(await rehydratedPoller.pollUntilDone(), expectation26);
-          await assertActionResults(await originalPoller.pollUntilDone(), expectation26);
+          await assertActionsResults(await rehydratedPoller.pollUntilDone(), expectation26);
+          await assertActionsResults(await originalPoller.pollUntilDone(), expectation26);
         });
 
         describe("stringIndexType", function () {
@@ -939,7 +939,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation18);
+            await assertActionsResults(await poller.pollUntilDone(), expectation18);
           });
 
           it("family emoji wit skin tone modifier with Utf16CodeUnit", async function () {
@@ -957,7 +957,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation22);
+            await assertActionsResults(await poller.pollUntilDone(), expectation22);
           });
 
           it("family emoji wit skin tone modifier with UnicodeCodePoint", async function () {
@@ -975,7 +975,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
                 updateIntervalInMs: pollingInterval,
               }
             );
-            await assertActionResults(await poller.pollUntilDone(), expectation23);
+            await assertActionsResults(await poller.pollUntilDone(), expectation23);
           });
         });
       });

--- a/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
@@ -1,7 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AnalyzeBatchResult } from "../../src/";
+import {
+  AnalyzeBatchResult,
+  EntityLinkingResult,
+  EntityRecognitionResult,
+  KeyPhraseExtractionResult,
+  LanguageDetectionResult,
+  PiiEntityRecognitionResult,
+  PiiEntityRecognitionSuccessResult,
+  SentimentAnalysisResult,
+} from "../../src/";
 
 const modelVersion = undefined as any;
 const completedOn = undefined as any;
@@ -2450,4 +2459,1557 @@ export const expectation26: AnalyzeBatchResult[] = [
     completedOn,
     modelVersion,
   },
+];
+
+export const expectation30: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
+        sentiment: "positive",
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 86,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "Unfortunately, it rained during my entire trip to Seattle. ",
+        sentiment: "negative",
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 59,
+        opinions: [],
+      },
+      {
+        text: "I didn't even get to visit the Space Needle",
+        sentiment: "neutral",
+        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        offset: 59,
+        length: 43,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentences: [
+      {
+        text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        offset: 0,
+        length: 101,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "I didn't like the last book I read at all.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 42,
+        opinions: [],
+      },
+    ],
+  },
+];
+
+export const expectation31: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "UnsupportedLanguageCode",
+      message:
+        "Invalid language code. Supported languages: ar,da,de,el,en,es,fi,fr,hi,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=sentiment-analysis",
+    },
+  },
+];
+
+export const expectation32: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
+    sentences: [
+      {
+        text: "The food was unacceptable",
+        sentiment: "negative",
+        confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
+        offset: 0,
+        length: 25,
+        opinions: [
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 4,
+              length: 4,
+              text: "food",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 13,
+                length: 12,
+                text: "unacceptable",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "The rooms were beautiful. ",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 26,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 4,
+              length: 5,
+              text: "rooms",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 15,
+                length: 9,
+                text: "beautiful",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        text: "The AC was good and quiet.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+        offset: 26,
+        length: 26,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 30,
+              length: 2,
+              text: "AC",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 37,
+                length: 4,
+                text: "good",
+                isNegated: false,
+              },
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 46,
+                length: 5,
+                text: "quiet",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.03, neutral: 0, negative: 0.97 },
+    sentences: [
+      {
+        text: "The breakfast was good, but the toilet was smelly.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.03, neutral: 0, negative: 0.97 },
+        offset: 0,
+        length: 50,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 4,
+              length: 9,
+              text: "breakfast",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 18,
+                length: 4,
+                text: "good",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 32,
+              length: 6,
+              text: "toilet",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 43,
+                length: 6,
+                text: "smelly",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "Loved this hotel - good breakfast - nice shuttle service - clean rooms.",
+        sentiment: "positive",
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 71,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 11,
+              length: 5,
+              text: "hotel",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 0,
+                length: 5,
+                text: "Loved",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 24,
+              length: 9,
+              text: "breakfast",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 19,
+                length: 4,
+                text: "good",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 41,
+              length: 15,
+              text: "shuttle service",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 36,
+                length: 4,
+                text: "nice",
+                isNegated: false,
+              },
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 59,
+                length: 5,
+                text: "clean",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 65,
+              length: 5,
+              text: "rooms",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 59,
+                length: 5,
+                text: "clean",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "4",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "I had a great unobstructed view of the Microsoft campus.",
+        sentiment: "positive",
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 56,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 27,
+              length: 4,
+              text: "view",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 8,
+                length: 5,
+                text: "great",
+                isNegated: false,
+              },
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 0.99, negative: 0.01 },
+                offset: 14,
+                length: 12,
+                text: "unobstructed",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "5",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.09, neutral: 0, negative: 0.91 },
+    sentences: [
+      {
+        text: "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.09, neutral: 0, negative: 0.91 },
+        offset: 0,
+        length: 75,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 5,
+              length: 5,
+              text: "rooms",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 0,
+                length: 4,
+                text: "Nice",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 15,
+              length: 9,
+              text: "bathrooms",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 30,
+                length: 3,
+                text: "old",
+                isNegated: false,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 42,
+              length: 6,
+              text: "toilet",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 53,
+                length: 5,
+                text: "dirty",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "6",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.02, neutral: 0.09, negative: 0.88 },
+    sentences: [
+      {
+        text: "The toilet smelled.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.02, neutral: 0.09, negative: 0.88 },
+        offset: 0,
+        length: 19,
+        opinions: [
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 4,
+              length: 6,
+              text: "toilet",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 11,
+                length: 7,
+                text: "smelled",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const expectation33: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
+        sentiment: "positive",
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 86,
+        opinions: [],
+      },
+    ],
+  },
+  { id: "1", error: { code: "InvalidDocument", message: "Document text is empty." } },
+  {
+    id: "2",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "Unfortunately, it rained during my entire trip to Seattle. ",
+        sentiment: "negative",
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 59,
+        opinions: [],
+      },
+      {
+        text: "I didn't even get to visit the Space Needle",
+        sentiment: "neutral",
+        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        offset: 59,
+        length: 43,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentences: [
+      {
+        text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        offset: 0,
+        length: 101,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "4",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "I didn't like the last book I read at all.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 42,
+        opinions: [],
+      },
+    ],
+  },
+];
+
+export const expectation34: SentimentAnalysisResult[] = [
+  {
+    id: "1",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    sentences: [
+      {
+        text: "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
+        sentiment: "positive",
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        offset: 0,
+        length: 86,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "Unfortunately, it rained during my entire trip to Seattle. ",
+        sentiment: "negative",
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 59,
+        opinions: [],
+      },
+      {
+        text: "I didn't even get to visit the Space Needle",
+        sentiment: "neutral",
+        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        offset: 59,
+        length: 43,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentences: [
+      {
+        text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        offset: 0,
+        length: 101,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "4",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    sentences: [
+      {
+        text: "I didn't like the last book I read at all.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        offset: 0,
+        length: 42,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "5",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0.01 },
+    sentences: [
+      {
+        text: "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0.01 },
+        offset: 0,
+        length: 73,
+        opinions: [],
+      },
+    ],
+  },
+  {
+    id: "6",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.07, neutral: 0.15, negative: 0.78 },
+    sentences: [
+      {
+        text: "La carretera estaba atascada. ",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.01, neutral: 0.05, negative: 0.94 },
+        offset: 0,
+        length: 30,
+        opinions: [],
+      },
+      {
+        text: "Había mucho tráfico el día de ayer.",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.12, neutral: 0.26, negative: 0.62 },
+        offset: 30,
+        length: 35,
+        opinions: [],
+      },
+    ],
+  },
+];
+
+export const expectation35: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0 },
+    sentences: [
+      {
+        text: "It has a sleek premium aluminum design that makes it beautiful to look at.",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0 },
+        offset: 0,
+        length: 74,
+        opinions: [
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 32,
+              length: 6,
+              text: "design",
+            },
+            assessments: [
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 9,
+                length: 5,
+                text: "sleek",
+                isNegated: false,
+              },
+              {
+                sentiment: "positive",
+                confidenceScores: { positive: 1, negative: 0 },
+                offset: 53,
+                length: 9,
+                text: "beautiful",
+                isNegated: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const expectation36: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "negative",
+    confidenceScores: { positive: 0.01, neutral: 0, negative: 0.99 },
+    sentences: [
+      {
+        text: "The food and service are not good",
+        sentiment: "negative",
+        confidenceScores: { positive: 0.01, neutral: 0, negative: 0.99 },
+        offset: 0,
+        length: 33,
+        opinions: [
+          {
+            target: {
+              sentiment: "negative",
+              confidenceScores: { positive: 0, negative: 1 },
+              offset: 4,
+              length: 4,
+              text: "food",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 29,
+                length: 4,
+                text: "good",
+                isNegated: true,
+              },
+            ],
+          },
+          {
+            target: {
+              sentiment: "positive",
+              confidenceScores: { positive: 1, negative: 0 },
+              offset: 13,
+              length: 7,
+              text: "service",
+            },
+            assessments: [
+              {
+                sentiment: "negative",
+                confidenceScores: { positive: 0, negative: 1 },
+                offset: 29,
+                length: 4,
+                text: "good",
+                isNegated: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const expectation37: SentimentAnalysisResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    sentiment: "positive",
+    confidenceScores: { positive: 0.58, neutral: 0.34, negative: 0.08 },
+    sentences: [
+      {
+        text: "today is a hot day",
+        sentiment: "positive",
+        confidenceScores: { positive: 0.58, neutral: 0.34, negative: 0.08 },
+        offset: 0,
+        length: 18,
+        opinions: [],
+      },
+    ],
+  },
+];
+
+export const expectation38: LanguageDetectionResult[] = [
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "0",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "1",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "2",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "3",
+    warnings: [],
+  },
+];
+
+export const expectation39: LanguageDetectionResult[] = [
+  {
+    primaryLanguage: { name: "French", iso6391Name: "fr", confidenceScore: 1 },
+    id: "0",
+    warnings: [],
+  },
+];
+
+export const expectation40: LanguageDetectionResult[] = [
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 0.95 },
+    id: "0",
+    warnings: [],
+  },
+];
+
+export const expectation41: LanguageDetectionResult[] = [
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "1",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "2",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "3",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "4",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "Spanish", iso6391Name: "es", confidenceScore: 0.99 },
+    id: "5",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "Spanish", iso6391Name: "es", confidenceScore: 1 },
+    id: "6",
+    warnings: [],
+  },
+];
+
+export const expectation42: LanguageDetectionResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "InvalidCountryHint",
+      message:
+        "Country hint is not valid. Please specify an ISO 3166-1 alpha-2 two letter country code.",
+    },
+  },
+];
+
+export const expectation43: LanguageDetectionResult[] = [
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "1",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "2",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "3",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "English", iso6391Name: "en", confidenceScore: 1 },
+    id: "4",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "Spanish", iso6391Name: "es", confidenceScore: 0.99 },
+    id: "5",
+    warnings: [],
+  },
+  {
+    primaryLanguage: { name: "Spanish", iso6391Name: "es", confidenceScore: 1 },
+    id: "6",
+    warnings: [],
+  },
+];
+
+export const expectation44: EntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 18, length: 4, confidenceScore: 0.61 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 26,
+        length: 7,
+        confidenceScore: 1,
+      },
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+      { text: "Space Needle", category: "Location", offset: 65, length: 12, confidenceScore: 0.96 },
+      {
+        text: "2",
+        category: "Quantity",
+        subCategory: "Number",
+        offset: 78,
+        length: 1,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 42, length: 4, confidenceScore: 0.82 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 50,
+        length: 7,
+        confidenceScore: 1,
+      },
+      { text: "Space Needle", category: "Location", offset: 90, length: 12, confidenceScore: 0.92 },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    entities: [{ text: "book", category: "Product", offset: 23, length: 4, confidenceScore: 0.92 }],
+  },
+];
+
+export const expectation45: EntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 18, length: 4, confidenceScore: 0.61 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 26,
+        length: 7,
+        confidenceScore: 1,
+      },
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+      { text: "Space Needle", category: "Location", offset: 65, length: 12, confidenceScore: 0.96 },
+      {
+        text: "2",
+        category: "Quantity",
+        subCategory: "Number",
+        offset: 78,
+        length: 1,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 42, length: 4, confidenceScore: 0.82 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 50,
+        length: 7,
+        confidenceScore: 1,
+      },
+      { text: "Space Needle", category: "Location", offset: 90, length: 12, confidenceScore: 0.92 },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    entities: [{ text: "book", category: "Product", offset: 23, length: 4, confidenceScore: 0.92 }],
+  },
+];
+
+export const expectation46: EntityRecognitionResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "UnsupportedLanguageCode",
+      message:
+        "Invalid language code. Supported languages: ar,cs,da,de,en,es,fi,fr,hu,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
+    },
+  },
+];
+
+export const expectation47: EntityRecognitionResult[] = [
+  {
+    id: "1",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 18, length: 4, confidenceScore: 0.61 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 26,
+        length: 7,
+        confidenceScore: 1,
+      },
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+      { text: "Space Needle", category: "Location", offset: 65, length: 12, confidenceScore: 0.96 },
+      {
+        text: "2",
+        category: "Quantity",
+        subCategory: "Number",
+        offset: 78,
+        length: 1,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    entities: [
+      { text: "trip", category: "Event", offset: 42, length: 4, confidenceScore: 0.82 },
+      {
+        text: "Seattle",
+        category: "Location",
+        subCategory: "GPE",
+        offset: 50,
+        length: 7,
+        confidenceScore: 1,
+      },
+      { text: "Space Needle", category: "Location", offset: 90, length: 12, confidenceScore: 0.92 },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "4",
+    warnings: [],
+    entities: [
+      {
+        text: "Monte Rainier",
+        category: "Location",
+        offset: 29,
+        length: 13,
+        confidenceScore: 0.85,
+      },
+    ],
+  },
+  {
+    id: "5",
+    warnings: [],
+    entities: [
+      { text: "carretera", category: "Location", offset: 3, length: 9, confidenceScore: 0.81 },
+      {
+        text: "ayer",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 60,
+        length: 4,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+];
+
+export const expectation48: KeyPhraseExtractionResult[] = [
+  { id: "0", warnings: [], keyPhrases: ["wonderful trip", "Space Needle", "Seattle"] },
+  { id: "1", warnings: [], keyPhrases: ["entire trip", "Space Needle", "Seattle"] },
+  { id: "2", warnings: [], keyPhrases: ["movie", "Saturday"] },
+  { id: "3", warnings: [], keyPhrases: ["last book"] },
+];
+
+export const expectation49: KeyPhraseExtractionResult[] = [
+  { id: "0", warnings: [], keyPhrases: ["wonderful trip", "Space Needle", "Seattle"] },
+  { id: "1", warnings: [], keyPhrases: ["entire trip", "Space Needle", "Seattle"] },
+  { id: "2", warnings: [], keyPhrases: ["movie", "Saturday"] },
+  { id: "3", warnings: [], keyPhrases: ["last book"] },
+];
+
+export const expectation50: KeyPhraseExtractionResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "UnsupportedLanguageCode",
+      message:
+        "Invalid language code. Supported languages: af,bg,ca,da,de,el,en,es,et,fi,fr,hr,hu,id,it,ja,ko,lv,nl,no,pl,pt-BR,pt-PT,ro,ru,sk,sl,sv,tr,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction",
+    },
+  },
+];
+
+export const expectation51: KeyPhraseExtractionResult[] = [
+  { id: "1", warnings: [], keyPhrases: ["wonderful trip", "Space Needle", "Seattle"] },
+  { id: "2", warnings: [], keyPhrases: ["entire trip", "Space Needle", "Seattle"] },
+  { id: "3", warnings: [], keyPhrases: ["movie", "Saturday"] },
+  { id: "4", warnings: [], keyPhrases: ["last book"] },
+  { id: "5", warnings: [], keyPhrases: ["Monte Rainier", "caminos"] },
+  { id: "6", warnings: [], keyPhrases: ["mucho tráfico", "día", "carretera", "ayer"] },
+];
+
+export const expectation52: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText:
+      "I had a wonderful trip to Seattle ********* and even visited the Space Needle 2 times!",
+    entities: [
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    redactedText:
+      "Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle",
+    entities: [],
+  },
+  {
+    id: "2",
+    warnings: [],
+    redactedText:
+      "I went to see a movie on ******** and it was perfectly average, nothing more or less than I expected.",
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    redactedText: "I didn't like the last book I read at all.",
+    entities: [],
+  },
+];
+
+export const expectation53: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText:
+      "I had a wonderful trip to Seattle ********* and even visited the Space Needle 2 times!",
+    entities: [
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    redactedText:
+      "Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle",
+    entities: [],
+  },
+  {
+    id: "2",
+    warnings: [],
+    redactedText:
+      "I went to see a movie on ******** and it was perfectly average, nothing more or less than I expected.",
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "3",
+    warnings: [],
+    redactedText: "I didn't like the last book I read at all.",
+    entities: [],
+  },
+];
+
+export const expectation54: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText: "Your Social Security Number is ***********.",
+    entities: [
+      {
+        text: "859-98-0987",
+        category: "USSocialSecurityNumber",
+        offset: 31,
+        length: 11,
+        confidenceScore: 0.65,
+      },
+    ],
+  },
+];
+
+export const expectation55: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "UnsupportedLanguageCode",
+      message:
+        "Invalid language code. Supported languages: de,en,es,fr,it,ja,ko,pt-BR,pt-PT,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
+    },
+  },
+];
+
+export const expectation56: PiiEntityRecognitionResult[] = [
+  {
+    id: "1",
+    warnings: [],
+    redactedText:
+      "I had a wonderful trip to Seattle ********* and even visited the Space Needle 2 times!",
+    entities: [
+      {
+        text: "last week",
+        category: "DateTime",
+        subCategory: "DateRange",
+        offset: 34,
+        length: 9,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    redactedText:
+      "Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle",
+    entities: [],
+  },
+  {
+    id: "3",
+    warnings: [],
+    redactedText:
+      "I went to see a movie on ******** and it was perfectly average, nothing more or less than I expected.",
+    entities: [
+      {
+        text: "Saturday",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 25,
+        length: 8,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+  {
+    id: "4",
+    warnings: [],
+    redactedText: "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
+    entities: [],
+  },
+  {
+    id: "5",
+    warnings: [],
+    redactedText: "La carretera estaba atascada. Había mucho tráfico el día de ****.",
+    entities: [
+      {
+        text: "ayer",
+        category: "DateTime",
+        subCategory: "Date",
+        offset: 60,
+        length: 4,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+];
+
+export const expectation57: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText: "I work at ********* and my phone number is ************",
+    entities: [
+      { text: "Microsoft", category: "Organization", offset: 10, length: 9, confidenceScore: 0.94 },
+      {
+        text: "333-333-3333",
+        category: "PhoneNumber",
+        offset: 43,
+        length: 12,
+        confidenceScore: 0.8,
+      },
+    ],
+  },
+];
+
+export const expectation58: PiiEntityRecognitionResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText: "Patient name is Joe and SSN is ***********",
+    entities: [
+      {
+        text: "859-98-0987",
+        category: "USSocialSecurityNumber",
+        offset: 31,
+        length: 11,
+        confidenceScore: 0.65,
+      },
+    ],
+  },
+];
+
+export const expectation59: PiiEntityRecognitionSuccessResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    redactedText: "Patient name is *** and SSN is ***********",
+    entities: [
+      { text: "Joe", category: "Person", offset: 16, length: 3, confidenceScore: 0.78 },
+      {
+        text: "859-98-0987",
+        category: "USSocialSecurityNumber",
+        offset: 31,
+        length: 11,
+        confidenceScore: 0.65,
+      },
+    ],
+  },
+];
+
+export const expectation60: EntityLinkingResult[] = [
+  {
+    id: "0",
+    warnings: [],
+    entities: [
+      {
+        name: "Seattle",
+        matches: [{ confidenceScore: 0.21, text: "Seattle", offset: 26, length: 7 }],
+        language: "en",
+        dataSourceEntityId: "Seattle",
+        url: "https://en.wikipedia.org/wiki/Seattle",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "5fbba6b8-85e1-4d41-9444-d9055436e473",
+      },
+      {
+        name: "Space Needle",
+        matches: [{ confidenceScore: 0.42, text: "Space Needle", offset: 65, length: 12 }],
+        language: "en",
+        dataSourceEntityId: "Space Needle",
+        url: "https://en.wikipedia.org/wiki/Space_Needle",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
+      },
+    ],
+  },
+  {
+    id: "1",
+    warnings: [],
+    entities: [
+      {
+        name: "Seattle",
+        matches: [{ confidenceScore: 0.2, text: "Seattle", offset: 50, length: 7 }],
+        language: "en",
+        dataSourceEntityId: "Seattle",
+        url: "https://en.wikipedia.org/wiki/Seattle",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "5fbba6b8-85e1-4d41-9444-d9055436e473",
+      },
+      {
+        name: "Space Needle",
+        matches: [{ confidenceScore: 0.36, text: "Space Needle", offset: 90, length: 12 }],
+        language: "en",
+        dataSourceEntityId: "Space Needle",
+        url: "https://en.wikipedia.org/wiki/Space_Needle",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "f8dd5b08-206d-2554-6e4a-893f51f4de7e",
+      },
+    ],
+  },
+  {
+    id: "2",
+    warnings: [],
+    entities: [
+      {
+        name: "Saturday",
+        matches: [{ confidenceScore: 0.05, text: "Saturday", offset: 25, length: 8 }],
+        language: "en",
+        dataSourceEntityId: "Saturday",
+        url: "https://en.wikipedia.org/wiki/Saturday",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "296617ab-4ddb-cc10-beba-56e0f42af76b",
+      },
+    ],
+  },
+  { id: "3", warnings: [], entities: [] },
+];
+
+export const expectation61: EntityLinkingResult[] = [
+  {
+    id: "0",
+    error: {
+      code: "UnsupportedLanguageCode",
+      message:
+        "Invalid language code 'notalanguage'. Supported languages: en,es. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
+    },
+  },
+];
+
+export const expectation62: EntityLinkingResult[] = [
+  {
+    id: "1",
+    warnings: [],
+    entities: [
+      {
+        name: "Saturday",
+        matches: [{ confidenceScore: 0.05, text: "Saturday", offset: 25, length: 8 }],
+        language: "en",
+        dataSourceEntityId: "Saturday",
+        url: "https://en.wikipedia.org/wiki/Saturday",
+        dataSource: "Wikipedia",
+        bingEntitySearchApiId: "296617ab-4ddb-cc10-beba-56e0f42af76b",
+      },
+    ],
+  },
+  { id: "2", warnings: [], entities: [] },
 ];

--- a/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
@@ -2495,7 +2495,7 @@ export const expectation30: SentimentAnalysisResult[] = [
       {
         text: "I didn't even get to visit the Space Needle",
         sentiment: "neutral",
-        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        confidenceScores: { positive: 0, neutral: 0.92, negative: 0.08 },
         offset: 59,
         length: 43,
         opinions: [],
@@ -2505,13 +2505,13 @@ export const expectation30: SentimentAnalysisResult[] = [
   {
     id: "2",
     warnings: [],
-    sentiment: "positive",
-    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentiment: "negative",
+    confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
     sentences: [
       {
         text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
-        sentiment: "positive",
-        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        sentiment: "negative",
+        confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
         offset: 0,
         length: 101,
         opinions: [],
@@ -2522,12 +2522,12 @@ export const expectation30: SentimentAnalysisResult[] = [
     id: "3",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
     sentences: [
       {
         text: "I didn't like the last book I read at all.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
         offset: 0,
         length: 42,
         opinions: [],
@@ -2542,7 +2542,7 @@ export const expectation31: SentimentAnalysisResult[] = [
     error: {
       code: "UnsupportedLanguageCode",
       message:
-        "Invalid language code. Supported languages: ar,da,de,el,en,es,fi,fr,hi,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=sentiment-analysis",
+        "Invalid language code 'notalanguage'. Supported languages: af,am,ar,as,az,be,bg,bn,br,bs,ca,cs,cy,da,de,el,en,eo,es,et,eu,fa,fi,fil,fr,fy,ga,gd,gl,gu,ha,he,hi,hr,hu,hy,id,it,ja,jv,ka,kk,km,kn,ko,ku,ky,la,lo,lt,lv,mg,mk,ml,mn,mr,ms,my,ne,nl,no,om,or,pa,pl,ps,pt-BR,pt-PT,ro,ru,sa,sd,si,sk,sl,so,sq,sr,su,sv,sw,ta,te,th,tr,ug,uk,ur,uz,vi,xh,yi,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=sentiment-analysis",
     },
   },
 ];
@@ -2552,12 +2552,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "0",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
+    confidenceScores: { positive: 0, neutral: 0, negative: 1 },
     sentences: [
       {
         text: "The food was unacceptable",
         sentiment: "negative",
-        confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
+        confidenceScores: { positive: 0, neutral: 0, negative: 1 },
         offset: 0,
         length: 25,
         opinions: [
@@ -2588,12 +2588,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "1",
     warnings: [],
     sentiment: "positive",
-    confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+    confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0 },
     sentences: [
       {
         text: "The rooms were beautiful. ",
         sentiment: "positive",
-        confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
         offset: 0,
         length: 26,
         opinions: [
@@ -2621,7 +2621,7 @@ export const expectation32: SentimentAnalysisResult[] = [
       {
         text: "The AC was good and quiet.",
         sentiment: "positive",
-        confidenceScores: { positive: 0.99, neutral: 0, negative: 0 },
+        confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0 },
         offset: 26,
         length: 26,
         opinions: [
@@ -2660,12 +2660,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "2",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.03, neutral: 0, negative: 0.97 },
+    confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
     sentences: [
       {
         text: "The breakfast was good, but the toilet was smelly.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.03, neutral: 0, negative: 0.97 },
+        confidenceScores: { positive: 0, neutral: 0, negative: 0.99 },
         offset: 0,
         length: 50,
         opinions: [
@@ -2816,12 +2816,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "4",
     warnings: [],
     sentiment: "positive",
-    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+    confidenceScores: { positive: 0.92, neutral: 0.07, negative: 0.01 },
     sentences: [
       {
         text: "I had a great unobstructed view of the Microsoft campus.",
         sentiment: "positive",
-        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
+        confidenceScores: { positive: 0.92, neutral: 0.07, negative: 0.01 },
         offset: 0,
         length: 56,
         opinions: [
@@ -2860,12 +2860,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "5",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.09, neutral: 0, negative: 0.91 },
+    confidenceScores: { positive: 0.04, neutral: 0, negative: 0.96 },
     sentences: [
       {
         text: "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.09, neutral: 0, negative: 0.91 },
+        confidenceScores: { positive: 0.04, neutral: 0, negative: 0.96 },
         offset: 0,
         length: 75,
         opinions: [
@@ -2934,12 +2934,12 @@ export const expectation32: SentimentAnalysisResult[] = [
     id: "6",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.02, neutral: 0.09, negative: 0.88 },
+    confidenceScores: { positive: 0, neutral: 0.02, negative: 0.98 },
     sentences: [
       {
         text: "The toilet smelled.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.02, neutral: 0.09, negative: 0.88 },
+        confidenceScores: { positive: 0, neutral: 0.02, negative: 0.98 },
         offset: 0,
         length: 19,
         opinions: [
@@ -3003,7 +3003,7 @@ export const expectation33: SentimentAnalysisResult[] = [
       {
         text: "I didn't even get to visit the Space Needle",
         sentiment: "neutral",
-        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        confidenceScores: { positive: 0, neutral: 0.92, negative: 0.08 },
         offset: 59,
         length: 43,
         opinions: [],
@@ -3013,13 +3013,13 @@ export const expectation33: SentimentAnalysisResult[] = [
   {
     id: "3",
     warnings: [],
-    sentiment: "positive",
-    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentiment: "negative",
+    confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
     sentences: [
       {
         text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
-        sentiment: "positive",
-        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        sentiment: "negative",
+        confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
         offset: 0,
         length: 101,
         opinions: [],
@@ -3030,12 +3030,12 @@ export const expectation33: SentimentAnalysisResult[] = [
     id: "4",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
     sentences: [
       {
         text: "I didn't like the last book I read at all.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
         offset: 0,
         length: 42,
         opinions: [],
@@ -3078,7 +3078,7 @@ export const expectation34: SentimentAnalysisResult[] = [
       {
         text: "I didn't even get to visit the Space Needle",
         sentiment: "neutral",
-        confidenceScores: { positive: 0.03, neutral: 0.58, negative: 0.39 },
+        confidenceScores: { positive: 0, neutral: 0.92, negative: 0.08 },
         offset: 59,
         length: 43,
         opinions: [],
@@ -3088,13 +3088,13 @@ export const expectation34: SentimentAnalysisResult[] = [
   {
     id: "3",
     warnings: [],
-    sentiment: "positive",
-    confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+    sentiment: "negative",
+    confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
     sentences: [
       {
         text: "I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.",
-        sentiment: "positive",
-        confidenceScores: { positive: 0.71, neutral: 0.06, negative: 0.23 },
+        sentiment: "negative",
+        confidenceScores: { positive: 0.19, neutral: 0.28, negative: 0.53 },
         offset: 0,
         length: 101,
         opinions: [],
@@ -3105,12 +3105,12 @@ export const expectation34: SentimentAnalysisResult[] = [
     id: "4",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+    confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
     sentences: [
       {
         text: "I didn't like the last book I read at all.",
         sentiment: "negative",
-        confidenceScores: { positive: 0.01, neutral: 0.01, negative: 0.99 },
+        confidenceScores: { positive: 0, neutral: 0.01, negative: 0.99 },
         offset: 0,
         length: 42,
         opinions: [],
@@ -3121,12 +3121,12 @@ export const expectation34: SentimentAnalysisResult[] = [
     id: "5",
     warnings: [],
     sentiment: "positive",
-    confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0.01 },
+    confidenceScores: { positive: 1, neutral: 0, negative: 0 },
     sentences: [
       {
         text: "Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.",
         sentiment: "positive",
-        confidenceScores: { positive: 0.99, neutral: 0.01, negative: 0.01 },
+        confidenceScores: { positive: 1, neutral: 0, negative: 0 },
         offset: 0,
         length: 73,
         opinions: [],
@@ -3137,20 +3137,20 @@ export const expectation34: SentimentAnalysisResult[] = [
     id: "6",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.07, neutral: 0.15, negative: 0.78 },
+    confidenceScores: { positive: 0, neutral: 0.03, negative: 0.97 },
     sentences: [
       {
         text: "La carretera estaba atascada. ",
         sentiment: "negative",
-        confidenceScores: { positive: 0.01, neutral: 0.05, negative: 0.94 },
+        confidenceScores: { positive: 0, neutral: 0.03, negative: 0.97 },
         offset: 0,
         length: 30,
         opinions: [],
       },
       {
         text: "Había mucho tráfico el día de ayer.",
-        sentiment: "negative",
-        confidenceScores: { positive: 0.12, neutral: 0.26, negative: 0.62 },
+        sentiment: "neutral",
+        confidenceScores: { positive: 0.03, neutral: 0.93, negative: 0.04 },
         offset: 30,
         length: 35,
         opinions: [],
@@ -3211,12 +3211,12 @@ export const expectation36: SentimentAnalysisResult[] = [
     id: "0",
     warnings: [],
     sentiment: "negative",
-    confidenceScores: { positive: 0.01, neutral: 0, negative: 0.99 },
+    confidenceScores: { positive: 0, neutral: 0, negative: 1 },
     sentences: [
       {
         text: "The food and service are not good",
         sentiment: "negative",
-        confidenceScores: { positive: 0.01, neutral: 0, negative: 0.99 },
+        confidenceScores: { positive: 0, neutral: 0, negative: 1 },
         offset: 0,
         length: 33,
         opinions: [
@@ -3268,13 +3268,13 @@ export const expectation37: SentimentAnalysisResult[] = [
   {
     id: "0",
     warnings: [],
-    sentiment: "positive",
-    confidenceScores: { positive: 0.58, neutral: 0.34, negative: 0.08 },
+    sentiment: "neutral",
+    confidenceScores: { positive: 0.17, neutral: 0.81, negative: 0.01 },
     sentences: [
       {
         text: "today is a hot day",
-        sentiment: "positive",
-        confidenceScores: { positive: 0.58, neutral: 0.34, negative: 0.08 },
+        sentiment: "neutral",
+        confidenceScores: { positive: 0.17, neutral: 0.81, negative: 0.01 },
         offset: 0,
         length: 18,
         opinions: [],
@@ -3545,7 +3545,7 @@ export const expectation46: EntityRecognitionResult[] = [
     error: {
       code: "UnsupportedLanguageCode",
       message:
-        "Invalid language code. Supported languages: ar,cs,da,de,en,es,fi,fr,hu,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
+        "Invalid language code 'notalanguage'. Supported languages: ar,cs,da,de,en,es,fi,fr,hu,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
     },
   },
 ];
@@ -3663,7 +3663,7 @@ export const expectation50: KeyPhraseExtractionResult[] = [
     error: {
       code: "UnsupportedLanguageCode",
       message:
-        "Invalid language code. Supported languages: af,bg,ca,da,de,el,en,es,et,fi,fr,hr,hu,id,it,ja,ko,lv,nl,no,pl,pt-BR,pt-PT,ro,ru,sk,sl,sv,tr,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction",
+        "Invalid language code 'notalanguage'. Supported languages: af,am,ar,as,az,be,bg,bn,br,bs,ca,cs,cy,da,de,el,en,eo,es,et,eu,fa,fi,fil,fr,fy,ga,gd,gl,gu,ha,he,hi,hr,hu,hy,id,it,ja,jv,ka,kk,km,kn,ko,ku,ky,la,lo,lt,lv,mg,mk,ml,mn,mr,ms,my,ne,nl,no,om,or,pa,pl,ps,pt-BR,pt-PT,ro,ru,sa,sd,si,sk,sl,so,sq,sr,su,sv,sw,ta,te,th,tr,ug,uk,ur,uz,vi,xh,yi,zh-Hans,zh-Hant. For additional details see https://aka.ms/text-analytics/language-support?tabs=key-phrase-extraction",
     },
   },
 ];
@@ -3796,7 +3796,7 @@ export const expectation55: PiiEntityRecognitionResult[] = [
     error: {
       code: "UnsupportedLanguageCode",
       message:
-        "Invalid language code. Supported languages: de,en,es,fr,it,ja,ko,pt-BR,pt-PT,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
+        "Invalid language code 'notalanguage'. Supported languages: de,en,es,fr,it,ja,ko,pt-BR,pt-PT,zh-Hans. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition",
     },
   },
 ];

--- a/sdk/cognitivelanguage/ai-language-text/test/public/utils/resultHelper.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/utils/resultHelper.ts
@@ -5,37 +5,11 @@ import {
   AnalyzeBatchResult,
   KnownTextAnalysisErrorCode,
   PagedAnalyzeBatchResult,
-  TextAnalysisErrorResult,
-  TextAnalysisSuccessResult,
 } from "../../../src/";
 import { assert } from "@azure/test-utils";
 import { isRestError } from "@azure/core-rest-pipeline";
 
-export function assertAllSuccess<TSuccess extends TextAnalysisSuccessResult>(
-  results: (TextAnalysisErrorResult | TSuccess)[]
-): void {
-  for (const result of results) {
-    assert.ok(isSuccess(result));
-  }
-}
-
-export function isSuccess<TSuccess extends TextAnalysisSuccessResult>(
-  res: TextAnalysisErrorResult | TSuccess
-): res is TSuccess {
-  return res.error === undefined;
-}
-
-export function getSuccRes<TSuccess extends TextAnalysisSuccessResult>(
-  res: TextAnalysisErrorResult | TSuccess
-): TSuccess {
-  if (!res.error) {
-    return res;
-  } else {
-    throw new Error(`Unexpected error: ${JSON.stringify(res.error)}`);
-  }
-}
-
-export async function assertActionResults(
+export async function assertActionsResults(
   actions: PagedAnalyzeBatchResult,
   expectations: AnalyzeBatchResult[],
   options: {
@@ -85,4 +59,16 @@ export async function assertRestError(
       assert.fail(`Unexpected error: ${JSON.stringify(e)}`);
     }
   }
+}
+
+export function assertActionResults<T>(
+  result: T[],
+  expectation: T[],
+  options: {
+    excludedAdditionalProps?: string[];
+  } = {}
+): void {
+  const { excludedAdditionalProps = [] } = options;
+  console.log(JSON.stringify(result));
+  assert.deepEqualExcludingEvery(result, expectation, excludedAdditionalProps as any);
 }

--- a/sdk/cognitivelanguage/ai-language-text/test/public/utils/resultHelper.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/utils/resultHelper.ts
@@ -69,6 +69,5 @@ export function assertActionResults<T>(
   } = {}
 ): void {
   const { excludedAdditionalProps = [] } = options;
-  console.log(JSON.stringify(result));
   assert.deepEqualExcludingEvery(result, expectation, excludedAdditionalProps as any);
 }


### PR DESCRIPTION
Migrates `analyze.spec.ts` to use snapshot testing, similar to `analyzeBatch.spec.ts`. Snapshot testing has several advantages, including:
- asserting the full result object so any issues in the service can be caught early
- better readability, it is clear for the unit test what are the expectation, and there is no need to traverse the object manually