### PR TITLE
[cspell] suppress unknown word for search and synapse

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -33,6 +33,7 @@
     "sdk/purview/purview-scanning-rest/review/*.md",
     "sdk/quantum/quantum-jobs/review/*.md",
     "sdk/synapse/synapse-access-control/review/*.md",
+    "sdk/synapse/synapse-access-control-rest/review/*.md",
     "sdk/synapse/synapse-artifacts/review/*.md",
     "sdk/synapse/synapse-managed-private-endpoints/review/*.md",
     "sdk/synapse/synapse-monitoring/review/*.md",
@@ -161,7 +162,8 @@
         "reranker",
         "Rslp",
         "sorani",
-        "Sorani"
+        "Sorani",
+        "beider"
       ]
     },
     {


### PR DESCRIPTION
- "beider" in "beiderMorse". Person name used in encoder types

```ts
export type PhoneticEncoder = "metaphone" | "doubleMetaphone" | "soundex" | "refinedSoundex" | "caverphone1" | "caverphone2" | "cologne" | "nysiis" | "koelnerPhonetik" | "haasePhonetik" | "beiderMorse";
```

- ignore unknown words in generated synapse-access-control-rest package.
