### PR TITLE
[Bot Rules] Update Cosmos contacts

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3511,7 +3511,7 @@
               "Cosmos"
             ],
             "mentionees": [
-              "jay-most",
+              "bkolant-MSFT",
               "sajeetharan",
               "pjohari-ms"
             ]


### PR DESCRIPTION
# Summary

The purpose of these changes is to update the set of service contacts for Cosmos to match the changes to CODEOWNERS in #23607.