### PR TITLE
[identity] upgrade @azure/msal-node-extensions

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1341,17 +1341,14 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /@azure/msal-node-extensions/1.0.0-alpha.9:
-    resolution: {integrity: sha512-p6ulfziYQDbPmFH0LZ7ekvC6WJu4coHTHPtH4iA6wEeMMy6aD8afv4KgXZDm7bX0rXlTIb+1O8hQYOATz4j5vA==}
+  /@azure/msal-node-extensions/1.0.0-alpha.25:
+    resolution: {integrity: sha512-7pOUdE2OZO2omA1DBAJhVGHJo8laqw+x5JgV/XLzyogapduAzps3lbM/G3VV+VuEb0KG1QHkpaOF/6eftPssKw==}
     engines: {node: '>=10'}
     requiresBuild: true
     dependencies:
-      '@azure/msal-common': 4.5.1
-      bindings: 1.5.0
+      '@azure/msal-common': 7.6.0
       keytar: 7.9.0
-      nan: 2.16.0
-    transitivePeerDependencies:
-      - supports-color
+      node-addon-api: 5.0.0
     dev: false
 
   /@azure/msal-node/1.0.0-beta.6_debug@4.3.4:
@@ -3353,12 +3350,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /bindings/1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-    dependencies:
-      file-uri-to-path: 1.0.0
-    dev: false
-
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -4132,7 +4123,7 @@ packages:
     dependencies:
       semver: 7.3.7
       shelljs: 0.8.5
-      typescript: 4.9.0-dev.20221025
+      typescript: 4.9.0-dev.20221027
     dev: false
 
   /downlevel-dts/0.8.0:
@@ -4850,10 +4841,6 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.0.4
-    dev: false
-
-  /file-uri-to-path/1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     dev: false
 
   /fill-range/7.0.1:
@@ -6930,10 +6917,6 @@ packages:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: false
 
-  /nan/2.16.0:
-    resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==}
-    dev: false
-
   /nanoid/3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7020,6 +7003,10 @@ packages:
 
   /node-addon-api/4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+    dev: false
+
+  /node-addon-api/5.0.0:
+    resolution: {integrity: sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==}
     dev: false
 
   /node-environment-flags/1.0.6:
@@ -9209,8 +9196,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.9.0-dev.20221025:
-    resolution: {integrity: sha512-3TZlt+3jGBjPRVFcNX6BmlajqwNExRm4rhG4llSH5WSMX/eQ54PSueTJ5UhLn9+6/byL31/WRmJJ/7W0j+gCtQ==}
+  /typescript/4.9.0-dev.20221027:
+    resolution: {integrity: sha512-CIkuppg1AjXN2O+njxomS97BHqIMH+NqXXD661ViFdVvesx9YLsNjiATUlfIkeVtVyG0PGpzES8lmzIhoSaniA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
@@ -17607,13 +17594,13 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-bB9LkrOYfx0XvibPyN2KP0A+BMapMpYc20zn0XudDtFipevFLIHSANLurhdLC5i7ptn25BG5oWJNr4iygU21Yw==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-QIrcYPl5Yr8PZr09ZgbhT6RJK0Bh224RViHIC5Fk9UizzmUv/L5nExtiO0FEb03AS8UrQnhEQk2qJ5C4COiNeA==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/msal-node': 1.14.2
-      '@azure/msal-node-extensions': 1.0.0-alpha.9
+      '@azure/msal-node-extensions': 1.0.0-alpha.25
       '@microsoft/api-extractor': 7.31.2
       '@types/jws': 3.2.4
       '@types/mocha': 7.0.2

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -62,7 +62,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/identity": "^2.1.0",
     "@azure/msal-node": "^1.14.2",
-    "@azure/msal-node-extensions": "1.0.0-alpha.9",
+    "@azure/msal-node-extensions": "1.0.0-alpha.25",
     "keytar": "^7.6.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/identity-cache-persistence

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Due to an old version of nan linked with a previous version of @azure/msal-node-extensions, it will fail to build in Node 19.  This upgrades the library from  1.0.0-alpha.9 to 1.0.0-alpha.25.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

N/A

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
