### PR TITLE
[Identity] Documentation improvements

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -277,11 +277,12 @@ Not all credentials require this configuration. Credentials that authenticate th
 
 #### Username and password
 
-| Variable name     | Value                                 |
-| ----------------- | ------------------------------------- |
-| `AZURE_CLIENT_ID` | ID of an Azure AD application         |
-| `AZURE_USERNAME`  | a username (usually an email address) |
-| `AZURE_PASSWORD`  | that user's password                  |
+| Variable name     | Value                                   |
+| ----------------- | --------------------------------------- |
+| `AZURE_CLIENT_ID` | ID of an Azure AD application           |
+| `AZURE_TENANT_ID` | ID of the application's Azure AD tenant |
+| `AZURE_USERNAME`  | a username (usually an email address)   |
+| `AZURE_PASSWORD`  | that user's password                    |
 
 Configuration is attempted in the above order. For example, if values for a client secret and certificate are both present, the client secret will be used.
 

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -38,8 +38,8 @@ const credentialName = "EnvironmentCredential";
 const logger = credentialLogger(credentialName);
 
 /**
- * Enables authentication to Azure Active Directory using client secret
- * details configured in environment variables
+ * Enables authentication to Azure Active Directory using a client secret or certificate, or as a user
+ * with a username and password.
  */
 export class EnvironmentCredential implements TokenCredential {
   private _credential?:

--- a/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/visualStudioCodeCredential.ts
@@ -90,6 +90,11 @@ export function getPropertyFromVSCode(property: string): string | undefined {
  * Connects to Azure using the credential provided by the VSCode extension 'Azure Account'.
  * Once the user has logged in via the extension, this credential can share the same refresh token
  * that is cached by the extension.
+ *
+ * It's a [known issue](https://github.com/Azure/azure-sdk-for-js/issues/20500) that this credential doesn't
+ * work with [Azure Account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account)
+ * versions newer than **0.9.11**. A long-term fix to this problem is in progress. In the meantime, consider
+ * authenticating with {@link AzureCliCredential}.
  */
 export class VisualStudioCodeCredential implements TokenCredential {
   private identityClient: IdentityClient;


### PR DESCRIPTION
Added a disclaimer about the current shortcomings of VisualStudioCodeCredential in the corresponding docstring so that users will be notified in the credential API doc.

Also, added a missing envvar to the README.

