### PR TITLE
Fix the type generation path

### DIFF
--- a/sdk/maps/maps-common/CHANGELOG.md
+++ b/sdk/maps/maps-common/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Correct the path of type declation files.
+
 ### Other Changes
 
 ## 1.0.0-beta.1 (2022-10-11)

--- a/sdk/maps/maps-common/api-extractor.json
+++ b/sdk/maps/maps-common/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/maps-common.d.ts"
+    "publicTrimmedFilePath": "./types/latest/maps-common.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/maps/maps-common/package.json
+++ b/sdk/maps/maps-common/package.json
@@ -5,11 +5,11 @@
   "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/index.js",
-  "types": "types/maps-common.d.ts",
+  "types": "types/latest/maps-common.d.ts",
   "typesVersions": {
     "<3.6": {
       "*": [
-        "types/3.1/index.d.ts"
+        "types/3.1/maps-common.d.ts"
       ]
     }
   },

--- a/sdk/maps/maps-route-rest/package.json
+++ b/sdk/maps/maps-route-rest/package.json
@@ -26,7 +26,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/maps-route.d.ts",
+    "types/maps-route-rest.d.ts",
     "README.md",
     "LICENSE",
     "review/*"

--- a/sdk/maps/maps-search/CHANGELOG.md
+++ b/sdk/maps/maps-search/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Correct the type declaration file generation.
+
 ### Other Changes
 
 ## 1.0.0-beta.1 (2022-10-11)

--- a/sdk/maps/maps-search/api-extractor.json
+++ b/sdk/maps/maps-search/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/maps-search.d.ts"
+    "publicTrimmedFilePath": "./types/latest/maps-search.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/maps/maps-search/package.json
+++ b/sdk/maps/maps-search/package.json
@@ -10,7 +10,7 @@
   "typesVersions": {
     "<3.6": {
       "*": [
-        "types/3.1/src/maps-search.d.ts"
+        "types/3.1/maps-search.d.ts"
       ]
     }
   },


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/maps-search`
- `@azure/maps-common`
- `@azure-rest/maps-route`

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Correct the path for type definition files else the users are not able to consume them.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA

### Are there test cases added in this PR? _(If not, why?)_
NA

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
