### PR TITLE
[Purview Catalog] Remove unsupported ES2020 optional chain in sample

### DIFF
--- a/sdk/purview/purview-catalog-rest/samples-dev/typedefs.ts
+++ b/sdk/purview/purview-catalog-rest/samples-dev/typedefs.ts
@@ -27,7 +27,7 @@ async function main() {
   }
 
   if (!dataSources.body.entityDefs) {
-    throw new Error("entityDefs is undefined");
+    throw new Error("entityDefs is not defined");
   }
 
   console.log(dataSources.body.entityDefs.map((ds) => ds.name).join("\n"));

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/README.md
@@ -1,0 +1,53 @@
+# Azure Purview Scanning rest client library samples for JavaScript (Beta)
+
+These sample programs show how to use the JavaScript client libraries for Azure Purview Scanning rest in some common scenarios.
+
+| **File Name**           | **Description**                      |
+| ----------------------- | ------------------------------------ |
+| [typedefs.js][typedefs] | gets a list of typedefs for entities |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure Cognitive Services instance][createinstance_azurecognitiveservicesinstance]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+3. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node typedefs.js
+```
+
+Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+npx cross-env ENDPOINT="<endpoint>" node typedefs.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[typedefs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/typedefs.js
+[apiref]: https://docs.microsoft.com/rest/api/purview/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azurecognitiveservicesinstance]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog-rest/README.md

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@azure-samples/purview-catalog-js-beta",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Purview Scanning rest client library samples for JavaScript (Beta)",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "sdk/purview/purview-catalog-rest"
+  },
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog-rest",
+  "dependencies": {
+    "@azure-rest/purview-catalog": "next",
+    "dotenv": "latest",
+    "@azure/identity": "^2.0.1"
+  }
+}

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/sample.env
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/sample.env
@@ -1,0 +1,7 @@
+# Purview Scanning resource endpoint
+ENDPOINT=
+
+# App registration secret for AAD authentication
+AZURE_CLIENT_SECRET=
+AZURE_CLIENT_ID=
+AZURE_TENANT_ID= 

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/typedefs.js
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/javascript/typedefs.js
@@ -5,14 +5,11 @@
  * This sample demonstrates how get a list of typedefs
  *
  * @summary gets a list of typedefs for entities
- * @azsdk-weight 40
  */
 
-import PurviewCatalog from "@azure-rest/purview-catalog";
-import { DefaultAzureCredential } from "@azure/identity";
-import dotenv from "dotenv";
-
-dotenv.config();
+const PurviewCatalog = require("@azure-rest/purview-catalog").default;
+const { DefaultAzureCredential } = require("@azure/identity");
+require("dotenv").config();
 
 const endpoint = process.env["ENDPOINT"] || "";
 

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/README.md
@@ -1,0 +1,66 @@
+# Azure Purview Scanning rest client library samples for TypeScript (Beta)
+
+These sample programs show how to use the TypeScript client libraries for Azure Purview Scanning rest in some common scenarios.
+
+| **File Name**           | **Description**                      |
+| ----------------------- | ------------------------------------ |
+| [typedefs.ts][typedefs] | gets a list of typedefs for entities |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
+
+```bash
+npm install -g typescript
+```
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure Cognitive Services instance][createinstance_azurecognitiveservicesinstance]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Compile the samples:
+
+```bash
+npm run build
+```
+
+3. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node dist/typedefs.js
+```
+
+Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+npx cross-env ENDPOINT="<endpoint>" node dist/typedefs.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[typedefs]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/src/typedefs.ts
+[apiref]: https://docs.microsoft.com/rest/api/purview/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azurecognitiveservicesinstance]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog-rest/README.md
+[typescript]: https://www.typescriptlang.org/docs/home.html

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@azure-samples/purview-catalog-ts-beta",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Purview Scanning rest client library samples for TypeScript (Beta)",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rimraf dist/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "sdk/purview/purview-catalog-rest"
+  },
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog-rest",
+  "dependencies": {
+    "@azure-rest/purview-catalog": "next",
+    "dotenv": "latest",
+    "@azure/identity": "^2.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^14.0.0",
+    "typescript": "~4.8.0",
+    "rimraf": "latest"
+  }
+}

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/sample.env
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/sample.env
@@ -1,0 +1,7 @@
+# Purview Scanning resource endpoint
+ENDPOINT=
+
+# App registration secret for AAD authentication
+AZURE_CLIENT_SECRET=
+AZURE_CLIENT_ID=
+AZURE_TENANT_ID= 

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/src/typedefs.ts
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/src/typedefs.ts
@@ -5,7 +5,6 @@
  * This sample demonstrates how get a list of typedefs
  *
  * @summary gets a list of typedefs for entities
- * @azsdk-weight 40
  */
 
 import PurviewCatalog from "@azure-rest/purview-catalog";

--- a/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/tsconfig.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1-beta/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**.ts"
+  ]
+}


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/purview-catalog

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/22749

### Describe the problem that is addressed by this PR
Sample was using optional chain which is not supported in ES2020 so adding an explicit nullcheck to fix samples publishing.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
