### PR TITLE
[core-amqp] request response link should reject when sender error

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue in `RequestResponseLink` where sender error is not rejected [PR #23646](https://github.com/Azure/azure-sdk-for-js/pull/23646).
+
 ### Other Changes
 
 ## 3.1.1 (2022-09-01)

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -349,8 +349,8 @@ function onSenderError(
         `[${connectionId}] Sender closed due to error when sending request with message_id "${key}"`
       );
       promise.cleanupBeforeResolveOrReject();
-      responsesMap.delete(key);
       promise.reject(context.sender.error);
     }
+    responsesMap.clear();
   }
 }

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -12,6 +12,7 @@ import {
   ReqResLink,
   Message as RheaMessage,
   Sender,
+  SenderEvents,
   SenderOptions,
   Session,
   generate_uuid,
@@ -66,6 +67,9 @@ export class RequestResponseLink implements ReqResLink {
     this.receiver = receiver;
     this.receiver.on(ReceiverEvents.message, (context) => {
       onMessageReceived(context, this.connection.id, this._responsesMap);
+    });
+    this.sender.on(SenderEvents.senderError, (context) => {
+      onSenderError(context, this.connection.id, this._responsesMap);
     });
   }
 
@@ -332,4 +336,21 @@ export function onMessageReceived(
   }
   logErrorStackTrace(error);
   return promise.reject(error);
+}
+
+function onSenderError(
+  context: Pick<EventContext, "sender">,
+  connectionId: string,
+  responsesMap: Map<string, DeferredPromiseWithCallback>
+): void {
+  if (context.sender) {
+    for (const [key, promise] of responsesMap.entries()) {
+      logger.verbose(
+        `[${connectionId}] Sender closed due to error when sending request with message_id "${key}"`
+      );
+      promise.cleanupBeforeResolveOrReject();
+      responsesMap.delete(key);
+      promise.reject(context.sender.error);
+    }
+  }
 }

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -103,6 +103,7 @@ describe("RequestResponseLink", function () {
           send: (request: any) => {
             req = request;
           },
+          on: () => { /* no_op */ },
         });
       },
       createReceiver: () => {
@@ -148,6 +149,9 @@ describe("RequestResponseLink", function () {
         return Promise.resolve({
           send: (request: RheaMessage) => {
             reqs.push(request);
+          },
+          on: () => {
+            /* no_op */
           },
         });
       },
@@ -216,6 +220,9 @@ describe("RequestResponseLink", function () {
           send: (request: RheaMessage) => {
             reqs.push(request);
           },
+          on: () => {
+            /* no_op */
+          },
         });
       },
       createReceiver: () => {
@@ -259,6 +266,9 @@ describe("RequestResponseLink", function () {
         return Promise.resolve({
           send: (request: RheaMessage) => {
             reqs.push(request);
+          },
+          on: () => {
+            /* no_op */
           },
         });
       },
@@ -341,6 +351,9 @@ describe("RequestResponseLink", function () {
             count++;
             messageId = request.message_id;
           },
+          on: () => {
+            /* no_op */
+          },
         });
       },
       createReceiver: () => {
@@ -419,6 +432,9 @@ describe("RequestResponseLink", function () {
           send: (request: any) => {
             req = request;
           },
+          on: () => {
+            /* no_op */
+          },
         });
       },
       createReceiver: () => {
@@ -478,6 +494,9 @@ describe("RequestResponseLink", function () {
         return Promise.resolve({
           send: (request: any) => {
             req = request;
+          },
+          on: () => {
+            /* no_op */
           },
         });
       },
@@ -549,6 +568,9 @@ describe("RequestResponseLink", function () {
         return Promise.resolve({
           send: (request: any) => {
             req = request;
+          },
+          on: () => {
+            /* no_op */
           },
         });
       },
@@ -627,6 +649,9 @@ describe("RequestResponseLink", function () {
             send: (request: any) => {
               req = request;
             },
+            on: () => {
+              /* no_op */
+            },
           });
         },
         createReceiver: () => {
@@ -681,6 +706,9 @@ describe("RequestResponseLink", function () {
             send: (request: any) => {
               req = request;
             },
+            on: () => {
+              /* no_op */
+            },
           });
         },
         createReceiver: () => {
@@ -730,6 +758,9 @@ describe("RequestResponseLink", function () {
               /* no op */
             },
             close: fake(),
+            on: () => {
+              /* no_op */
+            },
           });
         },
         createReceiver: () => {

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -103,7 +103,9 @@ describe("RequestResponseLink", function () {
           send: (request: any) => {
             req = request;
           },
-          on: () => { /* no_op */ },
+          on: () => {
+            /* no_op */
+          },
         });
       },
       createReceiver: () => {

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -181,7 +181,7 @@ describe("Sender Tests", () => {
 
   it(noSessionTestClientType + "should reject with proper error instead of OperationTimeoutError", async function (): Promise<void> {
     await beforeEachTest(noSessionTestClientType);
-    const content = (new Array(256 * 1024)).join("x"); //Generate a Large Message Content of 265KB
+    const content = (new Array(256 * 1024)).join("x"); // Generate a Large Message Content of 265KB
     const largeMessage = {
       contentType: "application/json",
       subject: "Scientist",

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -179,6 +179,29 @@ describe("Sender Tests", () => {
     await testSimpleSendArray();
   });
 
+  it(noSessionTestClientType + "should reject with proper error instead of OperationTimeoutError", async function (): Promise<void> {
+    await beforeEachTest(noSessionTestClientType);
+    const content = (new Array(256 * 1024)).join("x"); //Generate a Large Message Content of 265KB
+    const largeMessage = {
+      contentType: "application/json",
+      subject: "Scientist",
+      body: content,
+      timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
+    };
+
+    let actualErrorCode = "";
+    let actualErr;
+    try {
+      await sender.scheduleMessages(largeMessage, new Date(Date.now()));
+      throw new Error("Test fail if reaching here.");
+    } catch (err: any) {
+      actualErr = err;
+      actualErrorCode = err.code;
+    }
+
+    should.equal(actualErrorCode, "MessageSizeExceeded", actualErr);
+  });
+
   async function testScheduleSingleMessage(): Promise<void> {
     const testMessage = entityName.usesSessions
       ? TestMessage.getSessionSample()

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -179,28 +179,31 @@ describe("Sender Tests", () => {
     await testSimpleSendArray();
   });
 
-  it(noSessionTestClientType + "should reject with proper error instead of OperationTimeoutError", async function (): Promise<void> {
-    await beforeEachTest(noSessionTestClientType);
-    const content = (new Array(256 * 1024)).join("x"); // Generate a Large Message Content of 265KB
-    const largeMessage = {
-      contentType: "application/json",
-      subject: "Scientist",
-      body: content,
-      timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
-    };
+  it(
+    noSessionTestClientType + "should reject with proper error instead of OperationTimeoutError",
+    async function (): Promise<void> {
+      await beforeEachTest(noSessionTestClientType);
+      const content = new Array(256 * 1024).join("x"); // Generate a Large Message Content of 265KB
+      const largeMessage = {
+        contentType: "application/json",
+        subject: "Scientist",
+        body: content,
+        timeToLive: 2 * 60 * 1000, // message expires in 2 minutes
+      };
 
-    let actualErrorCode = "";
-    let actualErr;
-    try {
-      await sender.scheduleMessages(largeMessage, new Date(Date.now()));
-      throw new Error("Test fail if reaching here.");
-    } catch (err: any) {
-      actualErr = err;
-      actualErrorCode = err.code;
+      let actualErrorCode = "";
+      let actualErr;
+      try {
+        await sender.scheduleMessages(largeMessage, new Date(Date.now()));
+        throw new Error("Test fail if reaching here.");
+      } catch (err: any) {
+        actualErr = err;
+        actualErrorCode = err.code;
+      }
+
+      should.equal(actualErrorCode, "MessageSizeExceeded", actualErr);
     }
-
-    should.equal(actualErrorCode, "MessageSizeExceeded", actualErr);
-  });
+  );
 
   async function testScheduleSingleMessage(): Promise<void> {
     const testMessage = entityName.usesSessions


### PR DESCRIPTION
When the remote closes the sender with an error we currently just log the error logged as a warning and are not doing anything else. Since we won't receive any response, the send operation eventually times out, rejecting with `OperationTimeoutError`. As `OperationTimeoutError` is retryable, we would get the same time out error in each retry again, even though some sender errors are not retryable, for example, `MessageSizeExceeded` error in issue #23623.

This PR rejects the promise of request on sender_error events so that it fails with proper errors. These errors still go through the retry logic, but should be failing faster.


### Packages impacted by this PR
`@azure/core-amqp`
