### PR TITLE
Update Item batch operation method signature

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -896,7 +896,7 @@ export class ItemResponse<T extends ItemDefinition> extends ResourceResponse<T &
 // @public
 export class Items {
     constructor(container: Container, clientContext: ClientContext);
-    batch(operations: OperationInput[], partitionKey?: string, options?: RequestOptions): Promise<Response_2<any>>;
+    batch(operations: OperationInput[], partitionKey?: string, options?: RequestOptions): Promise<Response_2<OperationResponse[]>>;
     bulk(operations: OperationInput[], bulkOptions?: BulkOptions, options?: RequestOptions): Promise<OperationResponse[]>;
     changeFeed(partitionKey: string | number | boolean, changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
     changeFeed(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -501,7 +501,7 @@ export class Items {
     operations: OperationInput[],
     partitionKey: string = "[{}]",
     options?: RequestOptions
-  ): Promise<Response<any>> {
+  ): Promise<Response<OperationResponse[]>> {
     operations.map((operation) => decorateBatchOperation(operation, options));
 
     const path = getPathFromLink(this.container.url, ResourceType.item);
@@ -510,7 +510,7 @@ export class Items {
       throw new Error("Cannot run batch request with more than 100 operations per partition");
     }
     try {
-      const response = await this.clientContext.batch({
+      const response: Response<OperationResponse[]> = await this.clientContext.batch({
         body: operations,
         partitionKey,
         path,

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT license.
 import assert from "assert";
 import { Suite } from "mocha";
-import { Container, CosmosClient, PatchOperation, PatchOperationType } from "../../../src";
+import {
+  Container,
+  CosmosClient,
+  OperationResponse,
+  PatchOperation,
+  PatchOperationType,
+} from "../../../src";
 import { ItemDefinition } from "../../../src";
 import {
   bulkDeleteItems,
@@ -716,7 +722,12 @@ describe("bulk/batch item operations", function () {
     });
 
     function isOperationResponse(object: unknown): object is OperationResponse {
-      return typeof object === "object" && object !== null && Object.prototype.hasOwnProperty.call(object, "statusCode") && Object.prototype.hasOwnProperty.call(object, "requestCharge");
+      return (
+        typeof object === "object" &&
+        object !== null &&
+        Object.prototype.hasOwnProperty.call(object, "statusCode") &&
+        Object.prototype.hasOwnProperty.call(object, "requestCharge")
+      );
     }
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -37,7 +37,7 @@ describe("Item CRUD", function (this: Suite) {
   const documentCRUDTest = async function (isUpsertTest: boolean): Promise<void> {
     // create database
     const database = await getTestDatabase("sample 中文 database");
-    // create container                  
+    // create container
     const { resource: containerdef } = await database.containers.create({ id: "sample container" });
     const container: Container = database.container(containerdef.id);
 
@@ -679,7 +679,7 @@ describe("bulk/batch item operations", function () {
         },
         {
           operationType: BulkOperationType.Patch,
-          id: patchItemId, 
+          id: patchItemId,
           resourceBody: {
             operations: [{ op: PatchOperationType.add, path: "/good", value: "greatValue" }],
             condition: "from c where NOT IS_DEFINED(c.newImproved)",
@@ -716,7 +716,12 @@ describe("bulk/batch item operations", function () {
     });
 
     function isOperationResponse(object: any): boolean {
-      return 'statusCode' in object && 'requestCharge' in object && 'eTag' in object && 'resourceBody' in object;
+      return (
+        "statusCode" in object &&
+        "requestCharge" in object &&
+        "eTag" in object &&
+        "resourceBody" in object
+      );
     }
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -716,12 +716,7 @@ describe("bulk/batch item operations", function () {
     });
 
     function isOperationResponse(object: any): boolean {
-      return (
-        "statusCode" in object &&
-        "requestCharge" in object &&
-        "eTag" in object &&
-        "resourceBody" in object
-      );
+      return "statusCode" in object && "requestCharge" in object;
     }
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -37,7 +37,7 @@ describe("Item CRUD", function (this: Suite) {
   const documentCRUDTest = async function (isUpsertTest: boolean): Promise<void> {
     // create database
     const database = await getTestDatabase("sample 中文 database");
-    // create container
+    // create container                  
     const { resource: containerdef } = await database.containers.create({ id: "sample container" });
     const container: Container = database.container(containerdef.id);
 
@@ -679,7 +679,7 @@ describe("bulk/batch item operations", function () {
         },
         {
           operationType: BulkOperationType.Patch,
-          id: patchItemId,
+          id: patchItemId, 
           resourceBody: {
             operations: [{ op: PatchOperationType.add, path: "/good", value: "greatValue" }],
             condition: "from c where NOT IS_DEFINED(c.newImproved)",
@@ -688,6 +688,7 @@ describe("bulk/batch item operations", function () {
       ];
 
       const response = await container.items.batch(operations, "A");
+      assert(isOperationResponse(response.result[0]));
       assert.strictEqual(response.result[0].statusCode, 201);
       assert.strictEqual(response.result[1].statusCode, 201);
       assert.strictEqual(response.result[2].statusCode, 200);
@@ -711,7 +712,12 @@ describe("bulk/batch item operations", function () {
       assert.strictEqual(deleteResponse.result[1].statusCode, 404);
       const { resource: readItem } = await container.item(otherItemId).read();
       assert.strictEqual(readItem, undefined);
+      assert(isOperationResponse(deleteResponse.result[0]));
     });
+
+    function isOperationResponse(object: any): Boolean {
+      return 'statusCode' in object && 'requestCharge' in object && 'eTag' in object && 'resourceBody' in object;
+    }
   });
 });
 describe("patch operations", function () {

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -715,8 +715,8 @@ describe("bulk/batch item operations", function () {
       assert(isOperationResponse(deleteResponse.result[0]));
     });
 
-    function isOperationResponse(object: any): boolean {
-      return "statusCode" in object && "requestCharge" in object;
+    function isOperationResponse(object: unknown): object is OperationResponse {
+      return typeof object === "object" && object !== null && Object.prototype.hasOwnProperty.call(object, "statusCode") && Object.prototype.hasOwnProperty.call(object, "requestCharge");
     }
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -715,7 +715,7 @@ describe("bulk/batch item operations", function () {
       assert(isOperationResponse(deleteResponse.result[0]));
     });
 
-    function isOperationResponse(object: any): Boolean {
+    function isOperationResponse(object: any): boolean {
       return 'statusCode' in object && 'requestCharge' in object && 'eTag' in object && 'resourceBody' in object;
     }
   });


### PR DESCRIPTION
### Packages impacted by this PR
azure-sdk-for-js
### Issues associated with this PR
23518

### Describe the problem that is addressed by this PR
Item.batch has poorly defined return type of response, although it appears to be returning a list of OperationResponse objects in response.results. So, in this PR we are going to update the contract of Item.batch operation from type any to OperationResponse[].

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Updating the contract of batch operation.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
