### PR TITLE
[core-http] Handle special case for `x-ms-text` autorest extension

### DIFF
--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -885,8 +885,14 @@ function deserializeCompositeType(
           propertyObjectName,
           options
         );
-      } else if (propertyMapper.xmlIsMsText && responseBody[XML_CHARKEY] !== undefined) {
-        instance[key] = responseBody[XML_CHARKEY];
+      } else if (propertyMapper.xmlIsMsText) {
+        if (responseBody[XML_CHARKEY] !== undefined) {
+          instance[key] = responseBody[XML_CHARKEY];
+        } else if (typeof responseBody === "string") {
+          // The special case where xml parser parses "<Name>content</Name>" into JSON of
+          //   `{ name: "content"}` instead of `{ name: { "_": "content" }}`
+          instance[key] = responseBody;
+        }
       } else {
         const propertyName = xmlElementName || xmlName || serializedName;
         if (propertyMapper.xmlIsWrapped) {

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -1723,6 +1723,47 @@ describe("msrest", function () {
 
         assert.deepEqual(result, { encoded: true, content: "dir%EF%BF%BE0166562954291707607" });
       });
+
+      it("should handle xmlIsMsText flag for degenerated string case", function () {
+        const stringEncoded: msRest.CompositeMapper = {
+          serializedName: "StringEncoded",
+          type: {
+            name: "Composite",
+            className: "StringEncoded",
+            modelProperties: {
+              encoded: {
+                serializedName: "Encoded",
+                xmlName: "Encoded",
+                xmlIsAttribute: true,
+                type: {
+                  name: "Boolean",
+                },
+              },
+              content: {
+                serializedName: "content",
+                xmlName: "content",
+                xmlIsMsText: true,
+                type: {
+                  name: "String",
+                },
+              },
+            },
+          },
+        };
+
+        const mappers = {
+          StringEncoded: stringEncoded,
+        };
+        const serializer = new msRest.Serializer(mappers, true);
+        const result: any = serializer.deserialize(
+          stringEncoded,
+          "justastring",
+          "mockedStringEncoded"
+        );
+
+        assert.equal(result.content, "justastring");
+        assert.equal(result.encoded, undefined);
+      });
     });
 
     describe("polymorphic composite type array", () => {


### PR DESCRIPTION
where there's no XML attributes, and the XML parser parses
"\<Name\>content\</Name\>" into `Name: "content"` instead of `Name: { "_": "content" }`

### Packages impacted by this PR
`@azure/core-http`
