### PR TITLE
remove team for all Communication requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,9 +43,6 @@
 # PRLabel: %Batch
 /sdk/batch/ @dpwatrous @paterasMSFT @zfengms @deyaaeldeen
 
-# PRLabel: %Communication
-/sdk/communication/ @petrsvihlik @AikoBB @maximrytych-ms
-
 # PRLabel: %Communication - Identity
 /sdk/communication/communication-identity/ @petrsvihlik @AikoBB @maximrytych-ms @ostoliarova-msft
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,9 @@
 # PRLabel: %Batch
 /sdk/batch/ @dpwatrous @paterasMSFT @zfengms @deyaaeldeen
 
+# PRLabel: %Communication
+/sdk/communication/
+
 # PRLabel: %Communication - Identity
 /sdk/communication/communication-identity/ @petrsvihlik @AikoBB @maximrytych-ms @ostoliarova-msft
 


### PR DESCRIPTION
### Packages impacted by this PR
Communication

### Issues associated with this PR
As separate teams exist for SDKs under `Communication`, there is no need to have dedicated people for all PRs and issues for all these SDKs.

### Describe the problem that is addressed by this PR
Excessive `Communication` PR notifications.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
