### PR TITLE
Remove unnecessary @azure/core-http deps

### DIFF
--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -29,6 +29,9 @@
       "path": "sdk/communication/communication-common"
     },
     {
+      "path": "sdk/communication/communication-email"
+    },
+    {
       "name": "communication-identity",
       "path": "sdk/communication/communication-identity"
     },

--- a/sdk/appconfiguration/perf-tests/app-configuration/package.json
+++ b/sdk/appconfiguration/perf-tests/app-configuration/package.json
@@ -9,7 +9,6 @@
   "license": "ISC",
   "dependencies": {
     "@azure/app-configuration": "^1.2.0-beta.2",
-    "@azure/core-http": "^2.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0"
   },

--- a/sdk/appconfiguration/perf-tests/app-configuration/test/listSettings.spec.ts
+++ b/sdk/appconfiguration/perf-tests/app-configuration/test/listSettings.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { generateUuid } from "@azure/core-http";
+import { v4 as generateUuid } from "uuid";
 import { PerfOptionDictionary, executeParallel } from "@azure/test-utils-perf";
 import { AppConfigTest } from "./appConfigBase.spec";
 

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -49,8 +49,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.2",
-    "@azure/core-http": "^2.0.0",
-    "@azure/core-rest-pipeline": "^1.3.2",
+    "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/communication-common": "^2.1.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^1.9.3",

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -28,7 +28,7 @@
     "@azure/communication-sms": "latest",
     "dotenv": "latest",
     "@azure/communication-common": "^2.1.0",
-    "@azure/core-http": "^2.0.0",
+    "@azure/core-rest-pipeline": "^1.3.2",
     "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -28,7 +28,7 @@
     "@azure/communication-sms": "latest",
     "dotenv": "latest",
     "@azure/communication-common": "^2.1.0",
-    "@azure/core-rest-pipeline": "^1.3.2",
+    "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/identity": "^2.0.1"
   }
 }

--- a/sdk/communication/communication-sms/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/typescript/package.json
@@ -32,7 +32,7 @@
     "@azure/communication-sms": "latest",
     "dotenv": "latest",
     "@azure/communication-common": "^2.1.0",
-    "@azure/core-http": "^2.0.0",
+    "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/identity": "^2.0.1"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -105,7 +105,6 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
-    "@azure/core-http": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.1.0",

--- a/sdk/servicebus/service-bus/test/stress/app/package.json
+++ b/sdk/servicebus/service-bus/test/stress/app/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "applicationinsights": "^1.8.8",
     "@azure/service-bus": "latest",
-    "@azure/core-http": "latest",
     "dotenv": "^8.2.0",
     "minimist": "^1.2.5",
     "uuid": "^8.3.0"

--- a/sdk/servicebus/service-bus/test/stress/app/src/scenarioShortLivedReceivers.ts
+++ b/sdk/servicebus/service-bus/test/stress/app/src/scenarioShortLivedReceivers.ts
@@ -17,7 +17,7 @@ import {
 import { EventEmitter } from "stream";
 import { EventContext, ReceiverEvents } from "rhea-promise";
 import parsedArgs from "minimist";
-import { generateUuid } from "@azure/core-http";
+import { v4 as generateUuid } from "uuid";
 
 const messageNumberPropertyName = "messageNumber";
 

--- a/sdk/template/perf-tests/template/package.json
+++ b/sdk/template/perf-tests/template/package.json
@@ -9,7 +9,6 @@
   "license": "ISC",
   "dependencies": {
     "@azure/app-configuration": "^1.3.1",
-    "@azure/core-http": "^2.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^8.2.0",
     "@azure/template": "^1.0.11-beta.1 || ^1.0.12-beta.1",

--- a/sdk/template/perf-tests/template/test/getConfigurationSetting.spec.ts
+++ b/sdk/template/perf-tests/template/test/getConfigurationSetting.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { generateUuid } from "@azure/core-http";
+import { v4 as generateUuid } from "uuid";
 import { PerfOptionDictionary } from "@azure/test-utils-perf";
 import { TemplateTest } from "./templateBase.spec";
 


### PR DESCRIPTION
Trying to pay down some debt by removing places we depend on `@azure/core-http` where I think we don't actually need to.

Used this for discovery: https://cs.github.com/Azure/azure-sdk-for-js?q=%40azure%2Fcore-http%22+language%3AJSON

@HarshaNalluru can you confirm that the perf test changes won't affect anything? It looked like we were only using the generateUuid function.