### PR TITLE
[Language Text] Correct implementation of auto language detection

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
+++ b/sdk/cognitivelanguage/ai-language-text/review/ai-language-text.api.md
@@ -204,10 +204,10 @@ export interface BatchActionState<Kind extends AnalyzeBatchActionName> {
 }
 
 // @public
-export interface BatchActionSuccessResult<T extends DocumentDetectedLanguage, Kind extends AnalyzeBatchActionName> extends BatchActionState<Kind> {
+export interface BatchActionSuccessResult<T, Kind extends AnalyzeBatchActionName> extends BatchActionState<Kind> {
     readonly completedOn: Date;
     readonly error?: undefined;
-    readonly results: T[];
+    readonly results: WithDetectedLanguage<T>[];
 }
 
 // @public
@@ -1497,5 +1497,10 @@ export interface WeightResolution extends BaseResolution, QuantityResolution {
 
 // @public
 export type WeightUnit = string;
+
+// @public
+export type WithDetectedLanguage<T> = T & DocumentDetectedLanguage & {
+    isLanguageDefaulted?: boolean;
+};
 
 ```

--- a/sdk/cognitivelanguage/ai-language-text/src/models.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/models.ts
@@ -908,16 +908,23 @@ export interface CustomActionMetadata {
 }
 
 /**
+ * Document results with potentially automatically detected language.
+ */
+export type WithDetectedLanguage<T> = T &
+  DocumentDetectedLanguage & {
+    /** Indicates whether the default language hint was used */
+    isLanguageDefaulted?: boolean;
+  };
+
+/**
  * The state of a succeeded batched action.
  */
-export interface BatchActionSuccessResult<
-  T extends DocumentDetectedLanguage,
-  Kind extends AnalyzeBatchActionName
-> extends BatchActionState<Kind> {
+export interface BatchActionSuccessResult<T, Kind extends AnalyzeBatchActionName>
+  extends BatchActionState<Kind> {
   /**
    * The list of document results.
    */
-  readonly results: T[];
+  readonly results: WithDetectedLanguage<T>[];
   /**
    * When this action was completed by the service.
    */

--- a/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
@@ -47,6 +47,9 @@ import {
   TargetRelation,
   DynamicClassificationResultDocumentsItem,
   ClassificationCategory,
+  CustomEntitiesResultDocumentsItem,
+  ExtractedSummaryDocumentResultWithDetectedLanguage,
+  AbstractiveSummaryDocumentResultWithDetectedLanguage,
 } from "./generated";
 import {
   AnalyzeActionName,
@@ -509,7 +512,7 @@ export function transformAnalyzeBatchResults(
         const { deploymentName, projectName, statistics } = results;
         return {
           kind: "CustomEntityRecognition",
-          results: transformDocumentResults(docIds, results),
+          results: transformDocumentResults<CustomEntitiesResultDocumentsItem>(docIds, results),
           completedOn,
           ...(actionName ? { actionName } : {}),
           ...(statistics ? { statistics } : {}),
@@ -548,7 +551,10 @@ export function transformAnalyzeBatchResults(
         const { modelVersion, statistics } = results;
         return {
           kind: "ExtractiveSummarization",
-          results: transformDocumentResults(docIds, results),
+          results: transformDocumentResults<ExtractedSummaryDocumentResultWithDetectedLanguage>(
+            docIds,
+            results
+          ),
           completedOn,
           ...(actionName ? { actionName } : {}),
           ...(statistics ? { statistics } : {}),
@@ -560,7 +566,10 @@ export function transformAnalyzeBatchResults(
         const { modelVersion, statistics } = results;
         return {
           kind: "AbstractiveSummarization",
-          results: transformDocumentResults(docIds, results),
+          results: transformDocumentResults<AbstractiveSummaryDocumentResultWithDetectedLanguage>(
+            docIds,
+            results
+          ),
           completedOn,
           ...(actionName ? { actionName } : {}),
           ...(statistics ? { statistics } : {}),


### PR DESCRIPTION
The old implementation was an added type constraint but that was not correct because the types used for instantiation didn't respect the constraint. This PR replaces the constraint with an intersection type instead.

This implementation makes sure that `detectedLanguage` is part of the output models for `beginAnalyzeBatch` but not for the corresponding ones for `analyze`.

The PR also adds `isLanguageDefaulted` property which is returned by the service but not described in the swagger.