### PR TITLE
Revert "add move operation"

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -945,13 +945,6 @@ interface Location_2 {
 }
 export { Location_2 as Location }
 
-// @public (undocumented)
-export type MoveOperation = {
-    op: keyof typeof PatchOperationType;
-    from: string;
-    path: string;
-};
-
 // @public
 export type Next<T> = (context: RequestContext) => Promise<Response_2<T>>;
 
@@ -1117,7 +1110,7 @@ export interface PartitionKeyRangePropertiesNames {
 }
 
 // @public (undocumented)
-export type PatchOperation = ExistingKeyOperation | RemoveOperation | MoveOperation;
+export type PatchOperation = ExistingKeyOperation | RemoveOperation;
 
 // @public (undocumented)
 export interface PatchOperationInput {
@@ -1142,7 +1135,6 @@ export const PatchOperationType: {
     readonly remove: "remove";
     readonly set: "set";
     readonly incr: "incr";
-    readonly move: "move";
 };
 
 // @public (undocumented)

--- a/sdk/cosmosdb/cosmos/samples/v3/javascript/ItemManagement.js
+++ b/sdk/cosmosdb/cosmos/samples/v3/javascript/ItemManagement.js
@@ -208,11 +208,6 @@ async function run() {
         path: "/address/zip",
         value: 5,
       },
-      {
-        op: "move",
-        from: "/address/zip",
-        path: "/zip",
-      },
     ];
     const { resource: patchSource2 } = await container.item(patchId).patch(multipleOperations);
     if (patchSource2) {

--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -29,7 +29,6 @@ export {
   PatchOperation,
   PatchOperationType,
   ExistingKeyOperation,
-  MoveOperation,
   RemoveOperation,
   PatchRequestBody,
 } from "./utils/patch";

--- a/sdk/cosmosdb/cosmos/src/utils/patch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/patch.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export type PatchOperation = ExistingKeyOperation | RemoveOperation | MoveOperation;
+export type PatchOperation = ExistingKeyOperation | RemoveOperation;
 
 export const PatchOperationType = {
   add: "add",
@@ -9,14 +9,7 @@ export const PatchOperationType = {
   remove: "remove",
   set: "set",
   incr: "incr",
-  move: "move",
 } as const;
-
-export type MoveOperation = {
-  op: keyof typeof PatchOperationType;
-  from: string;
-  path: string;
-};
 
 export type ExistingKeyOperation = {
   op: keyof typeof PatchOperationType;

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -391,30 +391,6 @@ describe("bulk/batch item operations", function () {
             condition: "from c where NOT IS_DEFINED(c.newImproved)",
           },
         },
-        {
-          operationType: BulkOperationType.Patch,
-          partitionKey: 5,
-          id: patchItemId,
-          resourceBody: {
-            operations: [{ op: PatchOperationType.add, path: "/goodKey", value: "goodValue" }],
-          },
-        },
-        {
-          operationType: BulkOperationType.Patch,
-          partitionKey: 5,
-          id: patchItemId,
-          resourceBody: {
-            operations: [{ op: PatchOperationType.add, path: "/greatKey", value: "greatValue" }],
-          },
-        },
-        {
-          operationType: BulkOperationType.Patch,
-          partitionKey: 5,
-          id: patchItemId,
-          resourceBody: {
-            operations: [{ op: PatchOperationType.move, from: "/greatKey", path: "/goodKey" }],
-          },
-        },
       ];
       const response = await v2Container.items.bulk(operations);
       // Create
@@ -431,12 +407,9 @@ describe("bulk/batch item operations", function () {
       // Replace
       assert.strictEqual(response[4].resourceBody.name, "nice");
       assert.strictEqual(response[4].statusCode, 200);
-      // Patch add
+      // Patch
       assert.strictEqual(response[5].resourceBody.great, "goodValue");
       assert.strictEqual(response[5].statusCode, 200);
-      // Patch move
-      assert.strictEqual(response[9].resourceBody.goodKey, "greatValue");
-      assert.strictEqual(response[9].statusCode, 200);
     });
     it("respects order", async function () {
       readItemId = addEntropy("item1");


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-js#23128

Somehow tests got passed in this PR build (We are investigating how those tests are ignored)

Also we need to have the emulator support for this to work which is not in public yet!