### PR TITLE
[identity] Fix MSAL Flow additionallyAllowedTenantIds to pass through

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -13,6 +13,11 @@ import {
   publicToMsal,
 } from "../utils";
 import { MsalFlow, MsalFlowOptions } from "../flows";
+import {
+  processMultiTenantRequest,
+  resolveAddionallyAllowedTenantIds,
+  resolveTenantId,
+} from "../../util/tenantIdUtils";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { AuthenticationRecord } from "../types";
 import { AuthenticationRequiredError } from "../../errors";
@@ -20,10 +25,9 @@ import { CredentialFlowGetTokenOptions } from "../credentials";
 import { DeveloperSignOnClientId } from "../../constants";
 import { IdentityClient } from "../../client/identityClient";
 import { LogPolicyOptions } from "@azure/core-rest-pipeline";
+import { MultiTenantTokenCredentialOptions } from "../../credentials/multiTenantTokenCredentialOptions";
 import { RegionalAuthority } from "../../regionalAuthority";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
-import { TokenCredentialOptions } from "../../tokenCredentialOptions";
-import { processMultiTenantRequest, resolveTenantId } from "../../util/tenantIdUtils";
 
 /**
  * Union of the constructor parameters that all MSAL flow types for Node.
@@ -31,7 +35,7 @@ import { processMultiTenantRequest, resolveTenantId } from "../../util/tenantIdU
  */
 export interface MsalNodeOptions extends MsalFlowOptions {
   tokenCachePersistenceOptions?: TokenCachePersistenceOptions;
-  tokenCredentialOptions: TokenCredentialOptions;
+  tokenCredentialOptions: MultiTenantTokenCredentialOptions;
   /**
    * Specifies a regional authority. Please refer to the {@link RegionalAuthority} type for the accepted values.
    * If {@link RegionalAuthority.AutoDiscoverRegion} is specified, we will try to discover the regional authority endpoint.
@@ -79,6 +83,7 @@ export abstract class MsalNode extends MsalBaseUtilities implements MsalFlow {
   protected msalConfig: msalNode.Configuration;
   protected clientId: string;
   protected tenantId: string;
+  private additionallyAllowedTenantIds: string[];
   protected authorityHost?: string;
   protected identityClient?: IdentityClient;
   protected requiresConfidential: boolean = false;
@@ -97,6 +102,9 @@ export abstract class MsalNode extends MsalBaseUtilities implements MsalFlow {
     super(options);
     this.msalConfig = this.defaultNodeMsalConfig(options);
     this.tenantId = resolveTenantId(options.logger, options.tenantId, options.clientId);
+    this.additionallyAllowedTenantIds = resolveAddionallyAllowedTenantIds(
+      options?.tokenCredentialOptions?.additionallyAllowedTenants
+    );
     this.clientId = this.msalConfig.auth.clientId;
     if (options?.getAssertion) {
       this.getAssertion = options.getAssertion;
@@ -303,7 +311,9 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     scopes: string[],
     options: CredentialFlowGetTokenOptions = {}
   ): Promise<AccessToken> {
-    const tenantId = processMultiTenantRequest(this.tenantId, options) || this.tenantId;
+    const tenantId =
+      processMultiTenantRequest(this.tenantId, options, this.additionallyAllowedTenantIds) ||
+      this.tenantId;
 
     options.authority = getAuthority(tenantId, this.authorityHost);
 

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -205,7 +205,7 @@ export class MsalOpenBrowser extends MsalNode {
           });
         }
 
-        openPromise.then().catch((e) => {
+        openPromise.catch((e) => {
           cleanup();
           reject(e);
         });

--- a/sdk/identity/identity/src/util/processMultiTenantRequest.browser.ts
+++ b/sdk/identity/identity/src/util/processMultiTenantRequest.browser.ts
@@ -3,7 +3,7 @@
 
 import { GetTokenOptions } from "@azure/core-auth";
 
-function createConfigurationErrorMessage(tenantId: string) {
+function createConfigurationErrorMessage(tenantId: string): string {
   return `The current credential is not configured to acquire tokens for tenant ${tenantId}. To enable acquiring tokens for this tenant add it to the AdditionallyAllowedTenants on the credential options, or add "*" to AdditionallyAllowedTenants to allow acquiring tokens for any tenant.`;
 }
 

--- a/sdk/identity/identity/src/util/processMultiTenantRequest.ts
+++ b/sdk/identity/identity/src/util/processMultiTenantRequest.ts
@@ -3,7 +3,7 @@
 
 import { GetTokenOptions } from "@azure/core-auth";
 
-function createConfigurationErrorMessage(tenantId: string) {
+function createConfigurationErrorMessage(tenantId: string): string {
   return `The current credential is not configured to acquire tokens for tenant ${tenantId}. To enable acquiring tokens for this tenant add it to the AdditionallyAllowedTenants on the credential options, or add "*" to AdditionallyAllowedTenants to allow acquiring tokens for any tenant.`;
 }
 

--- a/sdk/identity/identity/test/httpRequests.browser.ts
+++ b/sdk/identity/identity/test/httpRequests.browser.ts
@@ -82,7 +82,7 @@ export class IdentityTestContext implements IdentityTestContextInterface {
     }
   }
 
-  private _trackRequest(url: RequestInfo, request?: RequestInit) {
+  private _trackRequest(url: RequestInfo, request?: RequestInit): void {
     const headers = new Headers(request?.headers);
     const rawHeaders: Record<string, string> = {};
 

--- a/sdk/identity/identity/test/httpRequests.ts
+++ b/sdk/identity/identity/test/httpRequests.ts
@@ -168,7 +168,10 @@ export class IdentityTestContext implements IdentityTestContextInterface {
     const totalOptions: http.RequestOptions[] = [];
 
     try {
-      const fakeRequest = (options: string | URL | http.RequestOptions, resolve: any) => {
+      const fakeRequest = (
+        options: string | URL | http.RequestOptions,
+        resolve: any
+      ): http.ClientRequest => {
         totalOptions.push(options as http.RequestOptions);
 
         if (!responses.length) {

--- a/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
@@ -115,7 +115,7 @@ async function createJWTTokenFromCertificate(
   authorityHost: string,
   clientId: string,
   certificatePath: string
-) {
+): Promise<string> {
   const privateKeyPemCert = fs.readFileSync(certificatePath);
   const audience = `${authorityHost}/v2.0`;
   const secureContext = tls.createSecureContext({

--- a/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
@@ -29,7 +29,7 @@ describe("OnBehalfOfCredential", function () {
       userAssertionToken: "user-assertion",
     });
 
-    const newMSALClientLogs = () =>
+    const newMSALClientLogs = (): number =>
       testContext.logMessages.filter((message) =>
         message.match("Initialized MSAL's On-Behalf-Of flow")
       ).length;
@@ -62,7 +62,7 @@ describe("OnBehalfOfCredential", function () {
       userAssertionToken: "user-assertion",
     });
 
-    const newMSALClientLogs = () =>
+    const newMSALClientLogs = (): number =>
       testContext.logMessages.filter((message) =>
         message.match("Initialized MSAL's On-Behalf-Of flow")
       ).length;


### PR DESCRIPTION
### Packages impacted by this PR

- [identity]

### Issues associated with this PR

- #23693

### Describe the problem that is addressed by this PR

The `additionallyAllowedTenantIds` was not passed through to the base `MsalFlow` class to allow it to resolve the additionally allowed tenant IDs in the `getToken()` method.  This fixes this bug and also fixes some minor ESLint issues.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
