### PR TITLE
[DevCenter] Move client workaround to customized code

### DIFF
--- a/sdk/devcenter/ci.yml
+++ b/sdk/devcenter/ci.yml
@@ -8,7 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - sdk/devcenter/developer-devcenter-arm
+      - sdk/devcenter/developer-devcenter-rest
       - sdk/devcenter/ci.yml
 
 pr:
@@ -22,7 +22,7 @@ pr:
       - feature/v4
   paths:
     include:
-      - sdk/devcenter/developer-devcenter-arm
+      - sdk/devcenter/developer-devcenter-rest
       - sdk/devcenter/ci.yml
 
 extends:

--- a/sdk/devcenter/developer-devcenter-rest/CHANGELOG.md
+++ b/sdk/devcenter/developer-devcenter-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2022-10-18)
+## 1.0.0-beta.1 (2022-11-11)
 
 ### Features Added
 Initial release of the Azure DevCenter package

--- a/sdk/devcenter/developer-devcenter-rest/karma.conf.js
+++ b/sdk/devcenter/developer-devcenter-rest/karma.conf.js
@@ -7,7 +7,7 @@ require("dotenv").config();
 const { relativeRecordingsPath } = require("@azure-tools/test-recorder");
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -27,7 +27,7 @@ module.exports = function (config) {
       "karma-coverage",
       "karma-sourcemap-loader",
       "karma-junit-reporter",
-      "karma-source-map-support",
+      "karma-source-map-support"
     ],
 
     // list of files / patterns to load in the browser
@@ -37,8 +37,8 @@ module.exports = function (config) {
         pattern: "dist-test/index.browser.js.map",
         type: "html",
         included: false,
-        served: true,
-      },
+        served: true
+      }
     ],
 
     // list of files / patterns to exclude
@@ -47,7 +47,7 @@ module.exports = function (config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"],
+      "**/*.js": ["sourcemap", "env"]
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.js": ["coverage"]
@@ -59,7 +59,7 @@ module.exports = function (config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_CLIENT_ID",
       "AZURE_TENANT_ID",
-      "SUBSCRIPTION_ID",
+      "SUBSCRIPTION_ID"
     ],
 
     // test results reporter to use
@@ -74,8 +74,8 @@ module.exports = function (config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
-      ],
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
+      ]
     },
 
     junitReporter: {
@@ -85,7 +85,7 @@ module.exports = function (config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {}, // key value pair of properties to add to the <properties> section of the report
+      properties: {} // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -107,8 +107,8 @@ module.exports = function (config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"],
-      },
+        flags: ["--no-sandbox", "--disable-web-security"]
+      }
     },
 
     // Continuous Integration mode
@@ -127,8 +127,8 @@ module.exports = function (config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000",
-      },
-    },
+        timeout: "600000"
+      }
+    }
   });
 };

--- a/sdk/devcenter/developer-devcenter-rest/karma.conf.js
+++ b/sdk/devcenter/developer-devcenter-rest/karma.conf.js
@@ -7,7 +7,7 @@ require("dotenv").config();
 const { relativeRecordingsPath } = require("@azure-tools/test-recorder");
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -27,7 +27,7 @@ module.exports = function(config) {
       "karma-coverage",
       "karma-sourcemap-loader",
       "karma-junit-reporter",
-      "karma-source-map-support"
+      "karma-source-map-support",
     ],
 
     // list of files / patterns to load in the browser
@@ -37,8 +37,8 @@ module.exports = function(config) {
         pattern: "dist-test/index.browser.js.map",
         type: "html",
         included: false,
-        served: true
-      }
+        served: true,
+      },
     ],
 
     // list of files / patterns to exclude
@@ -47,7 +47,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["sourcemap", "env"]
+      "**/*.js": ["sourcemap", "env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       // "dist-test/index.js": ["coverage"]
@@ -59,7 +59,7 @@ module.exports = function(config) {
       "AZURE_CLIENT_SECRET",
       "AZURE_CLIENT_ID",
       "AZURE_TENANT_ID",
-      "SUBSCRIPTION_ID"
+      "SUBSCRIPTION_ID",
     ],
 
     // test results reporter to use
@@ -74,8 +74,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -85,7 +85,7 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     // web server port
@@ -107,8 +107,8 @@ module.exports = function(config) {
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-web-security"]
-      }
+        flags: ["--no-sandbox", "--disable-web-security"],
+      },
     },
 
     // Continuous Integration mode
@@ -127,8 +127,8 @@ module.exports = function(config) {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/devcenter/developer-devcenter-rest/recordings/node/devcenter_dev_boxes_operations_test/recording_create_dev_box.json
+++ b/sdk/devcenter/developer-devcenter-rest/recordings/node/devcenter_dev_boxes_operations_test/recording_create_dev_box.json
@@ -167,7 +167,7 @@
       }
     },
     {
-      "RequestUri": "https://88888888-8888-8888-8888-888888888888-sdk-test-devcenter.devcenter.azure.com/projects/sdk-default-project/users/me/devboxes/SdkTestDevBox?api-version=2022-03-01-preview\u0026api-version=2022-03-01-preview",
+      "RequestUri": "https://88888888-8888-8888-8888-888888888888-sdk-test-devcenter.devcenter.azure.com/projects/sdk-default-project/users/me/devboxes/SdkTestDevBox?api-version=2022-03-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/devcenter/developer-devcenter-rest/recordings/node/devcenter_environments_operations_test/recording_create_environment.json
+++ b/sdk/devcenter/developer-devcenter-rest/recordings/node/devcenter_environments_operations_test/recording_create_environment.json
@@ -187,7 +187,7 @@
       }
     },
     {
-      "RequestUri": "https://88888888-8888-8888-8888-888888888888-sdk-test-devcenter.devcenter.azure.com/projects/sdk-default-project/users/me/environments/SdkTest-Environment?api-version=2022-03-01-preview\u0026api-version=2022-03-01-preview",
+      "RequestUri": "https://88888888-8888-8888-8888-888888888888-sdk-test-devcenter.devcenter.azure.com/projects/sdk-default-project/users/me/environments/SdkTest-Environment?api-version=2022-03-01-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",

--- a/sdk/devcenter/developer-devcenter-rest/review/developer-devcenter.api.md
+++ b/sdk/devcenter/developer-devcenter-rest/review/developer-devcenter.api.md
@@ -119,6 +119,9 @@ export interface CloudErrorOutput {
 }
 
 // @public
+function createClient(tenantId: string, devCenter: string, credentials: TokenCredential, options?: ClientOptions): AzureDevCenterClient;
+
+// @public
 function createClient(tenantId: string, devCenter: string, credentials: TokenCredential, devCenterDnsSuffix?: string, options?: ClientOptions): AzureDevCenterClient;
 export default createClient;
 

--- a/sdk/devcenter/developer-devcenter-rest/src/azureDevCenter.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/azureDevCenter.ts
@@ -6,19 +6,59 @@ import { TokenCredential } from "@azure/core-auth";
 import { AzureDevCenterClient } from "./generated/clientDefinitions";
 import getClientInternal from "./generated/azureDevCenter";
 
+const defaultDevCenterDnsSuffix = "devcenter.azure.com";
+
 /**
  * Initialize a new instance of the class AzureDevCenterClient class.
  * @param tenantId type: string The tenant to operate on.
  * @param devCenter type: string The DevCenter to operate on.
- * @param devCenterDnsSuffix type: string The DNS suffix used as the base for all devcenter requests.
  * @param credentials type: TokenCredential
+ * @param options type: ClientOptions
  */
 export default function createClient(
   tenantId: string,
   devCenter: string,
   credentials: TokenCredential,
-  devCenterDnsSuffix: string = "devcenter.azure.com",
-  options: ClientOptions = {}
+  options?: ClientOptions
+): AzureDevCenterClient;
+
+/**
+ * Initialize a new instance of the class AzureDevCenterClient class.
+ * @param tenantId type: string The tenant to operate on.
+ * @param devCenter type: string The DevCenter to operate on.
+ * @param credentials type: TokenCredential
+ * @param devCenterDnsSuffix type: string The DNS suffix used as the base for all devcenter requests.
+ * @param options type: ClientOptions
+ */
+export default function createClient(
+  tenantId: string,
+  devCenter: string,
+  credentials: TokenCredential,
+  devCenterDnsSuffix?: string,
+  options?: ClientOptions
+): AzureDevCenterClient;
+
+/**
+ * Initialize a new instance of the class AzureDevCenterClient class.
+ * @param tenantId type: string The tenant to operate on.
+ * @param devCenter type: string The DevCenter to operate on.
+ * @param credentials type: TokenCredential
+ * @param devCenterDnsSuffixOrOptions type: string | ClientOptions Either the DNS suffix used as the base for all devcenter requests or client options.
+ * @param options type: ClientOptions
+ */
+export default function createClient(
+  tenantId: string,
+  devCenter: string,
+  credentials: TokenCredential,
+  devCenterDnsSuffixOrOptions: string | ClientOptions = defaultDevCenterDnsSuffix,
+  options?: ClientOptions
 ): AzureDevCenterClient {
-  return getClientInternal(tenantId, devCenter, devCenterDnsSuffix, credentials, options);
+  const devCenterDnsSuffix =
+    typeof devCenterDnsSuffixOrOptions === "string"
+      ? devCenterDnsSuffixOrOptions
+      : defaultDevCenterDnsSuffix;
+  const internalOptions =
+    typeof devCenterDnsSuffixOrOptions === "string" ? options : devCenterDnsSuffixOrOptions;
+
+  return getClientInternal(tenantId, devCenter, devCenterDnsSuffix, credentials, internalOptions);
 }

--- a/sdk/devcenter/developer-devcenter-rest/src/azureDevCenter.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/azureDevCenter.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { ClientOptions } from "@azure-rest/core-client";
 import { TokenCredential } from "@azure/core-auth";
-import { AzureDevCenterClient } from "./clientDefinitions";
+import { AzureDevCenterClient } from "./generated/clientDefinitions";
+import getClientInternal from "./generated/azureDevCenter";
 
 /**
  * Initialize a new instance of the class AzureDevCenterClient class.
@@ -19,28 +20,5 @@ export default function createClient(
   devCenterDnsSuffix: string = "devcenter.azure.com",
   options: ClientOptions = {}
 ): AzureDevCenterClient {
-  const baseUrl = options.baseUrl ?? `https://${tenantId}-${devCenter}.${devCenterDnsSuffix}`;
-  options.apiVersion = options.apiVersion ?? "2022-03-01-preview";
-  options = {
-    ...options,
-    credentials: {
-      scopes: ["https://devcenter.azure.com/.default"],
-    },
-  };
-
-  const userAgentInfo = `azsdk-js-developer-devcenter-rest/1.0.0`;
-  const userAgentPrefix =
-    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
-      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
-      : `${userAgentInfo}`;
-  options = {
-    ...options,
-    userAgentOptions: {
-      userAgentPrefix,
-    },
-  };
-
-  const client = getClient(baseUrl, credentials, options) as AzureDevCenterClient;
-
-  return client;
+  return getClientInternal(tenantId, devCenter, devCenterDnsSuffix, credentials, options);
 }

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/azureDevCenter.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/azureDevCenter.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { TokenCredential } from "@azure/core-auth";
+import { AzureDevCenterClient } from "./clientDefinitions";
+
+/**
+ * Initialize a new instance of the class AzureDevCenterClient class.
+ * @param tenantId type: string The tenant to operate on.
+ * @param devCenter type: string The DevCenter to operate on.
+ * @param devCenterDnsSuffix type: string The DNS suffix used as the base for all devcenter requests.
+ * @param credentials type: TokenCredential
+ */
+export default function createClient(
+  tenantId: string,
+  devCenter: string,
+  devCenterDnsSuffix: string,
+  credentials: TokenCredential,
+  options: ClientOptions = {}
+): AzureDevCenterClient {
+  const baseUrl =
+    options.baseUrl ?? `https://${tenantId}-${devCenter}.${devCenterDnsSuffix}`;
+  options.apiVersion = options.apiVersion ?? "2022-03-01-preview";
+  options = {
+    ...options,
+    credentials: {
+      scopes: ["https://devcenter.azure.com/.default"]
+    }
+  };
+
+  const userAgentInfo = `azsdk-js-developer-devcenter-rest/1.0.0`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix
+    }
+  };
+
+  const client = getClient(
+    baseUrl,
+    credentials,
+    options
+  ) as AzureDevCenterClient;
+
+  return client;
+}

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/azureDevCenter.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/azureDevCenter.ts
@@ -29,7 +29,7 @@ export default function createClient(
     }
   };
 
-  const userAgentInfo = `azsdk-js-developer-devcenter-rest/1.0.0`;
+  const userAgentInfo = `azsdk-js-developer-devcenter-rest/1.0.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/clientDefinitions.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/clientDefinitions.ts
@@ -32,7 +32,7 @@ import {
   EnvironmentsGetCatalogItemParameters,
   EnvironmentsListCatalogItemVersionsParameters,
   EnvironmentsGetCatalogItemVersionParameters,
-  EnvironmentsListEnvironmentTypesParameters,
+  EnvironmentsListEnvironmentTypesParameters
 } from "./parameters";
 import {
   DevCenterListProjects200Response,
@@ -107,7 +107,7 @@ import {
   EnvironmentsGetCatalogItemVersion200Response,
   EnvironmentsGetCatalogItemVersionDefaultResponse,
   EnvironmentsListEnvironmentTypes200Response,
-  EnvironmentsListEnvironmentTypesDefaultResponse,
+  EnvironmentsListEnvironmentTypesDefaultResponse
 } from "./responses";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
@@ -115,14 +115,18 @@ export interface DevCenterListProjects {
   /** Lists all projects. */
   get(
     options?: DevCenterListProjectsParameters
-  ): StreamableMethod<DevCenterListProjects200Response | DevCenterListProjectsDefaultResponse>;
+  ): StreamableMethod<
+    DevCenterListProjects200Response | DevCenterListProjectsDefaultResponse
+  >;
 }
 
 export interface DevCenterGetProject {
   /** Gets a project. */
   get(
     options?: DevCenterGetProjectParameters
-  ): StreamableMethod<DevCenterGetProject200Response | DevCenterGetProjectDefaultResponse>;
+  ): StreamableMethod<
+    DevCenterGetProject200Response | DevCenterGetProjectDefaultResponse
+  >;
 }
 
 export interface DevCenterListAllDevBoxes {
@@ -130,7 +134,8 @@ export interface DevCenterListAllDevBoxes {
   get(
     options?: DevCenterListAllDevBoxesParameters
   ): StreamableMethod<
-    DevCenterListAllDevBoxes200Response | DevCenterListAllDevBoxesDefaultResponse
+    | DevCenterListAllDevBoxes200Response
+    | DevCenterListAllDevBoxesDefaultResponse
   >;
 }
 
@@ -139,7 +144,8 @@ export interface DevCenterListAllDevBoxesByUser {
   get(
     options?: DevCenterListAllDevBoxesByUserParameters
   ): StreamableMethod<
-    DevCenterListAllDevBoxesByUser200Response | DevCenterListAllDevBoxesByUserDefaultResponse
+    | DevCenterListAllDevBoxesByUser200Response
+    | DevCenterListAllDevBoxesByUserDefaultResponse
   >;
 }
 
@@ -147,14 +153,18 @@ export interface DevBoxesListPools {
   /** Lists available pools */
   get(
     options?: DevBoxesListPoolsParameters
-  ): StreamableMethod<DevBoxesListPools200Response | DevBoxesListPoolsDefaultResponse>;
+  ): StreamableMethod<
+    DevBoxesListPools200Response | DevBoxesListPoolsDefaultResponse
+  >;
 }
 
 export interface DevBoxesGetPool {
   /** Gets a pool */
   get(
     options?: DevBoxesGetPoolParameters
-  ): StreamableMethod<DevBoxesGetPool200Response | DevBoxesGetPoolDefaultResponse>;
+  ): StreamableMethod<
+    DevBoxesGetPool200Response | DevBoxesGetPoolDefaultResponse
+  >;
 }
 
 export interface DevBoxesListSchedulesByPool {
@@ -162,7 +172,8 @@ export interface DevBoxesListSchedulesByPool {
   get(
     options?: DevBoxesListSchedulesByPoolParameters
   ): StreamableMethod<
-    DevBoxesListSchedulesByPool200Response | DevBoxesListSchedulesByPoolDefaultResponse
+    | DevBoxesListSchedulesByPool200Response
+    | DevBoxesListSchedulesByPoolDefaultResponse
   >;
 }
 
@@ -171,7 +182,8 @@ export interface DevBoxesGetScheduleByPool {
   get(
     options?: DevBoxesGetScheduleByPoolParameters
   ): StreamableMethod<
-    DevBoxesGetScheduleByPool200Response | DevBoxesGetScheduleByPoolDefaultResponse
+    | DevBoxesGetScheduleByPool200Response
+    | DevBoxesGetScheduleByPoolDefaultResponse
   >;
 }
 
@@ -180,7 +192,8 @@ export interface DevBoxesListDevBoxesByUser {
   get(
     options?: DevBoxesListDevBoxesByUserParameters
   ): StreamableMethod<
-    DevBoxesListDevBoxesByUser200Response | DevBoxesListDevBoxesByUserDefaultResponse
+    | DevBoxesListDevBoxesByUser200Response
+    | DevBoxesListDevBoxesByUserDefaultResponse
   >;
 }
 
@@ -188,7 +201,9 @@ export interface DevBoxesGetDevBoxByUser {
   /** Gets a Dev Box */
   get(
     options?: DevBoxesGetDevBoxByUserParameters
-  ): StreamableMethod<DevBoxesGetDevBoxByUser200Response | DevBoxesGetDevBoxByUserDefaultResponse>;
+  ): StreamableMethod<
+    DevBoxesGetDevBoxByUser200Response | DevBoxesGetDevBoxByUserDefaultResponse
+  >;
   /** Creates or updates a Dev Box. */
   put(
     options: DevBoxesCreateDevBoxParameters
@@ -235,7 +250,8 @@ export interface DevBoxesGetRemoteConnection {
   get(
     options?: DevBoxesGetRemoteConnectionParameters
   ): StreamableMethod<
-    DevBoxesGetRemoteConnection200Response | DevBoxesGetRemoteConnectionDefaultResponse
+    | DevBoxesGetRemoteConnection200Response
+    | DevBoxesGetRemoteConnectionDefaultResponse
   >;
 }
 
@@ -244,7 +260,8 @@ export interface EnvironmentsListEnvironments {
   get(
     options?: EnvironmentsListEnvironmentsParameters
   ): StreamableMethod<
-    EnvironmentsListEnvironments200Response | EnvironmentsListEnvironmentsDefaultResponse
+    | EnvironmentsListEnvironments200Response
+    | EnvironmentsListEnvironmentsDefaultResponse
   >;
 }
 
@@ -263,7 +280,8 @@ export interface EnvironmentsGetEnvironmentByUser {
   get(
     options?: EnvironmentsGetEnvironmentByUserParameters
   ): StreamableMethod<
-    EnvironmentsGetEnvironmentByUser200Response | EnvironmentsGetEnvironmentByUserDefaultResponse
+    | EnvironmentsGetEnvironmentByUser200Response
+    | EnvironmentsGetEnvironmentByUserDefaultResponse
   >;
   /** Creates or updates an environment. */
   put(
@@ -277,7 +295,8 @@ export interface EnvironmentsGetEnvironmentByUser {
   patch(
     options: EnvironmentsUpdateEnvironmentParameters
   ): StreamableMethod<
-    EnvironmentsUpdateEnvironment200Response | EnvironmentsUpdateEnvironmentDefaultResponse
+    | EnvironmentsUpdateEnvironment200Response
+    | EnvironmentsUpdateEnvironmentDefaultResponse
   >;
   /** Deletes an environment and all it's associated resources */
   delete(
@@ -348,7 +367,8 @@ export interface EnvironmentsListCatalogItems {
   get(
     options?: EnvironmentsListCatalogItemsParameters
   ): StreamableMethod<
-    EnvironmentsListCatalogItems200Response | EnvironmentsListCatalogItemsDefaultResponse
+    | EnvironmentsListCatalogItems200Response
+    | EnvironmentsListCatalogItemsDefaultResponse
   >;
 }
 
@@ -357,7 +377,8 @@ export interface EnvironmentsGetCatalogItem {
   get(
     options?: EnvironmentsGetCatalogItemParameters
   ): StreamableMethod<
-    EnvironmentsGetCatalogItem200Response | EnvironmentsGetCatalogItemDefaultResponse
+    | EnvironmentsGetCatalogItem200Response
+    | EnvironmentsGetCatalogItemDefaultResponse
   >;
 }
 
@@ -376,7 +397,8 @@ export interface EnvironmentsGetCatalogItemVersion {
   get(
     options?: EnvironmentsGetCatalogItemVersionParameters
   ): StreamableMethod<
-    EnvironmentsGetCatalogItemVersion200Response | EnvironmentsGetCatalogItemVersionDefaultResponse
+    | EnvironmentsGetCatalogItemVersion200Response
+    | EnvironmentsGetCatalogItemVersionDefaultResponse
   >;
 }
 
@@ -385,7 +407,8 @@ export interface EnvironmentsListEnvironmentTypes {
   get(
     options?: EnvironmentsListEnvironmentTypesParameters
   ): StreamableMethod<
-    EnvironmentsListEnvironmentTypes200Response | EnvironmentsListEnvironmentTypesDefaultResponse
+    | EnvironmentsListEnvironmentTypes200Response
+    | EnvironmentsListEnvironmentTypesDefaultResponse
   >;
 }
 
@@ -397,9 +420,15 @@ export interface Routes {
   /** Resource for '/devboxes' has methods for the following verbs: get */
   (path: "/devboxes"): DevCenterListAllDevBoxes;
   /** Resource for '/users/\{userId\}/devboxes' has methods for the following verbs: get */
-  (path: "/users/{userId}/devboxes", userId: string): DevCenterListAllDevBoxesByUser;
+  (
+    path: "/users/{userId}/devboxes",
+    userId: string
+  ): DevCenterListAllDevBoxesByUser;
   /** Resource for '/projects/\{projectName\}/pools' has methods for the following verbs: get */
-  (path: "/projects/{projectName}/pools", projectName: string): DevBoxesListPools;
+  (
+    path: "/projects/{projectName}/pools",
+    projectName: string
+  ): DevBoxesListPools;
   /** Resource for '/projects/\{projectName\}/pools/\{poolName\}' has methods for the following verbs: get */
   (
     path: "/projects/{projectName}/pools/{poolName}",
@@ -454,7 +483,10 @@ export interface Routes {
     devBoxName: string
   ): DevBoxesGetRemoteConnection;
   /** Resource for '/projects/\{projectName\}/environments' has methods for the following verbs: get */
-  (path: "/projects/{projectName}/environments", projectName: string): EnvironmentsListEnvironments;
+  (
+    path: "/projects/{projectName}/environments",
+    projectName: string
+  ): EnvironmentsListEnvironments;
   /** Resource for '/projects/\{projectName\}/users/\{userId\}/environments' has methods for the following verbs: get */
   (
     path: "/projects/{projectName}/users/{userId}/environments",
@@ -505,7 +537,10 @@ export interface Routes {
     artifactPath: string
   ): EnvironmentsListArtifactsByEnvironmentAndPath;
   /** Resource for '/projects/\{projectName\}/catalogItems' has methods for the following verbs: get */
-  (path: "/projects/{projectName}/catalogItems", projectName: string): EnvironmentsListCatalogItems;
+  (
+    path: "/projects/{projectName}/catalogItems",
+    projectName: string
+  ): EnvironmentsListCatalogItems;
   /** Resource for '/projects/\{projectName\}/catalogItems/\{catalogItemId\}' has methods for the following verbs: get */
   (
     path: "/projects/{projectName}/catalogItems/{catalogItemId}",

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/index.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/index.ts
@@ -11,5 +11,6 @@ export * from "./isUnexpected";
 export * from "./models";
 export * from "./outputModels";
 export * from "./paginateHelper";
+export * from "./pollingHelper";
 
 export default AzureDevCenter;

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/index.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import AzureDevCenter from "./azureDevCenter";
+
+export * from "./azureDevCenter";
+export * from "./parameters";
+export * from "./responses";
+export * from "./clientDefinitions";
+export * from "./isUnexpected";
+export * from "./models";
+export * from "./outputModels";
+export * from "./paginateHelper";
+
+export default AzureDevCenter;

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/isUnexpected.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/isUnexpected.ts
@@ -74,7 +74,7 @@ import {
   EnvironmentsGetCatalogItemVersion200Response,
   EnvironmentsGetCatalogItemVersionDefaultResponse,
   EnvironmentsListEnvironmentTypes200Response,
-  EnvironmentsListEnvironmentTypesDefaultResponse,
+  EnvironmentsListEnvironmentTypesDefaultResponse
 } from "./responses";
 
 const responseMap: Record<string, string[]> = {
@@ -85,69 +85,107 @@ const responseMap: Record<string, string[]> = {
   "GET /projects/{projectName}/pools": ["200"],
   "GET /projects/{projectName}/pools/{poolName}": ["200"],
   "GET /projects/{projectName}/pools/{poolName}/schedules": ["200"],
-  "GET /projects/{projectName}/pools/{poolName}/schedules/{scheduleName}": ["200"],
+  "GET /projects/{projectName}/pools/{poolName}/schedules/{scheduleName}": [
+    "200"
+  ],
   "GET /projects/{projectName}/users/{userId}/devboxes": ["200"],
   "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}": ["200"],
-  "PUT /projects/{projectName}/users/{userId}/devboxes/{devBoxName}": ["200", "201"],
-  "DELETE /projects/{projectName}/users/{userId}/devboxes/{devBoxName}": ["200", "202", "204"],
-  "POST /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:start": ["200", "202"],
-  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:start": ["200", "202"],
-  "POST /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:stop": ["200", "202"],
-  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:stop": ["200", "202"],
-  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}/remoteConnection": ["200"],
+  "PUT /projects/{projectName}/users/{userId}/devboxes/{devBoxName}": [
+    "200",
+    "201"
+  ],
+  "DELETE /projects/{projectName}/users/{userId}/devboxes/{devBoxName}": [
+    "200",
+    "202",
+    "204"
+  ],
+  "POST /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:start": [
+    "200",
+    "202"
+  ],
+  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:start": [
+    "200",
+    "202"
+  ],
+  "POST /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:stop": [
+    "200",
+    "202"
+  ],
+  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}:stop": [
+    "200",
+    "202"
+  ],
+  "GET /projects/{projectName}/users/{userId}/devboxes/{devBoxName}/remoteConnection": [
+    "200"
+  ],
   "GET /projects/{projectName}/environments": ["200"],
   "GET /projects/{projectName}/users/{userId}/environments": ["200"],
-  "GET /projects/{projectName}/users/{userId}/environments/{environmentName}": ["200"],
-  "PUT /projects/{projectName}/users/{userId}/environments/{environmentName}": ["200", "201"],
-  "PATCH /projects/{projectName}/users/{userId}/environments/{environmentName}": ["200"],
+  "GET /projects/{projectName}/users/{userId}/environments/{environmentName}": [
+    "200"
+  ],
+  "PUT /projects/{projectName}/users/{userId}/environments/{environmentName}": [
+    "200",
+    "201"
+  ],
+  "PATCH /projects/{projectName}/users/{userId}/environments/{environmentName}": [
+    "200"
+  ],
   "DELETE /projects/{projectName}/users/{userId}/environments/{environmentName}": [
     "200",
     "202",
-    "204",
+    "204"
   ],
   "POST /projects/{projectName}/users/{userId}/environments/{environmentName}:deploy": [
     "200",
-    "202",
+    "202"
   ],
   "GET /projects/{projectName}/users/{userId}/environments/{environmentName}:deploy": [
     "200",
-    "202",
+    "202"
   ],
   "POST /projects/{projectName}/users/{userId}/environments/{environmentName}:delete": [
     "200",
-    "202",
+    "202"
   ],
   "GET /projects/{projectName}/users/{userId}/environments/{environmentName}:delete": [
     "200",
-    "202",
+    "202"
   ],
   "POST /projects/{projectName}/users/{userId}/environments/{environmentName}:custom": [
     "200",
-    "202",
+    "202"
   ],
   "GET /projects/{projectName}/users/{userId}/environments/{environmentName}:custom": [
     "200",
-    "202",
+    "202"
   ],
-  "GET /projects/{projectName}/users/{userId}/environments/{environmentName}/artifacts": ["200"],
+  "GET /projects/{projectName}/users/{userId}/environments/{environmentName}/artifacts": [
+    "200"
+  ],
   "GET /projects/{projectName}/users/{userId}/environments/{environmentName}/artifacts/{artifactPath}": [
-    "200",
+    "200"
   ],
   "GET /projects/{projectName}/catalogItems": ["200"],
   "GET /projects/{projectName}/catalogItems/{catalogItemId}": ["200"],
   "GET /projects/{projectName}/catalogItems/{catalogItemId}/versions": ["200"],
-  "GET /projects/{projectName}/catalogItems/{catalogItemId}/versions/{version}": ["200"],
-  "GET /projects/{projectName}/environmentTypes": ["200"],
+  "GET /projects/{projectName}/catalogItems/{catalogItemId}/versions/{version}": [
+    "200"
+  ],
+  "GET /projects/{projectName}/environmentTypes": ["200"]
 };
 
 export function isUnexpected(
-  response: DevCenterListProjects200Response | DevCenterListProjectsDefaultResponse
+  response:
+    | DevCenterListProjects200Response
+    | DevCenterListProjectsDefaultResponse
 ): response is DevCenterListProjectsDefaultResponse;
 export function isUnexpected(
   response: DevCenterGetProject200Response | DevCenterGetProjectDefaultResponse
 ): response is DevCenterGetProjectDefaultResponse;
 export function isUnexpected(
-  response: DevCenterListAllDevBoxes200Response | DevCenterListAllDevBoxesDefaultResponse
+  response:
+    | DevCenterListAllDevBoxes200Response
+    | DevCenterListAllDevBoxesDefaultResponse
 ): response is DevCenterListAllDevBoxesDefaultResponse;
 export function isUnexpected(
   response:
@@ -161,16 +199,24 @@ export function isUnexpected(
   response: DevBoxesGetPool200Response | DevBoxesGetPoolDefaultResponse
 ): response is DevBoxesGetPoolDefaultResponse;
 export function isUnexpected(
-  response: DevBoxesListSchedulesByPool200Response | DevBoxesListSchedulesByPoolDefaultResponse
+  response:
+    | DevBoxesListSchedulesByPool200Response
+    | DevBoxesListSchedulesByPoolDefaultResponse
 ): response is DevBoxesListSchedulesByPoolDefaultResponse;
 export function isUnexpected(
-  response: DevBoxesGetScheduleByPool200Response | DevBoxesGetScheduleByPoolDefaultResponse
+  response:
+    | DevBoxesGetScheduleByPool200Response
+    | DevBoxesGetScheduleByPoolDefaultResponse
 ): response is DevBoxesGetScheduleByPoolDefaultResponse;
 export function isUnexpected(
-  response: DevBoxesListDevBoxesByUser200Response | DevBoxesListDevBoxesByUserDefaultResponse
+  response:
+    | DevBoxesListDevBoxesByUser200Response
+    | DevBoxesListDevBoxesByUserDefaultResponse
 ): response is DevBoxesListDevBoxesByUserDefaultResponse;
 export function isUnexpected(
-  response: DevBoxesGetDevBoxByUser200Response | DevBoxesGetDevBoxByUserDefaultResponse
+  response:
+    | DevBoxesGetDevBoxByUser200Response
+    | DevBoxesGetDevBoxByUserDefaultResponse
 ): response is DevBoxesGetDevBoxByUserDefaultResponse;
 export function isUnexpected(
   response:
@@ -198,10 +244,14 @@ export function isUnexpected(
     | DevBoxesStopDevBoxDefaultResponse
 ): response is DevBoxesStopDevBoxDefaultResponse;
 export function isUnexpected(
-  response: DevBoxesGetRemoteConnection200Response | DevBoxesGetRemoteConnectionDefaultResponse
+  response:
+    | DevBoxesGetRemoteConnection200Response
+    | DevBoxesGetRemoteConnectionDefaultResponse
 ): response is DevBoxesGetRemoteConnectionDefaultResponse;
 export function isUnexpected(
-  response: EnvironmentsListEnvironments200Response | EnvironmentsListEnvironmentsDefaultResponse
+  response:
+    | EnvironmentsListEnvironments200Response
+    | EnvironmentsListEnvironmentsDefaultResponse
 ): response is EnvironmentsListEnvironmentsDefaultResponse;
 export function isUnexpected(
   response:
@@ -220,7 +270,9 @@ export function isUnexpected(
     | EnvironmentsCreateOrUpdateEnvironmentDefaultResponse
 ): response is EnvironmentsCreateOrUpdateEnvironmentDefaultResponse;
 export function isUnexpected(
-  response: EnvironmentsUpdateEnvironment200Response | EnvironmentsUpdateEnvironmentDefaultResponse
+  response:
+    | EnvironmentsUpdateEnvironment200Response
+    | EnvironmentsUpdateEnvironmentDefaultResponse
 ): response is EnvironmentsUpdateEnvironmentDefaultResponse;
 export function isUnexpected(
   response:
@@ -258,10 +310,14 @@ export function isUnexpected(
     | EnvironmentsListArtifactsByEnvironmentAndPathDefaultResponse
 ): response is EnvironmentsListArtifactsByEnvironmentAndPathDefaultResponse;
 export function isUnexpected(
-  response: EnvironmentsListCatalogItems200Response | EnvironmentsListCatalogItemsDefaultResponse
+  response:
+    | EnvironmentsListCatalogItems200Response
+    | EnvironmentsListCatalogItemsDefaultResponse
 ): response is EnvironmentsListCatalogItemsDefaultResponse;
 export function isUnexpected(
-  response: EnvironmentsGetCatalogItem200Response | EnvironmentsGetCatalogItemDefaultResponse
+  response:
+    | EnvironmentsGetCatalogItem200Response
+    | EnvironmentsGetCatalogItemDefaultResponse
 ): response is EnvironmentsGetCatalogItemDefaultResponse;
 export function isUnexpected(
   response:
@@ -411,11 +467,17 @@ function geParametrizedPathSuccess(method: string, path: string): string[] {
 
     // If the candidate and actual paths don't match in size
     // we move on to the next candidate path
-    if (candidateParts.length === pathParts.length && hasParametrizedPath(key)) {
+    if (
+      candidateParts.length === pathParts.length &&
+      hasParametrizedPath(key)
+    ) {
       // track if we have found a match to return the values found.
       let found = true;
       for (let i = 0; i < candidateParts.length; i++) {
-        if (candidateParts[i]?.startsWith("{") && candidateParts[i]?.endsWith("}")) {
+        if (
+          candidateParts[i]?.startsWith("{") &&
+          candidateParts[i]?.endsWith("}")
+        ) {
           // If the current part of the candidate is a "template" part
           // it is a match with the actual path part on hand
           // skip as the parameterized part can match anything

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/models.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/models.ts
@@ -50,7 +50,12 @@ export interface DevBox {
   /** The current action state of the Dev Box. This is state is based on previous action performed by user. */
   actionState?: string;
   /** The current power state of the Dev Box. */
-  powerState?: "Unknown" | "Deallocated" | "PoweredOff" | "Running" | "Hibernated";
+  powerState?:
+    | "Unknown"
+    | "Deallocated"
+    | "PoweredOff"
+    | "Running"
+    | "Hibernated";
   /** A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000). */
   uniqueId?: string;
   /** Provisioning or action error details. Populated only for error states. */

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/outputModels.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/outputModels.ts
@@ -140,7 +140,12 @@ export interface DevBoxOutput {
   /** The current action state of the Dev Box. This is state is based on previous action performed by user. */
   actionState?: string;
   /** The current power state of the Dev Box. */
-  powerState?: "Unknown" | "Deallocated" | "PoweredOff" | "Running" | "Hibernated";
+  powerState?:
+    | "Unknown"
+    | "Deallocated"
+    | "PoweredOff"
+    | "Running"
+    | "Hibernated";
   /** A unique identifier for the Dev Box. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000). */
   uniqueId?: string;
   /** Provisioning or action error details. Populated only for error states. */
@@ -320,7 +325,14 @@ export interface CatalogItemParameterOutput {
   /** Default value of the parameter */
   default?: Record<string, unknown>;
   /** A string of one of the basic JSON types (number, integer, null, array, object, boolean, string) */
-  type?: "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+  type?:
+    | "array"
+    | "boolean"
+    | "integer"
+    | "null"
+    | "number"
+    | "object"
+    | "string";
   /** Whether or not this parameter is read-only.  If true, default should have a value. */
   readOnly?: boolean;
   /** Whether or not this parameter is required */

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/paginateHelper.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/paginateHelper.ts
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getPagedAsyncIterator, PagedAsyncIterableIterator, PagedResult } from "@azure/core-paging";
-import { Client, createRestError, PathUncheckedResponse } from "@azure-rest/core-client";
+import {
+  getPagedAsyncIterator,
+  PagedAsyncIterableIterator,
+  PagedResult
+} from "@azure/core-paging";
+import {
+  Client,
+  createRestError,
+  PathUncheckedResponse
+} from "@azure-rest/core-client";
 
 /**
  * Helper type to extract the type of an array
@@ -67,16 +75,18 @@ export function paginate<TResponse extends PathUncheckedResponse>(
       typeof customGetPage === "function"
         ? customGetPage
         : async (pageLink: string) => {
-            const result = firstRun ? initialResponse : await client.pathUnchecked(pageLink).get();
+            const result = firstRun
+              ? initialResponse
+              : await client.pathUnchecked(pageLink).get();
             firstRun = false;
             checkPagingRequest(result);
             const nextLink = getNextLink(result.body, nextLinkName);
             const values = getElements<TElement>(result.body, itemName);
             return {
               page: values,
-              nextPageLink: nextLink,
+              nextPageLink: nextLink
             };
-          },
+          }
   };
 
   return getPagedAsyncIterator(pagedResult);
@@ -93,7 +103,9 @@ function getNextLink(body: unknown, nextLinkName?: string): string | undefined {
   const nextLink = (body as Record<string, unknown>)[nextLinkName];
 
   if (typeof nextLink !== "string" && typeof nextLink !== "undefined") {
-    throw new Error(`Body Property ${nextLinkName} should be a string or undefined`);
+    throw new Error(
+      `Body Property ${nextLinkName} should be a string or undefined`
+    );
   }
 
   return nextLink;
@@ -121,7 +133,18 @@ function getElements<T = unknown>(body: unknown, itemName: string): T[] {
  * Checks if a request failed
  */
 function checkPagingRequest(response: PathUncheckedResponse): void {
-  const Http2xxStatusCodes = ["200", "201", "202", "203", "204", "205", "206", "207", "208", "226"];
+  const Http2xxStatusCodes = [
+    "200",
+    "201",
+    "202",
+    "203",
+    "204",
+    "205",
+    "206",
+    "207",
+    "208",
+    "226"
+  ];
   if (!Http2xxStatusCodes.includes(response.status)) {
     throw createRestError(
       `Pagination failed with unexpected statusCode ${response.status}`,

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/parameters.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/parameters.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { RequestParameters } from "@azure-rest/core-client";
-import { DevBox, Environment, EnvironmentUpdateProperties, ActionRequest } from "./models";
+import {
+  DevBox,
+  Environment,
+  EnvironmentUpdateProperties,
+  ActionRequest
+} from "./models";
 
 export interface DevCenterListProjectsQueryParamProperties {
   /** An OData filter clause to apply to the operation. */
@@ -15,7 +20,8 @@ export interface DevCenterListProjectsQueryParam {
   queryParameters?: DevCenterListProjectsQueryParamProperties;
 }
 
-export type DevCenterListProjectsParameters = DevCenterListProjectsQueryParam & RequestParameters;
+export type DevCenterListProjectsParameters = DevCenterListProjectsQueryParam &
+  RequestParameters;
 export type DevCenterGetProjectParameters = RequestParameters;
 
 export interface DevCenterListAllDevBoxesQueryParamProperties {
@@ -57,7 +63,8 @@ export interface DevBoxesListPoolsQueryParam {
   queryParameters?: DevBoxesListPoolsQueryParamProperties;
 }
 
-export type DevBoxesListPoolsParameters = DevBoxesListPoolsQueryParam & RequestParameters;
+export type DevBoxesListPoolsParameters = DevBoxesListPoolsQueryParam &
+  RequestParameters;
 export type DevBoxesGetPoolParameters = RequestParameters;
 
 export interface DevBoxesListSchedulesByPoolQueryParamProperties {

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/pollingHelper.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/pollingHelper.ts
@@ -8,7 +8,7 @@ import {
   LroEngineOptions,
   LroResponse,
   PollerLike,
-  PollOperationState,
+  PollOperationState
 } from "@azure/core-lro";
 
 /**
@@ -37,19 +37,14 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
       // to get the latest status. We use the client provided and the polling path
       // which is an opaque URL provided by caller, the service sends this in one of the following headers: operation-location, azure-asyncoperation or location
       // depending on the lro pattern that the service implements. If non is provided we default to the initial path.
-
-      // This is a workaround to handle problems with the test recorder implementation. This allows us to send requests to the correct
-      // host in playback mode, while ensuring the path remains the same in normal operation.
-      const currentUrl = new URL(path ?? initialResponse.request.url);
-      const base: string =
-        initialResponse.request.headers.get("x-recording-upstream-base-uri") ?? currentUrl.host;
-      path = base + currentUrl.pathname;
-
-      const response = await client.pathUnchecked(path ?? initialResponse.request.url).get();
+      const response = await client
+        .pathUnchecked(path ?? initialResponse.request.url)
+        .get();
       const lroResponse = getLroResponse(response as TResult);
-      lroResponse.rawResponse.headers["x-ms-original-url"] = initialResponse.request.url;
+      lroResponse.rawResponse.headers["x-ms-original-url"] =
+        initialResponse.request.url;
       return lroResponse;
-    },
+    }
   };
 
   return new LroEngine(poller, options);
@@ -60,9 +55,13 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
  * @param response - a rest client http response
  * @returns - An LRO response that the LRO engine can work with
  */
-function getLroResponse<TResult extends HttpResponse>(response: TResult): LroResponse<TResult> {
+function getLroResponse<TResult extends HttpResponse>(
+  response: TResult
+): LroResponse<TResult> {
   if (Number.isNaN(response.status)) {
-    throw new TypeError(`Status code of the response is not a number. Value: ${response.status}`);
+    throw new TypeError(
+      `Status code of the response is not a number. Value: ${response.status}`
+    );
   }
 
   return {
@@ -70,7 +69,7 @@ function getLroResponse<TResult extends HttpResponse>(response: TResult): LroRes
     rawResponse: {
       ...response,
       statusCode: Number.parseInt(response.status),
-      body: response.body,
-    },
+      body: response.body
+    }
   };
 }

--- a/sdk/devcenter/developer-devcenter-rest/src/generated/responses.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/generated/responses.ts
@@ -21,7 +21,7 @@ import {
   CatalogItemOutput,
   CatalogItemVersionListResultOutput,
   CatalogItemVersionOutput,
-  EnvironmentTypeListResultOutput,
+  EnvironmentTypeListResultOutput
 } from "./outputModels";
 
 /** Lists all projects. */
@@ -67,7 +67,8 @@ export interface DevCenterListAllDevBoxesDefaultResponse extends HttpResponse {
 }
 
 /** Lists Dev Boxes in the Dev Center for a particular user. */
-export interface DevCenterListAllDevBoxesByUser200Response extends HttpResponse {
+export interface DevCenterListAllDevBoxesByUser200Response
+  extends HttpResponse {
   status: "200";
   body: DevBoxListResultOutput;
 }
@@ -78,7 +79,8 @@ export interface DevCenterListAllDevBoxesByUserDefaultHeaders {
 }
 
 /** Lists Dev Boxes in the Dev Center for a particular user. */
-export interface DevCenterListAllDevBoxesByUserDefaultResponse extends HttpResponse {
+export interface DevCenterListAllDevBoxesByUserDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & DevCenterListAllDevBoxesByUserDefaultHeaders;
@@ -132,7 +134,8 @@ export interface DevBoxesListSchedulesByPoolDefaultHeaders {
 }
 
 /** Lists available schedules for a pool. */
-export interface DevBoxesListSchedulesByPoolDefaultResponse extends HttpResponse {
+export interface DevBoxesListSchedulesByPoolDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & DevBoxesListSchedulesByPoolDefaultHeaders;
@@ -168,7 +171,8 @@ export interface DevBoxesListDevBoxesByUserDefaultHeaders {
 }
 
 /** Lists Dev Boxes in the project for a particular user. */
-export interface DevBoxesListDevBoxesByUserDefaultResponse extends HttpResponse {
+export interface DevBoxesListDevBoxesByUserDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & DevBoxesListDevBoxesByUserDefaultHeaders;
@@ -324,7 +328,8 @@ export interface DevBoxesGetRemoteConnectionDefaultHeaders {
 }
 
 /** Gets RDP Connection info */
-export interface DevBoxesGetRemoteConnectionDefaultResponse extends HttpResponse {
+export interface DevBoxesGetRemoteConnectionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & DevBoxesGetRemoteConnectionDefaultHeaders;
@@ -342,14 +347,16 @@ export interface EnvironmentsListEnvironmentsDefaultHeaders {
 }
 
 /** Lists the environments for a project. */
-export interface EnvironmentsListEnvironmentsDefaultResponse extends HttpResponse {
+export interface EnvironmentsListEnvironmentsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsListEnvironmentsDefaultHeaders;
 }
 
 /** Lists the environments for a project and user. */
-export interface EnvironmentsListEnvironmentsByUser200Response extends HttpResponse {
+export interface EnvironmentsListEnvironmentsByUser200Response
+  extends HttpResponse {
   status: "200";
   body: EnvironmentListResultOutput;
 }
@@ -360,14 +367,16 @@ export interface EnvironmentsListEnvironmentsByUserDefaultHeaders {
 }
 
 /** Lists the environments for a project and user. */
-export interface EnvironmentsListEnvironmentsByUserDefaultResponse extends HttpResponse {
+export interface EnvironmentsListEnvironmentsByUserDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsListEnvironmentsByUserDefaultHeaders;
 }
 
 /** Gets an environment */
-export interface EnvironmentsGetEnvironmentByUser200Response extends HttpResponse {
+export interface EnvironmentsGetEnvironmentByUser200Response
+  extends HttpResponse {
   status: "200";
   body: EnvironmentOutput;
 }
@@ -378,14 +387,16 @@ export interface EnvironmentsGetEnvironmentByUserDefaultHeaders {
 }
 
 /** Gets an environment */
-export interface EnvironmentsGetEnvironmentByUserDefaultResponse extends HttpResponse {
+export interface EnvironmentsGetEnvironmentByUserDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsGetEnvironmentByUserDefaultHeaders;
 }
 
 /** Creates or updates an environment. */
-export interface EnvironmentsCreateOrUpdateEnvironment200Response extends HttpResponse {
+export interface EnvironmentsCreateOrUpdateEnvironment200Response
+  extends HttpResponse {
   status: "200";
   body: EnvironmentOutput;
 }
@@ -396,7 +407,8 @@ export interface EnvironmentsCreateOrUpdateEnvironment201Headers {
 }
 
 /** Creates or updates an environment. */
-export interface EnvironmentsCreateOrUpdateEnvironment201Response extends HttpResponse {
+export interface EnvironmentsCreateOrUpdateEnvironment201Response
+  extends HttpResponse {
   status: "201";
   body: EnvironmentOutput;
   headers: RawHttpHeaders & EnvironmentsCreateOrUpdateEnvironment201Headers;
@@ -408,7 +420,8 @@ export interface EnvironmentsCreateOrUpdateEnvironmentDefaultHeaders {
 }
 
 /** Creates or updates an environment. */
-export interface EnvironmentsCreateOrUpdateEnvironmentDefaultResponse extends HttpResponse {
+export interface EnvironmentsCreateOrUpdateEnvironmentDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsCreateOrUpdateEnvironmentDefaultHeaders;
@@ -426,7 +439,8 @@ export interface EnvironmentsUpdateEnvironmentDefaultHeaders {
 }
 
 /** Partially updates an environment */
-export interface EnvironmentsUpdateEnvironmentDefaultResponse extends HttpResponse {
+export interface EnvironmentsUpdateEnvironmentDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsUpdateEnvironmentDefaultHeaders;
@@ -462,14 +476,16 @@ export interface EnvironmentsDeleteEnvironmentDefaultHeaders {
 }
 
 /** Deletes an environment and all it's associated resources */
-export interface EnvironmentsDeleteEnvironmentDefaultResponse extends HttpResponse {
+export interface EnvironmentsDeleteEnvironmentDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsDeleteEnvironmentDefaultHeaders;
 }
 
 /** Executes a deploy action */
-export interface EnvironmentsDeployEnvironmentAction200Response extends HttpResponse {
+export interface EnvironmentsDeployEnvironmentAction200Response
+  extends HttpResponse {
   status: "200";
   body: Record<string, unknown>;
 }
@@ -480,7 +496,8 @@ export interface EnvironmentsDeployEnvironmentAction202Headers {
 }
 
 /** Executes a deploy action */
-export interface EnvironmentsDeployEnvironmentAction202Response extends HttpResponse {
+export interface EnvironmentsDeployEnvironmentAction202Response
+  extends HttpResponse {
   status: "202";
   body: Record<string, unknown>;
   headers: RawHttpHeaders & EnvironmentsDeployEnvironmentAction202Headers;
@@ -492,14 +509,16 @@ export interface EnvironmentsDeployEnvironmentActionDefaultHeaders {
 }
 
 /** Executes a deploy action */
-export interface EnvironmentsDeployEnvironmentActionDefaultResponse extends HttpResponse {
+export interface EnvironmentsDeployEnvironmentActionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsDeployEnvironmentActionDefaultHeaders;
 }
 
 /** Executes a delete action */
-export interface EnvironmentsDeleteEnvironmentAction200Response extends HttpResponse {
+export interface EnvironmentsDeleteEnvironmentAction200Response
+  extends HttpResponse {
   status: "200";
   body: Record<string, unknown>;
 }
@@ -510,7 +529,8 @@ export interface EnvironmentsDeleteEnvironmentAction202Headers {
 }
 
 /** Executes a delete action */
-export interface EnvironmentsDeleteEnvironmentAction202Response extends HttpResponse {
+export interface EnvironmentsDeleteEnvironmentAction202Response
+  extends HttpResponse {
   status: "202";
   body: Record<string, unknown>;
   headers: RawHttpHeaders & EnvironmentsDeleteEnvironmentAction202Headers;
@@ -522,14 +542,16 @@ export interface EnvironmentsDeleteEnvironmentActionDefaultHeaders {
 }
 
 /** Executes a delete action */
-export interface EnvironmentsDeleteEnvironmentActionDefaultResponse extends HttpResponse {
+export interface EnvironmentsDeleteEnvironmentActionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsDeleteEnvironmentActionDefaultHeaders;
 }
 
 /** Executes a custom action */
-export interface EnvironmentsCustomEnvironmentAction200Response extends HttpResponse {
+export interface EnvironmentsCustomEnvironmentAction200Response
+  extends HttpResponse {
   status: "200";
   body: Record<string, unknown>;
 }
@@ -540,7 +562,8 @@ export interface EnvironmentsCustomEnvironmentAction202Headers {
 }
 
 /** Executes a custom action */
-export interface EnvironmentsCustomEnvironmentAction202Response extends HttpResponse {
+export interface EnvironmentsCustomEnvironmentAction202Response
+  extends HttpResponse {
   status: "202";
   body: Record<string, unknown>;
   headers: RawHttpHeaders & EnvironmentsCustomEnvironmentAction202Headers;
@@ -552,14 +575,16 @@ export interface EnvironmentsCustomEnvironmentActionDefaultHeaders {
 }
 
 /** Executes a custom action */
-export interface EnvironmentsCustomEnvironmentActionDefaultResponse extends HttpResponse {
+export interface EnvironmentsCustomEnvironmentActionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsCustomEnvironmentActionDefaultHeaders;
 }
 
 /** Lists the artifacts for an environment */
-export interface EnvironmentsListArtifactsByEnvironment200Response extends HttpResponse {
+export interface EnvironmentsListArtifactsByEnvironment200Response
+  extends HttpResponse {
   status: "200";
   body: ArtifactListResultOutput;
 }
@@ -570,14 +595,17 @@ export interface EnvironmentsListArtifactsByEnvironmentDefaultHeaders {
 }
 
 /** Lists the artifacts for an environment */
-export interface EnvironmentsListArtifactsByEnvironmentDefaultResponse extends HttpResponse {
+export interface EnvironmentsListArtifactsByEnvironmentDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
-  headers: RawHttpHeaders & EnvironmentsListArtifactsByEnvironmentDefaultHeaders;
+  headers: RawHttpHeaders &
+    EnvironmentsListArtifactsByEnvironmentDefaultHeaders;
 }
 
 /** Lists the artifacts for an environment at a specified path, or returns the file at the path. */
-export interface EnvironmentsListArtifactsByEnvironmentAndPath200Response extends HttpResponse {
+export interface EnvironmentsListArtifactsByEnvironmentAndPath200Response
+  extends HttpResponse {
   status: "200";
   body: ArtifactListResultOutput;
 }
@@ -588,10 +616,12 @@ export interface EnvironmentsListArtifactsByEnvironmentAndPathDefaultHeaders {
 }
 
 /** Lists the artifacts for an environment at a specified path, or returns the file at the path. */
-export interface EnvironmentsListArtifactsByEnvironmentAndPathDefaultResponse extends HttpResponse {
+export interface EnvironmentsListArtifactsByEnvironmentAndPathDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
-  headers: RawHttpHeaders & EnvironmentsListArtifactsByEnvironmentAndPathDefaultHeaders;
+  headers: RawHttpHeaders &
+    EnvironmentsListArtifactsByEnvironmentAndPathDefaultHeaders;
 }
 
 /** Lists latest version of all catalog items available for a project. */
@@ -606,7 +636,8 @@ export interface EnvironmentsListCatalogItemsDefaultHeaders {
 }
 
 /** Lists latest version of all catalog items available for a project. */
-export interface EnvironmentsListCatalogItemsDefaultResponse extends HttpResponse {
+export interface EnvironmentsListCatalogItemsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsListCatalogItemsDefaultHeaders;
@@ -624,14 +655,16 @@ export interface EnvironmentsGetCatalogItemDefaultHeaders {
 }
 
 /** Get a catalog item from a project. */
-export interface EnvironmentsGetCatalogItemDefaultResponse extends HttpResponse {
+export interface EnvironmentsGetCatalogItemDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsGetCatalogItemDefaultHeaders;
 }
 
 /** List all versions of a catalog item from a project. */
-export interface EnvironmentsListCatalogItemVersions200Response extends HttpResponse {
+export interface EnvironmentsListCatalogItemVersions200Response
+  extends HttpResponse {
   status: "200";
   body: CatalogItemVersionListResultOutput;
 }
@@ -642,14 +675,16 @@ export interface EnvironmentsListCatalogItemVersionsDefaultHeaders {
 }
 
 /** List all versions of a catalog item from a project. */
-export interface EnvironmentsListCatalogItemVersionsDefaultResponse extends HttpResponse {
+export interface EnvironmentsListCatalogItemVersionsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsListCatalogItemVersionsDefaultHeaders;
 }
 
 /** Get a specific catalog item version from a project. */
-export interface EnvironmentsGetCatalogItemVersion200Response extends HttpResponse {
+export interface EnvironmentsGetCatalogItemVersion200Response
+  extends HttpResponse {
   status: "200";
   body: CatalogItemVersionOutput;
 }
@@ -660,14 +695,16 @@ export interface EnvironmentsGetCatalogItemVersionDefaultHeaders {
 }
 
 /** Get a specific catalog item version from a project. */
-export interface EnvironmentsGetCatalogItemVersionDefaultResponse extends HttpResponse {
+export interface EnvironmentsGetCatalogItemVersionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsGetCatalogItemVersionDefaultHeaders;
 }
 
 /** Lists all environment types configured for a project. */
-export interface EnvironmentsListEnvironmentTypes200Response extends HttpResponse {
+export interface EnvironmentsListEnvironmentTypes200Response
+  extends HttpResponse {
   status: "200";
   body: EnvironmentTypeListResultOutput;
 }
@@ -678,7 +715,8 @@ export interface EnvironmentsListEnvironmentTypesDefaultHeaders {
 }
 
 /** Lists all environment types configured for a project. */
-export interface EnvironmentsListEnvironmentTypesDefaultResponse extends HttpResponse {
+export interface EnvironmentsListEnvironmentTypesDefaultResponse
+  extends HttpResponse {
   status: string;
   body: CloudErrorOutput;
   headers: RawHttpHeaders & EnvironmentsListEnvironmentTypesDefaultHeaders;

--- a/sdk/devcenter/developer-devcenter-rest/src/index.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/index.ts
@@ -4,13 +4,13 @@
 import AzureDevCenter from "./azureDevCenter";
 
 export * from "./azureDevCenter";
-export * from "./parameters";
-export * from "./responses";
-export * from "./clientDefinitions";
-export * from "./isUnexpected";
-export * from "./models";
-export * from "./outputModels";
-export * from "./paginateHelper";
+export * from "./generated/parameters";
+export * from "./generated/responses";
+export * from "./generated/clientDefinitions";
+export * from "./generated/isUnexpected";
+export * from "./generated/models";
+export * from "./generated/outputModels";
+export * from "./generated/paginateHelper";
 export * from "./pollingHelper";
 
 export default AzureDevCenter;

--- a/sdk/devcenter/developer-devcenter-rest/src/index.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/index.ts
@@ -11,6 +11,6 @@ export * from "./generated/isUnexpected";
 export * from "./generated/models";
 export * from "./generated/outputModels";
 export * from "./generated/paginateHelper";
-export * from "./pollingHelper";
+export * from "./generated/pollingHelper";
 
 export default AzureDevCenter;

--- a/sdk/devcenter/developer-devcenter-rest/src/pollingHelper.ts
+++ b/sdk/devcenter/developer-devcenter-rest/src/pollingHelper.ts
@@ -8,7 +8,7 @@ import {
   LroEngineOptions,
   LroResponse,
   PollerLike,
-  PollOperationState
+  PollOperationState,
 } from "@azure/core-lro";
 
 /**
@@ -41,17 +41,15 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
       // This is a workaround to handle problems with the test recorder implementation. This allows us to send requests to the correct
       // host in playback mode, while ensuring the path remains the same in normal operation.
       const currentUrl = new URL(path ?? initialResponse.request.url);
-      const base: string = initialResponse.request.headers.get("x-recording-upstream-base-uri") ?? currentUrl.host;
+      const base: string =
+        initialResponse.request.headers.get("x-recording-upstream-base-uri") ?? currentUrl.host;
       path = base + currentUrl.pathname;
-      
-      const response = await client
-        .pathUnchecked(path ?? initialResponse.request.url)
-        .get();
+
+      const response = await client.pathUnchecked(path ?? initialResponse.request.url).get();
       const lroResponse = getLroResponse(response as TResult);
-      lroResponse.rawResponse.headers["x-ms-original-url"] =
-        initialResponse.request.url;
+      lroResponse.rawResponse.headers["x-ms-original-url"] = initialResponse.request.url;
       return lroResponse;
-    }
+    },
   };
 
   return new LroEngine(poller, options);
@@ -62,13 +60,9 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
  * @param response - a rest client http response
  * @returns - An LRO response that the LRO engine can work with
  */
-function getLroResponse<TResult extends HttpResponse>(
-  response: TResult
-): LroResponse<TResult> {
+function getLroResponse<TResult extends HttpResponse>(response: TResult): LroResponse<TResult> {
   if (Number.isNaN(response.status)) {
-    throw new TypeError(
-      `Status code of the response is not a number. Value: ${response.status}`
-    );
+    throw new TypeError(`Status code of the response is not a number. Value: ${response.status}`);
   }
 
   return {
@@ -76,7 +70,7 @@ function getLroResponse<TResult extends HttpResponse>(
     rawResponse: {
       ...response,
       statusCode: Number.parseInt(response.status),
-      body: response.body
-    }
+      body: response.body,
+    },
   };
 }

--- a/sdk/devcenter/developer-devcenter-rest/swagger/README.md
+++ b/sdk/devcenter/developer-devcenter-rest/swagger/README.md
@@ -10,7 +10,7 @@ tag: v2022-03-01-preview
 generate-test: true
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
-source-code-folder-path: ./src
+source-code-folder-path: ./src/generated
 package-version: 1.0.0
 rest-level-client: true
 security: AADToken

--- a/sdk/devcenter/developer-devcenter-rest/swagger/README.md
+++ b/sdk/devcenter/developer-devcenter-rest/swagger/README.md
@@ -11,7 +11,7 @@ generate-test: true
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 1.0.0
+package-version: 1.0.0-beta.1
 rest-level-client: true
 security: AADToken
 security-scopes: https://devcenter.azure.com/.default

--- a/sdk/devcenter/developer-devcenter-rest/test/public/devBoxesTest.spec.ts
+++ b/sdk/devcenter/developer-devcenter-rest/test/public/devBoxesTest.spec.ts
@@ -34,7 +34,7 @@ describe("DevCenter Dev Boxes Operations Test", () => {
   it("Create dev box", async function () {
     // Skip until test proxy recorder bug is fixed https://github.com/Azure/azure-sdk-for-js/issues/23420
     if (isPlaybackMode()) {
-        this.skip();
+      this.skip();
     }
 
     // Build client and fetch required parameters

--- a/sdk/devcenter/developer-devcenter-rest/test/public/devBoxesTest.spec.ts
+++ b/sdk/devcenter/developer-devcenter-rest/test/public/devBoxesTest.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { env, Recorder } from "@azure-tools/test-recorder";
+import { env, isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { createRecordedClient, createRecorder } from "./utils/recordedClient";
 import { Context } from "mocha";
@@ -32,6 +32,11 @@ describe("DevCenter Dev Boxes Operations Test", () => {
   });
 
   it("Create dev box", async function () {
+    // Skip until test proxy recorder bug is fixed https://github.com/Azure/azure-sdk-for-js/issues/23420
+    if (isPlaybackMode()) {
+        this.skip();
+    }
+
     // Build client and fetch required parameters
     const projectName = env["DEFAULT_PROJECT_NAME"] || "sdk-default-project";
     const poolName = env["DEFAULT_POOL_NAME"] || "sdk-default-pool";

--- a/sdk/devcenter/developer-devcenter-rest/test/public/environmentsTest.spec.ts
+++ b/sdk/devcenter/developer-devcenter-rest/test/public/environmentsTest.spec.ts
@@ -35,7 +35,7 @@ describe("DevCenter Environments Operations Test", () => {
   it("Create environment", async function () {
     // Skip until test proxy recorder bug is fixed https://github.com/Azure/azure-sdk-for-js/issues/23420
     if (isPlaybackMode()) {
-        this.skip();
+      this.skip();
     }
 
     // Build client and fetch required parameters

--- a/sdk/devcenter/developer-devcenter-rest/test/public/environmentsTest.spec.ts
+++ b/sdk/devcenter/developer-devcenter-rest/test/public/environmentsTest.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { env, Recorder } from "@azure-tools/test-recorder";
+import { env, isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { Context } from "mocha";
 import { createRecordedClient, createRecorder } from "./utils/recordedClient";
@@ -33,6 +33,11 @@ describe("DevCenter Environments Operations Test", () => {
   });
 
   it("Create environment", async function () {
+    // Skip until test proxy recorder bug is fixed https://github.com/Azure/azure-sdk-for-js/issues/23420
+    if (isPlaybackMode()) {
+        this.skip();
+    }
+
     // Build client and fetch required parameters
     const projectName = env["DEFAULT_PROJECT_NAME"] || "sdk-default-project";
     const catalogName = env["DEFAULT_CATALOG_NAME"] || "sdk-default-catalog";


### PR DESCRIPTION
Regenerate client, update polling workaround, update client setup workaround

### Packages impacted by this PR
@azure-rest/developer-devcenter. Package is currently unreleased (will release with 11/8 release cycle)

### Issues associated with this PR
https://github.com/Azure/autorest.typescript/issues/1615
https://github.com/Azure/azure-sdk-for-js/issues/23420#issuecomment-1302500411

### Describe the problem that is addressed by this PR
Moving two fixes to the above issues into customized code folder to separate from generated code.
The first is adding a default option, which is not supported by JS autorest right now. The second is working around an issue with the test recorder when polling LROs. There was a change to recorder behavior that necessitated an update to our fix here.

During this, consumed some formatting changes from the latest autorest version.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Covered by existing tests

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A
### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary) N/A
