### PR TITLE
[Language Text] Mitigating bug in auto detected language for TA4H

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/src/generated/models/index.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/generated/models/index.ts
@@ -397,6 +397,11 @@ export interface HealthcareRelationEntity {
   role: string;
 }
 
+export interface DocumentDetectedLanguageForHealthcare {
+  /** If 'language' is set to 'auto' for the document in the request this field will contain a 2 letter ISO 639-1 representation of the language detected for this document. */
+  detectedLanguage?: string;
+}
+
 export interface PreBuiltResult {
   /** Errors by document id. */
   errors: InputError[];
@@ -944,10 +949,6 @@ export interface CustomLabelClassificationResultDocumentsItem
   extends ClassificationDocumentResult,
     DocumentDetectedLanguage {}
 
-export interface HealthcareResultDocumentsItem
-  extends HealthcareEntitiesDocumentResult,
-    DocumentDetectedLanguage {}
-
 export interface SentimentResponseDocumentsItem
   extends SentimentDocumentResult,
     DocumentDetectedLanguage {}
@@ -976,6 +977,10 @@ export interface KeyPhraseResultDocumentsItem
 export interface AbstractiveSummaryDocumentResultWithDetectedLanguage
   extends AbstractiveSummaryDocumentResult,
     DocumentDetectedLanguage {}
+
+export interface HealthcareResultDocumentsItem
+  extends HealthcareEntitiesDocumentResult,
+    DocumentDetectedLanguageForHealthcare {}
 
 export interface HealthcareResult extends PreBuiltResult {
   documents: HealthcareResultDocumentsItem[];

--- a/sdk/cognitivelanguage/ai-language-text/src/generated/models/index.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/generated/models/index.ts
@@ -398,7 +398,6 @@ export interface HealthcareRelationEntity {
 }
 
 export interface DocumentDetectedLanguageForHealthcare {
-  /** If 'language' is set to 'auto' for the document in the request this field will contain a 2 letter ISO 639-1 representation of the language detected for this document. */
   detectedLanguage?: string;
 }
 

--- a/sdk/cognitivelanguage/ai-language-text/src/generated/models/mappers.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/generated/models/mappers.ts
@@ -1025,6 +1025,21 @@ export const HealthcareRelationEntity: coreClient.CompositeMapper = {
   }
 };
 
+export const DocumentDetectedLanguageForHealthcare: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "DocumentDetectedLanguageForHealthcare",
+    modelProperties: {
+      detectedLanguage: {
+        serializedName: "detectedLanguage",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const PreBuiltResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2818,17 +2833,6 @@ export const CustomLabelClassificationResultDocumentsItem: coreClient.CompositeM
   }
 };
 
-export const HealthcareResultDocumentsItem: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "HealthcareResultDocumentsItem",
-    modelProperties: {
-      ...HealthcareEntitiesDocumentResult.type.modelProperties,
-      ...DocumentDetectedLanguage.type.modelProperties
-    }
-  }
-};
-
 export const SentimentResponseDocumentsItem: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2902,6 +2906,17 @@ export const AbstractiveSummaryDocumentResultWithDetectedLanguage: coreClient.Co
     modelProperties: {
       ...AbstractiveSummaryDocumentResult.type.modelProperties,
       ...DocumentDetectedLanguage.type.modelProperties
+    }
+  }
+};
+
+export const HealthcareResultDocumentsItem: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "HealthcareResultDocumentsItem",
+    modelProperties: {
+      ...HealthcareEntitiesDocumentResult.type.modelProperties,
+      ...DocumentDetectedLanguageForHealthcare.type.modelProperties
     }
   }
 };

--- a/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
@@ -30,7 +30,6 @@ import {
   PiiResult as GeneratedPiiEntityRecognitionResult,
   SentenceSentiment as GeneratedSentenceSentiment,
   SentimentResponse as GeneratedSentimentAnalysisResult,
-  HealthcareEntitiesDocumentResult,
   HealthcareLROResult,
   HealthcareRelation,
   HealthcareRelationEntity,

--- a/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/transforms.ts
@@ -365,6 +365,18 @@ export async function throwError<T>(p: Promise<T>): Promise<T> {
   }
 }
 
+export function deserializeDetectedLanguage(input: string): DetectedLanguage {
+  function helper(str: string): undefined {
+    try {
+      return JSON.parse(str);
+    } catch (e) {
+      return undefined;
+    }
+  }
+  const obj = helper(input);
+  return obj !== undefined ? obj : ({ iso6391Name: input } as any);
+}
+
 function toHealthcareResult(
   docIds: string[],
   results: GeneratedHealthcareResult
@@ -393,17 +405,6 @@ function toHealthcareResult(
         })
       ),
     });
-  }
-  function deserializeDetectedLanguage(input: string): DetectedLanguage {
-    function helper(str: string): undefined {
-      try {
-        return JSON.parse(str);
-      } catch (e) {
-        return undefined;
-      }
-    }
-    const obj = helper(input);
-    return obj !== undefined ? obj : ({ iso6391Name: input } as any);
   }
   return transformDocumentResults<
     HealthcareResultDocumentsItem,

--- a/sdk/cognitivelanguage/ai-language-text/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/swagger/README.md
@@ -12,8 +12,8 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: ./swagger.json
-#input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac205086f477776e8d9aa4ff771e98f174afbea2/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
+# input-file: ./swagger.json
+input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac205086f477776e8d9aa4ff771e98f174afbea2/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
 add-credentials: false
 package-version: 1.1.0-beta.1
 v3: true
@@ -319,6 +319,20 @@ directive:
   - from: swagger-document
     where: $.definitions.JobState
     transform: $.properties.lastUpdatedDateTime["x-ms-client-name"] = "modifiedOn";
+
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      if (!$.DocumentDetectedLanguageForHealthcare) {
+          $.DocumentDetectedLanguageForHealthcare = { "type": "object", "properties": { "detectedLanguage": { "type": "string" } } };
+      }
+
+  - from: swagger-document
+    where: $.definitions.HealthcareResult.properties.documents.items.allOf
+    transform: >
+      if ($[1]["$ref"] === "#/definitions/DocumentDetectedLanguage") {
+          $[1]["$ref"] = "#/definitions/DocumentDetectedLanguageForHealthcare";
+      }
 
 # Enhance documentation strings for some exported swagger types
 

--- a/sdk/cognitivelanguage/ai-language-text/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/swagger/README.md
@@ -12,7 +12,8 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac205086f477776e8d9aa4ff771e98f174afbea2/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
+input-file: ./swagger.json
+#input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac205086f477776e8d9aa4ff771e98f174afbea2/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
 add-credentials: false
 package-version: 1.1.0-beta.1
 v3: true

--- a/sdk/cognitivelanguage/ai-language-text/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/swagger/README.md
@@ -12,7 +12,6 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-# input-file: ./swagger.json
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/ac205086f477776e8d9aa4ff771e98f174afbea2/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
 add-credentials: false
 package-version: 1.1.0-beta.1

--- a/sdk/cognitivelanguage/ai-language-text/test/internal/utils.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/internal/utils.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "@azure/test-utils";
+import { deserializeDetectedLanguage } from "../../src/transforms";
+
+describe("Utilities", function () {
+  describe("deserializeDetectedLanguage", function () {
+    it("deserializes string", function () {
+      assert.deepEqual(deserializeDetectedLanguage("en"), { iso6391Name: "en" } as any);
+    });
+
+    it("deserializes object", function () {
+      const res = {
+        name: "English",
+        iso6391Name: "en",
+        confidenceScore: 0.98,
+      };
+      assert.deepEqual(deserializeDetectedLanguage(JSON.stringify(res)), res);
+    });
+  });
+});

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -862,7 +862,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           await assertActionsResults(await poller.pollUntilDone(), expectation15);
         });
 
-        it.only("whole batch input with auto language detection", async function () {
+        it("whole batch input with auto language detection", async function () {
           const docs = [
             "I will go to the park.",
             "Este es un document escrito en Español.",

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -862,7 +862,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           await assertActionsResults(await poller.pollUntilDone(), expectation15);
         });
 
-        it("whole batch input with auto language detection", async function () {
+        it.only("whole batch input with auto language detection", async function () {
           const docs = [
             "I will go to the park.",
             "Este es un document escrito en Español.",

--- a/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/expectations.ts
@@ -8696,7 +8696,7 @@ export const expectation71: any = [
         entityRelations: [],
         id: "0",
         warnings: [],
-        detectedLanguage: { "0": "e", "1": "n" },
+        detectedLanguage: { iso6391Name: "en" },
         isLanguageDefaulted: false,
       },
       {


### PR DESCRIPTION
It adds a swagger transform to specify the type of `detectedLanguage` to be a string and then attempts to deserialize it in the convenience layer and set the iso name correctly.