### PR TITLE
[@azure-rest/ai-anomaly-detector] remove unused export in sample 

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_change_point.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_change_point.ts
@@ -8,7 +8,6 @@
  */
 
 import AnomalyDetector, {
-  ChangePointDetectResponseOutput,
   DetectUnivariateChangePointParameters,
   isUnexpected,
   TimeSeriesPoint,

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_entire_series_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_entire_series_anomaly.ts
@@ -9,7 +9,6 @@
 
 import AnomalyDetector, {
   DetectUnivariateEntireSeriesParameters,
-  EntireDetectResponseOutput,
   isUnexpected,
   TimeSeriesPoint,
 } from "@azure-rest/ai-anomaly-detector";

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_last_point_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_detect_last_point_anomaly.ts
@@ -10,7 +10,6 @@
 import AnomalyDetector, {
   DetectUnivariateLastPointParameters,
   isUnexpected,
-  LastDetectResponseOutput,
   TimeSeriesPoint,
 } from "@azure-rest/ai-anomaly-detector";
 import { AzureKeyCredential } from "@azure/core-auth";

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_change_point.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_change_point.ts
@@ -8,7 +8,6 @@
  */
 
 import AnomalyDetector, {
-  ChangePointDetectResponseOutput,
   DetectUnivariateChangePointParameters,
   isUnexpected,
   TimeSeriesPoint,

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_entire_series_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_entire_series_anomaly.ts
@@ -9,7 +9,6 @@
 
 import AnomalyDetector, {
   DetectUnivariateEntireSeriesParameters,
-  EntireDetectResponseOutput,
   isUnexpected,
   TimeSeriesPoint,
 } from "@azure-rest/ai-anomaly-detector";

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_last_point_anomaly.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples/v1-beta/typescript/src/sample_detect_last_point_anomaly.ts
@@ -10,7 +10,6 @@
 import AnomalyDetector, {
   DetectUnivariateLastPointParameters,
   isUnexpected,
-  LastDetectResponseOutput,
   TimeSeriesPoint,
 } from "@azure-rest/ai-anomaly-detector";
 import { AzureKeyCredential } from "@azure/core-auth";


### PR DESCRIPTION
### Packages impacted by this PR

@azure-rest/ai-anomaly-detector


### Describe the problem that is addressed by this PR

Build break in main caused by this package failing to build when doing a global `rush build`