### PR TITLE
[Language Text] Mitigation for modifiedOn

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/src/lro.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/lro.ts
@@ -267,7 +267,7 @@ type Writable<T> = {
 export function createUpdateAnalyzeState(docIds?: string[]) {
   return (state: AnalyzeBatchOperationState, lastResponse: LroResponse): void => {
     const { createdOn, modifiedOn, id, displayName, expiresOn, tasks, lastUpdateDateTime } =
-      lastResponse.flatResponse as AnalyzeTextJobStatusResponse & { lastUpdateDateTime: Date };
+      lastResponse.flatResponse as AnalyzeTextJobStatusResponse & { lastUpdateDateTime: string };
     const mutableState = state as Writable<AnalyzeBatchOperationState> & {
       docIds?: string[];
     };

--- a/sdk/cognitivelanguage/ai-language-text/src/lro.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/lro.ts
@@ -266,13 +266,14 @@ type Writable<T> = {
  */
 export function createUpdateAnalyzeState(docIds?: string[]) {
   return (state: AnalyzeBatchOperationState, lastResponse: LroResponse): void => {
-    const { createdOn, modifiedOn, id, displayName, expiresOn, tasks } =
-      lastResponse.flatResponse as AnalyzeTextJobStatusResponse;
+    const { createdOn, modifiedOn, id, displayName, expiresOn, tasks, lastUpdateDateTime } =
+      lastResponse.flatResponse as AnalyzeTextJobStatusResponse & { lastUpdateDateTime: Date };
     const mutableState = state as Writable<AnalyzeBatchOperationState> & {
       docIds?: string[];
     };
     mutableState.createdOn = createdOn;
-    mutableState.modifiedOn = modifiedOn;
+    // FIXME: remove this mitigation when the service API is fixed
+    mutableState.modifiedOn = modifiedOn ? modifiedOn : new Date(lastUpdateDateTime);
     mutableState.expiresOn = expiresOn;
     mutableState.displayName = displayName;
     mutableState.id = id;

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -964,8 +964,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           poller.onProgress((state) => {
             assert.ok(state.createdOn, "createdOn is undefined!");
             assert.ok(state.expiresOn, "expiresOn is undefined!");
-            // FIXME uncomment this line when the service fixes the issue
-            // assert.ok(state.modifiedOn, "modifiedOn is undefined!");
+            assert.ok(state.modifiedOn, "modifiedOn is undefined!");
             assert.ok(state.status, "status is undefined!");
             assert.ok(state.id, "id is undefined!");
             assert.equal(state.displayName, "testJob");


### PR DESCRIPTION
Mitigation for the incorrect name used in for the `lastUpdatedDateTime` property in the job states. The service currently returns it as `lastUpdateDateTime` instead.