### PR TITLE
[identity] Fix MSAL Flow additionallyAllowedTenants to pass through

### DIFF
--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -76,6 +76,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
 
     const msalOptions: MsalBrowserFlowOptions = {
       ...options,
+      tokenCredentialOptions: options,
       logger,
       loginStyle: loginStyle,
       redirectUri:

--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -83,7 +83,7 @@ export abstract class MsalNode extends MsalBaseUtilities implements MsalFlow {
   protected msalConfig: msalNode.Configuration;
   protected clientId: string;
   protected tenantId: string;
-  private additionallyAllowedTenantIds: string[];
+  protected additionallyAllowedTenantIds: string[];
   protected authorityHost?: string;
   protected identityClient?: IdentityClient;
   protected requiresConfidential: boolean = false;

--- a/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
+++ b/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
@@ -36,7 +36,7 @@ describe("tenantIdUtils", () => {
 
       assert.equal(result.length, 2);
       assert.equal(result[0], "123");
-      assert.equal(result[2], "456");
+      assert.equal(result[1], "456");
     });
   });
 

--- a/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
+++ b/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
@@ -73,7 +73,22 @@ describe("tenantIdUtils", () => {
   });
 
   describe("resolveTenantId", () => {
-    it("should return 'common' for non-developer accounts", () => {
+    it("should throw if the tenant ID is invalid", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc_123";
+
+      assert.throws(() => {
+        resolveTenantId(logger, tenantId);
+      });
+
+      assert.equal(allParams.length, 1);
+    });
+
+    it("should return the tenant ID if properly set", () => {
       const allParams: any[] = [];
       const fakeLogger = {
         info: (...params: any) => allParams.push(params),
@@ -84,16 +99,30 @@ describe("tenantIdUtils", () => {
 
       const result = resolveTenantId(logger, tenantId, clientId);
 
-      assert.equal(result, "common");
+      assert.equal(result, tenantId);
     });
 
-    it("should return 'organizations' for developer accounts", () => {
+    it("should return 'common' for non-developer accounts with client ID", () => {
       const allParams: any[] = [];
       const fakeLogger = {
         info: (...params: any) => allParams.push(params),
       };
       const logger = credentialLogger("title", fakeLogger as any);
-      const tenantId = "abc-123";
+      let tenantId: string | undefined;
+      const clientId = "def-456";
+
+      const result = resolveTenantId(logger, tenantId, clientId);
+
+      assert.equal(result, "common");
+    });
+
+    it("should return 'organizations' for developer accounts with client ID", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      let tenantId: string | undefined;
       const clientId = DeveloperSignOnClientId;
 
       const result = resolveTenantId(logger, tenantId, clientId);
@@ -107,9 +136,8 @@ describe("tenantIdUtils", () => {
         info: (...params: any) => allParams.push(params),
       };
       const logger = credentialLogger("title", fakeLogger as any);
-      const tenantId = "abc-123";
 
-      const result = resolveTenantId(logger, tenantId);
+      const result = resolveTenantId(logger);
 
       assert.equal(result, "organizations");
     });

--- a/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
+++ b/sdk/identity/identity/test/internal/tenantIdUtils.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  checkTenantId,
+  resolveAddionallyAllowedTenantIds,
+  resolveTenantId,
+} from "../../src/util/tenantIdUtils";
+import { DeveloperSignOnClientId } from "../../src/constants";
+import { assert } from "@azure/test-utils";
+import { credentialLogger } from "../../src/util/logging";
+
+describe("tenantIdUtils", () => {
+  describe("resolveAddionallyAllowedTenantIds", () => {
+    it("should set to empty if resolveAddionallyAllowedTenantIds is passed null/undefined", () => {
+      let additionallyAllowedTenants: string[] | undefined;
+
+      const result = resolveAddionallyAllowedTenantIds(additionallyAllowedTenants);
+
+      assert.equal(result.length, 0);
+    });
+
+    it("should set back to ALL TENANTS '*' if includes '*'", () => {
+      const additionallyAllowedTenants = ["123", "456", "789", "*"];
+
+      const result = resolveAddionallyAllowedTenantIds(additionallyAllowedTenants);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], "*");
+    });
+
+    it("should flow through if tenants are set and doesn't include '*'", () => {
+      const additionallyAllowedTenants = ["123", "456"];
+
+      const result = resolveAddionallyAllowedTenantIds(additionallyAllowedTenants);
+
+      assert.equal(result.length, 2);
+      assert.equal(result[0], "123");
+      assert.equal(result[2], "456");
+    });
+  });
+
+  describe("checkTenantId", () => {
+    it("should throw if the tenant ID is invalid", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc_123";
+
+      assert.throws(() => {
+        checkTenantId(logger, tenantId);
+      });
+
+      assert.equal(allParams.length, 1);
+    });
+
+    it("should not throw if the tenant ID is valid", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc-123";
+
+      assert.doesNotThrow(() => {
+        checkTenantId(logger, tenantId);
+      });
+
+      assert.equal(allParams.length, 0);
+    });
+  });
+
+  describe("resolveTenantId", () => {
+    it("should return 'common' for non-developer accounts", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc-123";
+      const clientId = "def-456";
+
+      const result = resolveTenantId(logger, tenantId, clientId);
+
+      assert.equal(result, "common");
+    });
+
+    it("should return 'organizations' for developer accounts", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc-123";
+      const clientId = DeveloperSignOnClientId;
+
+      const result = resolveTenantId(logger, tenantId, clientId);
+
+      assert.equal(result, "organizations");
+    });
+
+    it("should return organizations if client ID not set", () => {
+      const allParams: any[] = [];
+      const fakeLogger = {
+        info: (...params: any) => allParams.push(params),
+      };
+      const logger = credentialLogger("title", fakeLogger as any);
+      const tenantId = "abc-123";
+
+      const result = resolveTenantId(logger, tenantId);
+
+      assert.equal(result, "organizations");
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- [identity]

### Issues associated with this PR

- #23693

### Describe the problem that is addressed by this PR

Fixes the browser flows for the associated bug to also allow through the `additionallyAllowedTenants` to flow through.  Also adds some unit tests.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
