### PR TITLE
[Maps] Fix the issue in the Smoke Test

### DIFF
--- a/sdk/maps/maps-search/samples-dev/search.ts
+++ b/sdk/maps/maps-search/samples-dev/search.ts
@@ -359,4 +359,4 @@ async function main() {
   console.log(await rehydratedFuzzySearchPoller.getResult());
 }
 
-main();
+main().catch((e) => console.error(e));

--- a/sdk/maps/maps-search/samples/v1-beta/javascript/search.js
+++ b/sdk/maps/maps-search/samples/v1-beta/javascript/search.js
@@ -346,4 +346,4 @@ async function main() {
   console.log(await rehydratedFuzzySearchPoller.getResult());
 }
 
-main();
+main().catch((e) => console.error(e));

--- a/sdk/maps/maps-search/samples/v1-beta/typescript/src/search.ts
+++ b/sdk/maps/maps-search/samples/v1-beta/typescript/src/search.ts
@@ -358,4 +358,4 @@ async function main() {
   console.log(await rehydratedFuzzySearchPoller.getResult());
 }
 
-main();
+main().catch((e) => console.error(e));


### PR DESCRIPTION
### Packages impacted by this PR
- @azure/maps-search

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
The smoke test of the `@azure/maps-search` failed with following message: 
```
TypeError: entryPoint is not a function
```
It turns out that in sample search.js doesn't follows the pattern `main().catch(...)`, which failed the transform script in the smoke test:  https://github.com/Azure/azure-sdk-for-js/blob/main/common/smoke-test/Initialize-SmokeTests.ps1#L132

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
