### PR TITLE
fix: search-documents - modified mocha tests to use function keyword instead of arrow syntax

### DIFF
--- a/sdk/search/search-documents/test/internal/base64.spec.ts
+++ b/sdk/search/search-documents/test/internal/base64.spec.ts
@@ -4,8 +4,8 @@
 import { assert } from "chai";
 import { decode, encode } from "../../src/base64";
 
-describe("base64", () => {
-  it("strings can roundtrip", () => {
+describe("base64", function () {
+  it("strings can roundtrip", function () {
     const message = "Only *you* can prevent null dereferences!";
     const encoded = encode(message);
     const decoded = decode(encoded);

--- a/sdk/search/search-documents/test/internal/browser/synonymMap.browser.spec.ts
+++ b/sdk/search/search-documents/test/internal/browser/synonymMap.browser.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import { createSynonymMapFromFile } from "../../../src/synonymMapHelper.browser";
 
-describe("synonymmap", () => {
+describe("synonymmap", function () {
   it("create synonymmap from file(browser)", async function () {
     let errorThrown = false;
     try {

--- a/sdk/search/search-documents/test/internal/geographyPoint.spec.ts
+++ b/sdk/search/search-documents/test/internal/geographyPoint.spec.ts
@@ -5,8 +5,8 @@ import { assert } from "chai";
 import * as sinon from "sinon";
 import GeographyPoint from "../../src/geographyPoint";
 
-describe("geographyPoint", () => {
-  it("JSON.stringify", () => {
+describe("geographyPoint", function () {
+  it("JSON.stringify", function () {
     const geoPoint = new GeographyPoint({
       longitude: -122.123889,
       latitude: 47.669444,
@@ -19,7 +19,7 @@ describe("geographyPoint", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 });

--- a/sdk/search/search-documents/test/internal/node/synonymMap.node.spec.ts
+++ b/sdk/search/search-documents/test/internal/node/synonymMap.node.spec.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 import { createSynonymMapFromFile } from "../../../src";
 import { SynonymMap } from "../../../src/serviceModels";
 
-describe("synonymmap", () => {
+describe("synonymmap", function () {
   it("create synonymmap from file(node)", async function () {
     const synonymMap: SynonymMap = await createSynonymMapFromFile(
       "my-synonym-map-1",

--- a/sdk/search/search-documents/test/internal/serialization.spec.ts
+++ b/sdk/search/search-documents/test/internal/serialization.spec.ts
@@ -6,21 +6,21 @@ import * as sinon from "sinon";
 import { deserialize, serialize } from "../../src/serialization";
 import GeographyPoint from "../../src/geographyPoint";
 
-describe("serialization.serialize", () => {
-  it("nested", () => {
+describe("serialization.serialize", function () {
+  it("nested", function () {
     const nestedInput = { a: { b: { c: { d: [42] } } } };
     const result = serialize(nestedInput);
     assert.deepEqual(nestedInput, result);
   });
 
-  it("circular", () => {
+  it("circular", function () {
     const circularInput: any = { a: null };
     circularInput.a = circularInput;
     const result = serialize(circularInput);
     assert.deepEqual(circularInput, result);
   });
 
-  it("recursive 1", () => {
+  it("recursive 1", function () {
     const child = { hello: "world" };
     const documents = [
       { id: "1", children: [child] },
@@ -30,7 +30,7 @@ describe("serialization.serialize", () => {
     assert.deepEqual(documents, result);
   });
 
-  it("recursive 2", () => {
+  it("recursive 2", function () {
     const child = { hello: Infinity, world: -Infinity, universe: NaN };
     const documents = [
       { id: "1", children: [child] },
@@ -41,41 +41,41 @@ describe("serialization.serialize", () => {
     assert.deepEqual(documents, result);
   });
 
-  it("NaN", () => {
+  it("NaN", function () {
     const result = serialize({ a: NaN });
     assert.deepEqual(result, { a: "NaN" });
   });
 
-  it("Infinity", () => {
+  it("Infinity", function () {
     const result = serialize({ a: Infinity });
     assert.deepEqual(result, { a: "INF" });
   });
 
-  it("Negative Infinity", () => {
+  it("Negative Infinity", function () {
     const result = serialize({ a: -Infinity });
     assert.deepEqual(result, { a: "-INF" });
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 });
 
-describe("serialization.deserialize", () => {
-  it("nested", () => {
+describe("serialization.deserialize", function () {
+  it("nested", function () {
     const nestedInput = { a: { b: { c: { d: [42] } } } };
     const result = deserialize(nestedInput);
     assert.deepEqual(nestedInput, result);
   });
 
-  it("circular", () => {
+  it("circular", function () {
     const circularInput: any = { a: null };
     circularInput.a = circularInput;
     const result = deserialize(circularInput);
     assert.deepEqual(circularInput, result);
   });
 
-  it("recursive 1", () => {
+  it("recursive 1", function () {
     const child = { hello: "world" };
     const documents = [
       { id: "1", children: [child] },
@@ -85,7 +85,7 @@ describe("serialization.deserialize", () => {
     assert.deepEqual(documents, result);
   });
 
-  it("recursive 2", () => {
+  it("recursive 2", function () {
     const child = { hello: "INF", world: "-INF", universe: "NaN" };
     const documents = [
       { id: "1", children: [child] },
@@ -96,45 +96,45 @@ describe("serialization.deserialize", () => {
     assert.deepEqual(documents, result);
   });
 
-  it("NaN", () => {
+  it("NaN", function () {
     const result = deserialize({ a: "NaN" });
     assert.deepEqual(result, { a: NaN });
   });
 
-  it("Infinity", () => {
+  it("Infinity", function () {
     const result = deserialize({ a: "INF" });
     assert.deepEqual(result, { a: Infinity });
   });
 
-  it("Negative Infinity", () => {
+  it("Negative Infinity", function () {
     const result = deserialize({ a: "-INF" });
     assert.deepEqual(result, { a: -Infinity });
   });
 
-  it("Date", () => {
+  it("Date", function () {
     const result = deserialize({ a: "1975-04-04T00:00:00.000Z" });
     assert.deepEqual(result, { a: new Date(Date.UTC(1975, 3, 4)) });
   });
 
-  it("doesn't deserialize as Date if text before", () => {
+  it("doesn't deserialize as Date if text before", function () {
     const value = "before 1975-04-04T00:00:00.000Z";
     const result = deserialize({ a: value });
     assert.deepEqual(result, { a: value });
   });
 
-  it("doesn't deserialize as Date if text after", () => {
+  it("doesn't deserialize as Date if text after", function () {
     const value = "1975-04-04T00:00:00.000Z after";
     const result = deserialize({ a: value });
     assert.deepEqual(result, { a: value });
   });
 
-  it("doesn't deserialize as Date if text before and after", () => {
+  it("doesn't deserialize as Date if text before and after", function () {
     const value = "before 1975-04-04T00:00:00.000Z after";
     const result = deserialize({ a: value });
     assert.deepEqual(result, { a: value });
   });
 
-  it("GeographyPoint", () => {
+  it("GeographyPoint", function () {
     const result: { location: GeographyPoint } = deserialize({
       location: {
         type: "Point",
@@ -147,7 +147,7 @@ describe("serialization.deserialize", () => {
     assert.equal(result.location.longitude, -84.527771);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 });

--- a/sdk/search/search-documents/test/internal/serviceUtils.spec.ts
+++ b/sdk/search/search-documents/test/internal/serviceUtils.spec.ts
@@ -7,8 +7,8 @@ import { SearchField as GeneratedSearchField } from "../../src/generated/service
 import { KnownLexicalAnalyzerName } from "../../src/index";
 import { ComplexField, SearchField } from "../../src/serviceModels";
 
-describe("serviceUtils", () => {
-  it("convert generated fields to public fields", () => {
+describe("serviceUtils", function () {
+  it("convert generated fields to public fields", function () {
     const publicFields: SearchField[] = convertFieldsToPublic([
       {
         name: "id",
@@ -44,7 +44,7 @@ describe("serviceUtils", () => {
     });
   });
 
-  it("convert generated fields (complex) to public fields", () => {
+  it("convert generated fields (complex) to public fields", function () {
     const publicFields: SearchField[] = convertFieldsToPublic([
       {
         name: "ComplexObj",
@@ -91,7 +91,7 @@ describe("serviceUtils", () => {
     });
   });
 
-  it("convert public fields to generated fields", () => {
+  it("convert public fields to generated fields", function () {
     const generatedFields: GeneratedSearchField[] = convertFieldsToGenerated([
       {
         name: "id",
@@ -127,7 +127,7 @@ describe("serviceUtils", () => {
     });
   });
 
-  it("convert public fields (complex) to generated fields", () => {
+  it("convert public fields (complex) to generated fields", function () {
     const generatedFields: GeneratedSearchField[] = convertFieldsToGenerated([
       {
         name: "ComplexObj",

--- a/sdk/search/search-documents/test/public/odata.spec.ts
+++ b/sdk/search/search-documents/test/public/odata.spec.ts
@@ -5,75 +5,75 @@ import { assert } from "chai";
 import * as sinon from "sinon";
 import { odata } from "../../src";
 
-describe("odata", () => {
-  it("simple string isn't changed", () => {
+describe("odata", function () {
+  it("simple string isn't changed", function () {
     const result = odata`Rooms/any(room: room/BaseRate lt 200) and Rating ge 4`;
     assert.strictEqual(result, "Rooms/any(room: room/BaseRate lt 200) and Rating ge 4");
   });
 
-  it("substitutions are incorporated", () => {
+  it("substitutions are incorporated", function () {
     const rate = 200;
     const rating = 4;
     const result = odata`Rooms/any(room: room/BaseRate lt ${rate}) and Rating ge ${rating}`;
     assert.strictEqual(result, "Rooms/any(room: room/BaseRate lt 200) and Rating ge 4");
   });
 
-  it("literals are escaped", () => {
+  it("literals are escaped", function () {
     const value = "you're";
     const result = odata`search.ismatch('${value}', 'Description')`;
     assert.strictEqual(result, "search.ismatch('you''re', 'Description')");
   });
 
-  it("unquoted literals are quoted", () => {
+  it("unquoted literals are quoted", function () {
     const value = "you're";
     const result = odata`search.ismatch(${value}, 'Description')`;
     assert.strictEqual(result, "search.ismatch('you''re', 'Description')");
   });
 
-  it("no arguments", () => {
+  it("no arguments", function () {
     assert.strictEqual(odata`Foo eq 2`, "Foo eq 2");
   });
 
-  it("one argument", () => {
+  it("one argument", function () {
     assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
   });
 
-  it("many arguments", () => {
+  it("many arguments", function () {
     assert.strictEqual(
       odata`Foo eq ${2} and Bar eq ${3} and Baz eq ${4} and Qux eq ${5} and Quux eq ${6}`,
       "Foo eq 2 and Bar eq 3 and Baz eq 4 and Qux eq 5 and Quux eq 6"
     );
   });
 
-  it("null", () => {
+  it("null", function () {
     assert.strictEqual(odata`Foo eq ${null}`, "Foo eq null");
   });
 
-  it("bool", () => {
+  it("bool", function () {
     const x: boolean = true;
     assert.strictEqual(odata`Foo eq ${x}`, "Foo eq true");
     assert.strictEqual(odata`Foo eq ${true}`, "Foo eq true");
   });
 
-  it("numbers", () => {
+  it("numbers", function () {
     assert.strictEqual(odata`Foo eq ${0}`, "Foo eq 0");
     assert.strictEqual(odata`Foo eq ${2}`, "Foo eq 2");
     assert.strictEqual(odata`Foo eq ${-2}`, "Foo eq -2");
     assert.strictEqual(odata`Foo eq ${2.5}`, "Foo eq 2.5");
   });
 
-  it("limits", () => {
+  it("limits", function () {
     assert.strictEqual(odata`Foo eq ${Number.NEGATIVE_INFINITY}`, "Foo eq -Infinity");
     assert.strictEqual(odata`Foo eq ${Number.POSITIVE_INFINITY}`, "Foo eq Infinity");
     assert.strictEqual(odata`Foo eq ${Number.NaN}`, "Foo eq NaN");
   });
 
-  it("dates", () => {
+  it("dates", function () {
     const result: string = odata`Foo eq ${new Date(1912, 6, 23, 11, 59, 59)}`;
     assert.strictEqual(result.includes("Tue Jul 23 1912 11:59:59"), true);
   });
 
-  it("text", () => {
+  it("text", function () {
     assert.strictEqual(odata`Foo eq ${"x"}`, "Foo eq 'x'");
     assert.strictEqual(odata`Foo eq ${"'"}`, "Foo eq ''''");
     assert.strictEqual(odata`Foo eq ${'"'}`, "Foo eq '\"'");
@@ -82,7 +82,7 @@ describe("odata", () => {
     assert.strictEqual(odata`Foo eq ${'"bar"'}`, "Foo eq '\"bar\"'");
   });
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
`sdk\search\search-documents`

### Issues associated with this PR
#13005 

### Describe the problem that is addressed by this PR
The existing mocha tests for the `sdk\search\search-documents`  made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context ([https://mochajs.org/#arrow-functions](https://mochajs.org/#arrow-functions)).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_
No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_
**_Not applicable._**

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
**_Not applicable._**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
  - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
