### PR TITLE
Use deployment/approval for npm admin task pipeline

### DIFF
--- a/eng/pipelines/npm-tasks.yml
+++ b/eng/pipelines/npm-tasks.yml
@@ -1,6 +1,6 @@
 trigger: none
 
-# This pipeline helps to run NPM admin tasks like remove or add tag to a released package version or deprecate a pacakge version
+# This pipeline helps to run NPM admin tasks like remove or add tag to a released package version or deprecate a package version
 # Following variables should be set at queue time to run this pipeline
 # variable name: TaskType
 # valid Options: 'AddTag', 'RemoveTag', 'Deprecate', 'Unpublish'
@@ -46,23 +46,28 @@ parameters:
     default: ''
 
 jobs:
-- job: 'NPM_Admin_Job'
+- deployment: 'NPM_Admin'
   displayName: NPM package management
+  environment: npm
 
   pool:
     vmImage: 'windows-2019'
 
-  steps:
-    - task: PowerShell@2
-      displayName: 'Run Task'
-      inputs:
-        targetType: filePath
-        filePath: "eng/scripts/npm-admin-tasks.ps1"
-        arguments: >
-          -taskType ${{parameters.TaskType}}
-          -packageName ${{parameters.PackageName}}
-          -pkgVersion ${{parameters.PkgVersion}}
-          -tagName ${{parameters.TagName}}
-          -npmToken "$(azure-sdk-npm-token)"
-          -reason "${{parameters.Reason}}"
-        pwsh: true
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          - task: PowerShell@2
+            displayName: 'Run Task'
+            inputs:
+              targetType: filePath
+              filePath: "eng/scripts/npm-admin-tasks.ps1"
+              arguments: >
+                -taskType ${{parameters.TaskType}}
+                -packageName ${{parameters.PackageName}}
+                -pkgVersion ${{parameters.PkgVersion}}
+                -tagName ${{parameters.TagName}}
+                -npmToken "$(azure-sdk-npm-token)"
+                -reason "${{parameters.Reason}}"
+              pwsh: true


### PR DESCRIPTION
This updates the npm admin tasks pipeline to gate permissions on an approval, not on pipeline invocation. There were larger permissions problems with the non-standard security setup in the base pipeline, so we're switching to the approval model consistent with how package releases are done.