### PR TITLE
fix: attestation - remove mocha arrow functions

### DIFF
--- a/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
+++ b/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
@@ -141,33 +141,33 @@ describe("AttestationClient in Browser", function () {
     "RHZvOGgyazVkdTFpV0RkQmtBbiswaWlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0" +
     "tLQoA";
 
-  it("#AttestOpenEnclaveShared", async () => {
+  it("#AttestOpenEnclaveShared", async function () {
     await testOpenEnclave("Shared");
   });
 
-  it("#AttestOpenEnclaveAad", async () => {
+  it("#AttestOpenEnclaveAad", async function () {
     await testOpenEnclave("AAD");
   });
 
-  it("#AttestOpenEnclaveIsolated", async () => {
+  it("#AttestOpenEnclaveIsolated", async function () {
     await testOpenEnclave("Isolated");
   });
 
-  it("#AttestSgxEnclaveShared", async () => {
+  it("#AttestSgxEnclaveShared", async function () {
     await testSgxEnclave("Shared");
   });
 
-  it("#AttestSgxEnclaveAad", async () => {
+  it("#AttestSgxEnclaveAad", async function () {
     await testSgxEnclave("AAD");
   });
 
-  it("#AttestSgxEnclaveIsolated", async () => {
+  it("#AttestSgxEnclaveIsolated", async function () {
     await testSgxEnclave("Isolated");
   });
 
   /* TPM Attestation can only be performed on an AAD or isolated mode client.
    */
-  it("#attestTpm", async () => {
+  it("#attestTpm", async function () {
     const client = createRecordedClient(recorder, "AAD", true);
     const adminClient = createRecordedAdminClient(recorder, "AAD");
 

--- a/sdk/attestation/attestation/test/public/attestationTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTests.spec.ts
@@ -141,33 +141,33 @@ describe("[AAD] Attestation Client", function () {
     "RHZvOGgyazVkdTFpV0RkQmtBbiswaWlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0" +
     "tLQoA";
 
-  it("#AttestOpenEnclaveShared", async () => {
+  it("#AttestOpenEnclaveShared", async function () {
     await testOpenEnclave("Shared");
   });
 
-  it("#AttestOpenEnclaveAad", async () => {
+  it("#AttestOpenEnclaveAad", async function () {
     await testOpenEnclave("AAD");
   });
 
-  it("#AttestOpenEnclaveIsolated", async () => {
+  it("#AttestOpenEnclaveIsolated", async function () {
     await testOpenEnclave("Isolated");
   });
 
-  it("#AttestSgxEnclaveShared", async () => {
+  it("#AttestSgxEnclaveShared", async function () {
     await testSgxEnclave("Shared");
   });
 
-  it("#AttestSgxEnclaveAad", async () => {
+  it("#AttestSgxEnclaveAad", async function () {
     await testSgxEnclave("AAD");
   });
 
-  it("#AttestSgxEnclaveIsolated", async () => {
+  it("#AttestSgxEnclaveIsolated", async function () {
     await testSgxEnclave("Isolated");
   });
 
   /* TPM Attestation can only be performed on an AAD or isolated mode client.
    */
-  it("#attestTpm", async () => {
+  it("#attestTpm", async function () {
     const client = createRecordedClient(recorder, "AAD", true);
     const adminClient = createRecordedAdminClient(recorder, "AAD");
 

--- a/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
@@ -30,7 +30,7 @@ describe("AttestationTokenTests", function () {
     await recorder.stop();
   });
 
-  it("#testUtf8ConversionFunctions", async () => {
+  it("#testUtf8ConversionFunctions", async function () {
     const buffer = stringToBytes("ABCDEF");
     assert.equal(65, buffer[0]);
     assert.equal(66, buffer[1]);
@@ -42,7 +42,7 @@ describe("AttestationTokenTests", function () {
     assert.equal("ABCDEF", str);
   });
 
-  it("#createRsaSigningKey", async () => {
+  it("#createRsaSigningKey", async function () {
     const [privKey, pubKey] = createRSAKey();
     const cert = createX509Certificate(privKey, pubKey, "testCert");
     assert.isTrue(privKey.length !== 0);
@@ -52,7 +52,7 @@ describe("AttestationTokenTests", function () {
     assert.isTrue(signingKey.certificate.length !== 0);
   });
 
-  it("#createEcdsSigningKey", async () => {
+  it("#createEcdsSigningKey", async function () {
     const [privKey, pubKey] = createECDSKey();
     const cert = createX509Certificate(privKey, pubKey, "testCert");
     assert.isTrue(privKey.length !== 0);
@@ -64,7 +64,7 @@ describe("AttestationTokenTests", function () {
 
   // Create a signing key, but use the wrong key - this should throw an
   // exception, because the key doesn't match the certificate.
-  it("#createSigningKeyWrongKey", async () => {
+  it("#createSigningKeyWrongKey", async function () {
     const [privKey, pubKey] = createECDSKey();
     const cert = createX509Certificate(privKey, pubKey, "testCert");
 
@@ -79,7 +79,7 @@ describe("AttestationTokenTests", function () {
   /**
    * Creates an unsecured attestation token.
    */
-  it("#createUnsecuredAttestationToken", async () => {
+  it("#createUnsecuredAttestationToken", async function () {
     const sourceObject = JSON.stringify({ foo: "foo", bar: 10 });
     const token = AttestationTokenImpl.create({ body: sourceObject });
 
@@ -91,7 +91,7 @@ describe("AttestationTokenTests", function () {
   /**
    * Creates an unsecured empty attestation token.
    */
-  it("#createUnsecuredEmptyAttestationToken", async () => {
+  it("#createUnsecuredEmptyAttestationToken", async function () {
     const token = AttestationTokenImpl.create({});
 
     // An empty unsecured attestation token has a well known value, check it.
@@ -104,7 +104,7 @@ describe("AttestationTokenTests", function () {
   /**
    * Creates a secured empty attestation token with the specified key.
    */
-  it("#createEmptySecuredAttestationToken", async () => {
+  it("#createEmptySecuredAttestationToken", async function () {
     const [privKey, pubKey] = createRSAKey();
     const cert = createX509Certificate(privKey, pubKey, "certificate");
 
@@ -131,7 +131,7 @@ describe("AttestationTokenTests", function () {
   /**
    * Creates a secured attestation token with the specified key.
    */
-  it("#createSecuredAttestationToken", async () => {
+  it("#createSecuredAttestationToken", async function () {
     const [privKey, pubKey] = createRSAKey();
     const cert = createX509Certificate(privKey, pubKey, "certificate");
 
@@ -167,7 +167,7 @@ describe("AttestationTokenTests", function () {
     expect(token.issuer).to.equal("this is an issuer");
   });
 
-  it("#verifyAttestationTokenCallback", async () => {
+  it("#verifyAttestationTokenCallback", async function () {
     const sourceObject = JSON.stringify({ foo: "foo", bar: 10 });
 
     const token = AttestationTokenImpl.create({ body: sourceObject });
@@ -196,7 +196,7 @@ describe("AttestationTokenTests", function () {
     );
   });
 
-  it("#verifyAttestationTokenIssuer", async () => {
+  it("#verifyAttestationTokenIssuer", async function () {
     const currentTime = Math.floor(new Date().getTime() / 1000);
     {
       // Source expires in 30 seconds.
@@ -231,7 +231,7 @@ describe("AttestationTokenTests", function () {
       );
     }
   });
-  it("#verifyAttestationTimeouts", async () => {
+  it("#verifyAttestationTimeouts", async function () {
     const currentTime = Math.floor(new Date().getTime() / 1000);
 
     {

--- a/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyGetSetTests.spec.ts
@@ -37,23 +37,23 @@ describe("PolicyGetSetTests ", function () {
     await recorder.stop();
   });
 
-  it("#GetPolicy SGX - Aad", async () => {
+  it("#GetPolicy SGX - Aad", async function () {
     await testGetPolicy(KnownAttestationType.SgxEnclave, "AAD");
   });
 
-  it("#GetPolicy SGX - Isolated", async () => {
+  it("#GetPolicy SGX - Isolated", async function () {
     await testGetPolicy(KnownAttestationType.SgxEnclave, "Isolated");
   });
 
-  it("#GetPolicy SGX - Shared", async () => {
+  it("#GetPolicy SGX - Shared", async function () {
     await testGetPolicy(KnownAttestationType.SgxEnclave, "Shared");
   });
 
-  it("Set Policy SGX - AAD Unsecured", async () => {
+  it("Set Policy SGX - AAD Unsecured", async function () {
     await testSetPolicy(KnownAttestationType.SgxEnclave, "AAD");
   });
 
-  it("Set Policy failure conditions", async () => {
+  it("Set Policy failure conditions", async function () {
     const adminClient = createRecordedAdminClient(recorder, "AAD");
 
     const minimalPolicy = "version=1.0; authorizationrules{=> permit();}; issuancerules{};";
@@ -91,7 +91,7 @@ describe("PolicyGetSetTests ", function () {
     await adminClient.resetPolicy(KnownAttestationType.SgxEnclave);
   });
 
-  it("Reset Policy failure conditions", async () => {
+  it("Reset Policy failure conditions", async function () {
     const adminClient = createRecordedAdminClient(recorder, "AAD");
 
     const [rsaKey, rsapubKey] = createRSAKey();
@@ -138,7 +138,7 @@ describe("PolicyGetSetTests ", function () {
     await testSetPolicy(KnownAttestationType.SgxEnclave, "Isolated", getIsolatedSigningKey());
   });
 
-  it("Reset Policy SGX - AAD Unsecured", async () => {
+  it("Reset Policy SGX - AAD Unsecured", async function () {
     await testResetPolicy(KnownAttestationType.SgxEnclave, "AAD");
   });
 

--- a/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/policyManagementGetSetTests.spec.ts
@@ -34,7 +34,7 @@ describe("PolicyManagementTests ", function () {
     await recorder.stop();
   });
 
-  it("#getPolicyCertificates - AAD", async () => {
+  it("#getPolicyCertificates - AAD", async function () {
     const client = createRecordedAdminClient(recorder, "AAD");
 
     const policyResult = await client.getPolicyManagementCertificates();
@@ -43,7 +43,7 @@ describe("PolicyManagementTests ", function () {
     assert(result, "Expected a token from the service but did not receive one");
   });
 
-  it("#getPolicyCertificates - Shared", async () => {
+  it("#getPolicyCertificates - Shared", async function () {
     const client = createRecordedAdminClient(recorder, "Shared");
     const policyResult = await client.getPolicyManagementCertificates();
 
@@ -52,7 +52,7 @@ describe("PolicyManagementTests ", function () {
     assert(result, "Expected a token from the service but did not receive one");
   });
 
-  it("#getPolicyCertificates - Isolated", async () => {
+  it("#getPolicyCertificates - Isolated", async function () {
     const client = createRecordedAdminClient(recorder, "Isolated");
     const policyResult = await client.getPolicyManagementCertificates();
 
@@ -62,7 +62,7 @@ describe("PolicyManagementTests ", function () {
     assert(policyResult.body.length !== 0);
   });
 
-  it("Add Policy Certificates failure conditions", async () => {
+  it("Add Policy Certificates failure conditions", async function () {
     const adminClient = createRecordedAdminClient(recorder, "Isolated");
 
     const [rsaKey, rsapubKey] = createRSAKey();
@@ -78,7 +78,7 @@ describe("PolicyManagementTests ", function () {
     ).to.be.rejectedWith("Key does not match Certificate");
   });
 
-  it("Remove Policy failure conditions", async () => {
+  it("Remove Policy failure conditions", async function () {
     const adminClient = createRecordedAdminClient(recorder, "Isolated");
 
     const [rsaKey, rsapubKey] = createRSAKey();

--- a/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/tokenCertTests.spec.ts
@@ -26,17 +26,17 @@ describe("TokenCertTests", function () {
     await recorder.stop();
   });
 
-  it("#GetCertificateAAD", async () => {
+  it("#GetCertificateAAD", async function () {
     const client = createRecordedClient(recorder, "AAD");
     await getCertificatesTest(client);
   });
 
-  it("#GetCertificatesIsolated", async () => {
+  it("#GetCertificatesIsolated", async function () {
     const client = createRecordedClient(recorder, "Isolated");
     await getCertificatesTest(client);
   });
 
-  it("#GetCertificatesShared", async () => {
+  it("#GetCertificatesShared", async function () {
     const client = createRecordedClient(recorder, "Shared");
     await getCertificatesTest(client);
   });
@@ -56,17 +56,17 @@ describe("TokenCertTests", function () {
     }
   }
 
-  it("#GetMetadataConfigAAD", async () => {
+  it("#GetMetadataConfigAAD", async function () {
     const client = createRecordedClient(recorder, "AAD");
     await getMetadataConfigTest(client, getAttestationUri("AAD"));
   });
 
-  it("#GetMetadataConfigIsolated", async () => {
+  it("#GetMetadataConfigIsolated", async function () {
     const client = createRecordedClient(recorder, "Isolated");
     await getMetadataConfigTest(client, getAttestationUri("Isolated"));
   });
 
-  it("#GetMetadataConfigShared", async () => {
+  it("#GetMetadataConfigShared", async function () {
     const client = createRecordedClient(recorder, "Shared");
     await getMetadataConfigTest(client, getAttestationUri("Shared"));
   });


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\attestation\attestation`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\attestation\attestation` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk/search/search-documents` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
  - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**

### Notes

I did run the package's test suite before and after the changes to confirm all remains as it should be.