### PR TITLE
[keyvault] keyvault-admin: fix user agent integration test

### DIFF
--- a/sdk/keyvault/keyvault-admin/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/internal/userAgent.spec.ts
@@ -46,7 +46,7 @@ describe("Key Vault Admin's user agent", function () {
       version = fileContents.version;
     } catch {
       const fileContents = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
+        fs.readFileSync(path.join(__dirname, "../../../package.json"), { encoding: "utf-8" })
       );
       version = fileContents.version;
     }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-admin`

### Issues associated with this PR

- #22705

### Describe the problem that is addressed by this PR

- Due to keyvault-admin no longer using the code-sharing approach for keyvault-common, the location of the test file when running integration tests has gone up one level.
- This means the relative path used in the integration tests to find the `package.json` is no longer accurate.

This PR updates the path so it is correct.