### PR TITLE
[ServiceBus] move a logging line to a better place

### DIFF
--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -121,12 +121,6 @@ export class BatchingReceiver extends MessageReceiver {
   ): Promise<ServiceBusMessageImpl[]> {
     throwErrorIfConnectionClosed(this._context);
     try {
-      logger.verbose(
-        "[%s] Receiver '%s', setting max concurrent calls to 0.",
-        this.logPrefix,
-        this.name
-      );
-
       const messages = await this._batchingReceiverLite.receiveMessages({
         maxMessageCount,
         maxWaitTimeInMs,

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -679,7 +679,12 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
     entityPath: string,
     options: ReceiveOptions
   ): BatchingReceiver {
-    return BatchingReceiver.create(this.identifier, context, entityPath, options);
+    const receiver = BatchingReceiver.create(this.identifier, context, entityPath, options);
+    logger.verbose(
+      `[${this.logPrefix}] receiver '${receiver.name}' created, with maxConcurrentCalls set to ${options.maxConcurrentCalls}.`
+    );
+
+    return receiver;
   }
 
   /**


### PR DESCRIPTION
Currently that log looks unrelated to any nearby code. This PR moves it to a better place where the `maxConcurrentCalls` option is set. The info logged still remains the same.
