### PR TITLE
[core-logger] Add support to include date prefix to log

### DIFF
--- a/sdk/core/logger/review/logger.api.md
+++ b/sdk/core/logger/review/logger.api.md
@@ -34,12 +34,17 @@ export interface Debugger {
     namespace: string;
 }
 
+// @public (undocumented)
+export function getIncludesDate(): boolean;
+
 // @public
 export function getLogLevel(): AzureLogLevel | undefined;
 
+// @public (undocumented)
+export function setIncludesDate(includesDate: boolean): void;
+
 // @public
 export function setLogLevel(level?: AzureLogLevel): void;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/logger/src/debug.ts
+++ b/sdk/core/logger/src/debug.ts
@@ -3,6 +3,24 @@
 
 import { log } from "./log";
 
+
+let includesDateInLog: boolean = false;
+
+/**
+ * Specifies whether to prefix logs with date strings (ISO format).
+ * @param includesDate - true to include date string as prefix; by default it is not included.
+ */
+export function setIncludesDate(includesDate: boolean) {
+  includesDateInLog = includesDate;
+}
+
+/**
+ * Retrieves current setting of whether to prefix logs with date string.
+ */
+export function getIncludesDate() {
+  return includesDateInLog;
+}
+
 /**
  * A simple mechanism for enabling logging.
  * Intended to mimic the publicly available `debug` package.
@@ -147,6 +165,11 @@ function createDebugger(namespace: string): Debugger {
     if (args.length > 0) {
       args[0] = `${namespace} ${args[0]}`;
     }
+
+    if (getIncludesDate()) {
+      args[0] = `${new Date().toISOString()} ${args[0]}`;
+    }
+
     newDebugger.log(...args);
   }
 

--- a/sdk/core/logger/src/index.ts
+++ b/sdk/core/logger/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import debug, { Debugger } from "./debug";
-export { Debugger } from "./debug";
+export { Debugger, getIncludesDate, setIncludesDate } from "./debug";
 
 const registeredLoggers = new Set<AzureDebugger>();
 const logLevelFromEnv =


### PR DESCRIPTION
example usage:
```js
const { setIncludesDate } = require("@azure/logger");
setIncludesDate(true);
```

Output is similar to
```
2022-11-16T18:13:57.334Z azure:core-amqp:verbose [connection-1] Success for 'sendMessage', after attempt number: 1.
```

### Packages impacted by this PR
`@azure/logger`
