### PR TITLE
fix: cogserv-luis-authoring: remove mocha arrow functions

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/appVersionImport.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/appVersionImport.test.ts
@@ -12,9 +12,9 @@ import { delay } from "@azure/ms-rest-js";
 
 let appIds: Array<string> = [];
 
-describe("Import Tests", () => {
+describe("Import Tests", function () {
 
-  it("should import version", async () => {
+  it("should import version", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportApp.json", "utf-8", async (err, data) => {
         if (err) {
@@ -40,7 +40,7 @@ describe("Import Tests", () => {
     });
   });
    
-  it("should import version in Lu format", async () => {
+  it("should import version in Lu format", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportLuApp.json", "utf-8", async (err, app) => {
         if (err) {
@@ -65,7 +65,7 @@ describe("Import Tests", () => {
     });
   });
 
-  it("should import v2 version", async () => {
+  it("should import v2 version", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportV2App.json", "utf-8", async (err, data) => {
         if (err) {

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/apps.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/apps.test.ts
@@ -12,9 +12,9 @@ import { AppsAddResponse } from "../../src/models";
 const trainedAppID = BaseTest.GlobalAppId;
 let testingApp: AppsAddResponse; 
 
-describe("Apps Module Functionality Tests", () => {
+describe("Apps Module Functionality Tests", function () {
 
-  before('add new app to test on', async () => {
+  before('add new app to test on', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
     testingApp = await client.apps.add({
         name: "Existing LUIS App",
@@ -26,13 +26,13 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  after('delete testing app', async () => {
+  after('delete testing app', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       await client.apps.deleteMethod(testingApp.body);
     });
   });
 
-  it('should list all luis applications', async () => {
+  it('should list all luis applications', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
      
       const list = await client.apps.list();
@@ -43,7 +43,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should add application", async () => {
+  it("should add application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "New LUIS App",
@@ -68,7 +68,7 @@ describe("Apps Module Functionality Tests", () => {
       chai.expect(saved_app.usageScenario).to.eql("IoT");
     });
 
-    it("should get application", async () => {
+    it("should get application", async function () {
       await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       
         let result = await client.apps.get(testingApp.body);
@@ -82,7 +82,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should update application", async () => {
+  it("should update application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
      
       await client.apps.update(testingApp.body, { name: "LUIS App name updated", description: "LUIS App description updated" });
@@ -94,7 +94,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should delete application", async () => {
+  it("should delete application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
 
       const appId = await client.apps.add({
@@ -115,7 +115,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should list all endpoints", async () => {
+  it("should list all endpoints", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const result = await client.apps.listEndpoints(testingApp.body);
 
@@ -127,7 +127,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should publish application", async () => {
+  it("should publish application", async function () {
 
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const result = await client.apps.publish(trainedAppID, {
@@ -140,7 +140,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("download query logs", async () => {
+  it("download query logs", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
      
       const stream = await client.apps.downloadQueryLogs(testingApp.body);
@@ -150,7 +150,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should get settings", async () => {
+  it("should get settings", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       
 
@@ -161,7 +161,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should update settings", async () => {
+  it("should update settings", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       
       await client.apps.updateSettings(testingApp.body, {
@@ -174,7 +174,7 @@ describe("Apps Module Functionality Tests", () => {
 
   });
 
-  it("should get publish settings", async () => {
+  it("should get publish settings", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       
       const settings = await client.apps.getPublishSettings(testingApp.body);
@@ -186,7 +186,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should update publish settings", async () => {
+  it("should update publish settings", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       
       await client.apps.updatePublishSettings(testingApp.body, {
@@ -203,7 +203,7 @@ describe("Apps Module Functionality Tests", () => {
   });
 
 
-  it("should list domains", async () => {
+  it("should list domains", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const result = await client.apps.listDomains();
       for (let domain of result) {
@@ -212,7 +212,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should list supported cultures", async () => {
+  it("should list supported cultures", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let cultures_map = {
         'en-us': 'English',
@@ -245,7 +245,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should list usage scenarios", async () => {
+  it("should list usage scenarios", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
 
       const result = await client.apps.listUsageScenarios();
@@ -255,7 +255,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it("should list available custom prebuild domains", async () => {
+  it("should list available custom prebuild domains", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
 
       const result = await client.apps.listAvailableCustomPrebuiltDomains();
@@ -268,7 +268,7 @@ describe("Apps Module Functionality Tests", () => {
     });
   });
 
-  it.skip("should list available custom prebuilt domains for culture", async () => {
+  it.skip("should list available custom prebuilt domains for culture", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let resultsUS = await client.apps.listAvailableCustomPrebuiltDomainsForCulture("en-us");
       let resultsCN = await client.apps.listAvailableCustomPrebuiltDomainsForCulture("zh-cn");
@@ -283,7 +283,7 @@ describe("Apps Module Functionality Tests", () => {
   });
 
 
-  it("should add custom prebuilt application", async () => {
+  it("should add custom prebuilt application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.addCustomPrebuiltDomain({
         culture: "en-us",

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/entityRole.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/entityRole.test.ts
@@ -10,8 +10,8 @@ import * as chai from "chai";
 
 let closedListSample = { name: "closed list model", subLists: [{ canonicalForm: "Test", list: [] }] };
 
-describe("Entity Role Tests", () => {
-  it("should add simple entity role", async () => {
+describe("Entity Role Tests", function () {
+  it("should add simple entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "simple entity" });
       await client.model.createEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -21,7 +21,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should add closed list entity role", async () => {
+  it("should add closed list entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       await client.model.createClosedListEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -31,7 +31,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should add regex entity role", async () => {
+  it("should add regex entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, "0.1", { name: "regex model", regexPattern: "a+" });
       await client.model.createRegexEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -42,7 +42,7 @@ describe("Entity Role Tests", () => {
   });
 
 
-  it("should add patternAny entity role", async () => {
+  it("should add patternAny entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any model", explicitList: [] });
       await client.model.createPatternAnyEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -53,7 +53,7 @@ describe("Entity Role Tests", () => {
   });
 
 
-  it("should add custom prebuilt domain entity role", async () => {
+  it("should add custom prebuilt domain entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addCustomPrebuiltEntity(BaseTest.GlobalAppId, "0.1", { modelName: "ContactName", domainName: "Communication" });
       await client.model.createCustomPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -63,7 +63,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get simple entity role", async () => {
+  it("should get simple entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "simple entity" });
       const roleId = await client.model.createEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -73,7 +73,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get closed list entity role", async () => {
+  it("should get closed list entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const roleId = await client.model.createClosedListEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -83,7 +83,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get regex entity role", async () => {
+  it("should get regex entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, "0.1", { name: "regex model", regexPattern: "a+" });
       const roleId = await client.model.createRegexEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -93,7 +93,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get patterAny entity role", async () => {
+  it("should get patterAny entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any model", explicitList: [] });
       const roleId = await client.model.createPatternAnyEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -103,7 +103,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get custom prebuilt domain entity role", async () => {
+  it("should get custom prebuilt domain entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addCustomPrebuiltEntity(BaseTest.GlobalAppId, "0.1", { modelName: "ContactName", domainName: "Communication" });
       const roleId = await client.model.createCustomPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -113,7 +113,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get simple entity roles", async () => {
+  it("should get simple entity roles", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "simple entity" });
       await client.model.createEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -124,7 +124,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get closed list entity roles", async () => {
+  it("should get closed list entity roles", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const roleId = await client.model.createClosedListEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -135,7 +135,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get regex entity roles", async () => {
+  it("should get regex entity roles", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, "0.1", { name: "regex model", regexPattern: "a+" });
 
@@ -150,7 +150,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get patterAny entity roles", async () => {
+  it("should get patterAny entity roles", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any model", explicitList: [] });
 
@@ -162,7 +162,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should get custom prebuilt domain entity roles", async () => {
+  it("should get custom prebuilt domain entity roles", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addCustomPrebuiltEntity(BaseTest.GlobalAppId, "0.1", { modelName: "ContactName", domainName: "Communication" });
       await client.model.createCustomPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -173,7 +173,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should update simple entity role", async () => {
+  it("should update simple entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "simple entity" });
       const roleId = await client.model.createEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -185,7 +185,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should update closed list entity role", async () => {
+  it("should update closed list entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const roleId = await client.model.createClosedListEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -196,7 +196,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should update regex entity role", async () => {
+  it("should update regex entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, "0.1", { name: "regex model", regexPattern: "a+" });
       const roleId = await client.model.createRegexEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -207,7 +207,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should update patterAny entity role", async () => {
+  it("should update patterAny entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any model", explicitList: [] });
       const roleId = await client.model.createPatternAnyEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -219,7 +219,7 @@ describe("Entity Role Tests", () => {
   });
 
 
-  it("should update custom prebuilt domain entity role", async () => {
+  it("should update custom prebuilt domain entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addCustomPrebuiltEntity(BaseTest.GlobalAppId, "0.1", { modelName: "ContactName", domainName: "Communication" });
       const roleId = await client.model.createCustomPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -230,7 +230,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should delete simple entity role", async () => {
+  it("should delete simple entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "simple entity" });
       const roleId = await client.model.createEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -241,7 +241,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should delete closed list entity role", async () => {
+  it("should delete closed list entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const roleId = await client.model.createClosedListEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -253,7 +253,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should delete regex entity role", async () => {
+  it("should delete regex entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, "0.1", { name: "regex model", regexPattern: "a+" });
       const roleId = await client.model.createRegexEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -264,7 +264,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should delete patterAny entity role", async () => {
+  it("should delete patterAny entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any model", explicitList: [] });
       const roleId = await client.model.createPatternAnyEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });
@@ -275,7 +275,7 @@ describe("Entity Role Tests", () => {
     });
   });
 
-  it("should delete custom prebuilt domain entity role", async () => {
+  it("should delete custom prebuilt domain entity role", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addCustomPrebuiltEntity(BaseTest.GlobalAppId, "0.1", { modelName: "ContactName", domainName: "Communication" });
       const roleId = await client.model.createCustomPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId.body, { name: "simple role" });

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/examples.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/examples.test.ts
@@ -9,15 +9,15 @@ import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import * as chai from "chai";
 
 
-describe("Example Module Functionality Tests", () => {
-  it("should list all examples", async () => {
+describe("Example Module Functionality Tests", function () {
+  it("should list all examples", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const examples = await client.examples.list(BaseTest.GlobalAppId, "0.1");
       chai.expect(examples.length).not.to.eql(0);
     });
   });
 
-  it("should list all examples in empty application returning empty", async () => {
+  it("should list all examples in empty application returning empty", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",
@@ -33,7 +33,7 @@ describe("Example Module Functionality Tests", () => {
   });
 
 
-  it("should add example", async () => {
+  it("should add example", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",
@@ -59,7 +59,7 @@ describe("Example Module Functionality Tests", () => {
     });
   });
 
-  it("should add example with nested children", async () => {
+  it("should add example with nested children", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",
@@ -103,7 +103,7 @@ describe("Example Module Functionality Tests", () => {
     });
   });
 
-  it("should add examples in batch", async () => {
+  it("should add examples in batch", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",
@@ -151,7 +151,7 @@ describe("Example Module Functionality Tests", () => {
   });
 
 
-  it("should add examples in batch with some invalid examples returning some errors", async () => {
+  it("should add examples in batch with some invalid examples returning some errors", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",
@@ -192,7 +192,7 @@ describe("Example Module Functionality Tests", () => {
   });
 
 
-  it("should delete example", async () => {
+  it("should delete example", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Examples Test App",

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/export.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/export.test.ts
@@ -13,9 +13,9 @@ const appName = "LUIS App Version Export";
 const newVersionID = "0.2";
 const defaultVersionID = "0.1";
 
-describe("Export Tests", () => {
+describe("Export Tests", function () {
 
-    before("add app for app version testing", async () => {
+    before("add app for app version testing", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           appId = await client.apps.add({
             name: appName,
@@ -27,13 +27,13 @@ describe("Export Tests", () => {
         });
       });
     
-      after("delete app added for app version testing", async () => {
+      after("delete app added for app version testing", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           await client.apps.deleteMethod(appId.body);
         });
       });
     
-      it("should export version", async () => {
+      it("should export version", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
          
           const luisApp = await client.versions.exportMethod(appId.body, defaultVersionID);
@@ -43,7 +43,7 @@ describe("Export Tests", () => {
         });
       });
     
-      it("should export version Lu format", async () => {
+      it("should export version Lu format", async function () {
           await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
             
             const luisApp = await client.versions.exportLuFormat(appId.body, defaultVersionID);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/features.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/features.test.ts
@@ -10,8 +10,8 @@ import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import { BaseTest } from "../baseTest";
 
 
-describe("Features Module Functionality", () => {
-  it('should list features', async () => {
+describe("Features Module Functionality", function () {
+  it('should list features', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       await fs.readFile("test/SessionRecords/ImportApp.json", "utf-8", async (err, data) => {
         if (err) {
@@ -27,7 +27,7 @@ describe("Features Module Functionality", () => {
     });
   });
 
-    it('should add required feature', async () => {
+    it('should add required feature', async function () {
       await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
         var entityId = await client.model.addEntity(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, {name: "flat entity"});
         var featureEntityId = await client.model.addEntity(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, {name: "feature entity"});

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/featuresPhraseLists.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/featuresPhraseLists.test.ts
@@ -8,9 +8,9 @@ import { BaseTest } from "../baseTest";
 import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import * as chai from "chai";
 
-describe("featuresPhraseLists.test.ts", () => {
+describe("featuresPhraseLists.test.ts", function () {
 
-  it("should add phrase list", async () => {
+  it("should add phrase list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const id = await client.features.addPhraseList(BaseTest.GlobalAppId, "0.1", {
         name: "DayOfWeekToAdd",
@@ -26,7 +26,7 @@ describe("featuresPhraseLists.test.ts", () => {
   });
 
 
-  it("should list phrase lists", async () => {
+  it("should list phrase lists", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const id = await client.features.addPhraseList(BaseTest.GlobalAppId, "0.1", {
         name: "DayOfWeekToList",
@@ -40,7 +40,7 @@ describe("featuresPhraseLists.test.ts", () => {
     });
   });
 
-  it("should get phrase list", async () => {
+  it("should get phrase list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const id = await client.features.addPhraseList(BaseTest.GlobalAppId, "0.1", {
         name: "DayOfWeekToGet",
@@ -58,7 +58,7 @@ describe("featuresPhraseLists.test.ts", () => {
   });
 
 
-  it("should update phrase list", async () => {
+  it("should update phrase list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const id = await client.features.addPhraseList(BaseTest.GlobalAppId, "0.1", {
         name: "DayOfWeekToUpdate",
@@ -83,7 +83,7 @@ describe("featuresPhraseLists.test.ts", () => {
     });
   });
 
-  it("should delete phrase list", async () => {
+  it("should delete phrase list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const id = await client.features.addPhraseList(BaseTest.GlobalAppId, "0.1", {
         name: "DayOfWeekToDelete",

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/import.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/import.test.ts
@@ -12,8 +12,8 @@ import { delay } from "@azure/ms-rest-js";
 
 let appIds: Array<string> = [];
 
-describe("Import Tests", () => {
-  it("should import application", async () => {
+describe("Import Tests", function () {
+  it("should import application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportApp.json", "utf-8", async (err, data) => {
         if (err) {
@@ -33,7 +33,7 @@ describe("Import Tests", () => {
     });
   });
 
-  it("should import application in Lu format", async () => {
+  it("should import application in Lu format", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportLuApp.json", "utf-8", async (err, app) => {
         if (err) {
@@ -52,7 +52,7 @@ describe("Import Tests", () => {
     });
   });
    
-  it("should import v2 application", async () => {
+  it("should import v2 application", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       fs.readFile("test/SessionRecords/ImportV2App.json", "utf-8", async (err, data) => {
         if (err) {

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/model.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/model.test.ts
@@ -8,8 +8,8 @@ import * as chai from "chai";
 import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import { BaseTest } from "../baseTest";
 
-describe("model Module Functionality", () => {
-  it('should list models', async () => {
+describe("model Module Functionality", function () {
+  it('should list models', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let models = await client.model.listModels(BaseTest.GlobalAppId, versionId);
@@ -27,7 +27,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should create model with no children', async () => {
+  it('should create model with no children', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let entityId = await client.model.addEntity(BaseTest.GlobalAppId, versionId, { name: "New Entity Test with no childern" });
@@ -35,7 +35,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should create model with children', async () => {
+  it('should create model with children', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let entityId = await client.model.addEntity(BaseTest.GlobalAppId, versionId, { name: "New Entity Test with childern", children: [ { name: "child1"}] } );
@@ -43,7 +43,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should create model with children and instance of', async () => {
+  it('should create model with children and instance of', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let prebuiltEntitiesAdded = await client.model.addPrebuilt(BaseTest.GlobalAppId, versionId, [ "email" ]);
@@ -53,7 +53,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should add model child', async () => {
+  it('should add model child', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let entityId = await client.model.addEntity(BaseTest.GlobalAppId, versionId, { name: "New Entity to add"} );
@@ -62,7 +62,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should get model', async () => {
+  it('should get model', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let entityId = await client.model.addEntity(BaseTest.GlobalAppId, versionId, { name: "New Entity Test to get", children: [{name: "child1"}]} );
@@ -73,7 +73,7 @@ describe("model Module Functionality", () => {
     });
   });
 
-  it('should update model child name', async () => {
+  it('should update model child name', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = BaseTest.GlobalVersionId;
       let entityId = await client.model.addEntity(BaseTest.GlobalAppId, versionId, { name: "New Entity Test to update" } );

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelClosedLists.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelClosedLists.test.ts
@@ -27,8 +27,8 @@ var closedListSample = {
 };
 
 
-describe("Model Closed Lists Tests", () => {
-  it("should list closed lists", async () => {
+describe("Model Closed Lists Tests", function () {
+  it("should list closed lists", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const result = await client.model.listClosedLists(BaseTest.GlobalAppId, "0.1");
@@ -37,7 +37,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should add closed list", async () => {
+  it("should add closed list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
 
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
@@ -45,7 +45,7 @@ describe("Model Closed Lists Tests", () => {
       chai.expect(listId).not.to.eql(BaseTest.EmptyId);
     });
   });
-  it("should get closed list", async () => {
+  it("should get closed list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const result = await client.model.getClosedList(BaseTest.GlobalAppId, "0.1", listId.body);
@@ -55,7 +55,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should update closed list", async () => {
+  it("should update closed list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       await client.model.updateClosedList(BaseTest.GlobalAppId, "0.1", listId.body, {
@@ -72,7 +72,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should delete closed list", async () => {
+  it("should delete closed list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       await client.model.deleteClosedList(BaseTest.GlobalAppId, "0.1", listId.body);
@@ -81,7 +81,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should patch closed list", async () => {
+  it("should patch closed list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       await client.model.patchClosedList(BaseTest.GlobalAppId, "0.1", listId.body, {
@@ -103,7 +103,7 @@ describe("Model Closed Lists Tests", () => {
 
 
 
-  it("should add sublist", async () => {
+  it("should add sublist", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       await client.model.addSubList(BaseTest.GlobalAppId, "0.1", listId.body, { canonicalForm: "Texas", list: ["tx", "texas"] });
@@ -114,7 +114,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should delete sublist", async () => {
+  it("should delete sublist", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       let list = await client.model.getClosedList(BaseTest.GlobalAppId, "0.1", listId.body);
@@ -132,7 +132,7 @@ describe("Model Closed Lists Tests", () => {
     });
   });
 
-  it("should update sublist", async () => {
+  it("should update sublist", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const listId = await client.model.addClosedList(BaseTest.GlobalAppId, "0.1", closedListSample);
       const list = await client.model.getClosedList(BaseTest.GlobalAppId, "0.1", listId.body);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelEntities.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelEntities.test.ts
@@ -9,9 +9,9 @@ import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import { BaseTest } from "../baseTest";
 
 
-describe("Model Entities Tests", () => {
+describe("Model Entities Tests", function () {
 
-  it("should list Entities", async () => {
+  it("should list Entities", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "Existing Entity Test" })
       const results = await client.model.listEntities(BaseTest.GlobalAppId, "0.1");
@@ -22,7 +22,7 @@ describe("Model Entities Tests", () => {
   });
 
 
-  it("should get entity", async () => {
+  it("should get entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test" })
       const result = await client.model.getEntity(BaseTest.GlobalAppId, "0.1", entityId.body);
@@ -34,7 +34,7 @@ describe("Model Entities Tests", () => {
   });
 
 
-  it("should add entity", async () => {
+  it("should add entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test" })
       const result = await client.model.getEntity(BaseTest.GlobalAppId, "0.1", entityId.body);
@@ -45,7 +45,7 @@ describe("Model Entities Tests", () => {
     })
   });
 
-  it("should delete entity", async () => {
+  it("should delete entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "Delete Entity Test" })
 
@@ -55,7 +55,7 @@ describe("Model Entities Tests", () => {
     });
   });
 
-  it("should get entity suggestions returning empty", async () => {
+  it("should get entity suggestions returning empty", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
 
       const entityId = await client.model.addEntity(BaseTest.GlobalAppId, "0.1", { name: "Suggestions Entity Test" })

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelIntents.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelIntents.test.ts
@@ -8,8 +8,8 @@ import * as chai from "chai";
 import { BaseTest } from "../baseTest";
 import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 
-describe("Model Intents Tests", () => {
-  it("should list intents", async () => {
+describe("Model Intents Tests", function () {
+  it("should list intents", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const intents = await client.model.listIntents(BaseTest.GlobalAppId, "0.1");
       let checker: boolean = true;
@@ -21,7 +21,7 @@ describe("Model Intents Tests", () => {
     });
   });
 
-  it("should add intent", async () => {
+  it("should add intent", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const newIntentId = await client.model.addIntent(BaseTest.GlobalAppId, "0.1", { name: "TestIntent" });
       const intents = await client.model.listIntents(BaseTest.GlobalAppId, "0.1");
@@ -32,7 +32,7 @@ describe("Model Intents Tests", () => {
     });
   });
 
-  it("should get intent", async () => {
+  it("should get intent", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const newIntentId = await client.model.addIntent(BaseTest.GlobalAppId, "0.1", { name: "TestIntent" });
       const intent = await client.model.getIntent(BaseTest.GlobalAppId, "0.1", newIntentId.body);
@@ -42,7 +42,7 @@ describe("Model Intents Tests", () => {
     });
   })
 
-  it("should update intent", async () => {
+  it("should update intent", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const intentId = await client.model.addIntent(BaseTest.GlobalAppId, "0.1", { name: "TestIntent" });
       const intent = await client.model.getIntent(BaseTest.GlobalAppId, "0.1", intentId.body);
@@ -55,7 +55,7 @@ describe("Model Intents Tests", () => {
     });
   });
 
-  it("should delete intent", async () => {
+  it("should delete intent", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const intentId = await client.model.addIntent(BaseTest.GlobalAppId, "0.1", { name: "TestIntent" });
       const intents = await client.model.listIntents(BaseTest.GlobalAppId, "0.1");

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPatternAny.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPatternAny.test.ts
@@ -10,9 +10,9 @@ import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import { ModelGetPatternAnyEntityInfoResponse } from "../../src/models";
 
 
-describe("Model Patters Tests", () => {
+describe("Model Patters Tests", function () {
 
-  it("should list entities", async () => {
+  it("should list entities", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "Pattern.Any entity", explicitList: ["item"] });
       const results = await client.model.listPatternAnyEntityInfos(BaseTest.GlobalAppId, "0.1");
@@ -29,7 +29,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should get entity", async () => {
+  it("should get entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item"] });
       const result = await client.model.getPatternAnyEntityInfo(BaseTest.GlobalAppId, "0.1", entityId.body);
@@ -41,7 +41,7 @@ describe("Model Patters Tests", () => {
     });
   });
 
-  it("should add entity", async () => {
+  it("should add entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item"] });
 
@@ -55,7 +55,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should update entity", async () => {
+  it("should update entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item"] });
       await client.model.updatePatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", entityId.body, {
@@ -71,7 +71,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should delete entity", async () => {
+  it("should delete entity", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item"] });
       await client.model.deletePatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", entityId.body);
@@ -80,7 +80,7 @@ describe("Model Patters Tests", () => {
     });
   });
 
-  it("should get explicit list", async () => {
+  it("should get explicit list", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item1", "item2"] });
       const result = await client.model.getExplicitList(BaseTest.GlobalAppId, "0.1", entityId.body);
@@ -92,7 +92,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should add explicit list item", async () => {
+  it("should add explicit list item", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: ["item1"] });
       const itemId = await client.model.addExplicitListItem(BaseTest.GlobalAppId, "0.1", entityId.body, { explicitListItem: "item2" });
@@ -104,7 +104,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should get explicit list item", async () => {
+  it("should get explicit list item", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: [] });
       const itemId = await client.model.addExplicitListItem(BaseTest.GlobalAppId, "0.1", entityId.body, { explicitListItem: "item" });
@@ -115,7 +115,7 @@ describe("Model Patters Tests", () => {
     });
   });
 
-  it("should update explicit list item", async () => {
+  it("should update explicit list item", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: [] });
       const itemId = await client.model.addExplicitListItem(BaseTest.GlobalAppId, "0.1", entityId.body, { explicitListItem: "item" });
@@ -128,7 +128,7 @@ describe("Model Patters Tests", () => {
   });
 
 
-  it("should delete explicit list item", async () => {
+  it("should delete explicit list item", async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const entityId = await client.model.createPatternAnyEntityModel(BaseTest.GlobalAppId, "0.1", { name: "New Entity Test", explicitList: [] });
       const itemId = await client.model.addExplicitListItem(BaseTest.GlobalAppId, "0.1", entityId.body, { explicitListItem: "item" });

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPrebuiltDomain.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPrebuiltDomain.test.ts
@@ -8,8 +8,8 @@ import * as chai from "chai";
 import { BaseTest } from "../baseTest";
 import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 
-describe("Model Prebuilt Domain Tests", () => {
-  it('should add custom prebuilt domain', async () => {
+describe("Model Prebuilt Domain Tests", function () {
+  it('should add custom prebuilt domain', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -37,7 +37,7 @@ describe("Model Prebuilt Domain Tests", () => {
     });
   });
 
-  it('should delete custom prebuilt domain', async () => {
+  it('should delete custom prebuilt domain', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -61,7 +61,7 @@ describe("Model Prebuilt Domain Tests", () => {
     });
   });
 
-  it('should list custom prebuilt entities', async () => {
+  it('should list custom prebuilt entities', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -87,7 +87,7 @@ describe("Model Prebuilt Domain Tests", () => {
     });
   });
 
-  it('should add custom prebuilt entity', async () => {
+  it('should add custom prebuilt entity', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -110,7 +110,7 @@ describe("Model Prebuilt Domain Tests", () => {
   });
 
 
-  it('should list custom prebuilt intents', async () => {
+  it('should list custom prebuilt intents', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -129,7 +129,7 @@ describe("Model Prebuilt Domain Tests", () => {
     });
   });
 
-  it('should add custom prebuilt intent', async () => {
+  it('should add custom prebuilt intent', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",
@@ -148,7 +148,7 @@ describe("Model Prebuilt Domain Tests", () => {
     });
   });
 
-  it('should list custom prebuilt models', async () => {
+  it('should list custom prebuilt models', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const appId = await client.apps.add({
         name: "Existing LUIS App",

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPrebuilts.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelPrebuilts.test.ts
@@ -9,9 +9,9 @@ import { LUISAuthoringClient } from "../../src/lUISAuthoringClient";
 import { BaseTest } from "../baseTest";
 
 
-describe("Model Prebuilts Tests", () => {
+describe("Model Prebuilts Tests", function () {
 
-  it('should list prebuilt entities', async () => {
+  it('should list prebuilt entities', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       var version = "0.1";
       var prebuiltEntities = await client.model.listPrebuiltEntities(BaseTest.GlobalAppId, version);
@@ -19,7 +19,7 @@ describe("Model Prebuilts Tests", () => {
     });
   });
 
-  it('should list prebuilts', async () => {
+  it('should list prebuilts', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       var version = "0.1";
       var addedId = (await client.model.addPrebuilt(BaseTest.GlobalAppId, version, ["ordinal"]))[0].id;
@@ -30,7 +30,7 @@ describe("Model Prebuilts Tests", () => {
     });
   });
 
-  it('should add prebuilt', async () => {
+  it('should add prebuilt', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       var version = "0.1";
       var prebuiltEntitiesToAdd = ["age", "ordinal"];
@@ -44,7 +44,7 @@ describe("Model Prebuilts Tests", () => {
     });
   });
 
-  it('should get prebuilt', async () => {
+  it('should get prebuilt', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       var version = "0.1";
       var addedId = (await client.model.addPrebuilt(BaseTest.GlobalAppId, version, ["ordinal"]))[0].id;
@@ -54,7 +54,7 @@ describe("Model Prebuilts Tests", () => {
     });
   });
 
-  it('should delete prebuilt', async () => {
+  it('should delete prebuilt', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       var version = "0.1";
       var addedId = (await client.model.addPrebuilt(BaseTest.GlobalAppId, version, ["ordinal"]))[0].id;

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelRegexEntities.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/modelRegexEntities.test.ts
@@ -14,8 +14,8 @@ const regextEntitySample = {
 };
 
 
-describe("Model Regex Entities Tests", () => {
-  it('should get regex entities', async () => {
+describe("Model Regex Entities Tests", function () {
+  it('should get regex entities', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const regexEntityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regextEntitySample);
       const regexEntities = await client.model.listRegexEntityInfos(BaseTest.GlobalAppId, BaseTest.GlobalVersionId);
@@ -25,7 +25,7 @@ describe("Model Regex Entities Tests", () => {
   });
 
 
-  it('should create regex entity', async () => {
+  it('should create regex entity', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const regexEntityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regextEntitySample);
       await client.model.deleteRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regexEntityId.body);
@@ -34,7 +34,7 @@ describe("Model Regex Entities Tests", () => {
   });
 
 
-  it('should get regex entity', async () => {
+  it('should get regex entity', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const regexEntityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regextEntitySample);
       const regexEntity = await client.model.getRegexEntityEntityInfo(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regexEntityId.body);
@@ -45,7 +45,7 @@ describe("Model Regex Entities Tests", () => {
   });
 
 
-  it('should update regex entity', async () => {
+  it('should update regex entity', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const regexEntityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regextEntitySample);
       await client.model.updateRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regexEntityId.body, { name: "regex entity 2", regexPattern: "regex pattern 2" });
@@ -56,7 +56,7 @@ describe("Model Regex Entities Tests", () => {
     });
   });
 
-  it('should delete regex entity', async () => {
+  it('should delete regex entity', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       const regexEntityId = await client.model.createRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regextEntitySample);
       await client.model.deleteRegexEntityModel(BaseTest.GlobalAppId, BaseTest.GlobalVersionId, regexEntityId.body);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/patterns.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/patterns.test.ts
@@ -15,9 +15,9 @@ let prebuiltEntitiesToAdd : string[]
 let prebuiltEntitiesToAddList : string[]
 const defautlVersionId = "0.1";
 
-describe("Patterns Module Functionality Tests", () => {
+describe("Patterns Module Functionality Tests", function () {
 
-  before('add prebuiltEntities', async () => {
+  before('add prebuiltEntities', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       prebuiltEntitiesToAdd = ["temperature"];
       prebuiltEntitiesToAddList = ["datetimeV2", "age"];
@@ -26,7 +26,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  after('delete prebuiltEntities', async () => {
+  after('delete prebuiltEntities', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
     for (let added of prebuiltEntitiesAdded) {
        await client.model.deletePrebuilt(BaseTest.GlobalAppId, defautlVersionId, added.id);
@@ -38,7 +38,7 @@ describe("Patterns Module Functionality Tests", () => {
   });
 
 
-  it('should add pattern', async () => {
+  it('should add pattern', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let result = await client.pattern.addPattern(BaseTest.GlobalAppId, "0.1", { intent: "None", pattern: "This is a {temperature}" });
       await client.pattern.deletePattern(BaseTest.GlobalAppId, "0.1", result.id);
@@ -50,7 +50,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should add patterns', async () => {
+  it('should add patterns', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let patterns = [{ intent: "None", pattern: "This is a {age}" }, { intent: "None", pattern: "This is a {datetimeV2}" }]
       let result = await client.pattern.batchAddPatterns(BaseTest.GlobalAppId, "0.1", patterns);
@@ -64,7 +64,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should update pattern', async () => {
+  it('should update pattern', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let pattern = { intent: "None", pattern: "This is a {temperature}" };
       let updatedPattern = { intent: "None", pattern: "This [is] a {temperature}" };
@@ -80,7 +80,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should update patterns', async () => {
+  it('should update patterns', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let patterns = [{ intent: "None", pattern: "This is a {age}" }];
       let addResult = await client.pattern.batchAddPatterns(BaseTest.GlobalAppId, "0.1", patterns);
@@ -100,7 +100,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should get patterns', async () => {
+  it('should get patterns', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let patternsToAdd = [{ intent: "None", pattern: "This is a {age}" }, { intent: "None", pattern: "This is a {datetimeV2}" }]
       let result = await client.pattern.batchAddPatterns(BaseTest.GlobalAppId, "0.1", patternsToAdd);
@@ -117,7 +117,7 @@ describe("Patterns Module Functionality Tests", () => {
   });
 
 
-  it('should get intent patterns', async () => {
+  it('should get intent patterns', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let patternsToAdd = [{ intent: "None", pattern: "This is a {age}" }, { intent: "None", pattern: "This is a {datetimeV2}" }]
       let result = await client.pattern.batchAddPatterns(BaseTest.GlobalAppId, "0.1", patternsToAdd);
@@ -134,7 +134,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should delete pattern', async () => {
+  it('should delete pattern', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let pattern = { intent: "None", pattern: "This is a {temperature}" };
       let result = await client.pattern.addPattern(BaseTest.GlobalAppId, "0.1", pattern);
@@ -144,7 +144,7 @@ describe("Patterns Module Functionality Tests", () => {
     });
   });
 
-  it('should delete patterns', async () => {
+  it('should delete patterns', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
      let patterns = [{ intent: "None", pattern: "This is a {age}" }, { intent: "None", pattern: "This is a {datetimeV2}" }]
       let result = await client.pattern.batchAddPatterns(BaseTest.GlobalAppId, "0.1", patterns);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/prebuiltEntityRole.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/prebuiltEntityRole.test.ts
@@ -11,9 +11,9 @@ import { ModelCreatePrebuiltEntityRoleResponse } from "../../src/models";
 
 let entityId :string;
 let roleId:  ModelCreatePrebuiltEntityRoleResponse;
-describe("Prebuilt Entity Role Tests", () => {
+describe("Prebuilt Entity Role Tests", function () {
     
-    beforeEach("add prebuilt entitiy to test", async () => {
+    beforeEach("add prebuilt entitiy to test", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
             entityId = (await client.model.addPrebuilt(BaseTest.GlobalAppId, "0.1", ["email"]))[0].id;
             roleId = await client.model.createPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, { name: "simple role" });
@@ -21,35 +21,35 @@ describe("Prebuilt Entity Role Tests", () => {
         });
     });
 
-    afterEach("delete prebuilt entitiy", async () => {
+    afterEach("delete prebuilt entitiy", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
             await client.model.deletePrebuilt(BaseTest.GlobalAppId, "0.1", entityId);
         });
     });
 
 
-    it("should add prebuilt entitiy role", async () => {
+    it("should add prebuilt entitiy role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           const roles = await client.model.listPrebuiltEntityRoles(BaseTest.GlobalAppId, "0.1", entityId);
           chai.expect(BaseTest.doesListContain(roles, "name", "simple role")).to.be.true;
         });
     });
 
-    it("should add prebuilt entitiy role", async () => {
+    it("should add prebuilt entitiy role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           const roles = await client.model.listPrebuiltEntityRoles(BaseTest.GlobalAppId, "0.1", entityId);
           chai.expect(BaseTest.doesListContain(roles, "name", "simple role")).to.be.true;
         });
     });
 
-    it("should get prebuilt entity role", async () => {
+    it("should get prebuilt entity role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
             const role = await client.model.getPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, roleId.body);
           chai.expect(role.name).to.eql("simple role");
         });
     });
 
-    it("should update prebuilt entity role", async () => {
+    it("should update prebuilt entity role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           await client.model.updatePrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, roleId.body, { name: "simple role 2" });
           const role = await client.model.getPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, roleId.body);
@@ -57,14 +57,14 @@ describe("Prebuilt Entity Role Tests", () => {
         });
     });
 
-    it("should get prebuilt entity role", async () => {
+    it("should get prebuilt entity role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           const role = await client.model.getPrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, roleId.body);
           chai.expect(role.name).to.eql("simple role");
         });
     });
 
-    it("should delete prebuilt entity role", async () => {
+    it("should delete prebuilt entity role", async function () {
         await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
           await client.model.deletePrebuiltEntityRole(BaseTest.GlobalAppId, "0.1", entityId, roleId.body);
           const roles = await client.model.listPrebuiltEntityRoles(BaseTest.GlobalAppId, "0.1", entityId);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/train.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/train.test.ts
@@ -21,9 +21,9 @@ function checkStatus(statusArr: TrainGetStatusResponse) {
 }
 
 
-describe("Train Module Functionality", () => {
+describe("Train Module Functionality", function () {
 
-  it('should get status', async () => {
+  it('should get status', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = "0.1";
       await client.train.trainVersion(BaseTest.GlobalAppId, versionId);
@@ -50,7 +50,7 @@ describe("Train Module Functionality", () => {
     });
   });
 
-  it('should train version', async () => {
+  it('should train version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versionId = "0.1";
       await client.train.trainVersion(BaseTest.GlobalAppId, versionId);

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/versions.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/test/Luis/versions.test.ts
@@ -10,9 +10,9 @@ import { BaseTest } from "../baseTest";
 
 
 
-describe("Versions Module Functionality Tests", () => {
+describe("Versions Module Functionality Tests", function () {
 
-  it('should list all versions', async () => {
+  it('should list all versions', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let results = await client.versions.list(BaseTest.GlobalAppId);
       chai.expect(results.length > 0).to.be.true;
@@ -22,7 +22,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should get version', async () => {
+  it('should get version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versions = await client.versions.list(BaseTest.GlobalAppId);
       for (let version of versions) {
@@ -32,7 +32,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should update version', async () => {
+  it('should update version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versions = await client.versions.list(BaseTest.GlobalAppId);
       let first = versions[0];
@@ -44,7 +44,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should delete version', async () => {
+  it('should delete version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versions = await client.versions.list(BaseTest.GlobalAppId);
       let first = versions[0];
@@ -57,7 +57,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should clone version', async () => {
+  it('should clone version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let versions = await client.versions.list(BaseTest.GlobalAppId);
       let first = versions[0];
@@ -71,7 +71,7 @@ describe("Versions Module Functionality Tests", () => {
   });
 
 
-  it('should list versions with error subsription key', async () => {
+  it('should list versions with error subsription key', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "401";
       await client.versions.list(BaseTest.GlobalAppId, {
@@ -87,7 +87,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should list versions with error app id', async () => {
+  it('should list versions with error app id', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "BadArgument";
       client.versions.list(BaseTest.GlobalAppIdError).catch(err => {
@@ -98,7 +98,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should get version with error version', async () => {
+  it('should get version with error version', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "BadArgument";
       let versions = await client.versions.list(BaseTest.GlobalAppId);
@@ -111,7 +111,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should update version with error model', async () => {
+  it('should update version with error model', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "BadArgument";
       let versions = await client.versions.list(BaseTest.GlobalAppId);
@@ -126,7 +126,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should delete version with error model', async () => {
+  it('should delete version with error model', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "BadArgument";
       let versions = await client.versions.list(BaseTest.GlobalAppId);
@@ -139,7 +139,7 @@ describe("Versions Module Functionality Tests", () => {
     });
   });
 
-  it('should clone version with error model', async () => {
+  it('should clone version with error model', async function () {
     await BaseTest.useClientFor(async (client: LUISAuthoringClient) => {
       let errorCode = "BadArgument";
       let versions = await client.versions.list(BaseTest.GlobalAppId);


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\cognitiveservices\cognitiveservices-luis-authoring`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
