### PR TITLE
[Maps] Add the correct API reference links in READMEs

### DIFF
--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -242,10 +242,8 @@ If you'd like to contribute to this library, please read the [contributing guide
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fmaps%2Fmaps-route-rest%2FREADME.png)
 
 [source_code]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-route-rest
-
-<!-- [npm_link]: https://www.npmjs.com/package/@azure-rest/maps-route -->
-<!-- [api_ref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-route?view=azure-node-preview -->
-
+[npm_link]: https://www.npmjs.com/package/@azure-rest/maps-route
+[api_ref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-route
 [samples]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-route-rest/samples
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/

--- a/sdk/maps/maps-route-rest/package.json
+++ b/sdk/maps/maps-route-rest/package.json
@@ -39,7 +39,8 @@
     ],
     "requiredResources": {
       "Azure Maps Resource": "https://docs.microsoft.com/azure/azure-maps/how-to-create-template"
-    }
+    },
+    "apiRefLink": "https://docs.microsoft.com/javascript/api/@azure-rest/maps-route"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/README.md
@@ -65,9 +65,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [matrix]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
 [range]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
 [resumelro]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/javascript/resumeLro.js
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-route -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-route
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-route-rest/README.md

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/README.md
@@ -77,9 +77,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [matrix]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
 [range]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
 [resumelro]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/resumeLro.ts
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-route -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-route
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-route-rest/README.md

--- a/sdk/maps/maps-search/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-search/samples/v1-beta/javascript/README.md
@@ -61,9 +61,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [search]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/javascript/search.js
 [batchrequest]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/javascript/batchRequest.js
 [searchaddressresult]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/javascript/searchAddressResult.js
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-search -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-search
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-search/README.md

--- a/sdk/maps/maps-search/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-search/samples/v1-beta/typescript/README.md
@@ -73,9 +73,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [search]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/typescript/src/search.ts
 [batchrequest]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/typescript/src/batchRequest.ts
 [searchaddressresult]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-search/samples/v1-beta/typescript/src/searchAddressResult.ts
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-search -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-search
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-search/README.md


### PR DESCRIPTION
### Packages impacted by this PR
- @azure/maps-search
- @azure-rest/maps-route

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
- Links like docs & npm aren't available unless the package is released. Add them back in this PR.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA

### Are there test cases added in this PR? _(If not, why?)_
No

### Provide a list of related PRs _(if any)_
NA

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
NA

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- x ] Added a changelog (if necessary)
