### PR TITLE
[identity] Expires on timestamp should be in seconds not ms

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.1.1 (2022-11-18)
+
+### Bugs Fixed
+
+- Fixed bug to update "expiresOnTimestamp" field in Managed Identity to be in seconds and not milliseconds.
+
 ## 3.1.0 (2022-11-08)
 
 ### Other Changes

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 3.1.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.1.1 (2022-11-18)
 
 ### Bugs Fixed

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -5,7 +5,7 @@
  * Current version of the `@azure/identity` package.
  */
 
-export const SDK_VERSION = `3.1.0`;
+export const SDK_VERSION = `3.1.2`;
 
 /**
  * The default client ID for authentication

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -255,7 +255,7 @@ export class ManagedIdentityCredential implements TokenCredential {
               logger.info(`token = ${resultToken.token}`);
               return {
                 accessToken: resultToken?.token,
-                expiresInSeconds: resultToken?.expiresOnTimestamp,
+                expiresInSeconds: resultToken?.expiresOnTimestamp/1000,
               };
             } else {
               logger.info(

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -255,7 +255,7 @@ export class ManagedIdentityCredential implements TokenCredential {
               logger.info(`token = ${resultToken.token}`);
               return {
                 accessToken: resultToken?.token,
-                expiresInSeconds: resultToken?.expiresOnTimestamp/1000,
+                expiresInSeconds: resultToken?.expiresOnTimestamp / 1000,
               };
             } else {
               logger.info(

--- a/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
@@ -114,7 +114,7 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
       "URL does not have expected version"
     );
     if (authDetails.result?.token) {
-      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000000);
+      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000);
     } else {
       assert.fail("No token was returned!");
     }

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -560,7 +560,7 @@ describe("ManagedIdentityCredential", function () {
       "URL does not have expected version"
     );
     if (authDetails.result?.token) {
-      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000000);
+      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -598,7 +598,7 @@ describe("ManagedIdentityCredential", function () {
       "URL does not have expected version"
     );
     if (authDetails.result?.token) {
-      assert.equal(authDetails.result.expiresOnTimestamp, 1624157878000000);
+      assert.equal(authDetails.result.expiresOnTimestamp, 1624157878000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -636,7 +636,7 @@ describe("ManagedIdentityCredential", function () {
       "URL does not have expected version"
     );
     if (authDetails.result?.token) {
-      assert.equal(authDetails.result.expiresOnTimestamp, 1624157878000000);
+      assert.equal(authDetails.result.expiresOnTimestamp, 1624157878000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -977,7 +977,7 @@ describe("ManagedIdentityCredential", function () {
 
     if (authDetails.result!.token) {
       // We use Date.now underneath.
-      assert.equal(authDetails.result!.expiresOnTimestamp, 1000000);
+      assert.equal(authDetails.result!.expiresOnTimestamp, 1000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -1019,7 +1019,7 @@ describe("ManagedIdentityCredential", function () {
 
     if (authDetails.result!.token) {
       // We use Date.now underneath.
-      assert.equal(authDetails.result!.expiresOnTimestamp, 1000000);
+      assert.equal(authDetails.result!.expiresOnTimestamp, 1000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -1046,7 +1046,7 @@ describe("ManagedIdentityCredential", function () {
     assert.equal(confidentialSpy.callCount, 1);
 
     if (authDetails.result?.token) {
-      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000000);
+      assert.equal(authDetails.result.expiresOnTimestamp, 1560999478000);
     } else {
       assert.fail("No token was returned!");
     }
@@ -1101,7 +1101,7 @@ describe("ManagedIdentityCredential", function () {
       );
       assert.strictEqual(decodeURIComponent(body.get("scope")!), "https://service/.default");
       assert.strictEqual(authDetails.result!.token, "token");
-      assert.strictEqual(authDetails.result!.expiresOnTimestamp, 1000000);
+      assert.strictEqual(authDetails.result!.expiresOnTimestamp, 1000);
     });
     it("reads from the token file again only after 5 minutes have passed", async function (this: Mocha.Context) {
       // Keep in mind that in this test we're also testing:
@@ -1198,7 +1198,7 @@ describe("ManagedIdentityCredential", function () {
       // For this reason, there is no subsequent requests being passed as before to the STS,
       // since the token is already retrieved from the double caching.
       assert.equal(authDetails.requests.length, 0);
-      assert.equal(authDetails.result?.expiresOnTimestamp, 1000000);
+      assert.equal(authDetails.result?.expiresOnTimestamp, 1000);
       assert.equal(authDetails.result?.token, "token");
 
       // More than 5 minutes means we read the file again.
@@ -1216,7 +1216,7 @@ describe("ManagedIdentityCredential", function () {
         ],
       });
       assert.equal(authDetails.requests.length, 0);
-      assert.equal(authDetails.result?.expiresOnTimestamp, 1000000);
+      assert.equal(authDetails.result?.expiresOnTimestamp, 1000);
       assert.equal(authDetails.result?.token, "token");
     });
 

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -1189,17 +1189,9 @@ describe("ManagedIdentityCredential", function () {
         ],
       });
 
-      // The Federated Token File is used in MSI Kubernetes Pods,
-      // and already has a layer of caching through the file
-      // A request is sent to STS (security token service) for fetching the token
-      // This token is saved in the file in this type of MSI authentication.
-      // Recently we added the Token Caching to Managed Identity Credential.
-      // This enables double caching on Federated Token File in MSI Kubernetes Pods
-      // For this reason, there is no subsequent requests being passed as before to the STS,
-      // since the token is already retrieved from the double caching.
-      assert.equal(authDetails.requests.length, 0);
-      assert.equal(authDetails.result?.expiresOnTimestamp, 1000);
-      assert.equal(authDetails.result?.token, "token");
+      authRequest = authDetails.requests[0];
+      body = new URLSearchParams(authRequest.body);
+      assert.strictEqual(decodeURIComponent(body.get("client_assertion")!), expectedAssertion);
 
       // More than 5 minutes means we read the file again.
       testContext.sandbox.restore();
@@ -1215,9 +1207,9 @@ describe("ManagedIdentityCredential", function () {
           }),
         ],
       });
-      assert.equal(authDetails.requests.length, 0);
-      assert.equal(authDetails.result?.expiresOnTimestamp, 1000);
-      assert.equal(authDetails.result?.token, "token");
+      authRequest = authDetails.requests[0];
+      body = new URLSearchParams(authRequest.body);
+      assert.strictEqual(decodeURIComponent(body.get("client_assertion")!), newExpectedAssertion);
     });
 
     it("the provided client ID overrides the AZURE_CLIENT_ID environment variable", async function (this: Mocha.Context) {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/23903

### Describe the problem that is addressed by this PR
The "expiresOnTimestamp" field in Managed Identity should be in seconds and was assigned milliseconds. The PR fixes the bug

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
