### PR TITLE
Enable codeQL for scheduled CI jobs

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -29,7 +29,9 @@ parameters:
 jobs:
   - job: "Build"
     variables:
-      - template: ../variables/globals.yml
+      Codeql.Enabled: true
+      Codeql.BuildIdentifier: ${{ parameters.ServiceDirectory }}
+      Codeql.SkipTaskAutoInjection: false
 
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general
@@ -51,8 +53,6 @@ jobs:
           IncludeRelease: ${{ parameters.IncludeRelease }}
 
   - job: "Analyze"
-    variables:
-      - template: ../variables/globals.yml
 
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -40,6 +40,9 @@ parameters:
     type: object
     default: []
 
+variables:
+  - template: ../variables/globals.yml
+
 stages:
   - stage: Build
     jobs:

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -6,5 +6,7 @@ variables:
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]
   ServiceVersion: ""
   Package.EnableSBOMSigning: true
+  # Disable CodeQL injections except for where we specifically enable it
+  Codeql.SkipTaskAutoInjection: true
   # Disable warning until issue 21765 and 21766 are closed
   DisableDockerDetector: true


### PR DESCRIPTION
This will enable codeQL to run on all scheduled CI jobs across all services.