### PR TITLE
For CosmosDB bulk api added support for splitting of batch based on size.

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.17.3 (Unreleased)
+
+### Features Added
+- Changes in bulk api to honour size restictions (i.e 2Mb) while creating individual batches.[#23923](https://github.com/Azure/azure-sdk-for-js/issues/23923)
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 # Release History
 
 ## 3.17.2 (2022-11-15)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -409,6 +409,7 @@ export const Constants: {
     AzurePackageName: string;
     SDKName: string;
     SDKVersion: string;
+    DefaultMaxBulkRequestBodySizeInBytes: number;
     Quota: {
         CollectionSize: string;
     };

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -24,6 +24,7 @@ import {
   OperationInput,
   BulkOptions,
   decorateBatchOperation,
+  splitBatchBasedOnBodySize,
 } from "../../utils/batch";
 import { hashV1PartitionKey } from "../../utils/hashing/v1";
 import { hashV2PartitionKey } from "../../utils/hashing/v2";
@@ -438,6 +439,7 @@ export class Items {
     await Promise.all(
       batches
         .filter((batch: Batch) => batch.operations.length)
+        .flatMap((batch: Batch) => splitBatchBasedOnBodySize(batch))
         .map(async (batch: Batch) => {
           if (batch.operations.length > 100) {
             throw new Error("Cannot run bulk request with more than 100 operations per partition");

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -186,6 +186,9 @@ export const Constants = {
   SDKName: "azure-cosmos-js",
   SDKVersion: "3.17.2",
 
+  // Bulk Operations
+  DefaultMaxBulkRequestBodySizeInBytes: 220201,
+  
   Quota: {
     CollectionSize: "collectionSize",
   },

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -188,7 +188,7 @@ export const Constants = {
 
   // Bulk Operations
   DefaultMaxBulkRequestBodySizeInBytes: 220201,
-  
+
   Quota: {
     CollectionSize: "collectionSize",
   },

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -8,7 +8,7 @@ import { RequestOptions } from "..";
 import { PatchRequestBody } from "./patch";
 import { v4 } from "uuid";
 import { bodyFromData } from "../request/request";
-import { Constants } from "../common/constants"
+import { Constants } from "../common/constants";
 const uuid = v4;
 
 export type Operation =
@@ -222,28 +222,28 @@ export function decorateOperation(
  * @hidden
  */
 export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
-  if(originalBatch?.operations === undefined && originalBatch.operations.length < 1) return [];
+  if (originalBatch?.operations === undefined && originalBatch.operations.length < 1) return [];
   let currentBatchSize = calculateObjectSizeInBytes(originalBatch.operations[0]);
   let currentBatch: Batch = {
     ...originalBatch,
     operations: [originalBatch.operations[0]],
-    indexes: [originalBatch.indexes[0]]
+    indexes: [originalBatch.indexes[0]],
   };
   const processedBatches: Batch[] = [];
   processedBatches.push(currentBatch);
 
-  for(let index = 1; index < originalBatch.operations.length; index++) {
+  for (let index = 1; index < originalBatch.operations.length; index++) {
     const operation = originalBatch.operations[index];
     const currentOpSize = calculateObjectSizeInBytes(operation);
-    if(currentBatchSize + currentOpSize > Constants.DefaultMaxBulkRequestBodySizeInBytes) {
+    if (currentBatchSize + currentOpSize > Constants.DefaultMaxBulkRequestBodySizeInBytes) {
       currentBatch = {
         ...originalBatch,
         operations: [],
-        indexes: []
+        indexes: [],
       };
       processedBatches.push(currentBatch);
       currentBatchSize = 0;
-    } 
+    }
     currentBatch.operations.push(operation);
     currentBatch.indexes.push(originalBatch.indexes[index]);
     currentBatchSize += currentOpSize;
@@ -256,7 +256,7 @@ export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
  * @hidden
  */
 export function calculateObjectSizeInBytes(obj: unknown): number {
-  return new TextEncoder().encode(bodyFromData(obj as any)).length
+  return new TextEncoder().encode(bodyFromData(obj as any)).length;
 }
 
 export function decorateBatchOperation(

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -7,6 +7,8 @@ import { PartitionKeyDefinition } from "../documents";
 import { RequestOptions } from "..";
 import { PatchRequestBody } from "./patch";
 import { v4 } from "uuid";
+import { bodyFromData } from "../request/request";
+import { Constants } from "../common/constants"
 const uuid = v4;
 
 export type Operation =
@@ -208,6 +210,53 @@ export function decorateOperation(
     return { ...operation, partitionKey: "[{}]" };
   }
   return operation as Operation;
+}
+
+/**
+ * Splits a batch into array of batches based on cumulative size of its operations by making sure
+ * cumulative size is not larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}.
+ * But if a single operation itself is larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}, that
+ * operation would be split into a batch containing only that operation.
+ * @param originalBatch 
+ * @returns 
+ */
+export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
+  if(originalBatch?.operations === undefined && originalBatch.operations.length < 1) return [];
+  let currentBatchSize = calculateObjectSizeInBytes(originalBatch.operations[0]);
+  let currentBatch: Batch = {
+    ...originalBatch,
+    operations: [originalBatch.operations[0]],
+    indexes: [originalBatch.indexes[0]]
+  };
+  const processedBatches: Batch[] = [];
+  processedBatches.push(currentBatch);
+
+  for(let index = 1; index < originalBatch.operations.length; index++) {
+    let operation = originalBatch.operations[index];
+    let currentOpSize = calculateObjectSizeInBytes(operation);
+    if(currentBatchSize + currentOpSize > Constants.DefaultMaxBulkRequestBodySizeInBytes) {
+      currentBatch = {
+        ...originalBatch,
+        operations: [],
+        indexes: []
+      };
+      processedBatches.push(currentBatch);
+      currentBatchSize = 0;
+    } 
+    currentBatch.operations.push(operation);
+    currentBatch.indexes.push(originalBatch.indexes[index]);
+    currentBatchSize += currentOpSize;
+  }
+  return processedBatches;
+}
+
+/**
+ * Calculates size of an JSON object in bytes with utf-8 encoding.
+ * @param obj 
+ * @returns 
+ */
+export function calculateObjectSizeInBytes(obj: any): number {
+  return new TextEncoder().encode(bodyFromData(obj)).length
 }
 
 export function decorateBatchOperation(

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -214,11 +214,12 @@ export function decorateOperation(
 
 /**
  * Splits a batch into array of batches based on cumulative size of its operations by making sure
- * cumulative size is not larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}.
- * But if a single operation itself is larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}, that
- * operation would be split into a batch containing only that operation.
- * @param originalBatch 
- * @returns 
+ * cumulative size of an individual batch is not larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}.
+ * If a single operation itself is larger than {@link Constants.DefaultMaxBulkRequestBodySizeInBytes}, that
+ * operation would be moved into a batch containing only that operation.
+ * @param originalBatch - A batch of operations needed to be checked.
+ * @returns
+ * @hidden
  */
 export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
   if(originalBatch?.operations === undefined && originalBatch.operations.length < 1) return [];
@@ -232,8 +233,8 @@ export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
   processedBatches.push(currentBatch);
 
   for(let index = 1; index < originalBatch.operations.length; index++) {
-    let operation = originalBatch.operations[index];
-    let currentOpSize = calculateObjectSizeInBytes(operation);
+    const operation = originalBatch.operations[index];
+    const currentOpSize = calculateObjectSizeInBytes(operation);
     if(currentBatchSize + currentOpSize > Constants.DefaultMaxBulkRequestBodySizeInBytes) {
       currentBatch = {
         ...originalBatch,
@@ -252,11 +253,10 @@ export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
 
 /**
  * Calculates size of an JSON object in bytes with utf-8 encoding.
- * @param obj 
- * @returns 
+ * @hidden
  */
-export function calculateObjectSizeInBytes(obj: any): number {
-  return new TextEncoder().encode(bodyFromData(obj)).length
+export function calculateObjectSizeInBytes(obj: unknown): number {
+  return new TextEncoder().encode(bodyFromData(obj as any)).length
 }
 
 export function decorateBatchOperation(

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -222,7 +222,7 @@ export function decorateOperation(
  * @hidden
  */
 export function splitBatchBasedOnBodySize(originalBatch: Batch): Batch[] {
-  if (originalBatch?.operations === undefined && originalBatch.operations.length < 1) return [];
+  if (originalBatch?.operations === undefined || originalBatch.operations.length < 1) return [];
   let currentBatchSize = calculateObjectSizeInBytes(originalBatch.operations[0]);
   let currentBatch: Batch = {
     ...originalBatch,

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -3,7 +3,14 @@
 
 import assert from "assert";
 import { Constants } from "../../../../src";
-import { Batch, BulkOperationType, calculateObjectSizeInBytes, deepFind, Operation, splitBatchBasedOnBodySize } from "../../../../src/utils/batch";
+import {
+  Batch,
+  BulkOperationType,
+  calculateObjectSizeInBytes,
+  deepFind,
+  Operation,
+  splitBatchBasedOnBodySize,
+} from "../../../../src/utils/batch";
 
 describe("batch utils", function () {
   it("deep finds nested partition key values in objects", function () {
@@ -31,52 +38,67 @@ describe("batch utils", function () {
 const operationSkeleton: Operation = {
   operationType: BulkOperationType.Create,
   resourceBody: {
-    value: ""
-  }
+    value: "",
+  },
 };
 
 const constantSize = calculateObjectSizeInBytes(operationSkeleton);
 
-export function generateOperationOfSize(sizeInBytes: number, attributes?: unknown, partitionKey?: unknown): Operation {
+export function generateOperationOfSize(
+  sizeInBytes: number,
+  attributes?: unknown,
+  partitionKey?: unknown
+): Operation {
   if (sizeInBytes < constantSize) {
     throw new Error(`Not possible to generate operation of size less than ${constantSize}`);
   }
   let sizeToAdd = sizeInBytes - constantSize;
-  if(partitionKey !== undefined) sizeToAdd -= (calculateObjectSizeInBytes({partitionKey}) + calculateObjectSizeInBytes({}));
+  if (partitionKey !== undefined)
+    sizeToAdd -= calculateObjectSizeInBytes({ partitionKey }) + calculateObjectSizeInBytes({});
   return {
-    ...attributes as any,
+    ...(attributes as any),
     operationType: BulkOperationType.Create,
     resourceBody: {
-      value: new Array(sizeToAdd + 1).join('a'),
-      partitionKey
-    }
-  }
+      value: new Array(sizeToAdd + 1).join("a"),
+      partitionKey,
+    },
+  };
 }
 
 describe("Test batch split based on size", function () {
   type BatchSplitTestCase = {
     inputOperationDescription: {
-      operationSize: number,
-      index: number
-    }[],
+      operationSize: number;
+      index: number;
+    }[];
     resultingBatchDescription: {
-      resultingBatchLength: number,
-      resultingOperationsLengths: number[]
-    }
-  }
+      resultingBatchLength: number;
+      resultingOperationsLengths: number[];
+    };
+  };
 
   function runBatchSplitTestCase(t: BatchSplitTestCase): void {
     const inputBatch: Batch = {
-      operations: t.inputOperationDescription.map(op => generateOperationOfSize(Math.floor(op.operationSize))),
-      min: '',
-      max: '',
-      rangeId: '',
-      indexes: t.inputOperationDescription.map(op => op.index)
+      operations: t.inputOperationDescription.map((op) =>
+        generateOperationOfSize(Math.floor(op.operationSize))
+      ),
+      min: "",
+      max: "",
+      rangeId: "",
+      indexes: t.inputOperationDescription.map((op) => op.index),
     };
     const processedBatches: Batch[] = splitBatchBasedOnBodySize(inputBatch);
-    assert.strictEqual(processedBatches.length, t.resultingBatchDescription.resultingBatchLength, `Should have split into ${t.resultingBatchDescription.resultingBatchLength} batch.`);
+    assert.strictEqual(
+      processedBatches.length,
+      t.resultingBatchDescription.resultingBatchLength,
+      `Should have split into ${t.resultingBatchDescription.resultingBatchLength} batch.`
+    );
     t.resultingBatchDescription.resultingOperationsLengths.forEach((op, index) =>
-      assert.strictEqual(processedBatches[index].operations.length, op, `${index}th batch should have ${processedBatches[index].operations.length} operations.`)
+      assert.strictEqual(
+        processedBatches[index].operations.length,
+        op,
+        `${index}th batch should have ${processedBatches[index].operations.length} operations.`
+      )
     );
   }
 
@@ -84,49 +106,48 @@ describe("Test batch split based on size", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 100,
-        index: index
+        index: index,
       })),
       resultingBatchDescription: {
         resultingBatchLength: 1,
-        resultingOperationsLengths: [20]
-      }
-    })
+        resultingOperationsLengths: [20],
+      },
+    });
   });
   it("20 operations with each 1/2 size of DefaultMaxBulkRequestBodySizeInBytes, should split in 10 batches.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 2,
-        index: index
+        index: index,
       })),
       resultingBatchDescription: {
         resultingBatchLength: 10,
-        resultingOperationsLengths: [...Array(10).keys()].map(() => 2)
-      }
+        resultingOperationsLengths: [...Array(10).keys()].map(() => 2),
+      },
     });
   });
   it("20 operations with each 1/3 size of DefaultMaxBulkRequestBodySizeInBytes, should split in 6 batches.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 3,
-        index: index
+        index: index,
       })),
       resultingBatchDescription: {
         resultingBatchLength: 7,
-        resultingOperationsLengths: [...[...Array(6).keys()].map(() => 3), 2]
-      }
-    })
+        resultingOperationsLengths: [...[...Array(6).keys()].map(() => 3), 2],
+      },
+    });
   });
   it("If an single operation is bigger than DefaultMaxBulkRequestBodySizeInBytes, it should be part of a Batch containing only that operation.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(2).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes + 1,
-        index: index
+        index: index,
       })),
       resultingBatchDescription: {
         resultingBatchLength: 2,
-        resultingOperationsLengths: [1,1]
-      }
-    })
+        resultingOperationsLengths: [1, 1],
+      },
+    });
   });
-})
-
+});

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import assert from "assert";
-import { deepFind } from "../../../../src/utils/batch";
+import { Constants } from "../../../../src";
+import { Batch, BulkOperationType, calculateObjectSizeInBytes, deepFind, Operation, splitBatchBasedOnBodySize } from "../../../../src/utils/batch";
 
 describe("batch utils", function () {
   it("deep finds nested partition key values in objects", function () {
@@ -26,3 +27,106 @@ describe("batch utils", function () {
     assert.equal(deepFind(testTwiceNested, "nested/nested2/key"), "value");
   });
 });
+
+const operationSkeleton: Operation = {
+  operationType: BulkOperationType.Create,
+  resourceBody: {
+    value: ""
+  }
+};
+
+const constantSize = calculateObjectSizeInBytes(operationSkeleton);
+
+export function generateOperationOfSize(sizeInBytes: number, attributes?: any, partitionKey?: any): Operation {
+  if (sizeInBytes < constantSize) {
+    throw new Error(`Not possible to generate operation of size less than ${constantSize}`);
+  }
+  const sizeToAdd = sizeInBytes - constantSize;
+  if(partitionKey !== undefined) sizeToAdd - calculateObjectSizeInBytes({partitionKey}) + calculateObjectSizeInBytes({})
+  return {
+    ...attributes,
+    operationType: BulkOperationType.Create,
+    resourceBody: {
+      value: new Array(sizeToAdd + 1).join('a'),
+      partitionKey
+    }
+  }
+}
+
+describe("Test batch split based on size", function () {
+  type BatchSplitTestCase = {
+    inputOperationDescription: {
+      operationSize: number,
+      index: number
+    }[],
+    resultingBatchDescription: {
+      resultingBatchLength: number,
+      resultingOperationsLengths: number[]
+    }
+  }
+
+  function runBatchSplitTestCase(t: BatchSplitTestCase) {
+    let inputBatch: Batch = {
+      operations: t.inputOperationDescription.map(op => generateOperationOfSize(Math.floor(op.operationSize))),
+      min: '',
+      max: '',
+      rangeId: '',
+      indexes: t.inputOperationDescription.map(op => op.index)
+    };
+    let processedBatches: Batch[] = splitBatchBasedOnBodySize(inputBatch);
+    assert.strictEqual(processedBatches.length, t.resultingBatchDescription.resultingBatchLength, `Should have split into ${t.resultingBatchDescription.resultingBatchLength} batch.`);
+    t.resultingBatchDescription.resultingOperationsLengths.forEach((op, index) =>
+      assert.strictEqual(processedBatches[index].operations.length, op, `${index}th batch should have ${processedBatches[index].operations.length} operations.`)
+    );
+  }
+
+  it("If all operations are cumulatively less than DefaultMaxBulkRequestBodySizeInBytes, Batch should not split", function () {
+    runBatchSplitTestCase({
+      inputOperationDescription: [...Array(20).keys()].map((index) => ({
+        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 100,
+        index: index
+      })),
+      resultingBatchDescription: {
+        resultingBatchLength: 1,
+        resultingOperationsLengths: [20]
+      }
+    })
+  });
+  it("20 operations with 1/2 size should split in 10 batches.", function () {
+    runBatchSplitTestCase({
+      inputOperationDescription: [...Array(20).keys()].map((index) => ({
+        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 2,
+        index: index
+      })),
+      resultingBatchDescription: {
+        resultingBatchLength: 10,
+        resultingOperationsLengths: [...Array(10).keys()].map(() => 2)
+      }
+    });
+  });
+  it("20 operations of 1/3 size should split in 6 batches.", function () {
+    runBatchSplitTestCase({
+      inputOperationDescription: [...Array(20).keys()].map((index) => ({
+        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 3,
+        index: index
+      })),
+      resultingBatchDescription: {
+        resultingBatchLength: 7,
+        resultingOperationsLengths: [...[...Array(6).keys()].map(() => 3), 2]
+      }
+    })
+  });
+  it("If an single operation is bigger than DefaultMaxBulkRequestBodySizeInBytes, it should be part of a Batch containing only that operation.", function () {
+    runBatchSplitTestCase({
+      inputOperationDescription: [...Array(2).keys()].map((index) => ({
+        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes +1,
+        index: index
+      })),
+      resultingBatchDescription: {
+        resultingBatchLength: 2,
+        resultingOperationsLengths: [1,1]
+      }
+    })
+  });
+})
+

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -47,20 +47,21 @@ const constantSize = calculateObjectSizeInBytes(operationSkeleton);
 export function generateOperationOfSize(
   sizeInBytes: number,
   attributes?: unknown,
-  partitionKey?: unknown
+  partitionKey?: { [P in string]: unknown }
 ): Operation {
   if (sizeInBytes < constantSize) {
     throw new Error(`Not possible to generate operation of size less than ${constantSize}`);
   }
   let sizeToAdd = sizeInBytes - constantSize;
-  if (partitionKey !== undefined)
+  if (partitionKey !== undefined) {
     sizeToAdd -= calculateObjectSizeInBytes({ partitionKey }) + calculateObjectSizeInBytes({});
+  }
   return {
     ...(attributes as any),
     operationType: BulkOperationType.Create,
     resourceBody: {
       value: new Array(sizeToAdd + 1).join("a"),
-      partitionKey,
+      ...partitionKey,
     },
   };
 }

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -37,14 +37,14 @@ const operationSkeleton: Operation = {
 
 const constantSize = calculateObjectSizeInBytes(operationSkeleton);
 
-export function generateOperationOfSize(sizeInBytes: number, attributes?: any, partitionKey?: any): Operation {
+export function generateOperationOfSize(sizeInBytes: number, attributes?: unknown, partitionKey?: unknown): Operation {
   if (sizeInBytes < constantSize) {
     throw new Error(`Not possible to generate operation of size less than ${constantSize}`);
   }
-  const sizeToAdd = sizeInBytes - constantSize;
-  if(partitionKey !== undefined) sizeToAdd - calculateObjectSizeInBytes({partitionKey}) + calculateObjectSizeInBytes({})
+  let sizeToAdd = sizeInBytes - constantSize;
+  if(partitionKey !== undefined) sizeToAdd -= (calculateObjectSizeInBytes({partitionKey}) + calculateObjectSizeInBytes({}));
   return {
-    ...attributes,
+    ...attributes as any,
     operationType: BulkOperationType.Create,
     resourceBody: {
       value: new Array(sizeToAdd + 1).join('a'),
@@ -65,15 +65,15 @@ describe("Test batch split based on size", function () {
     }
   }
 
-  function runBatchSplitTestCase(t: BatchSplitTestCase) {
-    let inputBatch: Batch = {
+  function runBatchSplitTestCase(t: BatchSplitTestCase): void {
+    const inputBatch: Batch = {
       operations: t.inputOperationDescription.map(op => generateOperationOfSize(Math.floor(op.operationSize))),
       min: '',
       max: '',
       rangeId: '',
       indexes: t.inputOperationDescription.map(op => op.index)
     };
-    let processedBatches: Batch[] = splitBatchBasedOnBodySize(inputBatch);
+    const processedBatches: Batch[] = splitBatchBasedOnBodySize(inputBatch);
     assert.strictEqual(processedBatches.length, t.resultingBatchDescription.resultingBatchLength, `Should have split into ${t.resultingBatchDescription.resultingBatchLength} batch.`);
     t.resultingBatchDescription.resultingOperationsLengths.forEach((op, index) =>
       assert.strictEqual(processedBatches[index].operations.length, op, `${index}th batch should have ${processedBatches[index].operations.length} operations.`)
@@ -92,7 +92,7 @@ describe("Test batch split based on size", function () {
       }
     })
   });
-  it("20 operations with 1/2 size should split in 10 batches.", function () {
+  it("20 operations with each 1/2 size of DefaultMaxBulkRequestBodySizeInBytes, should split in 10 batches.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 2,
@@ -104,7 +104,7 @@ describe("Test batch split based on size", function () {
       }
     });
   });
-  it("20 operations of 1/3 size should split in 6 batches.", function () {
+  it("20 operations with each 1/3 size of DefaultMaxBulkRequestBodySizeInBytes, should split in 6 batches.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({
         operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes / 3,
@@ -119,7 +119,7 @@ describe("Test batch split based on size", function () {
   it("If an single operation is bigger than DefaultMaxBulkRequestBodySizeInBytes, it should be part of a Batch containing only that operation.", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(2).keys()].map((index) => ({
-        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes +1,
+        operationSize: Constants.DefaultMaxBulkRequestBodySizeInBytes + 1,
         index: index
       })),
       resultingBatchDescription: {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/batch.spec.ts
@@ -103,6 +103,16 @@ describe("Test batch split based on size", function () {
     );
   }
 
+  it("For An empty batch, empty batch should be returned", function () {
+    runBatchSplitTestCase({
+      inputOperationDescription: [],
+      resultingBatchDescription: {
+        resultingBatchLength: 0,
+        resultingOperationsLengths: [],
+      },
+    });
+  });
+
   it("If all operations are cumulatively less than DefaultMaxBulkRequestBodySizeInBytes, Batch should not split", function () {
     runBatchSplitTestCase({
       inputOperationDescription: [...Array(20).keys()].map((index) => ({

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -257,7 +257,7 @@ describe("bulk/batch item operations", function () {
     });
     it("Check case when cumulative size of all operations is greater than threshold", async function() {
       const operations: OperationInput[] = [...Array(10).keys()].map(() => ({
-        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes/2)),
+        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2)),
         partitionKey: {}
       }) as any);
       const response = await container.items.bulk(operations);
@@ -266,7 +266,7 @@ describe("bulk/batch item operations", function () {
     });
     it("Check case when cumulative size of all operations is greater than threshold", async function() {
       const operations: OperationInput[] = [...Array(50).keys()].map(() => ({
-        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes/2), {}, v4())
+        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2), {}, v4())
       }) as any);
       const response = await container.items.bulk(operations);
       // Create

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -3,6 +3,7 @@
 import assert from "assert";
 import { Suite } from "mocha";
 import {
+  Constants,
   Container,
   CosmosClient,
   OperationResponse,
@@ -26,6 +27,8 @@ import {
 import { BulkOperationType, OperationInput } from "../../../src";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
+import { generateOperationOfSize } from "../../internal/unit/utils/batch.spec";
+import { v4 } from "uuid";
 
 interface TestItem {
   id?: string;
@@ -229,6 +232,47 @@ describe("Item CRUD", function (this: Suite) {
 });
 
 describe("bulk/batch item operations", function () {
+  describe("Check size based splitting of batches", function() {
+    let container: Container;
+    before(async function () {
+      container = await getTestContainer("bulk container", undefined, {
+        partitionKey: {
+          paths: ["/key"],
+          version: undefined,
+        },
+        throughput: 25100,
+      });
+    });
+    after(async () => {
+      await container.database.delete();
+    });
+    it("Check case when cumulative size of all operations is less than threshold", async function() {
+        const operations: OperationInput[] = [...Array(10).keys()].map(() => ({
+          ...generateOperationOfSize(100, {partitionKey: v4()}),
+          partitionKey: {}
+        }) as any);
+        const response = await container.items.bulk(operations);
+        // Create
+        response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
+    });
+    it("Check case when cumulative size of all operations is greater than threshold", async function() {
+      const operations: OperationInput[] = [...Array(10).keys()].map(() => ({
+        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes/2)),
+        partitionKey: {}
+      }) as any);
+      const response = await container.items.bulk(operations);
+      // Create
+      response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
+    });
+    it("Check case when cumulative size of all operations is greater than threshold", async function() {
+      const operations: OperationInput[] = [...Array(50).keys()].map(() => ({
+        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes/2), {}, v4())
+      }) as any);
+      const response = await container.items.bulk(operations);
+      // Create
+      response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
+    });
+  })
   describe("with v1 container", function () {
     let container: Container;
     let readItemId: string;

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -249,7 +249,6 @@ describe("bulk/batch item operations", function () {
         () =>
           ({
             ...generateOperationOfSize(100, { partitionKey: "key_value" }, { key: "key_value" }),
-            partitionKey: {},
           } as any)
       );
       const response = await container.items.bulk(operations);

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -232,7 +232,7 @@ describe("Item CRUD", function (this: Suite) {
 });
 
 describe("bulk/batch item operations", function () {
-  describe("Check size based splitting of batches", function() {
+  describe("Check size based splitting of batches", function () {
     let container: Container;
     before(async function () {
       container = await getTestContainer("bulk container", undefined, {
@@ -246,33 +246,54 @@ describe("bulk/batch item operations", function () {
     after(async () => {
       await container.database.delete();
     });
-    it("Check case when cumulative size of all operations is less than threshold", async function() {
-        const operations: OperationInput[] = [...Array(10).keys()].map(() => ({
-          ...generateOperationOfSize(100, {partitionKey: v4()}),
-          partitionKey: {}
-        }) as any);
-        const response = await container.items.bulk(operations);
-        // Create
-        response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
-    });
-    it("Check case when cumulative size of all operations is greater than threshold", async function() {
-      const operations: OperationInput[] = [...Array(10).keys()].map(() => ({
-        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2)),
-        partitionKey: {}
-      }) as any);
+    it("Check case when cumulative size of all operations is less than threshold", async function () {
+      const operations: OperationInput[] = [...Array(10).keys()].map(
+        () =>
+          ({
+            ...generateOperationOfSize(100, { partitionKey: v4() }),
+            partitionKey: {},
+          } as any)
+      );
       const response = await container.items.bulk(operations);
       // Create
-      response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
+      response.forEach((res, index) =>
+        assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`)
+      );
     });
-    it("Check case when cumulative size of all operations is greater than threshold", async function() {
-      const operations: OperationInput[] = [...Array(50).keys()].map(() => ({
-        ...generateOperationOfSize(Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2), {}, v4())
-      }) as any);
+    it("Check case when cumulative size of all operations is greater than threshold", async function () {
+      const operations: OperationInput[] = [...Array(10).keys()].map(
+        () =>
+          ({
+            ...generateOperationOfSize(
+              Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2)
+            ),
+            partitionKey: {},
+          } as any)
+      );
       const response = await container.items.bulk(operations);
       // Create
-      response.forEach((res, index) => assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`));
+      response.forEach((res, index) =>
+        assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`)
+      );
     });
-  })
+    it("Check case when cumulative size of all operations is greater than threshold", async function () {
+      const operations: OperationInput[] = [...Array(50).keys()].map(
+        () =>
+          ({
+            ...generateOperationOfSize(
+              Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2),
+              {},
+              v4()
+            ),
+          } as any)
+      );
+      const response = await container.items.bulk(operations);
+      // Create
+      response.forEach((res, index) =>
+        assert.strictEqual(res.statusCode, 201, `Status should be 201 for operation ${index}`)
+      );
+    });
+  });
   describe("with v1 container", function () {
     let container: Container;
     let readItemId: string;

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -238,7 +238,7 @@ describe("bulk/batch item operations", function () {
           paths: ["/key"],
           version: undefined,
         },
-        throughput: 25100,
+        throughput: 400,
       });
     });
     after(async () => {

--- a/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item.spec.ts
@@ -28,8 +28,6 @@ import { BulkOperationType, OperationInput } from "../../../src";
 import { endpoint } from "../common/_testConfig";
 import { masterKey } from "../common/_fakeTestSecrets";
 import { generateOperationOfSize } from "../../internal/unit/utils/batch.spec";
-import { v4 } from "uuid";
-
 interface TestItem {
   id?: string;
   name?: string;
@@ -250,7 +248,7 @@ describe("bulk/batch item operations", function () {
       const operations: OperationInput[] = [...Array(10).keys()].map(
         () =>
           ({
-            ...generateOperationOfSize(100, { partitionKey: v4() }),
+            ...generateOperationOfSize(100, { partitionKey: "key_value" }, { key: "key_value" }),
             partitionKey: {},
           } as any)
       );
@@ -283,7 +281,7 @@ describe("bulk/batch item operations", function () {
             ...generateOperationOfSize(
               Math.floor(Constants.DefaultMaxBulkRequestBodySizeInBytes / 2),
               {},
-              v4()
+              { key: "key_value" }
             ),
           } as any)
       );

--- a/sdk/cosmosdb/cosmos/test/tsconfig.json
+++ b/sdk/cosmosdb/cosmos/test/tsconfig.json
@@ -10,6 +10,7 @@
     "preserveConstEnums": true,
     "removeComments": false,
     "target": "es6",
+    "lib": ["es2019"],
     "sourceMap": true,
     "newLine": "LF",
     "composite": true,


### PR DESCRIPTION

### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#23923

### Describe the problem that is addressed by this PR
CosmosDB Items.bulk api doens't honour 2Mb cap imposed on a single batch request. With these changes if size of a batch (cumulative size of it's operations) exceeds 2Mb it is split into smaller batches before sending.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
