### PR TITLE
[engsys] upgrade dev dependency `@rollup/plugin-typescript` version to `^10.0.0`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2080,8 +2080,8 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-typescript/9.0.2_00178214b3136286fb7699b305322380:
-    resolution: {integrity: sha512-/sS93vmHUMjzDUsl5scNQr1mUlNE1QjBBvOhmRwJCH8k2RRhDIm3c977B3wdu3t3Ap17W6dDeXP3hj1P1Un1bA==}
+  /@rollup/plugin-typescript/10.0.1_00178214b3136286fb7699b305322380:
+    resolution: {integrity: sha512-wBykxRLlX7EzL8BmUqMqk5zpx2onnmRMSw/l9M1sVfkJvdwfxogZQVNUM9gVMJbjRLDR5H6U0OMOrlDGmIV45A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.14.0||^3.0.0
@@ -18115,12 +18115,12 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-QOCpIU9mFQu3DygIWkmyhkg44lTuX7hmKO0BD9GDHPb34MESU2Oo8xoAQmYWCxmjBU11L6mRoTYHobe+ws1/0w==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-f2Mz829O/deVSeFCWsgd/wsbBvyPQeEsbqiZ5Mpji8E1Mt73o5Hsgpio4UhGwYiamC+Tht7VgZ9Tz5PqqJ2jCw==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
       '@microsoft/api-extractor': 7.33.6
-      '@rollup/plugin-typescript': 9.0.2_00178214b3136286fb7699b305322380
+      '@rollup/plugin-typescript': 10.0.1_00178214b3136286fb7699b305322380
       '@types/chai': 4.3.4
       '@types/mocha': 10.0.1
       '@types/node': 14.18.33

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -133,7 +133,7 @@
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^5.1.1",
-    "@rollup/plugin-typescript": "^9.0.2",
+    "@rollup/plugin-typescript": "^10.0.0",
     "ts-node": "^10.8.1",
     "typescript": "^4.8.3",
     "util": "^0.12.4"


### PR DESCRIPTION
We use this to bundle browser tests. The breaking change
https://github.com/rollup/plugins/blob/master/packages/typescript/CHANGELOG.md#breaking-changes
doesn't affect us.

Resolves #24017 