### PR TITLE
[core-client] Port xmlIsMsText from core-http

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Ported support for `xmlIsMsText` from `@azure/core-http`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -42,6 +42,7 @@ export interface BaseMapper {
     type: MapperType;
     xmlElementName?: string;
     xmlIsAttribute?: boolean;
+    xmlIsMsText?: boolean;
     xmlIsWrapped?: boolean;
     xmlName?: string;
     xmlNamespace?: string;

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -594,6 +594,10 @@ export interface BaseMapper {
    */
   xmlIsAttribute?: boolean;
   /**
+   * Determines if the current property should be serialized as the inner content of the xml element
+   */
+  xmlIsMsText?: boolean;
+  /**
    * Name for the xml elements when serializing an array
    */
   xmlElementName?: string;

--- a/sdk/core/core-client/test/serializer.spec.ts
+++ b/sdk/core/core-client/test/serializer.spec.ts
@@ -1619,6 +1619,192 @@ describe("Serializer", function () {
 
         assert.deepEqual(result, { cors: [] });
       });
+
+      it("should handle xmlIsMsText flag", function () {
+        const stringEncoded: CompositeMapper = {
+          serializedName: "StringEncoded",
+          type: {
+            name: "Composite",
+            className: "StringEncoded",
+            modelProperties: {
+              encoded: {
+                serializedName: "Encoded",
+                xmlName: "Encoded",
+                xmlIsAttribute: true,
+                type: {
+                  name: "Boolean",
+                },
+              },
+              content: {
+                serializedName: "content",
+                xmlName: "content",
+                xmlIsMsText: true,
+                type: {
+                  name: "String",
+                },
+              },
+            },
+          },
+        };
+
+        const mappers = {
+          StringEncoded: stringEncoded,
+        };
+        const serializer = createSerializer(mappers, true);
+        const result: any = serializer.deserialize(
+          stringEncoded,
+          { $: { Encoded: true }, _: "dir%EF%BF%BE0166562954291707607" },
+          "mockedStringEncoded"
+        );
+
+        assert.deepEqual(result, { encoded: true, content: "dir%EF%BF%BE0166562954291707607" });
+      });
+
+      it("should handle xmlIsMsText flag for degenerated string case", function () {
+        const stringEncoded: CompositeMapper = {
+          serializedName: "StringEncoded",
+          type: {
+            name: "Composite",
+            className: "StringEncoded",
+            modelProperties: {
+              encoded: {
+                serializedName: "Encoded",
+                xmlName: "Encoded",
+                xmlIsAttribute: true,
+                type: {
+                  name: "Boolean",
+                },
+              },
+              content: {
+                serializedName: "content",
+                xmlName: "content",
+                xmlIsMsText: true,
+                type: {
+                  name: "String",
+                },
+              },
+            },
+          },
+        };
+
+        const mappers = {
+          StringEncoded: stringEncoded,
+        };
+        const serializer = createSerializer(mappers, true);
+        const result: any = serializer.deserialize(
+          stringEncoded,
+          "justastring",
+          "mockedStringEncoded"
+        );
+
+        assert.equal(result.content, "justastring");
+        assert.equal(result.encoded, undefined);
+      });
+
+      it("should handle xmlIsMsText flag with customized XML_CHARKEY", function () {
+        const stringEncoded: CompositeMapper = {
+          serializedName: "StringEncoded",
+          type: {
+            name: "Composite",
+            className: "StringEncoded",
+            modelProperties: {
+              encoded: {
+                serializedName: "Encoded",
+                xmlName: "Encoded",
+                xmlIsAttribute: true,
+                type: {
+                  name: "Boolean",
+                },
+              },
+              content: {
+                serializedName: "content",
+                xmlName: "content",
+                xmlIsMsText: true,
+                type: {
+                  name: "String",
+                },
+              },
+            },
+          },
+        };
+
+        const mappers = {
+          StringEncoded: stringEncoded,
+        };
+        const serializer = createSerializer(mappers, true);
+        const result: any = serializer.deserialize(
+          stringEncoded,
+          { $: { Encoded: true }, "#": "dir%EF%BF%BE0166562954291707607" },
+          "mockedStringEncoded",
+          {
+            xml: { xmlCharKey: "#" },
+          }
+        );
+
+        assert.deepEqual(result, { encoded: true, content: "dir%EF%BF%BE0166562954291707607" });
+      });
+
+      it("should not copy extra properties when xmlName is different from serializedName", function () {
+        const DirectoryItem: CompositeMapper = {
+          serializedName: "DirectoryItem",
+          xmlName: "Directory",
+          type: {
+            name: "Composite",
+            className: "DirectoryItem",
+            modelProperties: {
+              name: {
+                serializedName: "Name",
+                xmlName: "Name",
+                type: {
+                  name: "String",
+                },
+              },
+            },
+          },
+        };
+
+        const FilesAndDirectoriesListSegment: CompositeMapper = {
+          serializedName: "FilesAndDirectoriesListSegment",
+          xmlName: "Entries",
+          type: {
+            name: "Composite",
+            className: "FilesAndDirectoriesListSegment",
+            modelProperties: {
+              directoryItems: {
+                serializedName: "DirectoryItems",
+                required: true,
+                xmlName: "DirectoryItems",
+                xmlElementName: "Directory",
+                type: {
+                  name: "Sequence",
+                  element: {
+                    type: {
+                      name: "Composite",
+                      className: "DirectoryItem",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const mappers = {
+          FilesAndDirectoriesListSegment,
+          DirectoryItem,
+        };
+        const serializer = createSerializer(mappers, true);
+
+        const value = {
+          Directory: [{ Name: "d1" }, { Name: "d2" }],
+        };
+        const result: any = serializer.deserialize(
+          FilesAndDirectoriesListSegment,
+          value,
+          "mockedEntries"
+        );
+
+        assert.deepEqual(result, { directoryItems: [{ name: "d1" }, { name: "d2" }] });
+      });
     });
 
     describe("polymorphic composite type array", () => {


### PR DESCRIPTION
Ports the following PRs to core-client to ensure we deserialize Storage payloads correctly in CoreV2:

https://github.com/Azure/azure-sdk-for-js/pull/23631
https://github.com/Azure/azure-sdk-for-js/pull/23658
https://github.com/Azure/azure-sdk-for-js/pull/23660
https://github.com/Azure/azure-sdk-for-js/pull/23680

