### PR TITLE
[core-client] Allow resettable streams

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -8,14 +8,15 @@
 
 ### Bugs Fixed
 
+- Fix a serializer issue where resettable streams were not being accepted.
+
 ### Other Changes
 
 ## 1.6.1 (2022-08-04)
 
-
 ### Bugs Fixed
 
-- Fix serializer to find the correct discriminator index. Please refer to [#22523](https://github.com/Azure/azure-sdk-for-js/pull/22523) for further details.  
+- Fix serializer to find the correct discriminator index. Please refer to [#22523](https://github.com/Azure/azure-sdk-for-js/pull/22523) for further details.
 
 ### Other Changes
 

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -433,10 +433,11 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
         !(value instanceof ArrayBuffer) &&
         !ArrayBuffer.isView(value) &&
         // File objects count as a type of Blob, so we want to use instanceof explicitly
-        !((typeof Blob === "function" || typeof Blob === "object") && value instanceof Blob)
+        !((typeof Blob === "function" || typeof Blob === "object") && value instanceof Blob) &&
+        objectType !== "function"
       ) {
         throw new Error(
-          `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or NodeJS.ReadableStream.`
+          `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, NodeJS.ReadableStream, or () => NodeJS.ReadableStream.`
         );
       }
     }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-client`

### Describe the problem that is addressed by this PR

Support for resettable streams was added to `core-rest-pipeline` some time ago in #21013, but a corresponding change to `core-client`'s validation is also needed (see the issue: #24048)

### Provide a list of related PRs _(if any)_

- Follow up to https://github.com/Azure/azure-sdk-for-js/pull/21013
- Fixes #24048