### PR TITLE
Blob Storage - container name rules link

### DIFF
--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -509,7 +509,7 @@ export class BlobServiceClient extends StorageClient {
   }
 
   /**
-   * Create a Blob container.
+   * Create a Blob container. @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    *
    * @param containerName - Name of the container to create.
    * @param options - Options to configure Container Create operation.

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -776,6 +776,7 @@ export class ContainerClient extends StorageClient {
    * Creates a new container under the specified account. If the container with
    * the same name already exists, the operation fails.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
+   * Naming rules: @see https://learn.microsoft.com/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
    *
    * @param options - Options to Container Create operation.
    *
@@ -812,6 +813,7 @@ export class ContainerClient extends StorageClient {
    * Creates a new container under the specified account. If the container with
    * the same name already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
+   * Naming rules: @see https://learn.microsoft.com/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
    *
    * @param options -
    */


### PR DESCRIPTION
### Packages impacted by this PR
@azure/storage-blob

### Issues associated with this PR
Clarity on container name rules - by linking to rules.

### Describe the problem that is addressed by this PR
The developer doesn't know when they read this content that there are rules around what is an acceptable container name. They won't find that out until they get the error back from the method.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-docs-rest-apis/pull/5077

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
