### PR TITLE
identity: managedIdentityCredential expires-in/-on

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -254,14 +254,13 @@ export class ManagedIdentityCredential implements TokenCredential {
               logger.info(`SetAppTokenProvider has saved the token in cache`);
               logger.info(`token = ${resultToken.token}`);
 
-              const expiresInSeconds =
-                resultToken?.expiresOnTimestamp
+              const expiresInSeconds = resultToken?.expiresOnTimestamp
                 ? Math.floor((resultToken.expiresOnTimestamp - Date.now()) / 1000)
-                :  0;
+                : 0;
 
               return {
                 accessToken: resultToken?.token,
-                expiresInSeconds
+                expiresInSeconds,
               };
             } else {
               logger.info(

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -253,9 +253,15 @@ export class ManagedIdentityCredential implements TokenCredential {
             if (resultToken) {
               logger.info(`SetAppTokenProvider has saved the token in cache`);
               logger.info(`token = ${resultToken.token}`);
+
+              const expiresInSeconds =
+                (resultToken === null)
+                ? 0
+                : ((resultToken.expiresOnTimestamp - Date.now()) / 1000);
+
               return {
                 accessToken: resultToken?.token,
-                expiresInSeconds: resultToken?.expiresOnTimestamp / 1000,
+                expiresInSeconds: expiresInSeconds
               };
             } else {
               logger.info(

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -255,9 +255,9 @@ export class ManagedIdentityCredential implements TokenCredential {
               logger.info(`token = ${resultToken.token}`);
 
               const expiresInSeconds =
-                (resultToken === null)
-                ? 0
-                : ((resultToken.expiresOnTimestamp - Date.now()) / 1000);
+                resultToken?.expiresOnTimestamp
+                ? Math.floor((resultToken.expiresOnTimestamp - Date.now()) / 1000)
+                :  0;
 
               return {
                 accessToken: resultToken?.token,

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -261,7 +261,7 @@ export class ManagedIdentityCredential implements TokenCredential {
 
               return {
                 accessToken: resultToken?.token,
-                expiresInSeconds: expiresInSeconds
+                expiresInSeconds
               };
             } else {
               logger.info(


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

#24003

### Describe the problem that is addressed by this PR

Sometimes token lifetimes are tracked by absolute timestamps ("expires On") and sometimes using a time interval ("expires In").  The managedIdentityCredential AppTokenProvider implementation was inconsistent in its treatment, directly coercing an absolute timestamp to an interval.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

It would be better if the SDK were consistent internally in its use of relative or absolute time, but that's a much taller ask.

### Are there test cases added in this PR? _(If not, why?)_

No, but someone should.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
