### PR TITLE
service-bus: That's scopes, plural, to you!

### DIFF
--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -430,7 +430,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
       // renew sas token in every 45 minutes
       this._tokenTimeout = (3600 - 900) * 1000;
     } else {
-      const aadToken = await this._context.tokenCredential.getToken(Constants.aadServiceBusScope);
+      const aadToken = await this._context.tokenCredential.getToken([Constants.aadServiceBusScope]);
       if (!aadToken) {
         throw new Error(`Failed to get token from the provided "TokenCredential" object`);
       }

--- a/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusAtomManagementClient.ts
@@ -222,7 +222,7 @@ export class ServiceBusAdministrationClient extends ServiceClient {
       credentials = credentialOrOptions2;
       authPolicy = bearerTokenAuthenticationPolicy({
         credential: credentials,
-        scopes: AMQPConstants.aadServiceBusScope,
+        scopes: [AMQPConstants.aadServiceBusScope],
       });
     } else if (isNamedKeyCredential(credentialOrOptions2)) {
       fullyQualifiedNamespace = fullyQualifiedNamespaceOrConnectionString1;


### PR DESCRIPTION
### Packages impacted by this PR

service-bus

### Issues associated with this PR

### Describe the problem that is addressed by this PR

Don't pass the scope *string* to methods expecting *lists* of strings. Otherwise one ends up with amusing things like requests for

  scopes: [ 'h', 't', 'p', 's', ':', '/', 'e', 'r', 'v', 'i',
    'c', 'b', 'u', '.', 'a', 'z', 'n', 'd', 'f', 'l' ]


**Please note** that while I am confident of the delta at line 433. as it now matches the other call to `getToken` in the same file and I have seen it misbehave, the other one is more of a guess.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

No, but probably someone should.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
