### PR TITLE
[identity] Remove `UnavailableMessage` from `ChainedTokenCredential`

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -104,7 +104,6 @@ export type BrowserLoginStyle = "redirect" | "popup";
 export class ChainedTokenCredential implements TokenCredential {
     constructor(...sources: TokenCredential[]);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
-    protected UnavailableMessage: string;
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/azureApplicationCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureApplicationCredential.ts
@@ -41,7 +41,5 @@ export class AzureApplicationCredential extends ChainedTokenCredential {
    */
   constructor(options?: AzureApplicationCredentialOptions) {
     super(...AzureApplicationCredentials.map((ctor) => new ctor(options)));
-    this.UnavailableMessage =
-      "ApplicationCredential => failed to retrieve a token from the included credentials. To troubleshoot, visit https://aka.ms/azsdk/js/identity/applicationcredential/troubleshoot.";
   }
 }

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -16,7 +16,6 @@ export const logger = credentialLogger("ChainedTokenCredential");
  * until one of the getToken methods returns an access token.
  */
 export class ChainedTokenCredential implements TokenCredential {
-
   private _sources: TokenCredential[] = [];
 
   /**

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -16,11 +16,6 @@ export const logger = credentialLogger("ChainedTokenCredential");
  * until one of the getToken methods returns an access token.
  */
 export class ChainedTokenCredential implements TokenCredential {
-  /**
-   * The message to use when the chained token fails to get a token
-   */
-  protected UnavailableMessage =
-    "ChainedTokenCredential => failed to retrieve a token from the included credentials";
 
   private _sources: TokenCredential[] = [];
 

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -147,7 +147,5 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
       | DefaultAzureCredentialClientIdOptions
   ) {
     super(...defaultCredentials.map((ctor) => new ctor(options)));
-    this.UnavailableMessage =
-      "DefaultAzureCredential => failed to retrieve a token from the included credentials. To troubleshoot, visit https://aka.ms/azsdk/js/identity/defaultazurecredential/troubleshoot.";
   }
 }


### PR DESCRIPTION
This protected property is no longer used and has confused consumers when trying to log credential objects.

### Issues associated with this PR

#24075

### Describe the problem that is addressed by this PR

I believe that this property was previously used by `ChainedTokenCredential` to calculate an error message when all credentials in the chain failed. At some point this must have been refactored and now the property is unnecessary. Since it is a *protected* property rather than a public one, I believe it can be safely removed.