### PR TITLE
fix: cogserv-luis-runtime: remove mocha arrow functions

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-luis-runtime/test/Luis/predictions.test.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-runtime/test/Luis/predictions.test.ts
@@ -4,19 +4,17 @@
  * license information.
  */
 
-
 import { LUISRuntimeClient } from "../../src/lUISRuntimeClient";
-import { BaseTest } from "../baseTest"
+import { BaseTest } from "../baseTest";
 import * as chai from "chai";
 
-
-describe("Predections Tests", () => {
+describe("Predections Tests", function () {
   var versionId = "0.1";
   var utterance = "today this is a test with post";
   var slotName = "production";
   let externalResolution = { text: "post", external: true };
 
-  it('should test prediction slot', async () => {
+  it("should test prediction slot", async function () {
     await BaseTest.useClientFor(async (client: LUISRuntimeClient) => {
       let result = await client.prediction.getSlotPrediction(
         BaseTest.GlobalAppId,
@@ -25,25 +23,33 @@ describe("Predections Tests", () => {
           query: utterance,
           options: {
             datetimeReference: new Date("2019-01-01"),
-            preferExternalEntities: true
+            preferExternalEntities: true,
           },
-          externalEntities: [{
-            entityName: "simple",
-            startIndex: 26,
-            entityLength: 4,
-            score : 0.86,
-            resolution: externalResolution
-          }],
-          dynamicLists: [{
-            listEntityName: "list", requestLists: [{
-              name: "test",
-              canonicalForm: "testing",
-              synonyms: ["this"]
-            }]
-          }],
-        }, {
+          externalEntities: [
+            {
+              entityName: "simple",
+              startIndex: 26,
+              entityLength: 4,
+              score: 0.86,
+              resolution: externalResolution,
+            },
+          ],
+          dynamicLists: [
+            {
+              listEntityName: "list",
+              requestLists: [
+                {
+                  name: "test",
+                  canonicalForm: "testing",
+                  synonyms: ["this"],
+                },
+              ],
+            },
+          ],
+        },
+        {
           verbose: true,
-          showAllIntents: true
+          showAllIntents: true,
         }
       );
       var prediction = result.prediction;
@@ -73,12 +79,12 @@ describe("Predections Tests", () => {
 
       var dispatchTopIntent = child.intents[child.topIntent];
       chai.expect(dispatchTopIntent.score).to.be.above(0.5);
-      chai.expect(child.sentiment.label).to.eql("positive")
+      chai.expect(child.sentiment.label).to.eql("positive");
       chai.expect(child.sentiment.score).to.be.above(0.5);
-    })
+    });
   });
 
-  it("should test prediction with version", async () => {
+  it("should test prediction with version", async function () {
     await BaseTest.useClientFor(async (client: LUISRuntimeClient) => {
       let result = await client.prediction.getVersionPrediction(
         BaseTest.GlobalAppId,
@@ -87,27 +93,34 @@ describe("Predections Tests", () => {
           query: utterance,
           options: {
             datetimeReference: new Date("2019-01-01"),
-            preferExternalEntities: true
+            preferExternalEntities: true,
           },
-          externalEntities: [{
-            entityName: "simple",
-            startIndex: 26,
-            entityLength: 4,
-            resolution: externalResolution
-          }],
-          dynamicLists: [{
-            listEntityName: "list", requestLists: [{
-              name: "test",
-              canonicalForm: "testing",
-              synonyms: ["this"]
-            }]
-          }],
+          externalEntities: [
+            {
+              entityName: "simple",
+              startIndex: 26,
+              entityLength: 4,
+              resolution: externalResolution,
+            },
+          ],
+          dynamicLists: [
+            {
+              listEntityName: "list",
+              requestLists: [
+                {
+                  name: "test",
+                  canonicalForm: "testing",
+                  synonyms: ["this"],
+                },
+              ],
+            },
+          ],
         },
         {
           verbose: true,
-          showAllIntents: true
+          showAllIntents: true,
         }
-      )
+      );
       let prediction = result.prediction;
       chai.expect(utterance).to.eql(result.query);
       chai.expect(prediction.topIntent).to.eql("intent");
@@ -135,27 +148,30 @@ describe("Predections Tests", () => {
 
       var dispatchTopIntent = child.intents[child.topIntent];
       chai.expect(dispatchTopIntent.score).to.be.above(0.5);
-      chai.expect(child.sentiment.label).to.eql("positive")
+      chai.expect(child.sentiment.label).to.eql("positive");
       chai.expect(child.sentiment.score).to.be.above(0.5);
     });
   });
 
-  it("should test app not found - throws api error exception", async () => {
+  it("should test app not found - throws api error exception", async function () {
     await BaseTest.useClientFor(async (client: LUISRuntimeClient) => {
-      return client.prediction.getSlotPrediction(
-        "7555b7c1-e69c-4580-9d95-1abd6dfa8291",
-        "production",
-        { query: "this is a test with post" }).catch(err => {
+      return client.prediction
+        .getSlotPrediction("7555b7c1-e69c-4580-9d95-1abd6dfa8291", "production", {
+          query: "this is a test with post",
+        })
+        .catch((err) => {
           chai.expect(err.body.error.code).to.eql("NotFound");
         });
     });
   });
 
-  it("should test empty query throws validation excpetion", async () => {
+  it("should test empty query throws validation excpetion", async function () {
     await BaseTest.useClientFor(async (client: LUISRuntimeClient) => {
-      return client.prediction.getSlotPrediction(BaseTest.GlobalAppId, "production", { query: "" }).catch(err => {
-        chai.expect(err.body.error.code).to.eql("BadArgument");
-      });
+      return client.prediction
+        .getSlotPrediction(BaseTest.GlobalAppId, "production", { query: "" })
+        .catch((err) => {
+          chai.expect(err.body.error.code).to.eql("BadArgument");
+        });
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\cognitiveservices\cognitiveservices-luis-runtime`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring`

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
