### PR TITLE
fix: comm-chat: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-chat/test/internal/chatClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/internal/chatClient.mocked.spec.ts
@@ -21,18 +21,18 @@ import {
 
 const API_VERSION = apiVersion.mapper.defaultValue;
 
-describe("[Mocked] ChatClient", async () => {
+describe("[Mocked] ChatClient", async function () {
   let chatClient: ChatClient;
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 
-  it("can instantiate", async () => {
+  it("can instantiate", async function () {
     new ChatClient(baseUri, new AzureCommunicationTokenCredential(generateToken()));
   });
 
-  it("makes successful create thread request", async () => {
+  it("makes successful create thread request", async function () {
     const mockHttpClient = generateHttpClient(201, mockCreateThreadResult);
 
     chatClient = createChatClient(mockHttpClient);
@@ -63,7 +63,7 @@ describe("[Mocked] ChatClient", async () => {
     assert.isNotEmpty(request.headers.get("repeatability-request-id"));
   });
 
-  it("makes successful list threads request", async () => {
+  it("makes successful list threads request", async function () {
     const mockResponse: RestModel.ChatThreadsItemCollection = {
       value: [mockThreadItem, mockThreadItem],
     };
@@ -87,7 +87,7 @@ describe("[Mocked] ChatClient", async () => {
     assert.equal(request.method, "GET");
   });
 
-  it("makes successful delete thread request", async () => {
+  it("makes successful delete thread request", async function () {
     const mockHttpClient = generateHttpClient(204);
     chatClient = createChatClient(mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");

--- a/sdk/communication/communication-chat/test/internal/chatThreadClient.mocked.spec.ts
+++ b/sdk/communication/communication-chat/test/internal/chatThreadClient.mocked.spec.ts
@@ -29,19 +29,19 @@ import {
 
 const API_VERSION = apiVersion.mapper.defaultValue;
 
-describe("[Mocked] ChatThreadClient", async () => {
+describe("[Mocked] ChatThreadClient", async function () {
   const threadId: string = "threadId";
   let chatThreadClient: ChatThreadClient;
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 
-  it("can instantiate", async () => {
+  it("can instantiate", async function () {
     new ChatThreadClient(threadId, baseUri, new AzureCommunicationTokenCredential(generateToken()));
   });
 
-  it("makes successful get properties request", async () => {
+  it("makes successful get properties request", async function () {
     const mockHttpClient = generateHttpClient(200, mockThread);
     chatThreadClient = createChatThreadClient(mockThread.id, mockHttpClient);
 
@@ -68,7 +68,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "GET");
   });
 
-  it("makes successful update thread topic", async () => {
+  it("makes successful update thread topic", async function () {
     const mockHttpClient = generateHttpClient(204);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
 
@@ -85,7 +85,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.deepEqual(JSON.parse(request.body as string), { topic: topic });
   });
 
-  it("makes successful send message request", async () => {
+  it("makes successful send message request", async function () {
     const mockHttpClient = generateHttpClient(201, {
       id: mockMessage.id,
     });
@@ -119,7 +119,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     });
   });
 
-  it("makes successful get message request", async () => {
+  it("makes successful get message request", async function () {
     const mockHttpClient = generateHttpClient(200, mockMessage);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -155,7 +155,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "GET");
   });
 
-  it("makes successful list messages request", async () => {
+  it("makes successful list messages request", async function () {
     const { senderCommunicationIdentifier, ...rest } = mockMessage;
 
     const mockResponse: RestModel.ChatMessagesCollection = {
@@ -205,7 +205,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "GET");
   });
 
-  it("makes successful update message request", async () => {
+  it("makes successful update message request", async function () {
     const mockHttpClient = generateHttpClient(204);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -230,7 +230,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     });
   });
 
-  it("makes successful delete message request", async () => {
+  it("makes successful delete message request", async function () {
     const mockHttpClient = generateHttpClient(204);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -246,7 +246,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "DELETE");
   });
 
-  it("makes successful add chat participants request", async () => {
+  it("makes successful add chat participants request", async function () {
     const mockHttpClient = generateHttpClient(201);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -277,7 +277,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     );
   });
 
-  it("makes successful list chat participants request", async () => {
+  it("makes successful list chat participants request", async function () {
     const mockHttpClient = generateHttpClient(200, {
       value: [mockParticipant],
     });
@@ -309,7 +309,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "GET");
   });
 
-  it("makes successful remove chat participant request", async () => {
+  it("makes successful remove chat participant request", async function () {
     const mockHttpClient = generateHttpClient(204);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -327,7 +327,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.deepEqual(mockParticipant.communicationIdentifier, requestJson);
   });
 
-  it("makes successful sent typing notification request", async () => {
+  it("makes successful sent typing notification request", async function () {
     const mockHttpClient = generateHttpClient(200);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -344,7 +344,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "POST");
   });
 
-  it("makes only one sent typing notification request within 8 secs", async () => {
+  it("makes only one sent typing notification request within 8 secs", async function () {
     const mockHttpClient = generateHttpClient(400);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -368,7 +368,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     }
   });
 
-  it("makes successful sent typing notification request with sender display name", async () => {
+  it("makes successful sent typing notification request with sender display name", async function () {
     const mockHttpClient = generateHttpClient(200);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -387,7 +387,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.deepEqual(JSON.parse(request.body as string), options);
   });
 
-  it("makes successful sent read receipt request", async () => {
+  it("makes successful sent read receipt request", async function () {
     const mockHttpClient = generateHttpClient(200);
     chatThreadClient = createChatThreadClient(threadId, mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -403,7 +403,7 @@ describe("[Mocked] ChatThreadClient", async () => {
     assert.equal(request.method, "POST");
   });
 
-  it("makes successful list read receipts request", async () => {
+  it("makes successful list read receipts request", async function () {
     const mockHttpClient = generateHttpClient(200, {
       value: [mockChatMessageReadReceipt, mockChatMessageReadReceipt],
     });


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-chat`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-chat` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring`
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime`

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
