### PR TITLE
Make Statsbeat Exporter Publicly Accessible

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/review/monitor-opentelemetry-exporter.api.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/review/monitor-opentelemetry-exporter.api.md
@@ -59,8 +59,8 @@ export class AzureMonitorMetricExporter extends AzureMonitorBaseExporter impleme
     shutdown(): Promise<void>;
 }
 
-// @internal
-export class _AzureMonitorStatsbeatExporter extends AzureMonitorBaseExporter implements PushMetricExporter {
+// @public
+export class AzureMonitorStatsbeatExporter extends AzureMonitorBaseExporter implements PushMetricExporter {
     constructor(options: AzureMonitorExporterOptions);
     export(metrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): Promise<void>;
     forceFlush(): Promise<void>;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat.ts
@@ -9,10 +9,9 @@ import { resourceMetricsToEnvelope } from "../utils/metricUtils";
 import { AzureMonitorBaseExporter } from "./base";
 
 /**
- * @internal
- * Azure Monitor Statsbeat Exporter
+ * Statsbeat Exporter
  */
-export class _AzureMonitorStatsbeatExporter
+export class AzureMonitorStatsbeatExporter
   extends AzureMonitorBaseExporter
   implements PushMetricExporter
 {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -18,7 +18,7 @@ import {
   PeriodicExportingMetricReader,
   PeriodicExportingMetricReaderOptions,
 } from "@opentelemetry/sdk-metrics";
-import { AzureMonitorExporterOptions, _AzureMonitorStatsbeatExporter } from "../../index";
+import { AzureMonitorExporterOptions, AzureMonitorStatsbeatExporter } from "../../index";
 import * as ai from "../../utils/constants/applicationinsights";
 import {
   StatsbeatCounter,
@@ -44,7 +44,7 @@ export class StatsbeatMetrics {
   private _isInitialized: boolean = false;
   private _networkStatsbeatCollection: Array<NetworkStatsbeat> = [];
   private _meterProvider: MeterProvider;
-  private _azureExporter: _AzureMonitorStatsbeatExporter;
+  private _azureExporter: AzureMonitorStatsbeatExporter;
   private _metricReader: PeriodicExportingMetricReader;
   private _statsCollectionShortInterval: number = 900000; // 15 minutes
 
@@ -82,7 +82,7 @@ export class StatsbeatMetrics {
       connectionString: this._connectionString,
     };
 
-    this._azureExporter = new _AzureMonitorStatsbeatExporter(exporterConfig);
+    this._azureExporter = new AzureMonitorStatsbeatExporter(exporterConfig);
 
     const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
       exporter: this._azureExporter,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/index.ts
@@ -5,7 +5,7 @@ export { ApplicationInsightsSampler } from "./sampling";
 export { AzureMonitorBaseExporter } from "./export/base";
 export { AzureMonitorTraceExporter } from "./export/trace";
 export { AzureMonitorMetricExporter } from "./export/metric";
-export { _AzureMonitorStatsbeatExporter } from "./export/statsbeat";
+export { AzureMonitorStatsbeatExporter } from "./export/statsbeat";
 export { AzureMonitorExporterOptions } from "./config";
 export { ServiceApiVersion } from "./Declarations/Constants";
 export {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This PR allows the Application Insights Distro to access the Statsbeat Exporter class. This access will only be necessary temporarily.

### Are there test cases added in this PR? _(If not, why?)_
There are not as this PR does not meaningfully change the need for testing infrastructure.

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/23425

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
