### PR TITLE
[core-amqp] remove map entry when we are done processing its task queues

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fix an issue in `RequestResponseLink` where sender error is not rejected [PR #23646](https://github.com/Azure/azure-sdk-for-js/pull/23646).
+- Fix an memory leak in `CancellableAsyncLockImpl` where elements are never removed from the map [PR# 24133](https://github.com/Azure/azure-sdk-for-js/pull/24133).
 
 ### Other Changes
 

--- a/sdk/core/core-amqp/src/util/lock.ts
+++ b/sdk/core/core-amqp/src/util/lock.ts
@@ -200,6 +200,8 @@ export class CancellableAsyncLockImpl {
     // Indicate that the task queue for the key is empty
     // and we're done processing it.
     this._executionRunningSet.delete(key);
+    // clean up the key map
+    this._keyMap.delete(key);
   }
 
   private _removeTaskDetails(key: string, taskDetails: TaskDetails): void {


### PR DESCRIPTION
so that we don't get a map of ever-increasing size.
