### PR TITLE
[engsys] remove extraneous `safeName` entry in maps ci.yml

### DIFF
--- a/sdk/maps/ci.yml
+++ b/sdk/maps/ci.yml
@@ -40,6 +40,5 @@ extends:
         safeName: azurerestmapsrender
       - name: azure-rest-maps-geolocation
         safeName: azurerestmapsgeolocation
-        safeName: azuremapscommon 
       - name: azure-rest-maps-search
         safeName: azurerestmapssearch


### PR DESCRIPTION
It's likely a leftover from copy-and-paste
