### PR TITLE
[dev-tool] Remove stale sample guardrails

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -224,7 +224,7 @@ export const commandInfo = makeCommandInfo(
     "node-versions": {
       kind: "string",
       description: "A comma separated list of node versions to use",
-      default: "12,14,16,17",
+      default: "14,16,17",
     },
     "node-version": {
       kind: "string",

--- a/common/tools/dev-tool/src/util/samples/info.ts
+++ b/common/tools/dev-tool/src/util/samples/info.ts
@@ -19,7 +19,7 @@ export const PUBLIC_SAMPLES_BASE = "samples";
  */
 export const DEFAULT_TYPESCRIPT_CONFIG = {
   compilerOptions: {
-    target: "ES2018",
+    target: "ES2020",
     module: "commonjs",
 
     moduleResolution: "node",

--- a/common/tools/dev-tool/src/util/samples/syntax.ts
+++ b/common/tools/dev-tool/src/util/samples/syntax.ts
@@ -2,9 +2,6 @@
 // Licensed under the MIT license.
 
 import * as ts from "typescript";
-import { createPrinter } from "../printer";
-
-const log = createPrinter("samples:syntax");
 
 /**
  * Tests for syntax compatibility.
@@ -47,13 +44,6 @@ const SYNTAX_VIABILITY_TESTS = {
     ImportExpression: (node: ts.Node) =>
       ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword,
   },
-  // Supported in Node 14+
-  ES2020: {
-    // foo ?? bar
-    NullishCoalesce: ts.isNullishCoalesce,
-    // foo?.bar, foo?.(bar), and foo?.[bar]
-    OptionalChain: ts.isOptionalChain,
-  },
   ES2021: {
     // x ??= y, x ||= y, and x &&= y (Node 15+)
     ShorthandAssignment: (node: ts.Node) =>
@@ -63,9 +53,6 @@ const SYNTAX_VIABILITY_TESTS = {
         ts.SyntaxKind.BarBarEqualsToken,
         ts.SyntaxKind.QuestionQuestionEqualsToken,
       ].includes(node.operatorToken.kind),
-    // 1_000_000 (Node >= 12.8.0)
-    NumericSeparator: (node: ts.Node) =>
-      ts.isNumericLiteral(node) && !!node.getText().includes("_"),
   },
   ES2022: {
     // This is well-supported in TypeScript but is emitted as an assignment rather than a `static`
@@ -73,8 +60,6 @@ const SYNTAX_VIABILITY_TESTS = {
     StaticField: (node: ts.Node) =>
       ts.isPropertyDeclaration(node) &&
       node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword),
-    // #foo (Node 14+)
-    PrivateIdentifier: ts.isPrivateIdentifier,
     // static { ... } (Node 17+)
     StaticInitializer: ts.isClassStaticBlockDeclaration,
   },
@@ -107,37 +92,6 @@ const SUGGEST_SYNTAX: {
   ExportAssignment: "export each symbol individually instead of using `export =`",
   ExportDeclaration:
     "export each symbol individually where it is declared instead of using a blanket export declaration",
-  OptionalChain: (node) => {
-    const chain = node as ts.OptionalChain;
-    const expressionText = chain.expression.getText().replace(/\?\./g, ".");
-    // We need some text for the right-hand side
-    const rhs = (
-      ts.isPropertyAccessExpression(chain)
-        ? "." + chain.name.text
-        : ts.isElementAccessExpression(chain)
-        ? "[" + chain.argumentExpression.getText() + "]"
-        : ts.isCallExpression(chain)
-        ? "(" + chain.arguments.map((node) => node.getText()).join(", ") + ")"
-        : (() => {
-            log.warn(
-              "[Internal Error] Unknown right-hand-side of Optional Chain:",
-              chain.getText()
-            );
-            return "<unknown>";
-          })()
-    )
-      // Optional chains can be recursive nodes, so we'll also just replace all '?.' with '.', since there should be an
-      // error for each node.
-      .replace(/\?\./g, ".");
-
-    return `try \`${expressionText} && ${expressionText}${rhs}\` if it does not affect runtime behavior, or use an explicit \`if\` block to handle the nullish case`;
-  },
-  // For Nullish Coalescing, we can suggest using || for the same effect in most cases, but it is ultimately up to the
-  // developer to decide if this is the right behavior.
-  NullishCoalesce: (node) => {
-    const nullish = node as ts.BinaryExpression;
-    return `try \`${nullish.left.getText()} || ${nullish.right.getText()}\` if it does not affect runtime behavior, or use an explicit \`if\` block to handle the nullish case`;
-  },
 };
 
 /**

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/javascript/getConfigurationSetting.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/javascript/getConfigurationSetting.js
@@ -9,7 +9,14 @@
 require("dotenv").config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f = (n) => n;
+
+  console.log(f?.(n)?.toString());
 
   console.log("Here's what we found:", envValue);
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/src/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/src/getConfigurationSetting.ts
@@ -10,7 +10,14 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f: ((n: number) => number) | undefined = (n) => n;
+
+  console.log(f?.(n)?.toString());
 
   console.log("Here's what we found:", envValue);
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/javascript/getConfigurationSetting.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/javascript/getConfigurationSetting.js
@@ -8,7 +8,7 @@
 require("dotenv").config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
 
   console.log("Here's what we found:", envValue);
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/src/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/src/getConfigurationSetting.ts
@@ -9,7 +9,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
 
   console.log("Here's what we found:", envValue);
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/common/tools/dev-tool/test/samples/files/inputs/simple/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/simple/getConfigurationSetting.ts
@@ -10,7 +10,14 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f: ((n: number) => number) | undefined = (n) => n;
+
+  console.log(f?.(n)?.toString());
 
   console.log("Here's what we found:", envValue);
 }

--- a/common/tools/dev-tool/test/samples/files/inputs/simple@1.0.0-beta.1/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/simple@1.0.0-beta.1/getConfigurationSetting.ts
@@ -9,7 +9,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function main() {
-  const envValue = process.env.MY_VARIABLE || "<my variable>";
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
 
   console.log("Here's what we found:", envValue);
 }


### PR DESCRIPTION
This PR removes outdated syntax restrictions from dev-tool when generating samples. This follows the end of our Node.js 12 grace period. Additionally, it increases the compiler target in samples from ES2018 to ES2020.

I've also removed version 12 from the default `check-node-versions` configuration.

CC @xirzec