### PR TITLE
[identity] fix scope assignment logic

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -234,7 +234,7 @@ export class ManagedIdentityCredential implements TokenCredential {
         const appTokenParameters: AppTokenProviderParameters = {
           correlationId: this.identityClient.getCorrelationId(),
           tenantId: options?.tenantId || "organizations",
-          scopes: [...scopes],
+          scopes: Array.isArray(scopes) ? scopes : [scopes],
           claims: options?.claims,
         };
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR
`scopes` assignment in managed identity leads to splitting of a single string into characters' array due to the previous logic. Even though functionally, it works as expected within msal, this is incorrect. The single string shouldn't split and just be there as an entry in the array.


### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/24103#issuecomment-1338220243

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
