### PR TITLE
[core-lro] No polling allowed when the operation is in a terminal state

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- poll() no longer sends a polling request if the operation is already in a terminal state.
+
 ### Other Changes
 
 ## 2.4.0 (2022-09-29)

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.4.1 (Unreleased)
+## 2.5.0 (Unreleased)
 
 ### Features Added
 
@@ -8,9 +8,9 @@
 
 ### Bugs Fixed
 
-- poll() no longer sends a polling request if the operation is already in a terminal state.
-
 ### Other Changes
+
+- poll() is optimized to no longer send a polling request if the operation is already in a terminal state.
 
 ## 2.4.0 (2022-09-29)
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -87,7 +87,7 @@
     "test": "npm run build:test && npm run unit-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "mocha -r esm -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --timeout 1200000 --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\""
+    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc mocha -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace  --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\""
   },
   "sideEffects": false,
   "dependencies": {
@@ -103,6 +103,7 @@
     "@microsoft/api-extractor": "^7.31.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.0",
+    "cross-env": "^7.0.2",
     "eslint": "^8.0.0",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Isomorphic client library for supporting long-running operations in node.js and browser.",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -87,7 +87,7 @@
     "test": "npm run build:test && npm run unit-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" nyc mocha -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace  --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\""
+    "unit-test:node": "mocha -r esm -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace --timeout 1200000 --exclude \"test/**/browser/*.spec.ts\" \"test/**/*.spec.ts\""
   },
   "sideEffects": false,
   "dependencies": {
@@ -103,7 +103,6 @@
     "@microsoft/api-extractor": "^7.31.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.0",
-    "cross-env": "^7.0.2",
     "eslint": "^8.0.0",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -14,7 +14,6 @@ import {
 import { deserializeState, initOperation, pollOperation } from "./operation";
 import { POLL_INTERVAL_IN_MS } from "./constants";
 import { delayMs } from "./util/delayMs";
-import { logger } from "../logger";
 
 const createStateProxy: <TResult, TState extends OperationState<TResult>>() => StateProxy<
   TState,
@@ -97,7 +96,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     type Handler = (state: TState) => void;
     const handlers = new Map<symbol, Handler>();
     const handleProgressEvents = async (): Promise<void> => handlers.forEach((h) => h(state));
-
+    const cancelErrMsg = "Operation was canceled";
     let currentPollIntervalInMs = intervalInMs;
 
     const poller: SimplePollerLike<TState, TResult> = {
@@ -133,31 +132,36 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
               await poller.poll({ abortSignal });
             }
           }
-          switch (state.status) {
-            case "succeeded": {
-              return poller.getResult() as TResult;
-            }
-            case "canceled": {
-              if (!resolveOnUnsuccessful) throw new Error("Operation was canceled");
-              return poller.getResult() as TResult;
-            }
-            case "failed": {
-              if (!resolveOnUnsuccessful) throw state.error;
-              return poller.getResult() as TResult;
-            }
-            case "notStarted":
-            case "running": {
-              // Unreachable
-              throw new Error(`polling completed without succeeding or failing`);
+          if (resolveOnUnsuccessful) {
+            return poller.getResult() as TResult;
+          } else {
+            switch (state.status) {
+              case "succeeded":
+                return poller.getResult() as TResult;
+              case "canceled":
+                throw new Error(cancelErrMsg);
+              case "failed":
+                throw state.error;
+              case "notStarted":
+              case "running":
+                throw new Error(`Polling completed without succeeding or failing`);
             }
           }
         })().finally(() => {
           resultPromise = undefined;
         })),
       async poll(pollOptions?: { abortSignal?: AbortSignalLike }): Promise<void> {
-        if (poller.isDone()) {
-          logger.warning(`The operation status is already ${state.status} but poll() was called.`);
-          return;
+        if (resolveOnUnsuccessful) {
+          if (poller.isDone()) return;
+        } else {
+          switch (state.status) {
+            case "succeeded":
+              return;
+            case "canceled":
+              throw new Error(cancelErrMsg);
+            case "failed":
+              throw state.error;
+          }
         }
         await pollOperation({
           poll,
@@ -177,11 +181,13 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
           setErrorAsResult: !resolveOnUnsuccessful,
         });
         await handleProgressEvents();
-        if (state.status === "canceled" && !resolveOnUnsuccessful) {
-          throw new Error("Operation was canceled");
-        }
-        if (state.status === "failed" && !resolveOnUnsuccessful) {
-          throw state.error;
+        if (!resolveOnUnsuccessful) {
+          switch (state.status) {
+            case "canceled":
+              throw new Error(cancelErrMsg);
+            case "failed":
+              throw state.error;
+          }
         }
       },
     };

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -14,6 +14,7 @@ import {
 import { deserializeState, initOperation, pollOperation } from "./operation";
 import { POLL_INTERVAL_IN_MS } from "./constants";
 import { delayMs } from "./util/delayMs";
+import { logger } from "../logger";
 
 const createStateProxy: <TResult, TState extends OperationState<TResult>>() => StateProxy<
   TState,
@@ -154,6 +155,10 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
           resultPromise = undefined;
         })),
       async poll(pollOptions?: { abortSignal?: AbortSignalLike }): Promise<void> {
+        if (poller.isDone()) {
+          logger.warning(`The operation status is already ${state.status} but poll() was called.`);
+          return;
+        }
         await pollOperation({
           poll,
           state,

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -2498,6 +2498,22 @@ matrix(
           assert.equal(pollCount, implName === "createPoller" ? 2 : 1);
         });
       });
+      describe("general behavior", function () {
+        it("poll() doesn't poll after the operation is in a terminal state", async function () {
+          const poller = await createTestPoller({
+            routes: [
+              {
+                method: "PUT",
+                status: 200,
+                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
+              },
+            ],
+          });
+          const result = await poller.pollUntilDone();
+          await poller.poll(); // This will fail if a polling request is sent
+          assert.equal(result.properties?.provisioningState, "Succeeded");
+        });
+      });
     });
   }
 );

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -2510,8 +2510,8 @@ matrix(
             ],
             throwOnNon2xxResponse,
           });
-          const result = await poller.pollUntilDone();
           await poller.poll(); // This will fail if a polling request is sent
+          const result = await poller.pollUntilDone();
           assert.equal(result.properties?.provisioningState, "Succeeded");
         });
         it("poll() doesn't poll after the poller is in a failed status", async function () {
@@ -2527,9 +2527,9 @@ matrix(
             throwOnNon2xxResponse,
           });
           await assertDivergentBehavior({
-            op: poller.pollUntilDone(),
+            op: poller.poll() as any,
             notThrowing: {
-              result: { ...bodyObj, statusCode: 200 },
+              result: undefined,
             },
             throwing: {
               messagePattern: /failed/,
@@ -2537,9 +2537,9 @@ matrix(
             throwOnNon2xxResponse,
           });
           await assertDivergentBehavior({
-            op: poller.poll() as any,
+            op: poller.pollUntilDone(),
             notThrowing: {
-              result: undefined,
+              result: { ...bodyObj, statusCode: 200 },
             },
             throwing: {
               messagePattern: /failed/,
@@ -2560,9 +2560,9 @@ matrix(
             throwOnNon2xxResponse,
           });
           await assertDivergentBehavior({
-            op: poller.pollUntilDone(),
+            op: poller.poll() as any,
             notThrowing: {
-              result: { ...bodyObj, statusCode: 200 },
+              result: undefined,
             },
             throwing: {
               messagePattern: /canceled/,
@@ -2570,9 +2570,9 @@ matrix(
             throwOnNon2xxResponse,
           });
           await assertDivergentBehavior({
-            op: poller.poll() as any,
+            op: poller.pollUntilDone(),
             notThrowing: {
-              result: undefined,
+              result: { ...bodyObj, statusCode: 200 },
             },
             throwing: {
               messagePattern: /canceled/,

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -2499,22 +2499,6 @@ matrix(
         });
       });
       describe("general behavior", function () {
-        it("poll() doesn't poll after the operation is in a terminal state", async function () {
-          const poller = await createTestPoller({
-            routes: [
-              {
-                method: "PUT",
-                status: 200,
-                body: `{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }`,
-              },
-            ],
-          });
-          const result = await poller.pollUntilDone();
-          await poller.poll(); // This will fail if a polling request is sent
-          assert.equal(result.properties?.provisioningState, "Succeeded");
-        });
-      });
-      describe("general behavior", function () {
         it("poll() doesn't poll after the poller is in a succeed status", async function () {
           const poller = await createTestPoller({
             routes: [


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-lro

### Issues associated with this PR
[Failures](https://dev.azure.com/azure-sdk/public/_build/results?buildId=2034536&view=logs&j=71cc2e7d-6454-5bf0-71b5-f1eef07a6c23&t=f2857310-5d68-5640-1409-0ba88dcfe076&l=1299) in https://github.com/Azure/autorest.typescript/pull/1586

### Describe the problem that is addressed by this PR
`poll()` always sends the polling request as long as the operation has a location to poll from. However, once the operation is in a terminal state, there is no need to send the polling request.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Sending the useless polling request is not the end of the world and won't affect the state of the poller. I don't feel strongly about the change but it is nice to not do unjustified extra work.

### Are there test cases added in this PR? _(If not, why?)_
Yes.

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
