### PR TITLE
Adding email live tests resources to test-resources.json

### DIFF
--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -44,17 +44,24 @@
   },
   "variables": {
     "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
+    "emailServiceName": "[format('{0}-{1}', variables('uniqueSubDomainName'), 'email-service')]",
     "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
   },
   "resources": [
     {
       "type": "Microsoft.Communication/CommunicationServices",
-      "apiVersion": "2020-08-20-preview",
+      "apiVersion": "2021-10-01-preview",
       "name": "[variables('uniqueSubDomainName')]",
       "location": "global",
       "properties": {
-        "dataLocation": "UnitedStates"
-      }
+        "dataLocation": "UnitedStates",
+        "linkedDomains": [
+          "[resourceId('Microsoft.Communication/EmailServices/Domains', variables('emailServiceName'), 'AzureManagedDomain')]"
+        ]
+      },
+      "dependsOn": [
+        "AzureManagedDomain"
+      ]
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
@@ -65,6 +72,29 @@
         "principalId": "[parameters('testApplicationOid')]",
         "scope": "[resourceGroup().id]"
       }
+    },
+    {
+      "type": "Microsoft.Communication/EmailServices",
+      "apiVersion": "2021-10-01-preview",
+      "name": "[variables('emailServiceName')]",
+      "location": "global",
+      "properties": {
+        "dataLocation": "UnitedStates"
+      },
+      "resources": [
+        {
+          "type": "Domains",
+          "apiVersion": "2021-10-01-preview",
+          "name": "AzureManagedDomain",
+          "location": "global",
+          "dependsOn": [
+            "[variables('emailServiceName')]"
+          ],
+          "properties": {
+            "domainManagement": "AzureManaged"
+          }
+        }
+      ]
     }
   ],
   "outputs": {
@@ -86,15 +116,31 @@
     },
     "COMMUNICATION_CONNECTION_STRING": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
     },
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
     },
     "RESOURCE_GROUP_NAME": {
       "type": "string",
       "value": "[resourceGroup().Name]"
+    },
+    "COMMUNICATION_CONNECTION_STRING_EMAIL": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+    },
+    "SENDER_ADDRESS": {
+      "type": "string",
+      "value": "[format('{0}@{1}', 'DoNotReply', reference(resourceId('Microsoft.Communication/EmailServices/Domains', variables('emailServiceName'), 'AzureManagedDomain')).mailFromSenderDomain)]"
+    },
+    "RECIPIENT_ADDRESS": {
+      "type": "string",
+      "value": "acseaastesting@gmail.com"
+    },
+    "SECOND_RECIPIENT_ADDRESS": {
+      "type": "string",
+      "value": "acseaastesting@gmail.com"
     }
   }
 }


### PR DESCRIPTION
The email live tests were previously using pre-provisioned resources. The secrets for these resources were stored in a key vault and accessed by the pipeline.

We are now creating these test resources at the pipeline runtime using an arm template.