### PR TITLE
Add typescript-emitter-package.json

### DIFF
--- a/eng/typescript-emitter-package.json
+++ b/eng/typescript-emitter-package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/index.js",
   "dependencies": {
     "@cadl-lang/compiler": "0.37.0",
-    "@azure-tools/cadl-typescript": "latest",
+    "@azure-tools/cadl-typescript": "1.0.0-beta.5",
     "@cadl-lang/versioning": "0.10.0",
     "@azure-tools/cadl-autorest": "0.22.0",
     "@cadl-lang/eslint-config-cadl": "0.4.1",

--- a/eng/typescript-emitter-package.json
+++ b/eng/typescript-emitter-package.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
     "@cadl-lang/compiler": "~0.38.5",
-    "@azure-tools/cadl-typescript": "1.0.0-beta.7",
-    "@cadl-lang/versioning": "0.38.0",
+    "@azure-tools/cadl-typescript": "1.0.0-beta.8",
     "@azure-tools/cadl-autorest": "0.24.0",
     "@cadl-lang/eslint-config-cadl": "0.5.0",
     "@cadl-lang/eslint-plugin": "0.38.0",

--- a/eng/typescript-emitter-package.json
+++ b/eng/typescript-emitter-package.json
@@ -1,0 +1,12 @@
+{
+  "main": "dist/src/index.js",
+  "dependencies": {
+    "@cadl-lang/compiler": "0.37.0",
+    "@azure-tools/cadl-typescript": "latest",
+    "@cadl-lang/versioning": "0.10.0",
+    "@azure-tools/cadl-autorest": "0.22.0",
+    "@cadl-lang/eslint-config-cadl": "0.4.1",
+    "@cadl-lang/eslint-plugin": "0.1.1",
+    "@cadl-lang/library-linter": "0.2.2"
+  }
+}

--- a/eng/typescript-emitter-package.json
+++ b/eng/typescript-emitter-package.json
@@ -1,12 +1,11 @@
 {
-  "main": "dist/src/index.js",
   "dependencies": {
-    "@cadl-lang/compiler": "0.37.0",
-    "@azure-tools/cadl-typescript": "1.0.0-beta.5",
-    "@cadl-lang/versioning": "0.10.0",
-    "@azure-tools/cadl-autorest": "0.22.0",
-    "@cadl-lang/eslint-config-cadl": "0.4.1",
-    "@cadl-lang/eslint-plugin": "0.1.1",
-    "@cadl-lang/library-linter": "0.2.2"
+    "@cadl-lang/compiler": "~0.38.5",
+    "@azure-tools/cadl-typescript": "1.0.0-beta.7",
+    "@cadl-lang/versioning": "0.38.0",
+    "@azure-tools/cadl-autorest": "0.24.0",
+    "@cadl-lang/eslint-config-cadl": "0.5.0",
+    "@cadl-lang/eslint-plugin": "0.38.0",
+    "@cadl-lang/library-linter": "0.38.0"
   }
 }

--- a/eng/typescript-emitter-package.json
+++ b/eng/typescript-emitter-package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@cadl-lang/compiler": "~0.38.5",
     "@azure-tools/cadl-typescript": "1.0.0-beta.8",
     "@azure-tools/cadl-autorest": "0.24.0",
     "@cadl-lang/eslint-config-cadl": "0.5.0",


### PR DESCRIPTION
 `typescript-emitter-package.json` defines the depended cadl packages used by sdk automation pipeline.