### PR TITLE
[Tables] Fix problem when concurrent transactions are submitted

### DIFF
--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -91,7 +91,6 @@ export class TableClient {
   private table: Table;
   private generatedClient: ServiceClient;
   private credential?: NamedKeyCredential | SASCredential | TokenCredential;
-  private transactionClient?: InternalTableTransaction;
   private clientOptions: TableClientOptions;
   private readonly allowInsecureConnection: boolean;
 
@@ -862,40 +861,36 @@ export class TableClient {
     const transactionId = Uuid.generateUuid();
     const changesetId = Uuid.generateUuid();
 
-    if (!this.transactionClient) {
-      // Add pipeline
-      this.transactionClient = new InternalTableTransaction(
-        this.url,
-        partitionKey,
-        transactionId,
-        changesetId,
-        this.generatedClient,
-        new TableClient(this.url, this.tableName),
-        this.credential,
-        this.allowInsecureConnection
-      );
-    } else {
-      this.transactionClient.reset(transactionId, changesetId, partitionKey);
-    }
+    // Add pipeline
+    const transactionClient = new InternalTableTransaction(
+      this.url,
+      partitionKey,
+      transactionId,
+      changesetId,
+      this.generatedClient,
+      new TableClient(this.url, this.tableName),
+      this.credential,
+      this.allowInsecureConnection
+    );
 
     for (const item of actions) {
       const [action, entity, updateMode = "Merge", updateOptions] = item;
       switch (action) {
         case "create":
-          this.transactionClient.createEntity(entity);
+          transactionClient.createEntity(entity);
           break;
         case "delete":
-          this.transactionClient.deleteEntity(entity.partitionKey, entity.rowKey);
+          transactionClient.deleteEntity(entity.partitionKey, entity.rowKey);
           break;
         case "update":
-          this.transactionClient.updateEntity(entity, updateMode, updateOptions);
+          transactionClient.updateEntity(entity, updateMode, updateOptions);
           break;
         case "upsert":
-          this.transactionClient.upsertEntity(entity, updateMode);
+          transactionClient.upsertEntity(entity, updateMode);
       }
     }
 
-    return this.transactionClient.submitTransaction();
+    return transactionClient.submitTransaction();
   }
 
   /**

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -136,12 +136,9 @@ export class InternalTableTransaction {
    */
   public url: string;
   /**
-   * This part of the state can be reset by
-   * calling the reset function. Other parts of the state
-   * such as the credentials remain the same throughout the life
-   * of the instance.
+   * State that holds the information about a particular transation
    */
-  private resetableState: {
+  private state: {
     transactionId: string;
     changesetId: string;
     pendingOperations: Promise<any>[];
@@ -172,8 +169,8 @@ export class InternalTableTransaction {
     this.interceptClient = interceptClient;
     this.allowInsecureConnection = allowInsecureConnection;
 
-    // Initialize Reset-able properties
-    this.resetableState = this.initializeSharedState(transactionId, changesetId, partitionKey);
+    // Initialize the state
+    this.state = this.initializeState(transactionId, changesetId, partitionKey);
 
     // Depending on the auth method used we need to build the url
     if (!credential) {
@@ -188,14 +185,7 @@ export class InternalTableTransaction {
     }
   }
 
-  /**
-   * Resets the state of the Transaction.
-   */
-  reset(transactionId: string, changesetId: string, partitionKey: string): void {
-    this.resetableState = this.initializeSharedState(transactionId, changesetId, partitionKey);
-  }
-
-  private initializeSharedState(transactionId: string, changesetId: string, partitionKey: string) {
+  private initializeState(transactionId: string, changesetId: string, partitionKey: string) {
     const pendingOperations: Promise<any>[] = [];
     const bodyParts = getInitialTransactionBody(transactionId, changesetId);
     const isCosmos = isCosmosEndpoint(this.url);
@@ -216,7 +206,7 @@ export class InternalTableTransaction {
    */
   public createEntity<T extends object>(entity: TableEntity<T>): void {
     this.checkPartitionKey(entity.partitionKey);
-    this.resetableState.pendingOperations.push(this.interceptClient.createEntity(entity));
+    this.state.pendingOperations.push(this.interceptClient.createEntity(entity));
   }
 
   /**
@@ -226,7 +216,7 @@ export class InternalTableTransaction {
   public createEntities<T extends object>(entities: TableEntity<T>[]): void {
     for (const entity of entities) {
       this.checkPartitionKey(entity.partitionKey);
-      this.resetableState.pendingOperations.push(this.interceptClient.createEntity(entity));
+      this.state.pendingOperations.push(this.interceptClient.createEntity(entity));
     }
   }
 
@@ -242,7 +232,7 @@ export class InternalTableTransaction {
     options?: DeleteTableEntityOptions
   ): void {
     this.checkPartitionKey(partitionKey);
-    this.resetableState.pendingOperations.push(
+    this.state.pendingOperations.push(
       this.interceptClient.deleteEntity(partitionKey, rowKey, options)
     );
   }
@@ -259,9 +249,7 @@ export class InternalTableTransaction {
     options?: UpdateTableEntityOptions
   ): void {
     this.checkPartitionKey(entity.partitionKey);
-    this.resetableState.pendingOperations.push(
-      this.interceptClient.updateEntity(entity, mode, options)
-    );
+    this.state.pendingOperations.push(this.interceptClient.updateEntity(entity, mode, options));
   }
 
   /**
@@ -278,23 +266,21 @@ export class InternalTableTransaction {
     options?: OperationOptions
   ): void {
     this.checkPartitionKey(entity.partitionKey);
-    this.resetableState.pendingOperations.push(
-      this.interceptClient.upsertEntity(entity, mode, options)
-    );
+    this.state.pendingOperations.push(this.interceptClient.upsertEntity(entity, mode, options));
   }
 
   /**
    * Submits the operations in the transaction
    */
   public async submitTransaction(): Promise<TableTransactionResponse> {
-    await Promise.all(this.resetableState.pendingOperations);
+    await Promise.all(this.state.pendingOperations);
     const body = getTransactionHttpRequestBody(
-      this.resetableState.bodyParts,
-      this.resetableState.transactionId,
-      this.resetableState.changesetId
+      this.state.bodyParts,
+      this.state.transactionId,
+      this.state.changesetId
     );
 
-    const headers = getTransactionHeaders(this.resetableState.transactionId);
+    const headers = getTransactionHeaders(this.state.transactionId);
 
     return tracingClient.withSpan(
       "TableTransaction.submitTransaction",
@@ -316,7 +302,7 @@ export class InternalTableTransaction {
   }
 
   private checkPartitionKey(partitionKey: string): void {
-    if (this.resetableState.partitionKey !== partitionKey) {
+    if (this.state.partitionKey !== partitionKey) {
       throw new Error("All operations in a transaction must target the same partitionKey");
     }
   }

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -69,12 +69,12 @@ describe(`batch operations`, () => {
       return;
     }
     await Promise.all([
-      unRecordedClient.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk1", field: 1 }]]),
-      unRecordedClient.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk2", field: 2 }]]),
+      client.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk1", field: 1 }]]),
+      client.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk2", field: 2 }]]),
     ]);
 
-    const entity1 = await unRecordedClient.getEntity("pk22", "rk1");
-    const entity2 = await unRecordedClient.getEntity("pk22", "rk2");
+    const entity1 = await client.getEntity("pk22", "rk1");
+    const entity2 = await client.getEntity("pk22", "rk2");
 
     assert.equal(entity1.rowKey, "rk1");
     assert.equal(entity2.rowKey, "rk2");

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -45,10 +45,10 @@ describe("concurrent batch operations", () => {
     sinon.restore();
   });
 
-  it("should send concurrent transactions", async () => {
+  it("should send concurrent transactions", async function () {
     // Only run this in live mode. Enable playback when https://github.com/Azure/azure-sdk-for-js/issues/24189 is fixed
     if (!isLiveMode()) {
-      return;
+      this.skip();
     }
     await Promise.all([
       unRecordedClient.submitTransaction([

--- a/sdk/tables/data-tables/test/public/transaction.spec.ts
+++ b/sdk/tables/data-tables/test/public/transaction.spec.ts
@@ -69,12 +69,12 @@ describe(`batch operations`, () => {
       return;
     }
     await Promise.all([
-      client.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk1", field: 1 }]]),
-      client.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk2", field: 2 }]]),
+      unRecordedClient.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk1", field: 1 }]]),
+      unRecordedClient.submitTransaction([["create", { partitionKey: "pk22", rowKey: "rk2", field: 2 }]]),
     ]);
 
-    const entity1 = await client.getEntity("pk22", "rk1");
-    const entity2 = await client.getEntity("pk22", "rk2");
+    const entity1 = await unRecordedClient.getEntity("pk22", "rk1");
+    const entity2 = await unRecordedClient.getEntity("pk22", "rk2");
 
     assert.equal(entity1.rowKey, "rk1");
     assert.equal(entity2.rowKey, "rk2");


### PR DESCRIPTION
### Packages impacted by this PR
@azure/data-tables

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/22341

### Describe the problem that is addressed by this PR
If `submitTransaction` is called concurrently, concurrent transactions step into each other's feet, causing one of the transactions to win over the others and be sent multiple times.

### What are the possible designs available to address the problem? If there is more than one possible design, why was the one in this PR chosen?

Currently, we have a cached TransactionClient which we use internally to translate the transaction actions into the batch request body. This causes concurrent transactions to use the same resource causing issues. The fix in this PR removed the cached transaction client and creates a new one per transaction to ensure isolation between transactions

### Are there test cases added in this PR? _(If not, why?)_
YES
