### PR TITLE
[keyvault] keyvault-certificates: depend on keyvault-common

### DIFF
--- a/sdk/keyvault/keyvault-certificates/api-extractor.json
+++ b/sdk/keyvault/keyvault-certificates/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "types/keyvault-certificates/src/index.d.ts",
+  "mainEntryPointFilePath": "types/src/index.d.ts",
   "docModel": {
     "enabled": true
   },

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "main": "./dist/index.js",
-  "module": "dist-esm/keyvault-certificates/src/index.js",
+  "module": "dist-esm/src/index.js",
   "types": "./types/keyvault-certificates.d.ts",
   "engines": {
     "node": ">=14.0.0"
@@ -28,8 +28,7 @@
   "files": [
     "types/keyvault-certificates.d.ts",
     "dist/",
-    "dist-esm/keyvault-certificates/src",
-    "dist-esm/keyvault-common/src",
+    "dist-esm/src",
     "README.md",
     "LICENSE"
   ],
@@ -114,6 +113,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-util": "^1.0.0",
     "@azure/core-tracing": "^1.0.0",
+    "@azure/keyvault-common": "^1.0.0-beta.1",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/keyvault/keyvault-certificates/src/identifier.ts
+++ b/sdk/keyvault/keyvault-certificates/src/identifier.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { parseKeyVaultIdentifier } from "../../keyvault-common/src";
+import { parseKeyVaultIdentifier } from "@azure/keyvault-common";
 
 /**
  * Represents the segments that compose a Key Vault Certificate Id.

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -101,7 +101,7 @@ import {
 import { KeyVaultClient } from "./generated/keyVaultClient";
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
-import { createKeyVaultChallengeCallbacks } from "../../keyvault-common/src";
+import { createKeyVaultChallengeCallbacks } from "@azure/keyvault-common";
 import { CreateCertificatePoller } from "./lro/create/poller";
 import { CertificateOperationPoller } from "./lro/operation/poller";
 import { DeleteCertificatePoller } from "./lro/delete/poller";

--- a/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/userAgent.spec.ts
@@ -44,10 +44,10 @@ describe("Certificates client's user agent (only in Node, because of fs)", () =>
       );
       version = fileContents.version;
     } catch {
-      // The integration-test script has this test file in a considerably different place,
-      // Along the lines of: dist-esm/keyvault-keys/test/internal/userAgent.spec.ts
+      // The integration-test script has this test file in a different place,
+      // Along the lines of: dist-esm/test/internal/userAgent.spec.ts
       const fileContents = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../../../package.json"), { encoding: "utf-8" })
+        fs.readFileSync(path.join(__dirname, "../../../package.json"), { encoding: "utf-8" })
       );
       version = fileContents.version;
     }

--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -12,7 +12,6 @@
   "include": [
     "./src/**/*.ts",
     "./test/**/*.ts",
-    "../keyvault-common/src/**/*.ts",
     "samples-dev/**/*.ts"
   ]
 }

--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -9,9 +9,5 @@
       "@azure/keyvault-certificates": ["./src/index"]
     }
   },
-  "include": [
-    "./src/**/*.ts",
-    "./test/**/*.ts",
-    "samples-dev/**/*.ts"
-  ]
+  "include": ["./src/**/*.ts", "./test/**/*.ts", "samples-dev/**/*.ts"]
 }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`

### Issues associated with this PR

- #22705

### Describe the problem that is addressed by this PR

Migrates `keyvault-certificates` to use the keyvault-common common package.
