### PR TITLE
[communication-job-router] format with prettier

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3043,7 +3043,7 @@ packages:
     dev: false
 
   /array-flatten/1.1.1:
-    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: false
 
   /array-includes/3.1.6:
@@ -3282,7 +3282,7 @@ packages:
     dev: false
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
     dev: false
 
   /buffer-from/1.1.2:
@@ -3439,7 +3439,7 @@ packages:
     dev: false
 
   /charenc/0.0.2:
-    resolution: {integrity: sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=}
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
     dev: false
 
   /check-error/1.0.2:
@@ -3583,7 +3583,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /concurrently/6.5.1:
@@ -3644,7 +3644,7 @@ packages:
     dev: false
 
   /cookie-signature/1.0.6:
-    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: false
 
   /cookie/0.4.2:
@@ -3757,7 +3757,7 @@ packages:
     dev: false
 
   /crypt/0.0.2:
-    resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
     dev: false
 
   /csv-parse/5.3.3:
@@ -4034,11 +4034,11 @@ packages:
     dev: false
 
   /edge-launcher/1.2.2:
-    resolution: {integrity: sha1-60Cq+9Bnpup27/+rBke81VCbN7I=}
+    resolution: {integrity: sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==}
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
   /electron-to-chromium/1.4.284:
@@ -4919,7 +4919,7 @@ packages:
     dev: false
 
   /fresh/0.5.2:
-    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -5059,7 +5059,7 @@ packages:
     dev: false
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
     dev: false
 
   /glob-parent/5.1.2:
@@ -6475,7 +6475,7 @@ packages:
     dev: false
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -6485,7 +6485,7 @@ packages:
     dev: false
 
   /merge-descriptors/1.0.1:
-    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
     dev: false
 
   /merge-source-map/1.1.0:
@@ -6907,7 +6907,7 @@ packages:
     dev: false
 
   /noms/0.0.0:
-    resolution: {integrity: sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=}
+    resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
@@ -7421,12 +7421,6 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-    dev: false
-
-  /prettier/1.19.1:
-    resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==}
-    engines: {node: '>=4'}
-    hasBin: true
     dev: false
 
   /prettier/2.2.1:
@@ -9201,7 +9195,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: false
 
@@ -15906,7 +15900,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-aJ10TxMFU+MdVJyQmkeThKCZbnZ6QmU9tzOoBz7yXNgmNlTMDVjYE6dpwJnWgHpDjOLHlYfnO5sEepLhZ/8Z8A==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-XGZDSI9UZH8K7iSGClJ4DymIjEiKFk6FyyLkYVPlVlqRYdkNP8jG0jvkaOHOB+qywCxJr61CmZlbL1SlrG79Lg==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -15938,7 +15932,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
-      prettier: 1.19.1
+      prettier: 2.8.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0

--- a/sdk/communication/communication-job-router/karma.conf.js
+++ b/sdk/communication/communication-job-router/karma.conf.js
@@ -8,7 +8,7 @@ process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
 const { jsonRecordingFilterFunction, isRecordMode } = require("@azure-tools/test-recorder");
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "./",
@@ -29,7 +29,7 @@ module.exports = function(config) {
       "karma-sourcemap-loader",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
-      "karma-json-preprocessor"
+      "karma-json-preprocessor",
     ],
 
     // list of files / patterns to load in the browser
@@ -42,7 +42,7 @@ module.exports = function(config) {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       "**/*.js": ["sourcemap", "env"],
-      "recordings/browsers/**/*.json": ["json"]
+      "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
       //"dist-test/index.browser.js": ["coverage"]
@@ -65,8 +65,8 @@ module.exports = function(config) {
         { type: "json", subdir: ".", file: "coverage.json" },
         { type: "lcovonly", subdir: ".", file: "lcov.info" },
         { type: "html", subdir: "html" },
-        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" }
-      ]
+        { type: "cobertura", subdir: ".", file: "cobertura-coverage.xml" },
+      ],
     },
 
     junitReporter: {
@@ -76,12 +76,12 @@ module.exports = function(config) {
       useBrowserName: false, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
-      properties: {} // key value pair of properties to add to the <properties> section of the report
+      properties: {}, // key value pair of properties to add to the <properties> section of the report
     },
 
     jsonToFileReporter: {
       filter: jsonRecordingFilterFunction,
-      outputPath: "."
+      outputPath: ".",
     },
 
     // web server port
@@ -105,8 +105,8 @@ module.exports = function(config) {
     customLaunchers: {
       HeadlessChrome: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
-      }
+        flags: ["--no-sandbox"],
+      },
     },
 
     // Continuous Integration mode
@@ -121,15 +121,15 @@ module.exports = function(config) {
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
-      terminal: !isRecordMode()
+      terminal: !isRecordMode(),
     },
 
     client: {
       mocha: {
         // change Karma's debug.html to the mocha web reporter
         reporter: "html",
-        timeout: "600000"
-      }
-    }
+        timeout: "600000",
+      },
+    },
   });
 };

--- a/sdk/communication/communication-job-router/package.json
+++ b/sdk/communication/communication-job-router/package.json
@@ -115,7 +115,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "mocha": "^7.1.1",
     "nyc": "^14.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "sinon": "^9.0.2",
     "typescript": "~4.2.0",

--- a/sdk/communication/communication-job-router/src/models/models.ts
+++ b/sdk/communication/communication-job-router/src/models/models.ts
@@ -86,5 +86,5 @@ export {
   StaticWorkerSelectorAttachment,
   WeightedAllocationWorkerSelectorAttachment,
   FunctionRuleCredential,
-  QueueStatistics
+  QueueStatistics,
 } from "../generated/src/models";

--- a/sdk/communication/communication-job-router/src/models/options.ts
+++ b/sdk/communication/communication-job-router/src/models/options.ts
@@ -19,7 +19,7 @@ import {
   QueueSelectorAttachmentUnion,
   RouterJob,
   WorkerSelector,
-  WorkerStateSelector
+  WorkerStateSelector,
 } from "../generated/src";
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 

--- a/sdk/communication/communication-job-router/src/models/responses.ts
+++ b/sdk/communication/communication-job-router/src/models/responses.ts
@@ -7,14 +7,14 @@ import {
   ExceptionPolicy,
   JobQueue,
   RouterJob,
-  RouterWorker
+  RouterWorker,
 } from "../generated/src";
 
 export {
   JobRouterCancelJobActionResponse,
   JobRouterCloseJobActionResponse,
   JobRouterCompleteJobActionResponse,
-  JobRouterDeclineJobActionResponse
+  JobRouterDeclineJobActionResponse,
 } from "../generated/src/models";
 
 export interface UnAssignJobResponse {

--- a/sdk/communication/communication-job-router/src/routerAdministrationClient.ts
+++ b/sdk/communication/communication-job-router/src/routerAdministrationClient.ts
@@ -12,7 +12,7 @@ import {
   JobRouterAdministrationListDistributionPoliciesOptionalParams,
   JobRouterAdministrationListExceptionPoliciesOptionalParams,
   JobRouterAdministrationListQueuesOptionalParams,
-  JobRouterApiClient
+  JobRouterApiClient,
 } from "./generated/src";
 import {
   CreateClassificationPolicyOptions,
@@ -27,7 +27,7 @@ import {
   UpdateClassificationPolicyOptions,
   UpdateDistributionPolicyOptions,
   UpdateExceptionPolicyOptions,
-  UpdateQueueOptions
+  UpdateQueueOptions,
 } from "./models/options";
 
 import { InternalPipelineOptions } from "@azure/core-rest-pipeline";
@@ -36,7 +36,7 @@ import {
   CommunicationTokenCredential,
   createCommunicationAuthPolicy,
   isKeyCredential,
-  parseClientArguments
+  parseClientArguments,
 } from "@azure/communication-common";
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -46,7 +46,7 @@ import {
   ClassificationPolicyResponse,
   DistributionPolicyResponse,
   ExceptionPolicyResponse,
-  JobQueueResponse
+  JobQueueResponse,
 } from "./models/responses";
 
 /**
@@ -138,8 +138,8 @@ export class RouterAdministrationClient {
       ...options,
       userAgentOptions,
       loggingOptions: {
-        logger: logger.info
-      }
+        logger: logger.info,
+      },
     };
 
     const authPolicy = createCommunicationAuthPolicy(credential);

--- a/sdk/communication/communication-job-router/src/routerClient.ts
+++ b/sdk/communication/communication-job-router/src/routerClient.ts
@@ -6,7 +6,7 @@ import {
   CommunicationTokenCredential,
   createCommunicationAuthPolicy,
   isKeyCredential,
-  parseClientArguments
+  parseClientArguments,
 } from "@azure/communication-common";
 
 import { KeyCredential, TokenCredential } from "@azure/core-auth";
@@ -27,7 +27,7 @@ import {
   JobRouterReclassifyJobActionResponse,
   QueueStatistics,
   RouterJobItem,
-  RouterWorkerItem
+  RouterWorkerItem,
 } from "./generated/src";
 import { logger } from "./models/logger";
 import {
@@ -41,7 +41,7 @@ import {
   ReclassifyJobOptions,
   RouterClientOptions,
   UpdateJobOptions,
-  UpdateWorkerOptions
+  UpdateWorkerOptions,
 } from "./models/options";
 import { RouterJobResponse, RouterWorkerResponse, UnAssignJobResponse } from "./models/responses";
 
@@ -128,8 +128,8 @@ export class RouterClient {
       ...options,
       userAgentOptions,
       loggingOptions: {
-        logger: logger.info
-      }
+        logger: logger.info,
+      },
     };
 
     const authPolicy = createCommunicationAuthPolicy(credential);
@@ -270,7 +270,7 @@ export class RouterClient {
     const result = await this.client.jobRouter.unassignJobAction(jobId, assignmentId, options);
     return {
       jobId: result.jobId,
-      unAssignmentCount: result.unassignmentCount
+      unAssignmentCount: result.unassignmentCount,
     };
   }
 
@@ -353,7 +353,7 @@ export class RouterClient {
     options: OperationOptions = {}
   ): Promise<RouterWorkerResponse> {
     const worker = {
-      availableForOffers: true
+      availableForOffers: true,
     };
     const workerResult = await this.client.jobRouter.upsertWorker(workerId, worker, options);
     return <RouterWorkerResponse>workerResult;
@@ -370,7 +370,7 @@ export class RouterClient {
     options: OperationOptions = {}
   ): Promise<RouterWorkerResponse> {
     const worker = {
-      availableForOffers: false
+      availableForOffers: false,
     };
     const workerResult = await this.client.jobRouter.upsertWorker(workerId, worker, options);
     return <RouterWorkerResponse>workerResult;

--- a/sdk/communication/communication-job-router/test/internal/utils/mockClient.ts
+++ b/sdk/communication/communication-job-router/test/internal/utils/mockClient.ts
@@ -33,6 +33,6 @@ export async function createRecordedRouterClientWithConnectionString(
       env.COMMUNICATION_CONNECTION_STRING as string,
       recorder.configureClientOptions({}) as RouterAdministrationClientOptions
     ),
-    recorder
+    recorder,
   };
 }

--- a/sdk/communication/communication-job-router/test/public/exceptionPolicies.spec.ts
+++ b/sdk/communication/communication-job-router/test/public/exceptionPolicies.spec.ts
@@ -9,26 +9,26 @@ import { Context } from "mocha";
 import { exceptionPolicyRequest } from "./utils/testData";
 
 // TODO . Complete unit and integration tests https://github.com/Azure/azure-sdk-for-js/issues/23007
-describe("RouterClient", function() {
+describe("RouterClient", function () {
   let recorder: Recorder;
   // let client: RouterClient;
   let administrationClient: RouterAdministrationClient;
 
-  describe("Exception Policy Operations", function() {
-    beforeEach(async function(this: Context) {
+  describe("Exception Policy Operations", function () {
+    beforeEach(async function (this: Context) {
       ({ administrationClient, recorder } = await createRecordedRouterClientWithConnectionString(
         this
       ));
     });
 
-    afterEach(async function(this: Context) {
+    afterEach(async function (this: Context) {
       if (!this.currentTest?.isPending() && recorder) {
         await recorder.stop();
       }
     });
 
     // exception policy actions
-    it("should successfully create a exception policy", async function() {
+    it("should successfully create a exception policy", async function () {
       const request = exceptionPolicyRequest;
 
       const result = await administrationClient.createExceptionPolicy(request.id!, request);
@@ -38,11 +38,12 @@ describe("RouterClient", function() {
       assert.equal(result.name, request.name);
     }).timeout(8000);
 
-    it("should successfully update a exception policy", async function() {
-      const exceptionPolicy: ExceptionPolicyResponse = await administrationClient.createExceptionPolicy(
-        exceptionPolicyRequest.id!,
-        exceptionPolicyRequest
-      );
+    it("should successfully update a exception policy", async function () {
+      const exceptionPolicy: ExceptionPolicyResponse =
+        await administrationClient.createExceptionPolicy(
+          exceptionPolicyRequest.id!,
+          exceptionPolicyRequest
+        );
       exceptionPolicy.name = "some new name";
       const result = await administrationClient.updateExceptionPolicy(
         exceptionPolicyRequest.id!,
@@ -54,11 +55,12 @@ describe("RouterClient", function() {
       assert.equal(result.name, exceptionPolicy.name);
     }).timeout(8000);
 
-    it("should successfully get a exception policy", async function() {
-      const exceptionPolicy: ExceptionPolicyResponse = await administrationClient.createExceptionPolicy(
-        exceptionPolicyRequest.id!,
-        exceptionPolicyRequest
-      );
+    it("should successfully get a exception policy", async function () {
+      const exceptionPolicy: ExceptionPolicyResponse =
+        await administrationClient.createExceptionPolicy(
+          exceptionPolicyRequest.id!,
+          exceptionPolicyRequest
+        );
 
       const result = await administrationClient.getExceptionPolicy(exceptionPolicy.id!, {});
 
@@ -67,13 +69,13 @@ describe("RouterClient", function() {
       assert.deepEqual(result.exceptionRules, exceptionPolicyRequest.exceptionRules);
     }).timeout(8000);
 
-    it("should successfully list exception policies", async function() {
+    it("should successfully list exception policies", async function () {
       await administrationClient.createExceptionPolicy("id-1", exceptionPolicyRequest);
       await administrationClient.createExceptionPolicy("id-2", exceptionPolicyRequest);
 
       const receivedItems: ExceptionPolicy[] = [];
       for await (const policy of administrationClient.listExceptionPolicies({
-        maxPageSize: 20
+        maxPageSize: 20,
       })) {
         receivedItems.push(policy.exceptionPolicy!);
       }
@@ -81,7 +83,7 @@ describe("RouterClient", function() {
       assert.isNotNull(receivedItems);
     }).timeout(8000);
 
-    it("should successfully delete a exception policy", async function() {
+    it("should successfully delete a exception policy", async function () {
       await administrationClient.createExceptionPolicy(
         exceptionPolicyRequest.id!,
         exceptionPolicyRequest

--- a/sdk/communication/communication-job-router/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-job-router/test/public/utils/recordedClient.ts
@@ -12,7 +12,7 @@ if (isNode) {
 }
 
 const envSetupForPlayback: { [k: string]: string } = {
-  COMMUNICATION_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana"
+  COMMUNICATION_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
 };
 
 const fakeToken = generateToken();
@@ -22,11 +22,11 @@ export const recorderOptions: RecorderStartOptions = {
     connectionStringSanitizers: [
       {
         fakeConnString: envSetupForPlayback["COMMUNICATION_CONNECTION_STRING"],
-        actualConnString: env["COMMUNICATION_CONNECTION_STRING"] || undefined
-      }
+        actualConnString: env["COMMUNICATION_CONNECTION_STRING"] || undefined,
+      },
     ],
-    bodyKeySanitizers: [{ jsonPath: "$.accessToken.token", value: fakeToken }]
-  }
+    bodyKeySanitizers: [{ jsonPath: "$.accessToken.token", value: fakeToken }],
+  },
 };
 
 export async function createRecorder(context: Test | undefined): Promise<Recorder> {

--- a/sdk/communication/communication-job-router/test/public/utils/testData.ts
+++ b/sdk/communication/communication-job-router/test/public/utils/testData.ts
@@ -7,7 +7,7 @@ import {
   ExceptionPolicy,
   JobQueue,
   RouterJob,
-  RouterWorker
+  RouterWorker,
 } from "../../../src";
 
 export const exceptionPolicyRequest: ExceptionPolicy = {
@@ -20,16 +20,16 @@ export const exceptionPolicyRequest: ExceptionPolicy = {
           kind: "reclassify",
           classificationPolicyId: "Main",
           labelsToUpsert: {
-            escalated: true
-          }
-        }
+            escalated: true,
+          },
+        },
       },
       trigger: {
         kind: "wait-time",
-        thresholdSeconds: 5
-      }
-    }
-  }
+        thresholdSeconds: 5,
+      },
+    },
+  },
 };
 
 export const classificationPolicyRequest: ClassificationPolicy = {
@@ -43,15 +43,15 @@ export const classificationPolicyRequest: ClassificationPolicy = {
         {
           key: "foo",
           labelOperator: "equal",
-          value: { default: 10 }
-        }
-      ]
-    }
+          value: { default: 10 },
+        },
+      ],
+    },
   ],
   prioritizationRule: {
     kind: "static-rule",
-    value: { default: 2 }
-  }
+    value: { default: 2 },
+  },
 };
 
 export const distributionPolicyRequest: DistributionPolicy = {
@@ -60,9 +60,9 @@ export const distributionPolicyRequest: DistributionPolicy = {
     kind: "longest-idle",
     minConcurrentOffers: 1,
     maxConcurrentOffers: 5,
-    bypassSelectors: false
+    bypassSelectors: false,
   },
-  offerTtlInSeconds: 120
+  offerTtlInSeconds: 120,
 };
 
 export const queueRequest: JobQueue = {
@@ -70,7 +70,7 @@ export const queueRequest: JobQueue = {
   distributionPolicyId: "MainDistributionPolicy",
   name: "Main",
   labels: {},
-  exceptionPolicyId: "MainExceptionPolicy"
+  exceptionPolicyId: "MainExceptionPolicy",
 };
 
 export const workerRequest: RouterWorker = {
@@ -80,20 +80,20 @@ export const workerRequest: RouterWorker = {
   totalCapacity: 100,
   queueAssignments: {
     MainQueue: {},
-    SecondaryQueue: {}
+    SecondaryQueue: {},
   },
   labels: {},
   channelConfigurations: {
     CustomChatChannel: {
-      capacityCostPerJob: 10
+      capacityCostPerJob: 10,
     },
     CustomVoiceChannel: {
-      capacityCostPerJob: 100
-    }
-  }
+      capacityCostPerJob: 100,
+    },
+  },
 };
 
 export const jobRequest: RouterJob = {
   channelId: "ChatChannel",
-  labels: {}
+  labels: {},
 };


### PR DESCRIPTION
Somehow this package was still depending on an older version of prettier than we use everywhere else in the repo. Due to the version bump, the files in this package needed to be reformatted.

I split this out from #24206 to make it easier to review/stage.