### PR TITLE
[engsys] remove deprecated `@opentelemetry/api-metrics` dependency

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -108,7 +108,6 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/api-metrics": "^0.33.0",
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.8.0",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -6,13 +6,13 @@ import {
   createPipelineRequest,
   HttpMethods,
 } from "@azure/core-rest-pipeline";
-import { diag } from "@opentelemetry/api";
 import {
+  diag,
   BatchObservableResult,
+  Meter,
   ObservableGauge,
   ObservableResult,
-} from "@opentelemetry/api-metrics";
-import { Meter } from "@opentelemetry/api-metrics/build/src/types/Meter";
+} from "@opentelemetry/api";
 import {
   MeterProvider,
   PeriodicExportingMetricReader,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { MetricAttributes } from "@opentelemetry/api-metrics";
+import { MetricAttributes } from "@opentelemetry/api";
 import { DataPointType, Histogram, ResourceMetrics } from "@opentelemetry/sdk-metrics";
 import {
   TelemetryItem as Envelope,


### PR DESCRIPTION
`rush update` suggests

>  WARN  deprecated @opentelemetry/api-metrics@0.33.0: Please use @opentelemetry/api >= 1.3.0
