### PR TITLE
[Language Text] Fix min/max testing

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyzeBatch.spec.ts
@@ -54,7 +54,6 @@ import {
   expectation71,
 } from "./expectations";
 import { windows365ArticlePart1, windows365ArticlePart2 } from "./inputs";
-import { getDocIDsFromState } from "../../src/lro";
 
 const FIXME1 = {
   // FIXME: remove this check when the service updates its message
@@ -1056,7 +1055,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
           }
           const serializedState = originalPoller.toString();
           assert.deepEqual(
-            getDocIDsFromState(serializedState),
+            JSON.parse(serializedState).state.docIds,
             docs.map(({ id }) => id)
           );
           const rehydratedPoller = await client.restoreAnalyzeBatchPoller(serializedState, {


### PR DESCRIPTION
The `analyzeBatch.spec.ts` suite [doesn't get run by the min/max testing pipelines](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2066987&view=logs&j=abc7da81-7c4f-5087-422d-51020873ec4f&t=fb7db649-54ee-549f-6bbf-f1116b8abfe1) because that suite imports a non-public definition from the `src` directory. This PR fixes the issue by removing this non-conforming import.

[Succeeded run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2068887&view=results)