### PR TITLE
added extends string to use in string generation

### DIFF
--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -85,7 +85,7 @@ export type SerializedCommunicationCloudEnvironment = "public" | "dod" | "gcch";
 const assertNotNullOrUndefined = <
   T extends Record<string, unknown>,
   P extends keyof T,
-  Q extends keyof T[P]
+  Q extends string & keyof T[P]
 >(
   obj: T,
   prop: Q
@@ -95,7 +95,7 @@ const assertNotNullOrUndefined = <
   if (prop in subObj) {
     return subObj[prop];
   }
-  throw new Error(`Property ${String(prop)} is required for identifier of type ${subObjName}.`);
+  throw new Error(`Property ${prop} is required for identifier of type ${subObjName}.`);
 };
 
 const assertMaximumOneNestedModel = (identifier: SerializedCommunicationIdentifier): void => {

--- a/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/identifierModelSerializer.spec.ts
@@ -26,7 +26,7 @@ const assertDeserialize = (
 
 const assertThrowsMissingProperty = <
   P extends keyof SerializedCommunicationIdentifier,
-  Q extends keyof Required<SerializedCommunicationIdentifier>[P]
+  Q extends string & keyof Required<SerializedCommunicationIdentifier>[P]
 >(
   serializedIdentifier: SerializedCommunicationIdentifier,
   identifierType: P,
@@ -34,7 +34,7 @@ const assertThrowsMissingProperty = <
 ): void => {
   assert.throws(() => {
     deserializeCommunicationIdentifier(serializedIdentifier);
-  }, `Property ${String(missingPropertyName)} is required for identifier of type ${identifierType}.`);
+  }, `Property ${missingPropertyName} is required for identifier of type ${identifierType}.`);
 };
 
 const assertThrowsTooManyProperties = (


### PR DESCRIPTION
### Packages impacted by this PR
Communication - Common

### Issues associated with this PR
[User Story 3024912](https://skype.visualstudio.com/SPOOL/_workitems/edit/3024912): [SDK][JS][Common & Identity] Fix "strictNullChecks" error warning

### Describe the problem that is addressed by this PR
When passing the value directly to `{}` to generate an error message string (without explicitly casting to String), the following warning message is generated:
(parameter) missingPropertyName: Q extends keyof Required<SerializedCommunicationIdentifier>[P]
Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.ts(2731)

This pull request introduces a way to handle the error without an additional explicit type casting.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
No changes in behavior.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
