### PR TITLE
[dev-tool] try `/` and `\` path separators when checking bundling warnings

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -69,7 +69,6 @@ export function sourcemapsExtra() {
 export type WarningInhibitor = (warning: RollupWarning) => boolean;
 
 function matchesPathSegments(str: string | undefined, segments: string[]): boolean {
-  // Reported warnings use "/"
   return !str ? false : str.includes(segments.join("/")) || str.includes(segments.join("\\"));
 }
 

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -70,7 +70,7 @@ export type WarningInhibitor = (warning: RollupWarning) => boolean;
 
 function matchesPathSegments(str: string | undefined, segments: string[]): boolean {
   // Reported warnings use "/"
-  return str?.includes(segments.join("/")) ?? false;
+  return !str ? false : str.includes(segments.join("/")) || str.includes(segments.join("\\"));
 }
 
 function ignoreNiseSinonEval(warning: RollupWarning): boolean {


### PR DESCRIPTION

It turns out that on windows some warnings are reported with `\` separator while others with `/` at the same time, e.g.,

    str ../../../common/temp/node_modules/.pnpm/chai@4.3.7/node_modules/chai/lib/chai.js
    str C:\github\jeremymeng\js-main\common\temp\node_modules\.pnpm\sinon@9.2.4\node_modules\sinon\pkg\sinon-esm.js

This PR changes to try both separators when checking whether to suppress bundle warnings.
