### PR TITLE
[core-client] Ignore extra headers

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Only deserialize headers that are mapped in OperationSpec when using a header mapper. Previously core-client would include all header values when deserializing, leading to result objects having unintended extra metadata.
+
 ## 1.7.0 (2023-01-05)
 
 ### Features Added

--- a/sdk/core/core-client/review/core-client.api.md
+++ b/sdk/core/core-client/review/core-client.api.md
@@ -319,6 +319,7 @@ export interface Serializer {
 
 // @public
 export interface SerializerOptions {
+    ignoreUnknownProperties?: boolean;
     xml: XmlOptions;
 }
 

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -206,7 +206,8 @@ async function deserializeResponseBody(
       parsedResponse.parsedHeaders = operationSpec.serializer.deserialize(
         responseSpec.headersMapper,
         parsedResponse.headers.toJSON(),
-        "operationRes.parsedHeaders"
+        "operationRes.parsedHeaders",
+        { xml: {}, ignoreUnknownProperties: true }
       );
     }
   }

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -47,7 +47,8 @@ export interface SerializerOptions {
    */
   xml: XmlOptions;
   /**
-   * If additional properties should be included in the result object, even if there is no mapper for them.
+   * Normally additional properties are included in the result object, even if there is no mapper for them.
+   * This flag disables this behavior when true. It is used when parsing headers to avoid polluting the result object.
    */
   ignoreUnknownProperties?: boolean;
 }

--- a/sdk/core/core-client/src/interfaces.ts
+++ b/sdk/core/core-client/src/interfaces.ts
@@ -46,6 +46,10 @@ export interface SerializerOptions {
    * Options to configure xml parser/builder behavior.
    */
   xml: XmlOptions;
+  /**
+   * If additional properties should be included in the result object, even if there is no mapper for them.
+   */
+  ignoreUnknownProperties?: boolean;
 }
 
 export type RequiredSerializerOptions = {

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -229,6 +229,7 @@ class SerializerImpl implements Serializer {
         includeRoot: options.xml.includeRoot ?? false,
         xmlCharKey: options.xml.xmlCharKey ?? XML_CHARKEY,
       },
+      ignoreUnknownProperties: options.ignoreUnknownProperties ?? false
     };
     if (responseBody === undefined || responseBody === null) {
       if (this.isXML && mapper.type.name === "Sequence" && !mapper.xmlIsWrapped) {
@@ -1028,7 +1029,7 @@ function deserializeCompositeType(
         );
       }
     }
-  } else if (responseBody) {
+  } else if (responseBody && !options.ignoreUnknownProperties) {
     for (const key of Object.keys(responseBody)) {
       if (
         instance[key] === undefined &&

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -229,7 +229,7 @@ class SerializerImpl implements Serializer {
         includeRoot: options.xml.includeRoot ?? false,
         xmlCharKey: options.xml.xmlCharKey ?? XML_CHARKEY,
       },
-      ignoreUnknownProperties: options.ignoreUnknownProperties ?? false
+      ignoreUnknownProperties: options.ignoreUnknownProperties ?? false,
     };
     if (responseBody === undefined || responseBody === null) {
       if (this.isXML && mapper.type.name === "Sequence" && !mapper.xmlIsWrapped) {

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -735,18 +735,16 @@ describe("deserializationPolicy", function () {
         serializer,
       };
 
-
-        const result = await getDeserializedResponse({
-          operationSpec,
-          headers: { "x-ms-foo": "SomeHeaderValue", "x-ms-bar": "SomeOtherHeaderValue" },
-          bodyAsText: '{"message": "Some kind of message"}',
-          status: 200,
-        });
-        assert.exists(result);
-        assert.strictEqual(result.parsedHeaders?.foo, "SomeHeaderValue");
-        assert.strictEqual(result.parsedBody.message, "Some kind of message");
-        assert.notExists(result.parsedHeaders?.['x-ms-bar']);
-      
+      const result = await getDeserializedResponse({
+        operationSpec,
+        headers: { "x-ms-foo": "SomeHeaderValue", "x-ms-bar": "SomeOtherHeaderValue" },
+        bodyAsText: '{"message": "Some kind of message"}',
+        status: 200,
+      });
+      assert.exists(result);
+      assert.strictEqual(result.parsedHeaders?.foo, "SomeHeaderValue");
+      assert.strictEqual(result.parsedBody.message, "Some kind of message");
+      assert.notExists(result.parsedHeaders?.["x-ms-bar"]);
     });
   });
 });

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -738,13 +738,14 @@ describe("deserializationPolicy", function () {
       const result = await getDeserializedResponse({
         operationSpec,
         headers: { "x-ms-foo": "SomeHeaderValue", "x-ms-bar": "SomeOtherHeaderValue" },
-        bodyAsText: '{"message": "Some kind of message"}',
+        bodyAsText: '{"message": "Some kind of message", "extraProp": "An extra property value"}',
         status: 200,
       });
       assert.exists(result);
       assert.strictEqual(result.parsedHeaders?.foo, "SomeHeaderValue");
       assert.strictEqual(result.parsedBody.message, "Some kind of message");
       assert.notExists(result.parsedHeaders?.["x-ms-bar"]);
+      assert.strictEqual(result.parsedBody.extraProp, "An extra property value");
     });
   });
 });

--- a/sdk/core/core-client/test/deserializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/deserializationPolicy.spec.ts
@@ -688,6 +688,66 @@ describe("deserializationPolicy", function () {
         );
       }
     });
+
+    it(`json response with headers`, async function () {
+      const BodyMapper: CompositeMapper = {
+        serializedName: "getproperties-body",
+        type: {
+          name: "Composite",
+          className: "PropertiesBody",
+          modelProperties: {
+            message: {
+              serializedName: "message",
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const HeadersMapper: CompositeMapper = {
+        serializedName: "getproperties-headers",
+        type: {
+          name: "Composite",
+          className: "PropertiesHeaders",
+          modelProperties: {
+            foo: {
+              serializedName: "x-ms-foo",
+              type: {
+                name: "String",
+              },
+            },
+          },
+        },
+      };
+
+      const serializer = createSerializer({ HeadersMapper, BodyMapper }, false);
+
+      const operationSpec: OperationSpec = {
+        httpMethod: "GET",
+        responses: {
+          200: {
+            headersMapper: HeadersMapper,
+            bodyMapper: BodyMapper,
+          },
+        },
+        serializer,
+      };
+
+
+        const result = await getDeserializedResponse({
+          operationSpec,
+          headers: { "x-ms-foo": "SomeHeaderValue", "x-ms-bar": "SomeOtherHeaderValue" },
+          bodyAsText: '{"message": "Some kind of message"}',
+          status: 200,
+        });
+        assert.exists(result);
+        assert.strictEqual(result.parsedHeaders?.foo, "SomeHeaderValue");
+        assert.strictEqual(result.parsedBody.message, "Some kind of message");
+        assert.notExists(result.parsedHeaders?.['x-ms-bar']);
+      
+    });
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-client`


### Describe the problem that is addressed by this PR

While porting `@azure/digital-twins-core` I ran into an odd behavior in core-client. Namely, whenever an `OperationSpec` included a `headersMapper`, we would include *all* headers returned from the service, even if they were not mapped.

This led to some odd behavior in part due to the fact we collapse the `body` property when the body is a `DictionaryMapper` which changed from `@azure/core-http`. This lead to many extra properties being added to result shapes beyond the desired `etag`, such as

```
'content-length': '347',
'content-type': 'application/json; charset=utf-8',
'strict-transport-security': 'max-age=2592000',
traceresponse: '00-25c03f641ea6ddb793b38a8567a93d68-89d6b78c8e8dae10-01',
'mise-correlation-id': 'd96f6b01-eae3-4048-a411-d14c2927d99f',
date: 'Fri, 06 Jan 2023 21:43:10 GMT'
```


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Some alternatives I considered:

1. Work around this behavior in Digital Twins by ignoring the flattened result and using onResponse to get the original `FullOperationResponse`. The downside is this is manual work for each operation method.
2. Create a new field in the mappers to hint to core-client to not flatten and leave `body` as its own property and utilize this in Digital Twins. The downside here is needing to figure out how to plumb this through the codegen so it won't get erased when we regenerate.

Besides trying to avoid one-off work in the SDK itself (that might need to be done by other SDKS in the future), my main thought here is unlike extra properties in the service payload, header values tend to be less valuable. Any service could theoretically add additional headers at any time without intending to modify the model contract of the API, so us surfacing all headers feels like it creates a risk of breaking the real shapes we're handing back even if they're not strongly typed.

Furthermore, proxies and other middlemen can add their own headers which we certainly don't want to include in the final result object.

### Are there test cases added in this PR? _(If not, why?)_

Yes!
