### PR TITLE
[core-lro] Prepare release for v2.5

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 2.5.0 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 2.5.0 (2022-01-09)
 
 ### Other Changes
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.5.0 (2022-01-09)
+## 2.5.0 (2023-01-09)
 
 ### Other Changes
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.5.0 (2023-01-09)
+## 2.5.0 (2023-01-10)
 
 ### Other Changes
 


### PR DESCRIPTION
This release contains the work in https://github.com/Azure/azure-sdk-for-js/pull/24159 and is needed for the code generator tests to pass.