### PR TITLE
[Cognitive Language] Update test-resources.json

### DIFF
--- a/sdk/cognitivelanguage/test-resources.json
+++ b/sdk/cognitivelanguage/test-resources.json
@@ -50,7 +50,11 @@
     "cognitiveServicesEndpointSuffix": {
       "type": "string",
       "defaultValue": ".cognitiveservices.azure.com"
-    }
+    },
+    "storageRoleUniqueId": {
+      "defaultValue": "[newGuid()]",
+      "type": "String"
+    },
   },
   "variables": {
     "taRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
@@ -82,10 +86,27 @@
   },
   "resources": [
     {
+      "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[concat(variables('storageAccountName'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id, '/', variables('blobDataOwnerRoleId'), '/', parameters('storageRoleUniqueId'))))]",
+      "dependsOn": [
+        "[variables('storageAccountName')]",
+        "[resourceId('Microsoft.CognitiveServices/accounts', variables('cognitiveAccountName'))]"
+      ],
+      "location": "[parameters('location')]",
+      "properties": {
+        "roleDefinitionId": "[variables('blobDataOwnerRoleId')]",
+        "principalId": "[reference(concat('Microsoft.CognitiveServices/accounts/', variables('cognitiveAccountName')), variables('cognitiveApiVersion'), 'Full').identity.principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "[variables('authorizationApiVersion')]",
       "name": "[guid(concat('blobDataContributorRoleId', variables('storageAccountName')))]",
-      "dependsOn": ["[variables('storageAccountName')]"],
+      "dependsOn": [
+        "[variables('storageAccountName')]"
+      ],
       "properties": {
         "roleDefinitionId": "[variables('blobDataContributorRoleId')]",
         "principalId": "[parameters('testApplicationOid')]"
@@ -95,7 +116,9 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "[variables('authorizationApiVersion')]",
       "name": "[guid(concat('blobDataOwnerRoleId', variables('storageAccountName')))]",
-      "dependsOn": ["[variables('storageAccountName')]"],
+      "dependsOn": [
+        "[variables('storageAccountName')]"
+      ],
       "properties": {
         "roleDefinitionId": "[variables('blobDataOwnerRoleId')]",
         "principalId": "[parameters('testApplicationOid')]"
@@ -134,13 +157,17 @@
           "name": "default",
           "type": "blobServices",
           "apiVersion": "[variables('storageApiVersion')]",
-          "dependsOn": ["[variables('storageAccountName')]"],
+          "dependsOn": [
+            "[variables('storageAccountName')]"
+          ],
           "properties": {
             "isVersioningEnabled": "[parameters('enableVersioning')]",
             "cors": {
               "corsRules": [
                 {
-                  "allowedOrigins": ["*"],
+                  "allowedOrigins": [
+                    "*"
+                  ],
                   "allowedMethods": [
                     "DELETE",
                     "GET",
@@ -152,8 +179,12 @@
                     "PATCH"
                   ],
                   "maxAgeInSeconds": 86400,
-                  "exposedHeaders": ["*"],
-                  "allowedHeaders": ["*"]
+                  "exposedHeaders": [
+                    "*"
+                  ],
+                  "allowedHeaders": [
+                    "*"
+                  ]
                 }
               ]
             },
@@ -161,7 +192,9 @@
               "enable": true,
               "name": "AccessTimeTracking",
               "trackingGranularityInDays": 1,
-              "blobType": ["blockBlob"]
+              "blobType": [
+                "blockBlob"
+              ]
             }
           },
           "resources": []
@@ -170,16 +203,32 @@
           "name": "default",
           "type": "fileServices",
           "apiVersion": "[variables('storageApiVersion')]",
-          "dependsOn": ["[variables('storageAccountName')]"],
+          "dependsOn": [
+            "[variables('storageAccountName')]"
+          ],
           "properties": {
             "cors": {
               "corsRules": [
                 {
-                  "allowedOrigins": ["*"],
-                  "allowedMethods": ["DELETE", "GET", "HEAD", "MERGE", "POST", "OPTIONS", "PUT"],
+                  "allowedOrigins": [
+                    "*"
+                  ],
+                  "allowedMethods": [
+                    "DELETE",
+                    "GET",
+                    "HEAD",
+                    "MERGE",
+                    "POST",
+                    "OPTIONS",
+                    "PUT"
+                  ],
                   "maxAgeInSeconds": 86400,
-                  "exposedHeaders": ["*"],
-                  "allowedHeaders": ["*"]
+                  "exposedHeaders": [
+                    "*"
+                  ],
+                  "allowedHeaders": [
+                    "*"
+                  ]
                 }
               ]
             }
@@ -210,9 +259,11 @@
       ],
       "properties": {
         "customSubDomainName": "[variables('cognitiveAccountName')]",
-        "userOwnedStorage": [{
-          "resourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
-        }]
+        "userOwnedStorage": [
+          {
+            "resourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+          }
+        ]
       },
       "identity": {
         "type": "SystemAssigned"

--- a/sdk/cognitivelanguage/test-resources.json
+++ b/sdk/cognitivelanguage/test-resources.json
@@ -299,21 +299,9 @@
       "type": "string",
       "value": "[concat('https://', variables('cognitiveAccountName'), parameters('cognitiveServicesEndpointSuffix'), '/')]"
     },
-    "STORAGE_ACCOUNT_NAME": {
-      "type": "string",
-      "value": "[variables('storageAccountName')]"
-    },
     "STORAGE_ENDPOINT": {
       "type": "string",
       "value": "[concat('https://', variables('storageAccountName'), parameters('storageServicesEndpointSuffix'), '/')]"
-    },
-    "STORAGE_KEY": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[0].value]"
-    },
-    "STORAGE_KEY_ALT": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[1].value]"
     }
   }
 }

--- a/sdk/cognitivelanguage/test-resources.json
+++ b/sdk/cognitivelanguage/test-resources.json
@@ -55,6 +55,10 @@
       "defaultValue": "[newGuid()]",
       "type": "String"
     },
+    "storageServicesEndpointSuffix": {
+      "type": "string",
+      "defaultValue": ".blob.core.windows.net"
+    }
   },
   "variables": {
     "taRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
@@ -298,6 +302,18 @@
     "STORAGE_ACCOUNT_NAME": {
       "type": "string",
       "value": "[variables('storageAccountName')]"
+    },
+    "STORAGE_ENDPOINT": {
+      "type": "string",
+      "value": "[concat('https://', variables('storageAccountName'), parameters('storageServicesEndpointSuffix'), '/')]"
+    },
+    "STORAGE_KEY": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[0].value]"
+    },
+    "STORAGE_KEY_ALT": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), variables('storageApiVersion')).keys[1].value]"
     }
   }
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/ai-language-text

### Issues associated with this PR

### Describe the problem that is addressed by this PR
The Language resource doesn't have access to the storage account. This PR adds a new role assignment for the Language resource in the storage account. The ARM template bit is based on [Synapse's](https://github.com/Azure/azure-sdk-for-js/blob/741a885d2c4193fd3221a7a0081203852e9ed984/sdk/synapse/test-resources.json#L271).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
