### PR TITLE
Correct the version of maps-common in maps-search-rest

### DIFF
--- a/sdk/maps/maps-search-rest/package.json
+++ b/sdk/maps/maps-search-rest/package.json
@@ -66,7 +66,7 @@
     "@azure/core-rest-pipeline": "^1.8.0",
     "tslib": "^2.2.0",
     "@azure/core-lro": "^2.2.0",
-    "@azure/maps-common": "~1.0.0-beta.3"
+    "@azure/maps-common": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-rest/maps-search

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- The version for `@azure/maps-common` is incorrect. The beta.3 is the next release version, which has yet to exist.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
