### PR TITLE
Disable smoke tests in release pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -231,13 +231,6 @@ stages:
                           PRLabels: "auto-merge"
                           CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
 
-          - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-            - template: /eng/pipelines/templates/jobs/smoke.tests.yml
-              parameters:
-                Daily: false
-                ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                ArtifactName: ${{ parameters.ArtifactName }}
-                Artifact: ${{ artifact }}
 
   - stage: Integration
     dependsOn: ${{parameters.DependsOn}}


### PR DESCRIPTION
Per offline discussion, removing this leg until we can replace it with something more robust.