### PR TITLE
[digital-twins] bump minimum version of core-rest-pipeline

### DIFF
--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.7.1",
-    "@azure/core-rest-pipeline": "^1.8.0",
+    "@azure/core-rest-pipeline": "^1.8.1",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.0.0",


### PR DESCRIPTION
Address issue discovered by min-max testing.

### Packages impacted by this PR

`@azure/digital-twins-core`

### Issues associated with this PR

Fixes #24467

### Describe the problem that is addressed by this PR

Minimum specified version of core-rest-pipeline didn't expose the `isRestError` typeguard used by this package.

