### PR TITLE
[ServiceBuss] Ensure unique `replyTo` when new link is needed

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Ensure unique `replyTo` when new link is needed in ManagementClient. (PR #24509)[https://github.com/Azure/azure-sdk-for-js/pull/24509]
+
 ### Other Changes
 
 ## 7.7.3 (2022-11-08)

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -232,6 +232,12 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     this._context = context;
   }
 
+  private ensureUniqueReplyToForRequest() {
+    if (!this.isOpen()) {
+      this.replyTo = generate_uuid();
+    }
+  }
+
   private async _init(abortSignal?: AbortSignalLike): Promise<void> {
     throwErrorIfConnectionClosed(this._context);
     try {
@@ -514,6 +520,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         const omitMessageBodyKey = "omit-message-body"; // TODO: Service Bus specific. Put it somewhere
         messageBody[omitMessageBodyKey] = types.wrap_boolean(omitMessageBody);
       }
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -589,6 +596,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         0x98,
         undefined
       );
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -680,6 +688,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         throw error;
       }
     }
+    this.ensureUniqueReplyToForRequest();
     try {
       const request: RheaMessage = {
         body: { messages: messageBody },
@@ -748,6 +757,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         0x81,
         undefined
       );
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -826,6 +836,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       if (sessionId != null) {
         messageBody[Constants.sessionIdMapKey] = sessionId;
       }
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -911,6 +922,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       if (options.sessionId != null) {
         messageBody[Constants.sessionIdMapKey] = options.sessionId;
       }
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -953,6 +965,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1005,6 +1018,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
       messageBody["session-state"] = toBuffer(state);
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1046,6 +1060,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1108,6 +1123,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       messageBody["last-updated-time"] = lastUpdatedTime;
       messageBody["skip"] = types.wrap_int(skip);
       messageBody["top"] = types.wrap_int(top);
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1143,6 +1159,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   ): Promise<RuleProperties[]> {
     throwErrorIfConnectionClosed(this._context);
     try {
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: {
           top: options?.maxCount
@@ -1276,6 +1293,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     throwTypeErrorIfParameterIsEmptyString(this._context.connectionId, "ruleName", ruleName);
 
     try {
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: {
           "rule-name": types.wrap_string(ruleName),
@@ -1353,6 +1371,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           expression: String(sqlRuleActionExpression),
         };
       }
+      this.ensureUniqueReplyToForRequest();
       const request: RheaMessage = {
         body: {
           "rule-name": types.wrap_string(ruleName),


### PR DESCRIPTION
Some errors (e.g., `MessageSizeExceeded`) would close the underlying rhea link. Currently we have a `replyTo` property that is initialized when constructing the management client and remains unchanged. However, this leads to the following error when attempting to re-establish a new link:

```
InvalidOperationError: A link with the same 'attach.target.address' value '504c8ecd-6f73-1b4e-9108-d1e12fc3ac9f' address has been already registered to the entity management node $management.
```

This PR ensure that whenever we send a request, if we are going to establish a new link, the `replyTo` property has a unique value.

Fixes #24476


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

There's a live test failure due to the issue.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
