### PR TITLE
[NotificationHubs] fix unit tests

### DIFF
--- a/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
@@ -16,7 +16,6 @@ import { parseXML } from "@azure/core-xml";
 export async function parseNotificationDetails(bodyText: string): Promise<NotificationDetails> {
   const xml = await parseXML(bodyText, {
     includeRoot: true,
-    stopNodes: ["NotificationDetails.NotificationBody"],
   });
   const notificationDetails = xml["NotificationDetails"];
 


### PR DESCRIPTION
The xml parsing test started failing after core-xml changes in PR #24356. This PR applies test fix similar to what's been done to core-xml tests in PR #24356.
