### PR TITLE
[Perf] EventHubs SendTest should extend BatchPerfTest

### DIFF
--- a/sdk/eventhub/perf-tests/event-hubs/test/send.spec.ts
+++ b/sdk/eventhub/perf-tests/event-hubs/test/send.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getEnvVar, PerfOptionDictionary, PerfTest } from "@azure/test-utils-perf";
+import { getEnvVar, PerfOptionDictionary, BatchPerfTest } from "@azure/test-utils-perf";
 import { EventHubProducerClient, EventData } from "@azure/event-hubs";
 
 // Expects the .env file at the same level as the "test" folder
@@ -17,7 +17,7 @@ const connectionString = getEnvVar("EVENTHUB_CONNECTION_STRING");
 const eventHubName = getEnvVar("EVENTHUB_NAME");
 
 const producer = new EventHubProducerClient(connectionString, eventHubName);
-export class SendTest extends PerfTest<SendTestOptions> {
+export class SendTest extends BatchPerfTest<SendTestOptions> {
   producer: EventHubProducerClient;
   eventBatch: EventData[];
   public options: PerfOptionDictionary<SendTestOptions> = {
@@ -50,7 +50,8 @@ export class SendTest extends PerfTest<SendTestOptions> {
     await this.producer.close();
   }
 
-  async run(): Promise<void> {
+  async runBatch(): Promise<number> {
     await this.producer.sendBatch(this.eventBatch);
+    return this.eventBatch.length;
   }
 }


### PR DESCRIPTION
Validation build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2125764&view=logs&j=42ded549-05ee-5cdb-7ba7-7a948a0cc056&t=948263dc-2a7b-5031-89c1-ea1ca73fbaf3&l=12