### PR TITLE
[dev-tool] Inline snippet extraction.

### DIFF
--- a/common/tools/dev-tool/src/commands/run/index.ts
+++ b/common/tools/dev-tool/src/commands/run/index.ts
@@ -10,6 +10,7 @@ export default subCommand(commandInfo, {
   "test:node-js-input": () => import("./testNodeJSInput"),
   "test:browser": () => import("./testBrowser"),
   "check-api": () => import("./check-api"),
+  "update-snippets": () => import("./update-snippets"),
   bundle: () => import("./bundle"),
 
   // "vendored" is a special command that passes through execution to dev-tool's own commands

--- a/common/tools/dev-tool/src/commands/run/update-snippets.ts
+++ b/common/tools/dev-tool/src/commands/run/update-snippets.ts
@@ -21,6 +21,10 @@ const log = createPrinter("update-snippets");
 
 const SNIPPET_PATH = ["test", "snippets.spec.ts"];
 
+/**
+ * Describes a location where a snippet is actually presented to a reader, i.e. a Markdown file or JSDoc comment
+ * location.
+ */
 interface SnippetLocationInfo {
   /** The snippet name determined by the tag on its enclosing fence. */
   name: string;
@@ -28,17 +32,24 @@ interface SnippetLocationInfo {
   fence: string;
   /** The target language of the snippet. */
   language: "js" | "ts";
-  /** The aboslute path to the file the snippet is located in. */
+  /** The absolute path to the file the snippet is located in. */
   absoluteFilePath: string;
   /** The contents of the snippet with the line prefix stripped */
-  lineNormalizedContents: string[];
+  lineTrimmedContents: string[];
   /** The range of lines in the file where the snippet appears. */
   lineRange: [number, number];
   /** The prefix that appeared before the code fence, which will be inserted before each line in the snippet. */
   linePrefix: string;
 }
 
+/**
+ * Finds all candidate files that _might_ contain snippet locations.
+ *
+ * @param dir - the base directory of the package
+ */
 async function* getAllSnippetFiles(dir: string): AsyncIterable<string> {
+  // Only consider markdown files up to a depth of 1 (i.e. _in_ the project folder). This is to prevent grabbing things
+  // like samples/*/README.md and other similar files that are not really part of the "source" of the package.
   yield* findMatchingFiles(dir, (name) => name.endsWith(".md"), { maxDepth: 1 });
 
   yield* findMatchingFiles(path.join(dir, "src"), (name) => name.endsWith(".ts"));
@@ -48,11 +59,18 @@ async function* getAllSnippetFiles(dir: string): AsyncIterable<string> {
   yield* findMatchingFiles(path.join(dir, "samples-dev"), (name) => name.endsWith(".ts"));
 }
 
-async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]> {
+/**
+ * Finds all the snippet locations in a project.
+ *
+ * @param info
+ * @returns
+ */
+async function findAllSnippetLocations(info: ProjectInfo): Promise<SnippetLocationInfo[]> {
   const snippets: SnippetLocationInfo[] = [];
   let hadError = false;
 
   for await (const f of getAllSnippetFiles(info.path)) {
+    // We want to use some kind of semantically appropriate comment to allow ignoring a file.
     const ignoreString = f.endsWith(".md")
       ? "<!-- dev-tool snippets ignore -->"
       : "// dev-tool snippets ignore";
@@ -67,8 +85,10 @@ async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]
     let openFence: [RegExpMatchArray, number, string[]] | undefined = undefined;
 
     for (const [line, idx] of contents.split(/\r?\n/).map((line, idx) => [line, idx] as const)) {
-      // We'll scan the file for matching
+      // We'll scan the file for matching code fences manually.
       if (openFence === undefined) {
+        // We allow fences to be nested up to an arbitrary depth, but practically speaking we will never have fences
+        // longer than three backticks.
         const match = /^([^`]*)(````*)([a-zA-Z]*)(\s*.*)$/.exec(line);
 
         if (!match) continue;
@@ -77,17 +97,18 @@ async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]
       } else {
         const [[, , fence], , contents] = openFence;
 
+        // This line either starts with the fence or contains the unescaped fence somewhere in it.
         if (line.startsWith(fence) || new RegExp(`[^\\\\]${fence}`).test(line)) {
           // Fence ends on this line.
 
-          const [[, prefix, fence, language, metadata], startIdx, contents] = openFence;
+          const [[, linePrefix, fence, language, snippetName], startIdx, contents] = openFence;
           openFence = undefined;
 
-          // We don't care about bash, text, etc. snippets
+          // We don't care about bash, text, etc. snippets. Only JS/TS in any incarnation.
           if (!["js", "ts", "javascript", "typescript"].includes(language)) continue;
 
-          if (!metadata?.trim()?.startsWith("snippet:")) {
-            // No metadata
+          // TODO: have a mode where we can extract these nameless snippets and create definitions for them.
+          if (!snippetName?.trim()?.startsWith("snippet:")) {
             log.error(
               `${language} snippet at ${f}:${startIdx} does not have a snippet name, or has a malformed snippet name.`
             );
@@ -96,12 +117,13 @@ async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]
           }
 
           snippets.push({
-            name: metadata.trim().replace("snippet:", ""),
+            name: snippetName.trim().replace("snippet:", ""),
             fence,
+            // It's going to be way easier down the road if the language name is normalized.
             language: language === "javascript" || language === "js" ? "js" : "ts",
-            linePrefix: prefix,
+            linePrefix,
             absoluteFilePath: f,
-            lineNormalizedContents: contents.map((s) => s.replace(prefix, "")),
+            lineTrimmedContents: contents.map((s) => s.replace(linePrefix, "")),
             lineRange: [startIdx, idx],
           });
         } else {
@@ -116,13 +138,33 @@ async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]
   return snippets;
 }
 
+/**
+ * A definition for a snippet extracted from the snippets file.
+ */
 interface SnippetDefinition {
+  /**
+   * The name of this snippet.
+   */
   name: string;
+  /**
+   * The source text of this snippet in TypeScript.
+   */
   typescriptSourceText: string[];
+  /**
+   * A bound function that will produce an equivalent JavaScript text using our sample convention.
+   */
   convert(): string[];
 }
 
-async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetDefinition>> {
+/**
+ * Parses the snippets file for a project and extracts the text of snippet tests.
+ *
+ * @param project - the project to extract snippets for
+ * @returns a map from snippet name to definition.
+ */
+async function parseSnippetDefinitions(
+  project: ProjectInfo
+): Promise<Map<string, SnippetDefinition>> {
   const results = new Map<string, SnippetDefinition>();
 
   const snippetFile = path.join(project.path, ...SNIPPET_PATH);
@@ -140,10 +182,24 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
   const sourceFile = program.getSourceFile(snippetFile)!;
   const checker = program.getTypeChecker();
 
-  const visitor: ts.Visitor = (node: ts.Node) => {
+  const printer = ts.createPrinter({
+    newLine: EOL === "\r\n" ? ts.NewLineKind.CarriageReturnLineFeed : ts.NewLineKind.LineFeed,
+    removeComments: false,
+    noEmitHelpers: true,
+  });
+
+  const visitSnippetDefinition: ts.Visitor = (node: ts.Node) => {
     let expr: ts.Expression;
 
-    // it($<body:litstr>, functionlike() => $<body:block>)
+    // We accept any test definition that calls the exact symbol 'it' with a
+    // string literal and a function expression where the body of the function
+    // is a block. We don't care whether the function is named or async or what
+    // its type annotations are. Those may be used freely to ensure correctness.
+    //
+    // Snippet ::= 'it' ( $name:litstr , BlockFn )
+    // BlockFn ::=
+    //   | 'async'? ( $_:params ) => { $body:statements }
+    //   | 'async'? function $_:ident? ( ) { $body:statements }
     if (
       ts.isCallExpression(node) &&
       ts.isIdentifier((expr = node.expression)) &&
@@ -155,12 +211,7 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
       const name = node.arguments[0] as ts.StringLiteral;
       const body = (node.arguments[1] as ts.ArrowFunction | ts.FunctionExpression).body as ts.Block;
 
-      const printer = ts.createPrinter({
-        newLine: EOL === "\r\n" ? ts.NewLineKind.CarriageReturnLineFeed : ts.NewLineKind.LineFeed,
-        removeComments: false,
-        noEmitHelpers: true,
-      });
-
+      // Print the statements out as they are. We're going to recompile them later.
       const contents = printer.printList(
         ts.ListFormat.MultiLineBlockStatements,
         body.statements,
@@ -169,13 +220,16 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
 
       const imports: [string, string][] = [];
 
-      const symbolVisitor: ts.Visitor = (node: ts.Node) => {
+      // This nested visitor is just for extracting the imports of a symbol.
+      const symbolImportVisitor: ts.Visitor = (node: ts.Node) => {
         let importLocations: string[] | undefined;
         if (
           ts.isIdentifier(node) &&
           (importLocations = extractImportLocations(node)) !== undefined
         ) {
           if (importLocations.length > 1) {
+            // We can probably handle this, but it's an obscure case and it's probably better to let it error out and
+            // then observe whether or not we actually need (or even _want_) snippets with merged imports.
             throw new Error(
               `unrecoverable error: the type definition of '${node.text}' in the snippet file is merged between multiple imports, so we cannot extract it`
             );
@@ -184,18 +238,23 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
             log.debug(`symbol ${node.text} was imported from ${importLocations[0]}`);
             imports.push([node.text, importLocations[0]]);
           }
+          // else the symbol was not imported within this file, so it must be defined in the ambient context of the
+          // module, so we don't need to generate any code for it.
         }
 
-        ts.forEachChild(node, symbolVisitor);
+        ts.forEachChild(node, symbolImportVisitor);
 
         return undefined;
       };
 
-      ts.visitNodes(body.statements, symbolVisitor);
+      ts.visitNodes(body.statements, symbolImportVisitor);
 
-      // We've found a snippet. No need to recur any farther. We'll take the body of this snippet and transpile it as a file using `convert`.
+      // We've found a snippet. No need to recur any farther. We'll take the body of this snippet and transpile it as a
+      // file using `convert`.
       log.debug(`found a snippet named ${name.text}: \n${contents}`);
 
+      // We have a loose map of imports in the form { [k:symbol]: module } and we need to anneal it into a map
+      // { [k: module]: symbol[] } (one import statement per module with the whole list of symbols imported from it)
       const importMap = new Map<string, Set<string>>(
         imports.map(([, module]) => [module, new Set()])
       );
@@ -204,6 +263,7 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
         importMap.get(name)!.add(symbol);
       }
 
+      // Form import declarations and prepend them to the rest of the contents.
       const fullSnippetTypeScriptText = (
         [...importMap.entries()]
           .map(
@@ -222,6 +282,8 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
         )
         .trim();
 
+      // Run the same syntax validation pass that we run on samples when we convert to JS. This will prevent you from
+      // using any syntax that isn't supported by our min node in snippets!
       const checkSyntax: ts.TransformerFactory<ts.SourceFile> = (context) => (sourceFile) => {
         const emitError = createDiagnosticEmitter(sourceFile);
 
@@ -239,9 +301,16 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
       };
 
       // TODO: how can we run this on the TS source without emitting to JS?
+      // We'll also simplify the snippets a bit by getting rid of any expressions of the form
+      //
+      // EnvLookup ::= 'process' . 'env' . $_:ident ElseOp $e:expr
+      // ElseOp ::= '??' | '||'
+      //
+      // We'll just replace them with the expr $e, simplifying the snippets a bit.
       const replaceEnvLookup: ts.TransformerFactory<ts.SourceFile> = (context) => (sourceFile) => {
         const visitor: ts.Visitor = (node) => {
           if (
+            // Nullish coalesce is simply defined as a BinaryExpression where the operatorToken is a '??'.
             ts.isNullishCoalesce(node) ||
             (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.BarBarToken)
           ) {
@@ -249,7 +318,9 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
 
             if (
               ts.isPropertyAccessExpression(left) &&
-              left.expression.getText(sourceFile) === "process.env"
+              // Won't bother checking the AST any further than this. It's sufficient I think to just see if the text of
+              // the expression is something of the form `'process' '.' 'env'`
+              /^\s*process\s*\.\s*env\s*/.test(left.expression.getText(sourceFile))
             ) {
               return (node as ts.BinaryExpression).right;
             }
@@ -267,8 +338,8 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
             transformers: {
               before: [replaceEnvLookup, checkSyntax],
               after: [
-                // We're using ESM in snippets for now.
-                /*createToCommonJsTransform(bindRequireFunction(project))*/
+                // We're trying to move snippets to ESM syntax. The following line can be uncommented to generate CJS.
+                // createToCommonJsTransform(bindRequireFunction(project))
               ],
             },
           })
@@ -278,15 +349,25 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
       });
     }
 
-    ts.forEachChild(node, visitor);
+    ts.forEachChild(node, visitSnippetDefinition);
 
     return undefined;
   };
 
-  visitor(sourceFile);
+  visitSnippetDefinition(sourceFile);
 
   return results;
 
+  /**
+   * A helper function to extract imported symbols from TypeScript nodes.
+   *
+   * If the node has a symbol (for example, an identifier), then the symbol is resolved. Symbol declarations may be
+   * merged, so we extract all declarations that come from import clauses _in the same file_ and extract the module
+   * specifier from their parent. The symbol is considered "defined" by a combined import from those locations.
+   *
+   * @param node - the node to check for imports
+   * @returns a list of module specifiers that form the definition of the node's symbol, or undefined
+   */
   function extractImportLocations(node: ts.Node): string[] | undefined {
     const sym = checker.getSymbolAtLocation(node);
 
@@ -296,7 +377,8 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
         (decl) => decl.getSourceFile() === sourceFile && ts.isImportClause(decl.parent.parent)
       )
       .map(
-        // It is a grammar error for moduleSpecifier to be anything other than a string literal.
+        // It is a grammar error for moduleSpecifier to be anything other than a string literal. In future versions of
+        // ES, that might become untrue, but it seems unlikely.
         (decl) => {
           const moduleSpecifierText = (
             (decl.parent.parent as ts.ImportClause).parent.moduleSpecifier as ts.StringLiteral
@@ -316,27 +398,52 @@ async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetD
   }
 }
 
-interface FileInfo {
+/**
+ * Information about a file that contains snippet locations and that we're modifying.
+ */
+interface SnippetLocationFileContext {
   name: string;
   contents: string[];
   lineOffset: number;
 }
 
-async function writeAll(infos: Iterable<FileInfo>): Promise<void> {
-  for (const info of infos) {
+/**
+ * Writes the contents of an iterable of files to disk.
+ *
+ * @param files - the files to write
+ */
+async function writeAll(files: IterableIterator<SnippetLocationFileContext>): Promise<void> {
+  for (const info of files) {
     await fs.writeFile(info.name, Buffer.from(info.contents.join(EOL), "utf-8"));
   }
 }
 
+/**
+ * Replace existing snippet locations with new snippet definitions. This function fails if each snippet location does
+ * not have a snippet definition with a matching name.
+ *
+ * INVARIANT: locations must be grouped by file and sorted by line index.
+ *
+ * @param locations - the locations to replace
+ * @param snippets - the snippets to replace the existing locations with
+ * @returns true if successful, otherwise false
+ */
 async function replaceSnippetsWithNew(
   locations: SnippetLocationInfo[],
   snippets: Map<string, SnippetDefinition>
 ): Promise<boolean> {
-  const files = new Set(locations.map((l) => l.absoluteFilePath));
-  const fileInfos = new Map<string, FileInfo>();
+  // This algorithm iteratively goes through the locations and replaces the existing contents of the locations with the
+  // contents of a matching definition. If no matching definition is found, we produce an error. The only tricky part
+  // about this algorithm is keeping track of the net lines added/removed by replacing the snippets, as we are modifying
+  // the file line contents in place and need to know if, for example, we replaced a snippet with a shorter text,
+  // as that affects the line indices of all subsequent replacements.
 
+  const files = new Set(locations.map((l) => l.absoluteFilePath));
+  const fileContext = new Map<string, SnippetLocationFileContext>();
+
+  // Initialize output file contexts.
   for (const f of files) {
-    fileInfos.set(f, {
+    fileContext.set(f, {
       name: f,
       contents: (await fs.readFile(f)).toString("utf-8").split(/\r?\n/),
       lineOffset: 0,
@@ -345,8 +452,9 @@ async function replaceSnippetsWithNew(
 
   let hadError = false;
 
+  // Since the locations are sorted, we can just go through them and replace the text.
   for (const location of locations) {
-    let { contents, lineOffset } = fileInfos.get(location.absoluteFilePath)!;
+    let { contents, lineOffset } = fileContext.get(location.absoluteFilePath)!;
 
     const snippetDefinition = snippets.get(location.name);
 
@@ -366,36 +474,47 @@ async function replaceSnippetsWithNew(
       snippet = snippetDefinition.typescriptSourceText;
     }
 
+    // The original length of the line.
     const originalLineLength = location.lineRange[1] - location.lineRange[0] - 1;
+
+    // The part of the file that appears before the current snippet location, plus one to include the code fence itself.
     let newContents = contents.slice(0, lineOffset + location.lineRange[0] + 1);
+    // The contents of the new snippet definition
     newContents.push(...snippet.map((line) => (location.linePrefix + line).trimEnd()));
+    // The part of the file that apears after the current snippet location.
     newContents.push(...contents.slice(lineOffset + location.lineRange[1]));
-    fileInfos.set(location.absoluteFilePath, {
+
+    // Update the existing context
+    fileContext.set(location.absoluteFilePath, {
       name: location.absoluteFilePath,
       contents: newContents,
+      // Update the line offset by adding the difference between the new snippet length and the original length. The
+      // line offset may be any integer.
       lineOffset: lineOffset + (snippet.length - originalLineLength),
     });
   }
 
   if (!hadError) {
-    await writeAll(fileInfos.values());
+    await writeAll(fileContext.values());
   }
 
   return !hadError;
 }
 
 export default leafCommand(commandInfo, async (_) => {
+  // Conceptually, what we want to do is simple. find the snippet locations for a project, parse the definitions of the
+  // project's snippets, and then fill the locations in with the snippets.
   const project = await resolveProject(process.cwd());
 
   let snippetLocations: SnippetLocationInfo[];
 
   try {
-    snippetLocations = await findAllSnippets(project);
+    snippetLocations = await findAllSnippetLocations(project);
   } catch {
     return false;
   }
 
-  const snippetDefinitions = await parseSnippets(project);
+  const snippetDefinitions = await parseSnippetDefinitions(project);
 
   return replaceSnippetsWithNew(snippetLocations, snippetDefinitions);
 });

--- a/common/tools/dev-tool/src/commands/run/update-snippets.ts
+++ b/common/tools/dev-tool/src/commands/run/update-snippets.ts
@@ -1,0 +1,401 @@
+import fs from "fs/promises";
+import { EOL } from "os";
+import path from "path";
+import ts from "typescript";
+import { leafCommand, makeCommandInfo } from "../../framework/command";
+import { findMatchingFiles } from "../../util/findMatchingFiles";
+import { formatFile } from "../../util/prettier";
+import { createPrinter } from "../../util/printer";
+import { ProjectInfo, resolveProject } from "../../util/resolveProject";
+import { convert } from "../../util/samples/convert";
+import { testSyntax } from "../../util/samples/syntax";
+import { createDiagnosticEmitter } from "../../util/typescript/diagnostic";
+
+export const commandInfo = makeCommandInfo(
+  "update-snippets",
+  "find README and TSDoc snippets throughout the package and update their contents.",
+  {}
+);
+
+const log = createPrinter("update-snippets");
+
+const SNIPPET_PATH = ["test", "snippets.spec.ts"];
+
+interface SnippetLocationInfo {
+  /** The snippet name determined by the tag on its enclosing fence. */
+  name: string;
+  /** The fence string that started this snippet. */
+  fence: string;
+  /** The target language of the snippet. */
+  language: "js" | "ts";
+  /** The aboslute path to the file the snippet is located in. */
+  absoluteFilePath: string;
+  /** The contents of the snippet with the line prefix stripped */
+  lineNormalizedContents: string[];
+  /** The range of lines in the file where the snippet appears. */
+  lineRange: [number, number];
+  /** The prefix that appeared before the code fence, which will be inserted before each line in the snippet. */
+  linePrefix: string;
+}
+
+async function* getAllSnippetFiles(dir: string): AsyncIterable<string> {
+  yield* findMatchingFiles(dir, (name) => name.endsWith(".md"), { maxDepth: 1 });
+
+  yield* findMatchingFiles(path.join(dir, "src"), (name) => name.endsWith(".ts"));
+
+  yield* findMatchingFiles(path.join(dir, "test"), (name) => name.endsWith(".ts"));
+
+  yield* findMatchingFiles(path.join(dir, "samples-dev"), (name) => name.endsWith(".ts"));
+}
+
+async function findAllSnippets(info: ProjectInfo): Promise<SnippetLocationInfo[]> {
+  const snippets: SnippetLocationInfo[] = [];
+  let hadError = false;
+
+  for await (const f of getAllSnippetFiles(info.path)) {
+    const ignoreString = f.endsWith(".md")
+      ? "<!-- dev-tool snippets ignore -->"
+      : "// dev-tool snippets ignore";
+
+    const contents = (await fs.readFile(f)).toString("utf-8");
+
+    if (contents.includes(ignoreString)) {
+      log.info(`Ignoring file ${path.relative(info.path, f)} per file comment directive.`);
+      continue;
+    }
+
+    let openFence: [RegExpMatchArray, number, string[]] | undefined = undefined;
+
+    for (const [line, idx] of contents.split(/\r?\n/).map((line, idx) => [line, idx] as const)) {
+      // We'll scan the file for matching
+      if (openFence === undefined) {
+        const match = /^([^`]*)(````*)([a-zA-Z]*)(\s*.*)$/.exec(line);
+
+        if (!match) continue;
+
+        openFence = [match, idx, []];
+      } else {
+        const [[, , fence], , contents] = openFence;
+
+        if (line.startsWith(fence) || new RegExp(`[^\\\\]${fence}`).test(line)) {
+          // Fence ends on this line.
+
+          const [[, prefix, fence, language, metadata], startIdx, contents] = openFence;
+          openFence = undefined;
+
+          // We don't care about bash, text, etc. snippets
+          if (!["js", "ts", "javascript", "typescript"].includes(language)) continue;
+
+          if (!metadata?.trim()?.startsWith("snippet:")) {
+            // No metadata
+            log.error(
+              `${language} snippet at ${f}:${startIdx} does not have a snippet name, or has a malformed snippet name.`
+            );
+            hadError = true;
+            continue;
+          }
+
+          snippets.push({
+            name: metadata.trim().replace("snippet:", ""),
+            fence,
+            language: language === "javascript" || language === "js" ? "js" : "ts",
+            linePrefix: prefix,
+            absoluteFilePath: f,
+            lineNormalizedContents: contents.map((s) => s.replace(prefix, "")),
+            lineRange: [startIdx, idx],
+          });
+        } else {
+          contents.push(line);
+        }
+      }
+    }
+  }
+
+  if (hadError) throw new Error("some snippets had no associated metadata");
+
+  return snippets;
+}
+
+interface SnippetDefinition {
+  name: string;
+  typescriptSourceText: string[];
+  convert(): string[];
+}
+
+async function parseSnippets(project: ProjectInfo): Promise<Map<string, SnippetDefinition>> {
+  const results = new Map<string, SnippetDefinition>();
+
+  const snippetFile = path.join(project.path, ...SNIPPET_PATH);
+
+  const relativeIndexPath = path.relative(
+    path.dirname(snippetFile),
+    path.join(project.path, "src")
+  );
+
+  const program = ts.createProgram({
+    rootNames: [snippetFile],
+    options: {},
+  });
+
+  const sourceFile = program.getSourceFile(snippetFile)!;
+  const checker = program.getTypeChecker();
+
+  const visitor: ts.Visitor = (node: ts.Node) => {
+    let expr: ts.Expression;
+
+    // it($<body:litstr>, functionlike() => $<body:block>)
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier((expr = node.expression)) &&
+      (expr as ts.Identifier).escapedText === "it" &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      (ts.isFunctionExpression(node.arguments[1]) ||
+        (ts.isArrowFunction(node.arguments[1]) && ts.isBlock(node.arguments[1].body)))
+    ) {
+      const name = node.arguments[0] as ts.StringLiteral;
+      const body = (node.arguments[1] as ts.ArrowFunction | ts.FunctionExpression).body as ts.Block;
+
+      const printer = ts.createPrinter({
+        newLine: EOL === "\r\n" ? ts.NewLineKind.CarriageReturnLineFeed : ts.NewLineKind.LineFeed,
+        removeComments: false,
+        noEmitHelpers: true,
+      });
+
+      const contents = printer.printList(
+        ts.ListFormat.MultiLineBlockStatements,
+        body.statements,
+        sourceFile
+      );
+
+      const imports: [string, string][] = [];
+
+      const symbolVisitor: ts.Visitor = (node: ts.Node) => {
+        let importLocations: string[] | undefined;
+        if (
+          ts.isIdentifier(node) &&
+          (importLocations = extractImportLocations(node)) !== undefined
+        ) {
+          if (importLocations.length > 1) {
+            throw new Error(
+              `unrecoverable error: the type definition of '${node.text}' in the snippet file is merged between multiple imports, so we cannot extract it`
+            );
+          } else if (importLocations.length === 1) {
+            // The symbol was imported, so we need to track the imports to add them to the snippet later.
+            log.debug(`symbol ${node.text} was imported from ${importLocations[0]}`);
+            imports.push([node.text, importLocations[0]]);
+          }
+        }
+
+        ts.forEachChild(node, symbolVisitor);
+
+        return undefined;
+      };
+
+      ts.visitNodes(body.statements, symbolVisitor);
+
+      // We've found a snippet. No need to recur any farther. We'll take the body of this snippet and transpile it as a file using `convert`.
+      log.debug(`found a snippet named ${name.text}: \n${contents}`);
+
+      const importMap = new Map<string, Set<string>>(
+        imports.map(([, module]) => [module, new Set()])
+      );
+
+      for (const [symbol, name] of imports) {
+        importMap.get(name)!.add(symbol);
+      }
+
+      const fullSnippetTypeScriptText = (
+        [...importMap.entries()]
+          .map(
+            ([module, symbols]) =>
+              `import { ${[...symbols.values()].join(", ")} } from "${module}";`
+          )
+          .join(EOL) +
+        EOL +
+        EOL +
+        contents
+      )
+        .replace(
+          // Need to get rid of any ts-ignores that were added because of unused symbols
+          /\r?\n[ ]*\/\/\s*@ts-ignore\s*\r?\n/g,
+          EOL
+        )
+        .trim();
+
+      const checkSyntax: ts.TransformerFactory<ts.SourceFile> = (context) => (sourceFile) => {
+        const emitError = createDiagnosticEmitter(sourceFile);
+
+        const visitor: ts.Visitor = (node) => {
+          const syntaxError = testSyntax(node);
+
+          if (syntaxError) {
+            emitError(syntaxError.message, node, syntaxError.suggest);
+          }
+
+          return ts.visitEachChild(node, visitor, context);
+        };
+
+        return ts.visitNode(sourceFile, visitor);
+      };
+
+      // TODO: how can we run this on the TS source without emitting to JS?
+      const replaceEnvLookup: ts.TransformerFactory<ts.SourceFile> = (context) => (sourceFile) => {
+        const visitor: ts.Visitor = (node) => {
+          if (
+            ts.isNullishCoalesce(node) ||
+            (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+          ) {
+            const left = (node as ts.BinaryExpression).left;
+
+            if (
+              ts.isPropertyAccessExpression(left) &&
+              left.expression.getText(sourceFile) === "process.env"
+            ) {
+              return (node as ts.BinaryExpression).right;
+            }
+          }
+          return ts.visitEachChild(node, visitor, context);
+        };
+        return ts.visitNode(sourceFile, visitor);
+      };
+
+      results.set(name.text, {
+        name: name.text,
+        typescriptSourceText: formatFile(fullSnippetTypeScriptText).split(/\r?\n/),
+        convert() {
+          return convert(fullSnippetTypeScriptText, {
+            transformers: {
+              before: [replaceEnvLookup, checkSyntax],
+              after: [
+                // We're using ESM in snippets for now.
+                /*createToCommonJsTransform(bindRequireFunction(project))*/
+              ],
+            },
+          })
+            .trim()
+            .split(/\r?\n/);
+        },
+      });
+    }
+
+    ts.forEachChild(node, visitor);
+
+    return undefined;
+  };
+
+  visitor(sourceFile);
+
+  return results;
+
+  function extractImportLocations(node: ts.Node): string[] | undefined {
+    const sym = checker.getSymbolAtLocation(node);
+
+    // Get all the decls that are in source files and where the decl comes from an import clause.
+    return sym?.declarations
+      ?.filter(
+        (decl) => decl.getSourceFile() === sourceFile && ts.isImportClause(decl.parent.parent)
+      )
+      .map(
+        // It is a grammar error for moduleSpecifier to be anything other than a string literal.
+        (decl) => {
+          const moduleSpecifierText = (
+            (decl.parent.parent as ts.ImportClause).parent.moduleSpecifier as ts.StringLiteral
+          ).text;
+
+          if (
+            moduleSpecifierText === relativeIndexPath ||
+            moduleSpecifierText === path.join(relativeIndexPath, "index.js") ||
+            moduleSpecifierText === path.join(relativeIndexPath, "index")
+          ) {
+            return project.name;
+          } else {
+            return moduleSpecifierText;
+          }
+        }
+      );
+  }
+}
+
+interface FileInfo {
+  name: string;
+  contents: string[];
+  lineOffset: number;
+}
+
+async function writeAll(infos: Iterable<FileInfo>): Promise<void> {
+  for (const info of infos) {
+    await fs.writeFile(info.name, Buffer.from(info.contents.join(EOL), "utf-8"));
+  }
+}
+
+async function replaceSnippetsWithNew(
+  locations: SnippetLocationInfo[],
+  snippets: Map<string, SnippetDefinition>
+): Promise<boolean> {
+  const files = new Set(locations.map((l) => l.absoluteFilePath));
+  const fileInfos = new Map<string, FileInfo>();
+
+  for (const f of files) {
+    fileInfos.set(f, {
+      name: f,
+      contents: (await fs.readFile(f)).toString("utf-8").split(/\r?\n/),
+      lineOffset: 0,
+    });
+  }
+
+  let hadError = false;
+
+  for (const location of locations) {
+    let { contents, lineOffset } = fileInfos.get(location.absoluteFilePath)!;
+
+    const snippetDefinition = snippets.get(location.name);
+
+    if (!snippetDefinition) {
+      log.error(
+        `No matching snippet found for ${location.absoluteFilePath}:${location.lineRange[0]} (${location.name})`
+      );
+      hadError = true;
+      continue;
+    }
+
+    let snippet: string[];
+
+    if (location.language === "js") {
+      snippet = snippetDefinition.convert();
+    } else {
+      snippet = snippetDefinition.typescriptSourceText;
+    }
+
+    const originalLineLength = location.lineRange[1] - location.lineRange[0] - 1;
+    let newContents = contents.slice(0, lineOffset + location.lineRange[0] + 1);
+    newContents.push(...snippet.map((line) => (location.linePrefix + line).trimEnd()));
+    newContents.push(...contents.slice(lineOffset + location.lineRange[1]));
+    fileInfos.set(location.absoluteFilePath, {
+      name: location.absoluteFilePath,
+      contents: newContents,
+      lineOffset: lineOffset + (snippet.length - originalLineLength),
+    });
+  }
+
+  if (!hadError) {
+    await writeAll(fileInfos.values());
+  }
+
+  return !hadError;
+}
+
+export default leafCommand(commandInfo, async (_) => {
+  const project = await resolveProject(process.cwd());
+
+  let snippetLocations: SnippetLocationInfo[];
+
+  try {
+    snippetLocations = await findAllSnippets(project);
+  } catch {
+    return false;
+  }
+
+  const snippetDefinitions = await parseSnippets(project);
+
+  return replaceSnippetsWithNew(snippetLocations, snippetDefinitions);
+});

--- a/common/tools/dev-tool/src/util/findMatchingFiles.ts
+++ b/common/tools/dev-tool/src/util/findMatchingFiles.ts
@@ -31,6 +31,10 @@ export interface FileInfo {
    * File stats from the `fs.stat` Node API
    */
   stat: fs.Stats;
+  /**
+   * Depth of this find.
+   */
+  depth: number;
 }
 
 /**
@@ -39,11 +43,13 @@ export interface FileInfo {
 export interface FindOptions {
   ignore: string[];
   skips: string[];
+  maxDepth: number;
 }
 
 const defaultFindOptions: FindOptions = {
   ignore: [],
   skips: [],
+  maxDepth: Number.MAX_SAFE_INTEGER,
 };
 
 /**
@@ -62,7 +68,7 @@ export async function* findMatchingFiles(
 
   const options: FindOptions = { ...defaultFindOptions, ...findOptions };
 
-  async function enqueueAll(dir: string) {
+  async function enqueueAll(dir: string, depth: number) {
     const files = await fs.readdir(dir);
     for (const file of files) {
       const fullPath = path.join(dir, file);
@@ -71,11 +77,12 @@ export async function* findMatchingFiles(
         fullPath,
         name: file,
         stat: await fs.stat(fullPath),
+        depth,
       });
     }
   }
 
-  await enqueueAll(dir);
+  if (options.maxDepth > 0) await enqueueAll(dir, 1);
 
   while (q.length) {
     const info = q.shift() as FileInfo;
@@ -86,7 +93,9 @@ export async function* findMatchingFiles(
     }
 
     if (info.stat.isDirectory()) {
-      await enqueueAll(info.fullPath);
+      if (info.depth < options.maxDepth) {
+        await enqueueAll(info.fullPath, info.depth + 1);
+      }
     } else if (shouldSkip(info, options.skips)) {
       logInfo(`Skipping ${info.fullPath} because it was configured to be skipped.`);
     } else if (matches(info.name, info.stat)) {

--- a/common/tools/dev-tool/src/util/prettier.ts
+++ b/common/tools/dev-tool/src/util/prettier.ts
@@ -1,0 +1,16 @@
+import * as prettier from "prettier";
+
+const prettierOptions: prettier.Options = {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  ...(require("../../../eslint-plugin-azure-sdk/prettier.json") as prettier.Options),
+};
+
+export function formatFile(text: string, useTypeScript: boolean = true): string {
+  const options = { ...prettierOptions };
+
+  if (useTypeScript) {
+    options.parser = "typescript";
+  }
+
+  return prettier.format(text, options);
+}

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -165,3 +165,21 @@ export async function resolveRoot(start?: string): Promise<string> {
     }
   }
 }
+
+/**
+ * @param info - the project to bind to
+ * @returns - a "require"-like function that always resolves relative to the input project
+ */
+export function bindRequireFunction(info: ProjectInfo): (id: string) => unknown {
+  return (moduleSpecifier) => {
+    try {
+      return require(path.join(
+        info.path,
+        "node_modules",
+        moduleSpecifier.split("/").join(path.sep)
+      ));
+    } catch {
+      return require(moduleSpecifier);
+    }
+  };
+}

--- a/common/tools/dev-tool/src/util/samples/convert.ts
+++ b/common/tools/dev-tool/src/util/samples/convert.ts
@@ -3,18 +3,12 @@
 
 import { EOL } from "os";
 
-import * as prettier from "prettier";
 import ts from "typescript";
+import { formatFile } from "../prettier";
 
 import { createPrinter } from "../printer";
 
 const log = createPrinter("ts-to-js");
-
-const prettierOptions: prettier.Options = {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  ...(require("../../../../eslint-plugin-azure-sdk/prettier.json") as prettier.Options),
-  parser: "typescript",
-};
 
 const compilerOptions: ts.CompilerOptions = {
   target: ts.ScriptTarget.ESNext,
@@ -22,7 +16,7 @@ const compilerOptions: ts.CompilerOptions = {
 };
 
 const NEWLINE_SIGIL = `${EOL}//@@TS-MAGIC-NEWLINE@@${EOL}`;
-const NEWLINE_SIGIL_SEARCH = /\r?\n\s*\/\/@@TS-MAGIC-NEWLINE@@\r?\n/;
+const NEWLINE_SIGIL_SEARCH = /(\r?\n)?\s*\/\/@@TS-MAGIC-NEWLINE@@\r?\n/;
 
 /**
  * A set of replacements to perform. Structured as an array of doubles:
@@ -53,7 +47,7 @@ function postTransform(outText: string): string {
 
   // Format first so that we can write matching regexps
   // that are humanly comprehensible
-  text = prettier.format(text, prettierOptions);
+  text = formatFile(text);
 
   for (const [rx, replacement] of REGEX_STACK) {
     const match = typeof rx === "function" ? rx() : rx;
@@ -61,7 +55,7 @@ function postTransform(outText: string): string {
   }
 
   // Format once more for the final output.
-  return prettier.format(text, prettierOptions);
+  return formatFile(text);
 }
 
 /**

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { copy, dir, file, FileTreeFactory, lazy, safeClean, temp } from "../fileTree";
 import { findMatchingFiles } from "../findMatchingFiles";
 import { createPrinter } from "../printer";
-import { ProjectInfo, resolveRoot } from "../resolveProject";
+import { bindRequireFunction, ProjectInfo, resolveRoot } from "../resolveProject";
 import {
   getSampleConfiguration,
   MIN_SUPPORTED_NODE_VERSION,
@@ -103,17 +103,7 @@ export async function makeSampleGenerationInfo(
     return undefined as never;
   }
 
-  const requireInScope = (moduleSpecifier: string) => {
-    try {
-      return require(path.join(
-        projectInfo.path,
-        "node_modules",
-        moduleSpecifier.split("/").join(path.sep)
-      ));
-    } catch {
-      return require(moduleSpecifier);
-    }
-  };
+  const requireInScope = bindRequireFunction(projectInfo);
 
   const moduleInfos = await processSources(sampleSourcesPath, sampleSources, fail, requireInScope);
 

--- a/sdk/template/template/README-EXAMPLE.md
+++ b/sdk/template/template/README-EXAMPLE.md
@@ -2,6 +2,8 @@
 
 <!-- NOTE: This is an example README copied from the real Azure App Configuration SDK. The real SDK has much more functionality than is exposed in the template/tutorial project, but this README can serve as an example to help you write a high-quality README for your own package. -->
 
+<!-- dev-tool snippets ignore -->
+
 [Azure App Configuration](https://docs.microsoft.com/azure/azure-app-configuration/overview) is a managed service that helps developers centralize their application and feature settings simply and securely.
 
 Use the client library for App Configuration to:
@@ -100,7 +102,7 @@ This means this pattern works:
 
 ```typescript
 const setting = await client.getConfigurationSetting({
-  key: "hello"
+  key: "hello",
 });
 
 setting.value = "new value!";
@@ -119,7 +121,7 @@ or, for example, re-getting a setting:
 
 ```typescript
 let setting = await client.getConfigurationSetting({
-  key: "hello"
+  key: "hello",
 });
 
 // re-get the setting
@@ -144,12 +146,12 @@ async function run() {
     // Labels allow you to create variants of a key tailored
     // for specific use-cases like supporting multiple environments.
     // https://docs.microsoft.com/azure/azure-app-configuration/concept-key-value#label-keys
-    label: "optional-label"
+    label: "optional-label",
   });
 
   let retrievedSetting = await client.getConfigurationSetting({
     key: "testkey",
-    label: "optional-label"
+    label: "optional-label",
   });
 
   console.log("Retrieved value:", retrievedSetting.value);

--- a/sdk/template/template/README.md
+++ b/sdk/template/template/README.md
@@ -75,16 +75,27 @@ Create a section for each top-level service concept you want to explain.
 
 Create several code examples for how someone would use your library to accomplish a common task with the service.
 
+```js snippet:FooBar
+const x = "<whatever>";
+void x;
+```
+
+```ts snippet:Bar
+const x: number = 5;
+void x;
+
+```
+
 ## Troubleshooting
 
 ### Logging
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
-```javascript
-const { setLogLevel } = require("@azure/logger");
+```javascript snippet:setloglevel
+import { setLogLevel } from "@azure/logger";
 
-setLogLevel("info");
+setLogLevel("verbose");
 ```
 
 For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/logger).

--- a/sdk/template/template/src/configurationClient.ts
+++ b/sdk/template/template/src/configurationClient.ts
@@ -50,13 +50,13 @@ export class ConfigurationClient {
    * Creates an instance of a ConfigurationClient.
    *
    * Example usage:
-   * ```ts
-   * import { ConfigurationClient} from "@azure/ai-text-analytics";
-   * import { DefaultAzureCredential} from "@azure/identity";
+   * ```js snippet:new_configurationclient
+   * import { ConfigurationClient } from "@azure/template";
+   * import { DefaultAzureCredential } from "@azure/identity";
    *
    * const client = new ConfigurationClient(
-   *    "<app configuration endpoint>",
-   *    new DefaultAzureCredential()
+   *   "<app configuration endpoint>",
+   *   new DefaultAzureCredential()
    * );
    * ```
    * @param endpointUrl - the URL to the App Configuration endpoint

--- a/sdk/template/template/test/snippets.spec.ts
+++ b/sdk/template/template/test/snippets.spec.ts
@@ -1,0 +1,29 @@
+import { DefaultAzureCredential } from "@azure/identity";
+import { setLogLevel } from "@azure/logger";
+import { ConfigurationClient } from "../src";
+
+describe("snippets", function () {
+  it("new_configurationclient", function () {
+    // @ts-ignore
+    const client = new ConfigurationClient(
+      process.env.ENDPOINT ?? "<app configuration endpoint>",
+      new DefaultAzureCredential()
+    );
+  });
+
+  it("FooBar", () => {
+    const x = process.env.WHATEVER ?? "<whatever>";
+
+    void x;
+  });
+
+  it("Bar", () => {
+    const x: number = 5;
+
+    void x;
+  });
+
+  it("setloglevel", () => {
+    setLogLevel("verbose");
+  });
+});


### PR DESCRIPTION
This PR implements a new dev-tool command: `dev-tool run update-snippets`.

This command looks for code fences in markdown files and JSDoc comments, and updates them with the contents of test methods in a file named `snippets.spec.ts`.

For example, the following fence indicates that the contents of a test named "new_configurationclient" should be used:

````
```js snippet:new_configurationclient
```
````

After running `dev-tool run update-snippets`, the contents of the snippet will be populated:

````
```js snippet:new_configurationclient
import { ConfigurationClient } from "@azure/template";
import { DefaultAzureCredential } from "@azure/identity";

const client = new ConfigurationClient(
  "<app configuration endpoint>",
  new DefaultAzureCredential()
);
```
````

To accomplish this, the command uses the TypeScript compiler API to extract and transpile snippets from `snippets.spec.ts`. Snippets are the contents of calls to the `it` function. If syntax with the shape `it(<literal string>, <function with block>)` appears in `snippets.spec.ts`, it will be considered a snippet that is valid for injection.

("Function with block" means either a `function () { ... }` expression or an arrow function with a block on the arrow side (`() => { ... }`). An arrow function that has an expression on the right hand side (`() => (...)`) will not be recognized.)

For example:

```ts
  it("new_configurationclient", function () {
    // @ts-ignore
    const client = new ConfigurationClient(
      process.env.ENDPOINT ?? "<app configuration endpoint>",
      new DefaultAzureCredential()
    );
  });
```

The transpiler automatically "cleans" and validates the snippet using similar techniques as the sample transpiler. As a result, it enforces the same syntactic rules that the sample transpiler does. In addition to those, it removes references to `process.env` (if an alternative is specified), removes compiler pragmas like `// @ts-ignore`, and automatically inserts imports for symbols that the snippet uses. So in the above snippet, imports for `ConfigurationClient` and `DefaultAzureCredential` are required, automatically detected, and injected into the resulting snippet.

Snippets without `snippet:${name}` tags are _errors_ when using this command, so a package must be fully migrated to use it.