### PR TITLE
[ServiceBus] Add option to preserve Date type when receiving messages

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -501,6 +501,7 @@ export interface ServiceBusReceiver {
 // @public
 export interface ServiceBusReceiverOptions {
     identifier?: string;
+    keepDateType?: boolean;
     maxAutoLockRenewalDurationInMs?: number;
     receiveMode?: "peekLock" | "receiveAndDelete";
     skipParsingBodyAsJson?: boolean;
@@ -547,6 +548,7 @@ export interface ServiceBusSessionReceiver extends ServiceBusReceiver {
 // @public
 export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
     identifier?: string;
+    keepDateType?: boolean;
     maxAutoLockRenewalDurationInMs?: number;
     receiveMode?: "peekLock" | "receiveAndDelete";
     skipParsingBodyAsJson?: boolean;

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -77,7 +77,8 @@ export class BatchingReceiver extends MessageReceiver {
         return this.link;
       },
       this.receiveMode,
-      options.skipParsingBodyAsJson ?? false
+      options.skipParsingBodyAsJson ?? false,
+      options.keepDateType ?? false
     );
   }
 
@@ -247,7 +248,8 @@ export class BatchingReceiverLite {
       abortSignal?: AbortSignalLike
     ) => Promise<MinimalReceiver | undefined>,
     private _receiveMode: ReceiveMode,
-    _skipParsingBodyAsJson: boolean
+    _skipParsingBodyAsJson: boolean,
+    _keepDateType: boolean
   ) {
     this._createServiceBusMessage = (context: MessageAndDelivery) => {
       return new ServiceBusMessageImpl(
@@ -255,7 +257,8 @@ export class BatchingReceiverLite {
         context.delivery!,
         true,
         this._receiveMode,
-        _skipParsingBodyAsJson
+        _skipParsingBodyAsJson,
+        _keepDateType
       );
     };
 

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -75,6 +75,12 @@ export interface SendManagementRequestOptions extends SendRequestOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * Whether to preserve Date type on properties of message annotations or application properties
+   * when receiving the message. By default, properties of Date type is converted into ISO string
+   * for compatibility.
+   */
+  keepDateType?: boolean;
 }
 
 /**
@@ -546,10 +552,10 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         const messages = result.body.messages as { message: Buffer }[];
         for (const msg of messages) {
           const decodedMessage = RheaMessageUtil.decode(msg.message);
-          const message = fromRheaMessage(
-            decodedMessage as any,
-            options?.skipParsingBodyAsJson ?? false
-          );
+          const message = fromRheaMessage(decodedMessage as any, {
+            skipParsingBodyAsJson: options?.skipParsingBodyAsJson ?? false,
+            keepDateType: options?.keepDateType ?? false,
+          });
           messageList.push(message);
           this._lastPeekedSequenceNumber = message.sequenceNumber!;
         }
@@ -866,7 +872,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           { tag: msg["lock-token"] } as any,
           false,
           receiveMode,
-          options?.skipParsingBodyAsJson ?? false
+          options?.skipParsingBodyAsJson ?? false,
+          false
         );
         messageList.push(message);
       }

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -57,6 +57,13 @@ export interface ReceiveOptions extends SubscribeOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson: boolean;
+
+  /**
+   * Whether to preserve Date type on properties of message annotations or application properties
+   * when receiving the message. By default, properties of Date type is converted into ISO string
+   * for compatibility.
+   */
+  keepDateType: boolean;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -255,7 +255,8 @@ export class StreamingReceiver extends MessageReceiver {
         context.delivery!,
         true,
         this.receiveMode,
-        options.skipParsingBodyAsJson ?? false
+        options.skipParsingBodyAsJson ?? false,
+        options.keepDateType ?? false
       );
 
       this._lockRenewer?.start(this, bMessage, (err) => {

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -166,6 +166,12 @@ export interface ServiceBusReceiverOptions {
    */
   skipParsingBodyAsJson?: boolean;
   /**
+   * Whether to preserve Date type on properties of message annotations or application properties
+   * when receiving the message. By default, properties of Date type is converted into ISO string
+   * for compatibility.
+   */
+  keepDateType?: boolean;
+  /**
    * Sets the name to identify the receiver. This can be used to correlate logs and exceptions.
    * If not specified or empty, a random unique one will be used.
    */
@@ -291,6 +297,12 @@ export interface ServiceBusSessionReceiverOptions extends OperationOptionsBase {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * Whether to preserve Date type on properties of message annotations or application properties
+   * when receiving the message. By default, properties of Date type is converted into ISO string
+   * for compatibility.
+   */
+  keepDateType?: boolean;
   /**
    * Sets the name to identify the session receiver. This can be used to correlate logs and exceptions.
    * If not specified or empty, a random unique one will be used.

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -307,6 +307,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
     public receiveMode: "peekLock" | "receiveAndDelete",
     maxAutoRenewLockDurationInMs: number,
     private skipParsingBodyAsJson: boolean,
+    private keepDateType: boolean = false,
     retryOptions: RetryOptions = {},
     identifier?: string
   ) {
@@ -372,6 +373,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
           receiveMode: this.receiveMode,
           lockRenewer: this._lockRenewer,
           skipParsingBodyAsJson: this.skipParsingBodyAsJson,
+          keepDateType: this.keepDateType,
         };
         this._batchingReceiver = this._createBatchingReceiver(
           this._context,
@@ -526,6 +528,7 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
         retryOptions: this._retryOptions,
         lockRenewer: this._lockRenewer,
         skipParsingBodyAsJson: this.skipParsingBodyAsJson,
+        keepDateType: this.keepDateType,
       });
 
     // this ensures that if the outer service bus client is closed that  this receiver is cleaned up.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -229,6 +229,7 @@ export class ServiceBusClient {
       receiveMode,
       maxLockAutoRenewDurationInMs,
       options?.skipParsingBodyAsJson ?? false,
+      options?.keepDateType ?? false,
       this._clientOptions.retryOptions,
       options?.identifier
     );
@@ -362,6 +363,7 @@ export class ServiceBusClient {
         abortSignal: options?.abortSignal,
         retryOptions: this._clientOptions.retryOptions,
         skipParsingBodyAsJson: options?.skipParsingBodyAsJson ?? false,
+        keepDateType: options?.keepDateType ?? false,
       }
     );
 
@@ -449,6 +451,7 @@ export class ServiceBusClient {
         abortSignal: options?.abortSignal,
         retryOptions: this._clientOptions.retryOptions,
         skipParsingBodyAsJson: options?.skipParsingBodyAsJson ?? false,
+        keepDateType: options?.keepDateType ?? false,
       }
     );
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -63,6 +63,7 @@ export type MessageSessionOptions = Pick<
   receiveMode?: ReceiveMode;
   retryOptions: RetryOptions | undefined;
   skipParsingBodyAsJson: boolean;
+  keepDateType: boolean;
 };
 
 /**
@@ -185,6 +186,12 @@ export class MessageSession extends LinkEntity<Receiver> {
    * Whether to prevent the client from running JSON.parse() on the message body when receiving the message.
    */
   private skipParsingBodyAsJson: boolean;
+
+  /**
+   * Whether to preserve Date type on properties of message annotations or application properties
+   * when receiving the message.
+   */
+  private keepDateType: boolean;
 
   public get receiverHelper(): ReceiverHelper {
     return this._receiverHelper;
@@ -391,6 +398,7 @@ export class MessageSession extends LinkEntity<Receiver> {
     if (isDefined(this._providedSessionId)) this.sessionId = this._providedSessionId;
     this.receiveMode = options.receiveMode || "peekLock";
     this.skipParsingBodyAsJson = options.skipParsingBodyAsJson;
+    this.keepDateType = options.keepDateType;
     this.maxAutoRenewDurationInMs =
       options.maxAutoLockRenewalDurationInMs != null
         ? options.maxAutoLockRenewalDurationInMs
@@ -406,7 +414,8 @@ export class MessageSession extends LinkEntity<Receiver> {
         return this.link!;
       },
       this.receiveMode,
-      this.skipParsingBodyAsJson
+      this.skipParsingBodyAsJson,
+      this.keepDateType
     );
 
     // setting all the handlers
@@ -648,7 +657,8 @@ export class MessageSession extends LinkEntity<Receiver> {
           context.delivery!,
           true,
           this.receiveMode,
-          this.skipParsingBodyAsJson
+          this.skipParsingBodyAsJson,
+          this.keepDateType
         );
 
         try {

--- a/sdk/servicebus/service-bus/test/internal/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/retries.spec.ts
@@ -354,6 +354,7 @@ describe("Retries - Receive methods", () => {
           lockRenewer: undefined,
           receiveMode: "peekLock",
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
       batchingReceiver.isOpen = () => true;

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -6,6 +6,7 @@ import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import * as dotenv from "dotenv";
 import { Constants as CoreAmqpConstants } from "@azure/core-amqp";
+import { isObjectWithProperties } from "@azure/core-util";
 import Long from "long";
 import {
   isServiceBusError,
@@ -74,6 +75,10 @@ describe("ServiceBusClient live tests", () => {
         const testMessages = entities.usesSessions
           ? TestMessage.getSessionSample()
           : TestMessage.getSample();
+        testMessages.applicationProperties = {
+          ...testMessages.applicationProperties,
+          date1: new Date(),
+        };
         await sender.sendMessages(testMessages);
         await testPeekMsgsLength(receiver, 1);
 
@@ -88,6 +93,12 @@ describe("ServiceBusClient live tests", () => {
           "MessageId is different than expected"
         );
         should.equal(msgs[0].deliveryCount, 0, "DeliveryCount is different than expected");
+        should.equal(
+          typeof msgs[0].applicationProperties!["date1"],
+          "number",
+          "expect date1 to be an epoch value"
+        );
+
         await receiver.completeMessage(msgs[0]);
 
         await testPeekMsgsLength(receiver, 0);
@@ -99,6 +110,61 @@ describe("ServiceBusClient live tests", () => {
         await sbClientWithRelaxedEndPoint.close();
       }
     });
+
+    it(
+      noSessionTestClientType + ": preserve Date type if choosing to",
+      async function (): Promise<void> {
+        // Create a test client to get the entity types
+        const sbClient = createServiceBusClientForTests();
+        const entities = await sbClient.test.createTestEntities(noSessionTestClientType);
+        await sbClient.close();
+
+        // Create a sb client, sender, receiver with relaxed endpoint
+        const sbClientWithRelaxedEndPoint = new ServiceBusClient(
+          getEnvVars().SERVICEBUS_CONNECTION_STRING.replace("sb://", "CheeseBurger://")
+        );
+        const sender = sbClientWithRelaxedEndPoint.createSender(entities.queue || entities.topic!);
+        const receiveOptions = { keepDateType: true };
+        const receiver = entities.queue
+          ? sbClientWithRelaxedEndPoint.createReceiver(entities.queue, receiveOptions)
+          : sbClientWithRelaxedEndPoint.createReceiver(
+              entities.topic!,
+              entities.subscription!,
+              receiveOptions
+            );
+
+        try {
+          // Send and receive messages
+          const testMessages = entities.usesSessions
+            ? TestMessage.getSessionSample()
+            : TestMessage.getSample();
+          testMessages.applicationProperties = {
+            date1: new Date(),
+          };
+          await sender.sendMessages(testMessages);
+          await testPeekMsgsLength(receiver, 1);
+
+          const msgs = await receiver.receiveMessages(1);
+
+          should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
+          should.equal(msgs.length, 1, "Unexpected number of messages");
+          should.equal(
+            isObjectWithProperties(msgs[0].applicationProperties!["date1"], ["getTime"]),
+            true,
+            "expect date1 to be an instance of Date"
+          );
+          await receiver.completeMessage(msgs[0]);
+
+          await testPeekMsgsLength(receiver, 0);
+        } finally {
+          // Clean up
+          await sbClient.test.after();
+          await sender.close();
+          await receiver.close();
+          await sbClientWithRelaxedEndPoint.close();
+        }
+      }
+    );
 
     it.skip(
       noSessionTestClientType + ":can omit message body when peeking",

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -31,6 +31,7 @@ describe("AbortSignal", () => {
     lockRenewer: undefined,
     receiveMode: <ReceiveMode>"peekLock",
     skipParsingBodyAsJson: false,
+    keepDateType: false,
   };
 
   const testMessageThatDoesntMatter = {
@@ -391,6 +392,7 @@ describe("AbortSignal", () => {
         {
           retryOptions: undefined,
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
@@ -47,6 +47,7 @@ describe("AMQP message encoding", () => {
       {} as Delivery,
       false,
       "receiveAndDelete",
+      false,
       false
     );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -93,6 +93,7 @@ describe("BatchingReceiver unit tests", () => {
           receiveMode: "peekLock",
           lockRenewer: undefined,
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 
@@ -118,6 +119,7 @@ describe("BatchingReceiver unit tests", () => {
           receiveMode: "peekLock",
           lockRenewer: undefined,
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
       closeables.push(receiver);
@@ -209,6 +211,7 @@ describe("BatchingReceiver unit tests", () => {
             receiveMode: lockMode,
             lockRenewer: undefined,
             skipParsingBodyAsJson: false,
+            keepDateType: false,
           }
         );
         closeables.push(batchingReceiver);
@@ -243,6 +246,7 @@ describe("BatchingReceiver unit tests", () => {
             receiveMode: lockMode,
             lockRenewer: undefined,
             skipParsingBodyAsJson: false,
+            keepDateType: false,
           }
         );
         closeables.push(receiver);
@@ -277,6 +281,7 @@ describe("BatchingReceiver unit tests", () => {
               receiveMode: lockMode,
               lockRenewer: undefined,
               skipParsingBodyAsJson: false,
+              keepDateType: false,
             }
           );
           closeables.push(batchingReceiver);
@@ -327,6 +332,7 @@ describe("BatchingReceiver unit tests", () => {
             receiveMode: lockMode,
             lockRenewer: undefined,
             skipParsingBodyAsJson: false,
+            keepDateType: false,
           }
         );
         closeables.push(batchingReceiver);
@@ -383,6 +389,7 @@ describe("BatchingReceiver unit tests", () => {
               receiveMode: lockMode,
               lockRenewer: undefined,
               skipParsingBodyAsJson: false,
+              keepDateType: false,
             }
           );
           closeables.push(batchingReceiver);
@@ -550,6 +557,7 @@ describe("BatchingReceiver unit tests", () => {
           return fakeRheaReceiver;
         },
         "peekLock",
+        false,
         false
       );
 
@@ -581,6 +589,7 @@ describe("BatchingReceiver unit tests", () => {
           return fakeRheaReceiver;
         },
         "peekLock",
+        false,
         false
       );
 
@@ -617,6 +626,7 @@ describe("BatchingReceiver unit tests", () => {
           return fakeRheaReceiver;
         },
         "peekLock",
+        false,
         false
       );
 
@@ -671,6 +681,7 @@ describe("BatchingReceiver unit tests", () => {
           return fakeRheaReceiver;
         },
         "peekLock",
+        false,
         false
       );
 
@@ -733,6 +744,7 @@ describe("BatchingReceiver unit tests", () => {
         return fakeRheaReceiver;
       },
       "peekLock",
+      false,
       false
     );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -353,6 +353,7 @@ describe("LinkEntity unit tests", () => {
           lockRenewer: undefined,
           receiveMode: "receiveAndDelete",
           skipParsingBodyAsJson: false,
+          keepDateType: false,
           tracingOptions: {},
         }
       );
@@ -382,6 +383,7 @@ describe("LinkEntity unit tests", () => {
           lockRenewer: undefined,
           receiveMode: "receiveAndDelete",
           skipParsingBodyAsJson: false,
+          keepDateType: false,
           tracingOptions: {},
         }
       );
@@ -429,6 +431,7 @@ describe("LinkEntity unit tests", () => {
           abortSignal: undefined,
           retryOptions: {},
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
@@ -57,6 +57,7 @@ describe("Message session unit tests", () => {
               receiveMode: lockMode,
               retryOptions: undefined,
               skipParsingBodyAsJson: false,
+              keepDateType: false,
             }
           );
 
@@ -89,6 +90,7 @@ describe("Message session unit tests", () => {
               receiveMode: lockMode,
               retryOptions: undefined,
               skipParsingBodyAsJson: false,
+              keepDateType: false,
             }
           );
 
@@ -121,6 +123,7 @@ describe("Message session unit tests", () => {
                 receiveMode: lockMode,
                 retryOptions: undefined,
                 skipParsingBodyAsJson: false,
+                keepDateType: false,
               }
             );
 
@@ -169,6 +172,7 @@ describe("Message session unit tests", () => {
               receiveMode: lockMode,
               retryOptions: undefined,
               skipParsingBodyAsJson: false,
+              keepDateType: false,
             }
           );
 
@@ -223,6 +227,7 @@ describe("Message session unit tests", () => {
                 receiveMode: lockMode,
                 retryOptions: undefined,
                 skipParsingBodyAsJson: false,
+                keepDateType: false,
               }
             );
 
@@ -373,6 +378,7 @@ describe("Message session unit tests", () => {
           receiveMode: "receiveAndDelete",
           retryOptions: undefined,
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/receivedMessageProps.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receivedMessageProps.spec.ts
@@ -24,7 +24,7 @@ describe("Message translations", () => {
         ...toRheaMessage(testMessage, { encode: (body) => body }),
         message_annotations: { [Constants.enqueuedTime]: Date.now().valueOf() },
       };
-      const expiresAtUtc = fromRheaMessage(rheaMsg, false).expiresAtUtc;
+      const expiresAtUtc = fromRheaMessage(rheaMsg, { skipParsingBodyAsJson: false }).expiresAtUtc;
       should.not.equal(expiresAtUtc?.toString(), "Invalid Date", "expiresAtUtc is Invalid Date");
     }
 

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -34,6 +34,7 @@ describe("Receiver unit tests", () => {
         lockRenewer: undefined,
         receiveMode: "peekLock",
         skipParsingBodyAsJson: false,
+        keepDateType: false,
       }
     );
     const options = batchingReceiver["_createReceiverOptions"](false, {});
@@ -53,6 +54,7 @@ describe("Receiver unit tests", () => {
           lockRenewer: undefined,
           receiveMode: "peekLock",
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 
@@ -82,6 +84,7 @@ describe("Receiver unit tests", () => {
           lockRenewer: undefined,
           receiveMode: "peekLock",
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 
@@ -267,6 +270,7 @@ describe("Receiver unit tests", () => {
         {
           retryOptions: undefined,
           skipParsingBodyAsJson: false,
+          keepDateType: false,
         }
       );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/serviceBusMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/serviceBusMessage.spec.ts
@@ -43,6 +43,7 @@ describe("ServiceBusMessageImpl unit tests", () => {
         { tag: fakeDeliveryTag } as Delivery,
         false,
         "peekLock",
+        false,
         false
       );
 
@@ -55,6 +56,7 @@ describe("ServiceBusMessageImpl unit tests", () => {
         { tag: fakeDeliveryTag } as Delivery,
         false,
         "receiveAndDelete",
+        false,
         false
       );
 
@@ -112,6 +114,7 @@ describe("ServiceBusMessageImpl unit tests", () => {
       fakeDelivery,
       false,
       "peekLock",
+      false,
       false
     );
 

--- a/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
@@ -75,6 +75,7 @@ describe("StreamingReceiver unit tests", () => {
         lockRenewer: undefined,
         receiveMode: "receiveAndDelete",
         skipParsingBodyAsJson: false,
+        keepDateType: false,
       });
 
       try {
@@ -246,6 +247,7 @@ describe("StreamingReceiver unit tests", () => {
       lockRenewer: undefined,
       receiveMode: "peekLock",
       skipParsingBodyAsJson: false,
+      keepDateType: false,
     });
 
     let processErrorMessages: string[] = [];

--- a/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/unittestUtils.ts
@@ -288,6 +288,7 @@ export function addTestStreamingReceiver(): (
         receiveMode: <ReceiveMode>"peekLock",
         maxConcurrentCalls: 101,
         skipParsingBodyAsJson: false,
+        keepDateType: false,
       };
     }
 


### PR DESCRIPTION
For compatibility reason we convert Date properties into epoch numbers even though the underlying rhea library supports Date type now.

This PR adds an option to keep the Date type when receiving messages. By default we still convert properties of Date type into numbers.


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
