### PR TITLE
[storage-blob] Fix issue with missing `return` in blobBatch

### DIFF
--- a/sdk/storage/storage-blob/src/BlobBatch.ts
+++ b/sdk/storage/storage-blob/src/BlobBatch.ts
@@ -184,7 +184,7 @@ export class BlobBatch {
       options = {};
     }
 
-    tracingClient.withSpan("BatchDeleteRequest-addSubRequest", options, async (updatedOptions) => {
+    return tracingClient.withSpan("BatchDeleteRequest-addSubRequest", options, async (updatedOptions) => {
       this.setBatchType("delete");
       await this.addSubRequestInternal(
         {

--- a/sdk/storage/storage-blob/src/BlobBatch.ts
+++ b/sdk/storage/storage-blob/src/BlobBatch.ts
@@ -184,20 +184,24 @@ export class BlobBatch {
       options = {};
     }
 
-    return tracingClient.withSpan("BatchDeleteRequest-addSubRequest", options, async (updatedOptions) => {
-      this.setBatchType("delete");
-      await this.addSubRequestInternal(
-        {
-          url: url,
-          credential: credential,
-        },
-        async () => {
-          await new BlobClient(url, this.batchRequest.createPipeline(credential)).delete(
-            updatedOptions
-          );
-        }
-      );
-    });
+    return tracingClient.withSpan(
+      "BatchDeleteRequest-addSubRequest",
+      options,
+      async (updatedOptions) => {
+        this.setBatchType("delete");
+        await this.addSubRequestInternal(
+          {
+            url: url,
+            credential: credential,
+          },
+          async () => {
+            await new BlobClient(url, this.batchRequest.createPipeline(credential)).delete(
+              updatedOptions
+            );
+          }
+        );
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/storage-blob`

### Describe the problem that is addressed by this PR

Noticed failing tests for batch caused by a missing `return` statement which caused a race condition in assembling the batch body. This was introduced by PR #24548 - not sure why the tests didn't catch it sooner, possibly there was a bad merge or a side effect of promise resolution timing.

