### PR TITLE
[web-pubsub-client] Fix naming restoreGroup and add tests

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client.api.md
+++ b/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client.api.md
@@ -121,7 +121,7 @@ export interface OnGroupDataMessageArgs {
 }
 
 // @public
-export interface OnRestoreGroupFailedArgs {
+export interface OnRejoinGroupFailedArgs {
     error: Error;
     group: string;
 }
@@ -239,13 +239,13 @@ export class WebPubSubClient {
     off(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     off(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     off(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
-    off(event: "rejoin-group-failed", listener: (e: OnRestoreGroupFailedArgs) => void): void;
+    off(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
     on(event: "connected", listener: (e: OnConnectedArgs) => void): void;
     on(event: "disconnected", listener: (e: OnDisconnectedArgs) => void): void;
     on(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     on(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     on(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
-    on(event: "rejoin-group-failed", listener: (e: OnRestoreGroupFailedArgs) => void): void;
+    on(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
     sendEvent(eventName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendEventOptions): Promise<WebPubSubResult>;
     sendToGroup(groupName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendToGroupOptions): Promise<void | WebPubSubResult>;
     start(options?: StartOptions): Promise<void>;
@@ -260,7 +260,7 @@ export interface WebPubSubClientCredential {
 // @public
 export interface WebPubSubClientOptions {
     autoReconnect?: boolean;
-    autoRestoreGroups?: boolean;
+    autoRejoinGroups?: boolean;
     messageRetryOptions?: WebPubSubRetryOptions;
     protocol?: WebPubSubClientProtocol;
     reconnectRetryOptions?: WebPubSubRetryOptions;

--- a/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
@@ -20,7 +20,7 @@ export interface WebPubSubClientOptions {
   /**
    * Whether to enable restoring group after reconnecting
    */
-  autoRestoreGroups?: boolean;
+  autoRejoinGroups?: boolean;
   /**
    * The retry options for operations like joining group and sending messages
    */
@@ -195,9 +195,9 @@ export interface OnGroupDataMessageArgs {
 }
 
 /**
- * Parameter of RestoreGroupFailed callback
+ * Parameter of RejoinGroupFailed callback
  */
-export interface OnRestoreGroupFailedArgs {
+export interface OnRejoinGroupFailedArgs {
   /**
    * The group name
    */

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -623,12 +623,12 @@ export class WebPubSubClient {
                   );
                 }
               });
-  
+
               try {
                 await Promise.all(groupPromises);
               } catch {}
             }
-            
+
             this._safeEmitConnected(message.connectionId, message.userId);
           }
         };

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -319,10 +319,10 @@ describe("WebPubSubClient", function () {
         reconnectRetryOptions: { retryDelayInMs: 10 } as WebPubSubRetryOptions,
       } as WebPubSubClientOptions);
       const mock = sinon.mock(client);
-        mock
-          .expects("_joinGroupCore")
-          .exactly(4)
-          .callsFake((_) => Promise.resolve());
+      mock
+        .expects("_joinGroupCore")
+        .exactly(4)
+        .callsFake((_) => Promise.resolve());
 
       const testWs = new TestWebSocketClient(client);
       makeStartable(testWs);
@@ -339,7 +339,7 @@ describe("WebPubSubClient", function () {
 
       // join 2 groups first
       await client.joinGroup("a");
-      await client.joinGroup("b");      
+      await client.joinGroup("b");
 
       // drop connection
       testWs.invokeclose(1006);
@@ -357,10 +357,10 @@ describe("WebPubSubClient", function () {
         autoRejoinGroups: false,
       } as WebPubSubClientOptions);
       const mock = sinon.mock(client);
-        mock
-          .expects("_joinGroupCore")
-          .exactly(2)
-          .callsFake((_) => Promise.resolve());
+      mock
+        .expects("_joinGroupCore")
+        .exactly(2)
+        .callsFake((_) => Promise.resolve());
 
       const testWs = new TestWebSocketClient(client);
       makeStartable(testWs);
@@ -377,7 +377,7 @@ describe("WebPubSubClient", function () {
 
       // join 2 groups first
       await client.joinGroup("a");
-      await client.joinGroup("b");      
+      await client.joinGroup("b");
 
       // drop connection
       testWs.invokeclose(1006);

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -312,6 +312,81 @@ describe("WebPubSubClient", function () {
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
       await spinCheck(() => assert.equal("conn2", conn));
     });
+
+    it("rejoin group after reconnection", async () => {
+      const client = new WebPubSubClient("wss://service.com", {
+        protocol: WebPubSubJsonProtocol(),
+        reconnectRetryOptions: { retryDelayInMs: 10 } as WebPubSubRetryOptions,
+      } as WebPubSubClientOptions);
+      const mock = sinon.mock(client);
+        mock
+          .expects("_joinGroupCore")
+          .exactly(4)
+          .callsFake((_) => Promise.resolve());
+
+      const testWs = new TestWebSocketClient(client);
+      makeStartable(testWs);
+
+      let conn: string;
+      client.on("connected", (connected) => {
+        conn = connected.connectionId;
+      });
+
+      await client.start();
+      testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
+
+      await spinCheck(() => assert.equal("conn", conn));
+
+      // join 2 groups first
+      await client.joinGroup("a");
+      await client.joinGroup("b");      
+
+      // drop connection
+      testWs.invokeclose(1006);
+      await spinCheck(() => testWs.openTime === 2);
+      testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
+      await spinCheck(() => assert.equal("conn2", conn));
+
+      mock.verify();
+    });
+
+    it("rejoin group after reconnection can be disabled", async () => {
+      const client = new WebPubSubClient("wss://service.com", {
+        protocol: WebPubSubJsonProtocol(),
+        reconnectRetryOptions: { retryDelayInMs: 10 } as WebPubSubRetryOptions,
+        autoRejoinGroups: false,
+      } as WebPubSubClientOptions);
+      const mock = sinon.mock(client);
+        mock
+          .expects("_joinGroupCore")
+          .exactly(2)
+          .callsFake((_) => Promise.resolve());
+
+      const testWs = new TestWebSocketClient(client);
+      makeStartable(testWs);
+
+      let conn: string;
+      client.on("connected", (connected) => {
+        conn = connected.connectionId;
+      });
+
+      await client.start();
+      testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
+
+      await spinCheck(() => assert.equal("conn", conn));
+
+      // join 2 groups first
+      await client.joinGroup("a");
+      await client.joinGroup("b");      
+
+      // drop connection
+      testWs.invokeclose(1006);
+      await spinCheck(() => testWs.openTime === 2);
+      testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
+      await spinCheck(() => assert.equal("conn2", conn));
+
+      mock.verify();
+    });
   });
 
   function makeStartable(ws: TestWebSocketClient): sinon.SinonStub<[fn: () => void], void> {


### PR DESCRIPTION
### Packages impacted by this PR
web-pubsub-client

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
`autoRejoinGroup` options didn't take effect and some naming are `autoRestoreGroup` which doesn't keep consistent.

### Are there test cases added in this PR? _(If not, why?)_
yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
