### PR TITLE
[Maps] Correct the file path for type declaration in `@azure-rest/maps-search`

### DIFF
--- a/sdk/maps/maps-search-rest/CHANGELOG.md
+++ b/sdk/maps/maps-search-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Correct the path of the type declaration file.
+
 ### Other Changes
 
 ## 1.0.0-beta.1 (2023-01-10)

--- a/sdk/maps/maps-search-rest/package.json
+++ b/sdk/maps/maps-search-rest/package.json
@@ -23,7 +23,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/maps-search.d.ts",
+    "types/maps-search-rest.d.ts",
     "README.md",
     "LICENSE",
     "review/*"


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-rest/maps-search

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- The type declaration file path is incorrect in the `files` prop in `package.json`, thus causing the user cannot access the file.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
