### PR TITLE
[RUSH] Pin "@microsoft/api-extractor": "7.34.0" to fix `rush update --full`

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,6 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
+    "@microsoft/api-extractor": "7.34.0" // https://github.com/Azure/azure-sdk-for-js/issues/24635
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@microsoft/api-extractor': 7.34.0
   '@rush-temp/abort-controller': file:./projects/abort-controller.tgz
   '@rush-temp/agrifood-farming': file:./projects/agrifood-farming.tgz
   '@rush-temp/ai-anomaly-detector': file:./projects/ai-anomaly-detector.tgz
@@ -326,6 +327,7 @@ specifiers:
   '@rush-temp/web-pubsub-express': file:./projects/web-pubsub-express.tgz
 
 dependencies:
+  '@microsoft/api-extractor': 7.34.0
   '@rush-temp/abort-controller': file:projects/abort-controller.tgz
   '@rush-temp/agrifood-farming': file:projects/agrifood-farming.tgz
   '@rush-temp/ai-anomaly-detector': file:projects/ai-anomaly-detector.tgz
@@ -667,7 +669,7 @@ packages:
       '@azure/core-auth': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
       '@azure/core-util': 1.1.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -682,7 +684,7 @@ packages:
       md5: 2.3.0
       nise: 4.1.0
       nock: 12.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -692,7 +694,7 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/ai-form-recognizer/3.1.0-beta.3:
@@ -705,7 +707,7 @@ packages:
       '@azure/core-paging': 1.4.0
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -721,7 +723,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.9
       '@azure/logger': 1.0.3
       '@opentelemetry/api': 0.10.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -736,7 +738,7 @@ packages:
       '@azure/core-lro': 2.5.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -751,7 +753,7 @@ packages:
       '@azure/core-lro': 2.5.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -764,7 +766,7 @@ packages:
       '@azure/core-client': 1.7.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -779,7 +781,7 @@ packages:
       '@azure/core-lro': 2.5.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -794,7 +796,7 @@ packages:
       '@azure/core-lro': 2.5.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -809,7 +811,7 @@ packages:
       '@azure/core-lro': 2.5.0
       '@azure/core-paging': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -837,7 +839,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-client/1.7.0:
@@ -850,7 +852,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -878,10 +880,10 @@ packages:
       '@types/node-fetch': 2.6.2
       '@types/tunnel': 0.0.1
       form-data: 3.0.1
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       process: 0.11.10
       tough-cookie: 4.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       tunnel: 0.0.6
       uuid: 8.3.2
       xml2js: 0.4.23
@@ -901,10 +903,10 @@ packages:
       '@types/node-fetch': 2.6.2
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       process: 0.11.10
       tough-cookie: 4.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       tunnel: 0.0.6
       uuid: 8.3.2
       xml2js: 0.4.23
@@ -920,7 +922,7 @@ packages:
       '@azure/core-http': 1.2.6
       '@azure/core-tracing': 1.0.0-preview.11
       events: 3.3.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -932,7 +934,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-lro/2.5.0:
@@ -941,14 +943,14 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-paging/1.4.0:
     resolution: {integrity: sha512-tabFtZTg8D9XqZKEfNUOGh63SuYeOxmvH4GDcOJN+R1bZWZ1FZskctgY9Pmuwzhn+0Xvq9rmimK9hsvtLkeBsw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-rest-pipeline/1.10.1:
@@ -963,7 +965,7 @@ packages:
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -975,7 +977,7 @@ packages:
     dependencies:
       '@opencensus/web-types': 0.0.7
       '@opentelemetry/api': 1.0.0-rc.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-tracing/1.0.0-preview.13:
@@ -983,7 +985,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@opentelemetry/api': 1.4.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-tracing/1.0.0-preview.9:
@@ -992,14 +994,14 @@ packages:
     dependencies:
       '@opencensus/web-types': 0.0.7
       '@opentelemetry/api': 0.10.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-tracing/1.0.1:
     resolution: {integrity: sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-util/1.1.1:
@@ -1007,15 +1009,15 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/core-xml/1.3.2:
     resolution: {integrity: sha512-0YROtnH4dCq3NZwPsPsaTfeH/7PZLMuhCaeb/HkFcaaERQ0OFR0DOMgpP698yeDTXnKAl3kZdw72tgVtTqD2xQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      fast-xml-parser: 4.0.13
-      tslib: 2.4.1
+      fast-xml-parser: 4.0.15
+      tslib: 2.5.0
     dev: false
 
   /@azure/data-tables/12.1.2:
@@ -1029,7 +1031,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-xml': 1.3.2
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -1061,7 +1063,7 @@ packages:
       jws: 4.0.0
       open: 8.4.0
       stoppable: 1.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -1081,7 +1083,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1100,7 +1102,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1119,7 +1121,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1134,7 +1136,7 @@ packages:
     resolution: {integrity: sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@azure/maps-common/1.0.0-beta.2:
@@ -1160,7 +1162,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.3
       pako: 2.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1171,7 +1173,7 @@ packages:
       '@azure/core-auth': 1.4.0
       abort-controller: 3.0.0
       form-data: 2.5.1
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       tough-cookie: 3.0.1
       tslib: 1.14.1
       tunnel: 0.0.6
@@ -1185,7 +1187,7 @@ packages:
     resolution: {integrity: sha512-1YqGzXtPG3QrZPFBKaMWr2WQdukDj+PelqUCv351+p+hlw/AhdRrb8haY73/iqkhT6Cdrbnh7sL4gikVsF4O1g==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 9.0.2
+      '@azure/msal-common': 9.1.1
     dev: false
 
   /@azure/msal-common/7.6.0:
@@ -1193,8 +1195,8 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /@azure/msal-common/9.0.2:
-    resolution: {integrity: sha512-qzwxuF8kZAp+rNUactMCgJh8fblq9D4lSqrrIxMDzLjgSZtjN32ix7r/HBe8QdOr76II9SVVPcMkX4sPzPfQ7w==}
+  /@azure/msal-common/9.1.1:
+    resolution: {integrity: sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw==}
     engines: {node: '>=0.8.0'}
     dev: false
 
@@ -1212,7 +1214,7 @@ packages:
     resolution: {integrity: sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==}
     engines: {node: 10 || 12 || 14 || 16 || 18}
     dependencies:
-      '@azure/msal-common': 9.0.2
+      '@azure/msal-common': 9.1.1
       jsonwebtoken: 9.0.0
       uuid: 8.3.2
     dev: false
@@ -1226,7 +1228,7 @@ packages:
       '@azure/core-rest-pipeline': 1.10.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1242,7 +1244,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1260,8 +1262,8 @@ packages:
       '@babel/highlight': 7.18.6
     dev: false
 
-  /@babel/compat-data/7.20.10:
-    resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
+  /@babel/compat-data/7.20.14:
+    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
     engines: {node: '>=6.9.0'}
     dev: false
 
@@ -1271,13 +1273,13 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
       '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.7
-      '@babel/parser': 7.20.7
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.20.13
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
       debug: 4.3.4
@@ -1288,8 +1290,8 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/generator/7.20.7:
-    resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
+  /@babel/generator/7.20.14:
+    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
@@ -1303,10 +1305,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.10
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.20.12
       '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
+      browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
     dev: false
@@ -1348,7 +1350,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -1383,12 +1385,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helpers/7.20.7:
-    resolution: {integrity: sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==}
+  /@babel/helpers/7.20.13:
+    resolution: {integrity: sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -1403,14 +1405,14 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser/7.20.7:
-    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
+  /@babel/parser/7.20.13:
+    resolution: {integrity: sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: false
 
-  /@babel/runtime/7.20.7:
-    resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
+  /@babel/runtime/7.20.13:
+    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
@@ -1421,21 +1423,21 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
     dev: false
 
-  /@babel/traverse/7.20.12:
-    resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
+  /@babel/traverse/7.20.13:
+    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
       debug: 4.3.4
       globals: 11.12.0
@@ -1471,7 +1473,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 7.3.1
-      globals: 13.19.0
+      globals: 13.20.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
@@ -1488,7 +1490,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.1
-      globals: 13.19.0
+      globals: 13.20.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -1590,19 +1592,19 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
-  /@microsoft/api-extractor-model/7.25.3:
-    resolution: {integrity: sha512-WWxBUq77p2iZ+5VF7Nmrm3y/UtqCh5bYV8ii3khwq3w99+fXWpvfsAhgSLsC7k8XDQc6De4ssMxH6He/qe1pzg==}
+  /@microsoft/api-extractor-model/7.26.0:
+    resolution: {integrity: sha512-iUlscM9a3/scqgaL+sipTYsfbkF/frrZhdYWXm5+zEVMW6QlP5jDV6cYNeIEIdMeGSbzk1yxpBjyeBDAZQLdyA==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
       '@rushstack/node-core-library': 3.53.3
     dev: false
 
-  /@microsoft/api-extractor/7.33.7:
-    resolution: {integrity: sha512-fQT2v/j/55DhvMFiopLtth66E7xTFNhnumMKgKY14SaG6qU/V1W0e4nOAgbA+SmLakQjAd1Evu06ofaVaxBPbA==}
+  /@microsoft/api-extractor/7.34.0:
+    resolution: {integrity: sha512-U9opcYpFrN0eIVunEx90SDSYzmjgO2mEVbttHwtJBjOHUhK2cY2QykH8uiBnJuVtuBvHVCdEFUGt6i/8LVexYA==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.25.3
+      '@microsoft/api-extractor-model': 7.26.0
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
       '@rushstack/node-core-library': 3.53.3
@@ -1610,7 +1612,7 @@ packages:
       '@rushstack/ts-command-line': 4.13.1
       colors: 1.2.5
       lodash: 4.17.21
-      resolve: 1.17.0
+      resolve: 1.22.1
       semver: 7.3.8
       source-map: 0.6.1
       typescript: 4.8.4
@@ -1672,8 +1674,8 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@opentelemetry/context-async-hooks/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-Ur+TgRmJgAEvg6VQuhkqzsWsqoOtr+QSZ8r8Yf6WrvlZpAl/sdRU+yUXWjA7r8JFS9VbBq7IEp7oMStFuJT2ow==}
+  /@opentelemetry/context-async-hooks/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-HmycxnnIm00gdmxfD5OkDotL15bGqazLYqQJdcv1uNt22OSc5F/a3Paz3yznmf+/gWdPG8nlq/zd9H0mNXJnGg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
@@ -1686,33 +1688,33 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@opentelemetry/core/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-Koy1ApRUp5DB5KpOqhDk0JjO9x6QeEkmcePl8qQDsXZGF4MuHUBShXibd+J2tRNckTsvgEHi1uEuUckDgN+c/A==}
+  /@opentelemetry/core/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/semantic-conventions': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.9.1
     dev: false
 
-  /@opentelemetry/instrumentation-http/0.35.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-lV6q947aIQuvPwbRwbfZROzlAz9SoIUDDyesVlPUcGPE9YQtokw3yAjrHTHzY3ElUboT2JU94tj9qNr0NiOJPw==}
+  /@opentelemetry/instrumentation-http/0.35.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/instrumentation': 0.35.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/semantic-conventions': 1.9.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/semantic-conventions': 1.9.1
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@opentelemetry/instrumentation/0.35.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-pQ5shVG53acTtq72DF7kx+4690ZKh3lATMRqf2JDMRvn0bcX/JaQ+NjPmt7oyT3h9brMA1rSFMVFS6yj8kd2OQ==}
+  /@opentelemetry/instrumentation/0.35.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1725,78 +1727,78 @@ packages:
       - supports-color
     dev: false
 
-  /@opentelemetry/propagator-b3/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-5M/NvJj7ZHZXEU8lkAFhrSrWaHmCCkFLstNbL8p16qpTn1AOZowuSjMOYRoJJBmL5PUobkZ3W8Gjov1UgldPBg==}
+  /@opentelemetry/propagator-b3/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-V+/ufHnZSr0YlbNhPg4PIQAZOhP61fVwL0JZJ6qnl9i0jgaZBSAtV99ZvHMxMy0Z1tf+oGj1Hk+S6jRRXL+j1Q==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
     dev: false
 
-  /@opentelemetry/propagator-jaeger/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-oo8RyuyzEbbXdIfeEG9iA5vmTH4Kld+dZMIZICd5G5SmeNcNes3sLrparpunIGms41wIP2mWiIlcOelDCmGceg==}
+  /@opentelemetry/propagator-jaeger/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-xjG5HnOgu/1f9+GphWr8lqxaU51iFL9HgFdnSQBSFqhM2OeMuzpFt6jmkpZJBAK3oqQ9BG52fHfCdYlw3GOkVQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
     dev: false
 
-  /@opentelemetry/resources/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-zCyien0p3XWarU6zv72c/JZ6QlG5QW/hc61Nh5TSR1K9ndnljzAGrH55x4nfyQdubfoh9QxLNh9FXH0fWK6vcg==}
+  /@opentelemetry/resources/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/semantic-conventions': 1.9.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/semantic-conventions': 1.9.1
     dev: false
 
-  /@opentelemetry/sdk-metrics/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-fSlJWhp86kCan1zuxdH6LTyUBYlohQwDKnxep5qHMnRTNErkYmdjgsmjZvSMdAfUFtQqfZmTXe2Lap7a5AIf9Q==}
+  /@opentelemetry/sdk-metrics/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-AyhKDcA8NuV7o1+9KvzRMxNbATJ8AcrutKilJ6hWSo9R5utnzxgffV4y+Hp4mJn84iXxkv+CBb99GOJ2A5OMzA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/resources': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.0
       lodash.merge: 4.6.2
     dev: false
 
-  /@opentelemetry/sdk-trace-base/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-glNgtJjxAIrDku8DG5Xu3nBK25rT+hkyg7yuXh8RUurp/4BcsXjMyVqpyJvb2kg+lxAX73VJBhncRKGHn9t8QQ==}
+  /@opentelemetry/sdk-trace-base/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/resources': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/semantic-conventions': 1.9.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/semantic-conventions': 1.9.1
     dev: false
 
-  /@opentelemetry/sdk-trace-node/1.9.0_@opentelemetry+api@1.4.0:
-    resolution: {integrity: sha512-VTpjiqGQ4s8f0/szgZmVrtNSSmXFNoHwC4PNVwXyNeEqQcqyAygHvobpUG6m7qCiBFh6ZtrCuLdhhqWE04Objw==}
+  /@opentelemetry/sdk-trace-node/1.9.1_@opentelemetry+api@1.4.0:
+    resolution: {integrity: sha512-wwwCM2G/A0LY3oPLDyO31uRnm9EMNkhhjSxL9cmkK2kM+F915em8K0pXkPWFNGWu0OHkGALWYwH6Oz0P5nVcHA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/context-async-hooks': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/propagator-b3': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/propagator-jaeger': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-base': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/context-async-hooks': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/propagator-b3': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/propagator-jaeger': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.0
       semver: 7.3.8
     dev: false
 
-  /@opentelemetry/semantic-conventions/1.9.0:
-    resolution: {integrity: sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==}
+  /@opentelemetry/semantic-conventions/1.9.1:
+    resolution: {integrity: sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==}
     engines: {node: '>=14'}
     dev: false
 
@@ -1880,8 +1882,8 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.75.7
       '@types/resolve': 1.17.1
-      deepmerge: 4.2.2
-      is-builtin-module: 3.2.0
+      deepmerge: 4.3.0
+      is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 2.75.7
@@ -1895,8 +1897,8 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       '@types/resolve': 1.17.1
-      deepmerge: 4.2.2
-      is-builtin-module: 3.2.0
+      deepmerge: 4.3.0
+      is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 2.79.1
@@ -1912,7 +1914,7 @@ packages:
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deep-freeze: 0.0.1
-      deepmerge: 4.2.2
+      deepmerge: 4.3.0
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 2.79.1
@@ -1928,7 +1930,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-typescript/10.0.1_905125611895ceb1b1b2fc58dab912cd:
+  /@rollup/plugin-typescript/10.0.1_09c4cab51ef954b1bc178cd63b85c611:
     resolution: {integrity: sha512-wBykxRLlX7EzL8BmUqMqk5zpx2onnmRMSw/l9M1sVfkJvdwfxogZQVNUM9gVMJbjRLDR5H6U0OMOrlDGmIV45A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1944,8 +1946,8 @@ packages:
       '@rollup/pluginutils': 5.0.2_rollup@2.79.1
       resolve: 1.22.1
       rollup: 2.79.1
-      tslib: 2.4.1
-      typescript: 4.9.4
+      tslib: 2.5.0
+      typescript: 4.9.5
     dev: false
 
   /@rollup/plugin-virtual/2.1.0_rollup@2.79.1:
@@ -2194,19 +2196,19 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: false
 
-  /@types/express-serve-static-core/4.17.32:
-    resolution: {integrity: sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==}
+  /@types/express-serve-static-core/4.17.33:
+    resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
       '@types/node': 12.20.55
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
 
-  /@types/express/4.17.15:
-    resolution: {integrity: sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==}
+  /@types/express/4.17.16:
+    resolution: {integrity: sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==}
     dependencies:
       '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.32
+      '@types/express-serve-static-core': 4.17.33
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.0
     dev: false
@@ -2223,8 +2225,8 @@ packages:
       '@types/node': 14.18.36
     dev: false
 
-  /@types/glob/8.0.0:
-    resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
+  /@types/glob/8.0.1:
+    resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 14.18.36
@@ -2256,8 +2258,8 @@ packages:
       '@types/node': 14.18.36
     dev: false
 
-  /@types/jws/3.2.4:
-    resolution: {integrity: sha512-aqtH4dPw1wUjFZaeMD1ak/pf8iXlu/odFe+trJrvw0g1sTh93i+SCykg0Ek8C6B7rVK3oBORbfZAsKO7P10etg==}
+  /@types/jws/3.2.5:
+    resolution: {integrity: sha512-xGTxZH34xOryaTN8CMsvhh9lfNqFuHiMoRvsLYWQdBJHqiECyfInXVl2eK8Jz2emxZWMIn5RBlmr3oDVPeWujw==}
     dependencies:
       '@types/node': 14.18.36
     dev: false
@@ -2450,8 +2452,8 @@ packages:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: false
 
-  /@types/yargs/17.0.19:
-    resolution: {integrity: sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==}
+  /@types/yargs/17.0.22:
+    resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: false
@@ -2464,7 +2466,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.46.1_9915f8eb2680b99db13ca80ed7b3a32e:
+  /@typescript-eslint/eslint-plugin/5.46.1_d11dc6fd8031cdb46eb60587aa225b16:
     resolution: {integrity: sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2475,12 +2477,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.46.1_eslint@8.32.0+typescript@4.8.4
+      '@typescript-eslint/parser': 5.46.1_eslint@8.33.0+typescript@4.8.4
       '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/type-utils': 5.46.1_eslint@8.32.0+typescript@4.8.4
-      '@typescript-eslint/utils': 5.46.1_eslint@8.32.0+typescript@4.8.4
+      '@typescript-eslint/type-utils': 5.46.1_eslint@8.33.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.46.1_eslint@8.33.0+typescript@4.8.4
       debug: 4.3.4
-      eslint: 8.32.0
+      eslint: 8.33.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -2491,20 +2493,20 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils/5.46.1_eslint@8.32.0+typescript@4.8.4:
+  /@typescript-eslint/experimental-utils/5.46.1_eslint@8.33.0+typescript@4.8.4:
     resolution: {integrity: sha512-M79mkB+wOuiBG8jzOVNA2h5izOip5CNPZV1K3tvE/qry/1Oh/bnKYhNWQNiH2h9O3B73YK60GmiqrUpprnQ5sQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.46.1_eslint@8.32.0+typescript@4.8.4
-      eslint: 8.32.0
+      '@typescript-eslint/utils': 5.46.1_eslint@8.33.0+typescript@4.8.4
+      eslint: 8.33.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.46.1_eslint@8.32.0+typescript@4.8.4:
+  /@typescript-eslint/parser/5.46.1_eslint@8.33.0+typescript@4.8.4:
     resolution: {integrity: sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2518,7 +2520,7 @@ packages:
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.8.4
       debug: 4.3.4
-      eslint: 8.32.0
+      eslint: 8.33.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
@@ -2532,7 +2534,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.46.1
     dev: false
 
-  /@typescript-eslint/type-utils/5.46.1_eslint@8.32.0+typescript@4.8.4:
+  /@typescript-eslint/type-utils/5.46.1_eslint@8.33.0+typescript@4.8.4:
     resolution: {integrity: sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2543,9 +2545,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.8.4
-      '@typescript-eslint/utils': 5.46.1_eslint@8.32.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.46.1_eslint@8.33.0+typescript@4.8.4
       debug: 4.3.4
-      eslint: 8.32.0
+      eslint: 8.33.0
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -2578,7 +2580,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.46.1_eslint@8.32.0+typescript@4.8.4:
+  /@typescript-eslint/utils/5.46.1_eslint@8.33.0+typescript@4.8.4:
     resolution: {integrity: sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2589,9 +2591,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.8.4
-      eslint: 8.32.0
+      eslint: 8.33.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.32.0
+      eslint-utils: 3.0.0_eslint@8.33.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -2629,12 +2631,12 @@ packages:
       acorn: 7.4.1
     dev: false
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.8.2
     dev: false
 
   /acorn-walk/8.2.0:
@@ -2648,8 +2650,8 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn/8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
@@ -2774,7 +2776,7 @@ packages:
     dev: false
 
   /array-flatten/1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
     dev: false
 
   /array-includes/3.1.6:
@@ -2784,7 +2786,7 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.21.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-string: 1.0.7
     dev: false
 
@@ -2970,7 +2972,7 @@ packages:
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.4
+      content-type: 1.0.5
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
@@ -3007,15 +3009,15 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: false
 
-  /browserslist/4.21.4:
-    resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
+  /browserslist/4.21.5:
+    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001445
+      caniuse-lite: 1.0.30001449
       electron-to-chromium: 1.4.284
-      node-releases: 2.0.8
-      update-browserslist-db: 1.0.10_browserslist@4.21.4
+      node-releases: 2.0.9
+      update-browserslist-db: 1.0.10_browserslist@4.21.5
     dev: false
 
   /buffer-crc32/0.2.13:
@@ -3023,7 +3025,7 @@ packages:
     dev: false
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
     dev: false
 
   /buffer-from/1.1.2:
@@ -3075,7 +3077,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /callsites/3.1.0:
@@ -3088,8 +3090,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /caniuse-lite/1.0.30001445:
-    resolution: {integrity: sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==}
+  /caniuse-lite/1.0.30001449:
+    resolution: {integrity: sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==}
     dev: false
 
   /chai-as-promised/7.1.1_chai@4.3.7:
@@ -3165,7 +3167,7 @@ packages:
     dev: false
 
   /charenc/0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    resolution: {integrity: sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=}
     dev: false
 
   /check-error/1.0.2:
@@ -3311,7 +3313,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
   /concurrently/6.5.1:
@@ -3338,7 +3340,7 @@ packages:
       date-fns: 2.29.3
       lodash: 4.17.21
       rxjs: 7.8.0
-      shell-quote: 1.7.4
+      shell-quote: 1.8.0
       spawn-command: 0.0.2-1
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -3362,8 +3364,8 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /content-type/1.0.4:
-    resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
+  /content-type/1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -3372,7 +3374,7 @@ packages:
     dev: false
 
   /cookie-signature/1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
     dev: false
 
   /cookie/0.4.2:
@@ -3398,8 +3400,8 @@ packages:
       yargs: 16.2.0
     dev: false
 
-  /core-js/3.27.1:
-    resolution: {integrity: sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==}
+  /core-js/3.27.2:
+    resolution: {integrity: sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==}
     requiresBuild: true
     dev: false
 
@@ -3466,11 +3468,11 @@ packages:
     dev: false
 
   /crypt/0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
     dev: false
 
-  /csv-parse/5.3.3:
-    resolution: {integrity: sha512-kEWkAPleNEdhFNkHQpFHu9RYPogsFj3dx6bCxL847fsiLgidzWg0z/O0B1kVWMJUc5ky64zGp18LX2T3DQrOfw==}
+  /csv-parse/5.3.4:
+    resolution: {integrity: sha512-f2E4NzkIX4bVIx5Ff2gKT1BlVwyFQ+2iFy+QrqgUXaFLUo7vSzN6XQ8LV5V/T/p/9g7mJdtYHKLkwG5PiG82fg==}
     dev: false
 
   /custom-event/1.0.1:
@@ -3566,8 +3568,8 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: false
 
-  /deepmerge/4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+  /deepmerge/4.3.0:
+    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -3617,8 +3619,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /devtools-protocol/0.0.1068969:
-    resolution: {integrity: sha512-ATFTrPbY1dKYhPPvpjtwWKSK2mIwGmRwX54UASn9THEuIZCe2n9k3vVuMmt6jWeL+e5QaaguEv/pMyR+JQB7VQ==}
+  /devtools-protocol/0.0.1082910:
+    resolution: {integrity: sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==}
     dev: false
 
   /di/0.0.1:
@@ -3690,7 +3692,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 5.0.0-dev.20230117
+      typescript: 5.0.0-dev.20230131
     dev: false
 
   /downlevel-dts/0.7.0:
@@ -3699,7 +3701,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 4.9.4
+      typescript: 4.9.5
     dev: false
 
   /downlevel-dts/0.8.0:
@@ -3718,11 +3720,11 @@ packages:
     dev: false
 
   /edge-launcher/1.2.2:
-    resolution: {integrity: sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==}
+    resolution: {integrity: sha1-60Cq+9Bnpup27/+rBke81VCbN7I=}
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
   /electron-to-chromium/1.4.284:
@@ -3800,7 +3802,7 @@ packages:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
@@ -3837,7 +3839,7 @@ packages:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: false
@@ -3907,13 +3909,13 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-config-prettier/8.6.0_eslint@8.32.0:
+  /eslint-config-prettier/8.6.0_eslint@8.33.0:
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.32.0
+      eslint: 8.33.0
     dev: false
 
   /eslint-import-resolver-node/0.3.7:
@@ -3924,7 +3926,7 @@ packages:
       resolve: 1.22.1
     dev: false
 
-  /eslint-module-utils/2.7.4_eslint@8.32.0:
+  /eslint-module-utils/2.7.4_eslint@8.33.0:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3934,21 +3936,21 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.32.0
+      eslint: 8.33.0
     dev: false
 
-  /eslint-plugin-es/3.0.1_eslint@8.32.0:
+  /eslint-plugin-es/3.0.1_eslint@8.33.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.32.0
+      eslint: 8.33.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import/2.27.5_eslint@8.32.0:
+  /eslint-plugin-import/2.27.5_eslint@8.33.0:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3959,9 +3961,9 @@ packages:
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4_eslint@8.32.0
+      eslint-module-utils: 2.7.4_eslint@8.33.0
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -3972,13 +3974,13 @@ packages:
       tsconfig-paths: 3.14.1
     dev: false
 
-  /eslint-plugin-markdown/3.0.0_eslint@8.32.0:
+  /eslint-plugin-markdown/3.0.0_eslint@8.33.0:
     resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.32.0
+      eslint: 8.33.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
@@ -3989,14 +3991,14 @@ packages:
     engines: {node: '>=5.0.0'}
     dev: false
 
-  /eslint-plugin-node/11.1.0_eslint@8.32.0:
+  /eslint-plugin-node/11.1.0_eslint@8.33.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.32.0
-      eslint-plugin-es: 3.0.1_eslint@8.32.0
+      eslint: 8.33.0
+      eslint-plugin-es: 3.0.1_eslint@8.33.0
       eslint-utils: 2.1.0
       ignore: 5.2.4
       minimatch: 3.1.2
@@ -4004,13 +4006,13 @@ packages:
       semver: 6.3.0
     dev: false
 
-  /eslint-plugin-promise/6.1.1_eslint@8.32.0:
+  /eslint-plugin-promise/6.1.1_eslint@8.33.0:
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.32.0
+      eslint: 8.33.0
     dev: false
 
   /eslint-plugin-tsdoc/0.2.17:
@@ -4043,13 +4045,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: false
 
-  /eslint-utils/3.0.0_eslint@8.32.0:
+  /eslint-utils/3.0.0_eslint@8.33.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.32.0
+      eslint: 8.33.0
       eslint-visitor-keys: 2.1.0
     dev: false
 
@@ -4093,7 +4095,7 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 5.1.2
-      globals: 13.19.0
+      globals: 13.20.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -4117,8 +4119,8 @@ packages:
       - supports-color
     dev: false
 
-  /eslint/8.32.0:
-    resolution: {integrity: sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==}
+  /eslint/8.33.0:
+    resolution: {integrity: sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -4133,7 +4135,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.32.0
+      eslint-utils: 3.0.0_eslint@8.33.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
       esquery: 1.4.0
@@ -4142,14 +4144,14 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.19.0
+      globals: 13.20.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-sdsl: 4.2.0
+      js-sdsl: 4.3.0
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -4183,8 +4185,8 @@ packages:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2_acorn@8.8.2
       eslint-visitor-keys: 3.3.0
     dev: false
 
@@ -4300,7 +4302,7 @@ packages:
       array-flatten: 1.1.1
       body-parser: 1.20.1
       content-disposition: 0.5.4
-      content-type: 1.0.4
+      content-type: 1.0.5
       cookie: 0.5.0
       cookie-signature: 1.0.6
       debug: 2.6.9
@@ -4385,8 +4387,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: false
 
-  /fast-xml-parser/4.0.13:
-    resolution: {integrity: sha512-g+OboAw8ol1FgTHhKLR7ZHcItNudceiY04BBrvqa0JBWoPhi/+e5r4H5AeW+EsQCroJLJwsuOP3dD3c6cc5uOg==}
+  /fast-xml-parser/4.0.15:
+    resolution: {integrity: sha512-bF4/E33/K/EZDHV23IJpSK2SU7rZTaSkDH5G85nXX8SKlQ9qBpWQhyPpm2nlTBewDJgtpd6+1x4TNpKmocmthQ==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -4408,7 +4410,7 @@ packages:
       pend: 1.2.0
     dev: false
 
-  /fetch-mock/9.11.0_node-fetch@2.6.8:
+  /fetch-mock/9.11.0_node-fetch@2.6.9:
     resolution: {integrity: sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==}
     engines: {node: '>=4.0.0'}
     peerDependencies:
@@ -4418,13 +4420,13 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/runtime': 7.20.7
-      core-js: 3.27.1
+      '@babel/runtime': 7.20.13
+      core-js: 3.27.2
       debug: 4.3.4
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       path-to-regexp: 2.4.0
       querystring: 0.2.1
       whatwg-url: 6.5.0
@@ -4599,7 +4601,7 @@ packages:
     dev: false
 
   /fresh/0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -4695,8 +4697,8 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: false
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -4725,7 +4727,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /getos/3.2.1:
@@ -4735,7 +4737,7 @@ packages:
     dev: false
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
     dev: false
 
   /glob-parent/5.1.2:
@@ -4821,8 +4823,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /globals/13.19.0:
-    resolution: {integrity: sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==}
+  /globals/13.20.0:
+    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -4850,7 +4852,7 @@ packages:
   /gopd/1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /graceful-fs/4.2.10:
@@ -4894,7 +4896,7 @@ packages:
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /has-proto/1.0.1:
@@ -5104,7 +5106,7 @@ packages:
     resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
@@ -5147,7 +5149,7 @@ packages:
     resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-typed-array: 1.1.10
     dev: false
 
@@ -5185,8 +5187,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /is-builtin-module/3.2.0:
-    resolution: {integrity: sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==}
+  /is-builtin-module/3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
@@ -5428,7 +5430,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.13
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -5480,8 +5482,8 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: false
 
-  /js-sdsl/4.2.0:
-    resolution: {integrity: sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==}
+  /js-sdsl/4.3.0:
+    resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}
     dev: false
 
   /js-tokens/4.0.0:
@@ -5779,7 +5781,7 @@ packages:
       socket.io: 4.5.4
       source-map: 0.6.1
       tmp: 0.2.1
-      ua-parser-js: 0.7.32
+      ua-parser-js: 0.7.33
       yargs: 16.2.0
     transitivePeerDependencies:
       - bufferutil
@@ -5815,7 +5817,7 @@ packages:
       socket.io: 4.5.4
       source-map: 0.6.1
       tmp: 0.2.1
-      ua-parser-js: 0.7.32
+      ua-parser-js: 0.7.33
       yargs: 16.2.0
     transitivePeerDependencies:
       - bufferutil
@@ -6047,7 +6049,7 @@ packages:
     dev: false
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -6057,7 +6059,7 @@ packages:
     dev: false
 
   /merge-descriptors/1.0.1:
-    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
     dev: false
 
   /merge-stream/2.0.0:
@@ -6355,8 +6357,8 @@ packages:
       semver: 7.3.8
     dev: false
 
-  /node-abort-controller/3.0.1:
-    resolution: {integrity: sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==}
+  /node-abort-controller/3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
     dev: false
 
   /node-addon-api/4.3.0:
@@ -6386,8 +6388,8 @@ packages:
       whatwg-url: 5.0.0
     dev: false
 
-  /node-fetch/2.6.8:
-    resolution: {integrity: sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==}
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -6405,12 +6407,12 @@ packages:
       process-on-spawn: 1.0.0
     dev: false
 
-  /node-releases/2.0.8:
-    resolution: {integrity: sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==}
+  /node-releases/2.0.9:
+    resolution: {integrity: sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA==}
     dev: false
 
   /noms/0.0.0:
-    resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
+    resolution: {integrity: sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=}
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
@@ -6442,7 +6444,7 @@ packages:
       minimatch: 3.1.2
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.7.4
+      shell-quote: 1.8.0
       string.prototype.padend: 3.1.4
     dev: false
 
@@ -6919,18 +6921,18 @@ packages:
     resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
     dev: false
 
-  /punycode/2.2.0:
-    resolution: {integrity: sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==}
+  /punycode/2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
     dev: false
 
-  /puppeteer-core/19.5.2:
-    resolution: {integrity: sha512-Rqk+3kqM+Z2deooTYqcYt8lRtGffJdifWa9td9nbJSjhANWsFouk8kLBNUKycewCCFHM8TZUKS0x28OllavW2A==}
+  /puppeteer-core/19.6.2:
+    resolution: {integrity: sha512-il7uK658MNC1FlxPABvcnv1RdpDa9CaBFHzvtEsl+9Y4tbAJKZurkegpcvWeIWcRYGiuBIVo+t+ZSh3G82CCjw==}
     engines: {node: '>=14.1.0'}
     dependencies:
       cross-fetch: 3.1.5
       debug: 4.3.4
-      devtools-protocol: 0.0.1068969
+      devtools-protocol: 0.0.1082910
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
       proxy-from-env: 1.1.0
@@ -6945,8 +6947,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /puppeteer/19.5.2:
-    resolution: {integrity: sha512-xlqRyrhXhVH114l79Y0XqYXUVG+Yfw4sKlvN55t8Y9DxtA5fzI1uqF8SVXbWK5DUMbD6Jo4lpixTZCTTZGD05g==}
+  /puppeteer/19.6.2:
+    resolution: {integrity: sha512-Y5OAXXwXLfJYbl0dEFg8JKIhvCGxn+UYaBW9yra9ErmIhkVroDnYusM6oYxJCt/YIfC2pQWhvhxoZyf/E5fV6w==}
     engines: {node: '>=14.1.0'}
     requiresBuild: true
     dependencies:
@@ -6954,7 +6956,7 @@ packages:
       https-proxy-agent: 5.0.1
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      puppeteer-core: 19.5.2
+      puppeteer-core: 19.6.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -7201,7 +7203,7 @@ packages:
     dependencies:
       debug: 3.2.7
       rhea: 2.0.8
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /rhea/1.0.24:
@@ -7345,7 +7347,7 @@ packages:
   /rxjs/7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /safe-buffer/5.1.2:
@@ -7360,7 +7362,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: false
 
@@ -7456,8 +7458,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /shell-quote/1.7.4:
-    resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}
+  /shell-quote/1.8.0:
+    resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
     dev: false
 
   /shelljs/0.8.5:
@@ -7487,7 +7489,7 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       object-inspect: 1.12.3
     dev: false
 
@@ -7558,8 +7560,8 @@ packages:
     resolution: {integrity: sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==}
     dev: false
 
-  /socket.io-parser/4.2.1:
-    resolution: {integrity: sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==}
+  /socket.io-parser/4.2.2:
+    resolution: {integrity: sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
@@ -7577,7 +7579,7 @@ packages:
       debug: 4.3.4
       engine.io: 6.2.1
       socket.io-adapter: 2.4.0
-      socket.io-parser: 4.2.1
+      socket.io-parser: 4.2.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7939,7 +7941,7 @@ packages:
     dependencies:
       ip-regex: 2.1.0
       psl: 1.9.0
-      punycode: 2.2.0
+      punycode: 2.3.0
     dev: false
 
   /tough-cookie/4.1.2:
@@ -7947,7 +7949,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
-      punycode: 2.2.0
+      punycode: 2.3.0
       universalify: 0.2.0
       url-parse: 1.5.10
     dev: false
@@ -7959,7 +7961,7 @@ packages:
   /tr46/1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
-      punycode: 2.2.0
+      punycode: 2.3.0
     dev: false
 
   /tree-kill/1.2.2:
@@ -7987,7 +7989,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.36
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -8018,7 +8020,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.36
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -8049,44 +8051,13 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 17.0.45
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.6.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: false
-
-  /ts-node/10.9.1_7090bf76c41628793231709c04ba8879:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.36
-      acorn: 8.8.1
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: false
@@ -8111,7 +8082,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.36
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -8142,13 +8113,44 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 12.20.55
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.6.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
+
+  /ts-node/10.9.1_fa30498cc56410e89ff0a3d53093f367:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 14.18.36
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: false
@@ -8197,8 +8199,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: false
 
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
 
   /tsutils/3.21.0_typescript@4.8.4:
@@ -8297,20 +8299,20 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
 
-  /typescript/5.0.0-dev.20230117:
-    resolution: {integrity: sha512-t4oWIiyz6CecNWyma3JrWhQttymyjEjU22fblThjweyNJHzgScOrKO6TYWZmJT4vbi486mTLLu5ologS69czow==}
+  /typescript/5.0.0-dev.20230131:
+    resolution: {integrity: sha512-A1VAxSLhrW5D7zq7nLkE36JAfDL72gJrN8p5Y6zvvndkOGtfgJp3//M0iqCRfLe0l8noJb8cRI+kdpgSuC1giw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
 
-  /ua-parser-js/0.7.32:
-    resolution: {integrity: sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==}
+  /ua-parser-js/0.7.33:
+    resolution: {integrity: sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==}
     dev: false
 
   /uglify-js/3.17.4:
@@ -8335,8 +8337,8 @@ packages:
       through: 2.3.8
     dev: false
 
-  /undici/5.15.0:
-    resolution: {integrity: sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==}
+  /undici/5.16.0:
+    resolution: {integrity: sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0
@@ -8377,13 +8379,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /update-browserslist-db/1.0.10_browserslist@4.21.4:
+  /update-browserslist-db/1.0.10_browserslist@4.21.5:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.21.5
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: false
@@ -8391,7 +8393,7 @@ packages:
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.2.0
+      punycode: 2.3.0
     dev: false
 
   /url-parse/1.5.10:
@@ -8423,7 +8425,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
     dev: false
 
@@ -8828,14 +8830,14 @@ packages:
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -8853,7 +8855,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -8871,14 +8873,14 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -8900,7 +8902,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -8916,16 +8918,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       autorest: 3.6.3
       chai: 4.3.7
       cross-env: 7.0.3
-      csv-parse: 5.3.3
+      csv-parse: 5.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -8945,7 +8947,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -8960,14 +8962,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -8988,7 +8990,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -9003,7 +9005,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
@@ -9014,7 +9016,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -9036,7 +9038,7 @@ packages:
       rollup: 2.75.7
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -9051,7 +9053,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9065,7 +9067,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -9089,7 +9091,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_3c6f2d890c35fbed909ffee7a21fc9e6
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9107,7 +9109,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -9117,7 +9119,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 16.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -9138,7 +9140,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -9157,7 +9159,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -9166,7 +9168,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -9188,7 +9190,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -9206,7 +9208,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
@@ -9233,7 +9235,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -9248,7 +9250,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -9258,7 +9260,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -9279,7 +9281,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -9295,16 +9297,16 @@ packages:
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@types/chai': 4.3.4
-      '@types/glob': 8.0.0
+      '@types/glob': 8.0.1
       '@types/inquirer': 8.2.5
       '@types/mocha': 7.0.2
       '@types/mustache': 4.2.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
-      '@types/yargs': 17.0.19
+      '@types/yargs': 17.0.22
       '@types/yargs-parser': 21.0.0
       chai: 4.3.7
       chalk: 4.1.2
@@ -9322,7 +9324,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.75.7
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
       yargs: 17.6.2
@@ -9337,16 +9339,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@types/chai': 4.3.4
-      '@types/glob': 8.0.0
+      '@types/glob': 8.0.1
       '@types/mime': 3.0.1
       '@types/mocha': 7.0.2
       '@types/mustache': 4.2.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
-      '@types/yargs': 17.0.19
+      '@types/yargs': 17.0.22
       '@types/yargs-parser': 21.0.0
       chai: 4.3.7
       cross-env: 7.0.3
@@ -9374,7 +9376,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.75.7
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -9392,7 +9394,7 @@ packages:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
       '@azure/keyvault-secrets': 4.6.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -9401,7 +9403,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -9422,7 +9424,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
       uuid: 8.3.2
@@ -9441,7 +9443,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9455,7 +9457,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9468,7 +9470,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9482,7 +9484,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9495,7 +9497,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9509,7 +9511,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9522,7 +9524,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9536,7 +9538,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9549,7 +9551,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9563,7 +9565,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9576,7 +9578,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9590,7 +9592,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9603,7 +9605,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9617,7 +9619,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9630,7 +9632,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9644,7 +9646,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9657,7 +9659,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9671,7 +9673,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9684,7 +9686,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9698,7 +9700,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9711,7 +9713,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9726,7 +9728,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9739,7 +9741,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
@@ -9766,7 +9768,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -9781,7 +9783,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9795,7 +9797,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9808,7 +9810,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9823,7 +9825,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9835,7 +9837,7 @@ packages:
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@2.79.1
@@ -9843,7 +9845,7 @@ packages:
       mkdirp: 1.0.4
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9856,7 +9858,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9869,7 +9871,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9883,7 +9885,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9896,7 +9898,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9910,7 +9912,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9924,7 +9926,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9937,7 +9939,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9951,7 +9953,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9964,7 +9966,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -9978,7 +9980,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -9991,7 +9993,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10005,7 +10007,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10019,7 +10021,7 @@ packages:
     dependencies:
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10033,7 +10035,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10046,7 +10048,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10060,7 +10062,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10073,7 +10075,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10087,7 +10089,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10100,7 +10102,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10115,7 +10117,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10128,7 +10130,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10142,7 +10144,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10155,7 +10157,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10169,7 +10171,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10182,7 +10184,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10196,7 +10198,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10210,7 +10212,7 @@ packages:
     dependencies:
       '@azure/arm-cosmosdb': 15.2.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10224,7 +10226,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10237,7 +10239,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10251,7 +10253,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10264,7 +10266,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10279,7 +10281,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10292,7 +10294,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10306,7 +10308,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10319,7 +10321,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10333,7 +10335,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10346,7 +10348,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10359,7 +10361,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10374,7 +10376,7 @@ packages:
     dependencies:
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10389,7 +10391,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10402,7 +10404,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10417,7 +10419,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10432,14 +10434,14 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -10459,7 +10461,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -10474,7 +10476,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10487,7 +10489,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10501,7 +10503,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10515,7 +10517,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10528,7 +10530,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10543,7 +10545,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10556,7 +10558,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10571,7 +10573,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10584,7 +10586,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10599,7 +10601,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10612,7 +10614,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10626,7 +10628,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10639,7 +10641,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10654,7 +10656,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10668,7 +10670,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
@@ -10695,7 +10697,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -10710,7 +10712,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10725,7 +10727,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10738,7 +10740,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10752,7 +10754,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10765,7 +10767,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10780,7 +10782,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10793,7 +10795,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10807,7 +10809,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10820,7 +10822,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10835,7 +10837,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10848,7 +10850,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10862,7 +10864,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10875,7 +10877,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10889,7 +10891,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10902,7 +10904,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10916,7 +10918,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10929,7 +10931,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10943,7 +10945,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10956,7 +10958,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10971,7 +10973,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -10984,7 +10986,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -10998,7 +11000,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11011,7 +11013,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11025,7 +11027,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11038,7 +11040,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11052,7 +11054,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11065,7 +11067,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11079,7 +11081,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11092,7 +11094,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11106,7 +11108,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11119,7 +11121,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11134,7 +11136,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11147,7 +11149,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11162,7 +11164,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11175,7 +11177,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11188,7 +11190,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11202,7 +11204,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11216,7 +11218,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11229,7 +11231,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11243,7 +11245,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11256,7 +11258,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11270,7 +11272,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11283,7 +11285,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11298,7 +11300,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11311,7 +11313,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11325,7 +11327,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11338,7 +11340,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11351,7 +11353,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11365,7 +11367,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11379,7 +11381,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11392,7 +11394,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11405,7 +11407,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11419,7 +11421,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11432,7 +11434,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11446,7 +11448,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11460,7 +11462,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11473,7 +11475,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11488,7 +11490,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11501,7 +11503,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11516,7 +11518,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11529,7 +11531,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11544,7 +11546,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11559,7 +11561,7 @@ packages:
       '@azure/arm-network': 26.0.0
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11573,7 +11575,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11586,7 +11588,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11601,7 +11603,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11614,7 +11616,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11628,7 +11630,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11641,7 +11643,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11656,7 +11658,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11669,7 +11671,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11683,7 +11685,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11696,7 +11698,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11710,7 +11712,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11723,7 +11725,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11737,7 +11739,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11750,7 +11752,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11763,7 +11765,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11777,7 +11779,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11791,7 +11793,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11804,7 +11806,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11818,7 +11820,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11831,7 +11833,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11845,7 +11847,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11858,7 +11860,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11872,7 +11874,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11885,7 +11887,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11899,7 +11901,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11914,7 +11916,7 @@ packages:
       '@azure/arm-compute': 17.3.1
       '@azure/arm-msi': 2.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11928,7 +11930,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11941,7 +11943,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11955,7 +11957,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11968,7 +11970,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -11983,7 +11985,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -11996,7 +11998,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12010,7 +12012,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12023,7 +12025,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12038,7 +12040,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12051,7 +12053,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12065,7 +12067,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12078,7 +12080,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12092,7 +12094,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12105,7 +12107,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12118,7 +12120,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12132,7 +12134,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12145,7 +12147,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12159,7 +12161,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12173,7 +12175,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12186,7 +12188,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12200,7 +12202,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12213,7 +12215,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12228,7 +12230,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12241,7 +12243,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12255,7 +12257,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12268,7 +12270,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12281,7 +12283,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12295,7 +12297,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12309,7 +12311,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12322,7 +12324,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12336,7 +12338,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12349,7 +12351,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12362,7 +12364,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12376,7 +12378,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12390,7 +12392,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12403,7 +12405,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12417,7 +12419,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12430,7 +12432,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12443,7 +12445,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12457,7 +12459,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12471,7 +12473,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12484,7 +12486,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12498,7 +12500,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12511,7 +12513,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12524,7 +12526,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12539,7 +12541,7 @@ packages:
     dependencies:
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12554,7 +12556,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12567,7 +12569,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12580,7 +12582,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12594,7 +12596,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12608,7 +12610,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12621,7 +12623,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12636,7 +12638,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12649,7 +12651,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12664,7 +12666,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12679,7 +12681,7 @@ packages:
       '@azure/arm-operationalinsights': 8.0.1
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12692,7 +12694,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12706,7 +12708,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12719,7 +12721,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12733,7 +12735,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12748,7 +12750,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12761,7 +12763,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12775,7 +12777,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12788,7 +12790,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12801,7 +12803,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12815,7 +12817,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12829,7 +12831,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12842,7 +12844,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12857,7 +12859,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12871,14 +12873,14 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -12898,7 +12900,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -12913,7 +12915,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12927,7 +12929,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12940,7 +12942,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12954,7 +12956,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12967,7 +12969,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -12981,7 +12983,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -12994,7 +12996,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13008,7 +13010,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13021,7 +13023,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13034,7 +13036,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13048,7 +13050,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13062,7 +13064,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13075,7 +13077,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13088,7 +13090,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13102,7 +13104,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13116,7 +13118,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13129,7 +13131,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13144,7 +13146,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13157,7 +13159,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13171,7 +13173,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13184,7 +13186,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13198,7 +13200,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13211,7 +13213,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13224,7 +13226,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13238,7 +13240,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13253,7 +13255,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13266,7 +13268,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13280,7 +13282,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13293,7 +13295,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13306,7 +13308,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13320,7 +13322,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13334,7 +13336,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13347,7 +13349,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13361,7 +13363,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13374,7 +13376,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13388,7 +13390,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13401,7 +13403,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13415,7 +13417,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13428,7 +13430,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13442,7 +13444,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13455,7 +13457,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13468,7 +13470,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13482,7 +13484,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13496,7 +13498,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13510,7 +13512,7 @@ packages:
     dependencies:
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13524,7 +13526,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13537,7 +13539,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13551,7 +13553,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13564,7 +13566,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13577,7 +13579,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13591,7 +13593,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13604,7 +13606,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13618,7 +13620,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13631,7 +13633,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13645,7 +13647,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13659,7 +13661,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13672,7 +13674,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13685,7 +13687,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13699,7 +13701,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13713,7 +13715,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13726,7 +13728,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13741,7 +13743,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13754,7 +13756,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13768,7 +13770,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13781,7 +13783,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13795,7 +13797,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13808,7 +13810,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13821,7 +13823,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13835,7 +13837,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13849,7 +13851,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13862,7 +13864,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13876,7 +13878,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13889,7 +13891,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13902,7 +13904,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13916,7 +13918,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13929,7 +13931,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13943,7 +13945,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13957,7 +13959,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13970,7 +13972,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -13984,7 +13986,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -13997,7 +13999,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14011,7 +14013,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14025,7 +14027,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
@@ -14052,7 +14054,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -14067,7 +14069,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14080,7 +14082,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14094,7 +14096,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14109,7 +14111,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14122,7 +14124,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14137,7 +14139,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14150,7 +14152,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14165,7 +14167,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14178,7 +14180,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14192,7 +14194,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14205,7 +14207,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14219,7 +14221,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14232,7 +14234,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14245,7 +14247,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14259,7 +14261,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14274,7 +14276,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14287,7 +14289,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14301,7 +14303,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14314,7 +14316,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14327,7 +14329,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14341,7 +14343,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14354,7 +14356,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14368,7 +14370,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14382,7 +14384,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14395,7 +14397,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14409,7 +14411,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14422,7 +14424,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14436,7 +14438,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14449,7 +14451,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14463,7 +14465,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14476,7 +14478,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14491,7 +14493,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14504,7 +14506,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14518,7 +14520,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14531,7 +14533,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14544,7 +14546,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14558,7 +14560,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14573,7 +14575,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14586,7 +14588,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14600,7 +14602,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14613,7 +14615,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14628,7 +14630,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14641,7 +14643,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14655,7 +14657,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14668,7 +14670,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14682,7 +14684,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14695,7 +14697,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14708,7 +14710,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14722,7 +14724,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14736,7 +14738,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14749,7 +14751,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14763,7 +14765,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14776,7 +14778,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14789,7 +14791,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14803,7 +14805,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -14817,7 +14819,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -14830,7 +14832,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -14841,7 +14843,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       jsrsasign: 10.6.1
@@ -14867,7 +14869,7 @@ packages:
       safe-buffer: 5.2.1
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -14885,7 +14887,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -14893,7 +14895,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -14912,7 +14914,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -14927,7 +14929,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/communication-signaling': 1.0.0-beta.15
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -14936,7 +14938,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -14958,7 +14960,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -14975,7 +14977,7 @@ packages:
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -14984,7 +14986,7 @@ packages:
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       jwt-decode: 3.1.2
@@ -15005,7 +15007,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15020,7 +15022,7 @@ packages:
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15063,7 +15065,7 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/msal-node': 1.14.6
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15071,7 +15073,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -15095,7 +15097,7 @@ packages:
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -15109,7 +15111,7 @@ packages:
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15140,7 +15142,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       util: 0.12.5
       uuid: 8.3.2
@@ -15157,7 +15159,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@2.79.1
@@ -15170,7 +15172,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -15195,7 +15197,7 @@ packages:
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -15210,7 +15212,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15219,7 +15221,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -15239,7 +15241,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -15254,7 +15256,7 @@ packages:
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/sinon': 10.0.13
@@ -15262,7 +15264,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-env-preprocessor: 0.1.1
       mkdirp: 1.0.4
@@ -15291,7 +15293,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15300,7 +15302,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -15320,7 +15322,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -15336,7 +15338,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15345,7 +15347,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -15365,7 +15367,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -15383,7 +15385,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15391,7 +15393,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -15412,7 +15414,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -15428,7 +15430,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -15437,7 +15439,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15455,7 +15457,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15470,7 +15472,7 @@ packages:
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
@@ -15488,7 +15490,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.4
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       jssha: 3.3.0
       karma: 6.4.1_debug@4.3.4
@@ -15499,7 +15501,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       process: 0.11.10
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rhea: 2.0.8
       rhea-promise: 2.1.0
       rimraf: 3.0.2
@@ -15508,7 +15510,7 @@ packages:
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       ws: 8.12.0
@@ -15526,20 +15528,20 @@ packages:
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15551,7 +15553,7 @@ packages:
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15559,7 +15561,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15578,7 +15580,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15595,14 +15597,14 @@ packages:
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       chai: 4.3.7
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15620,7 +15622,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -15634,10 +15636,10 @@ packages:
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
@@ -15654,10 +15656,10 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger-js': 1.3.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
       '@types/chai': 4.3.4
-      '@types/express': 4.17.15
+      '@types/express': 4.17.16
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/node-fetch': 2.6.2
@@ -15670,9 +15672,9 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       express: 4.18.2
-      fetch-mock: 9.11.0_node-fetch@2.6.8
+      fetch-mock: 9.11.0_node-fetch@2.6.9
       form-data: 4.0.0
       karma: 6.4.1
       karma-chai: 0.1.0_chai@4.3.7+karma@6.4.1
@@ -15683,19 +15685,19 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       npm-run-all: 4.1.5
       nyc: 15.1.0
       prettier: 2.8.3
       process: 0.11.10
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       regenerator-runtime: 0.13.11
       rimraf: 3.0.2
       shx: 0.3.4
       sinon: 9.2.4
       tough-cookie: 4.1.2
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       tunnel: 0.0.6
       typescript: 4.8.4
       uglify-js: 3.17.4
@@ -15717,11 +15719,11 @@ packages:
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -15739,7 +15741,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -15755,13 +15757,13 @@ packages:
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -15777,7 +15779,7 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -15791,7 +15793,7 @@ packages:
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
@@ -15803,7 +15805,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -15822,11 +15824,11 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -15843,14 +15845,14 @@ packages:
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       chai: 4.3.7
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15868,7 +15870,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15883,7 +15885,7 @@ packages:
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15891,7 +15893,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15909,7 +15911,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15924,7 +15926,7 @@ packages:
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15933,8 +15935,8 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
-      fast-xml-parser: 4.0.13
+      eslint: 8.33.0
+      fast-xml-parser: 4.0.15
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -15953,7 +15955,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -15971,7 +15973,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/debug': 4.1.7
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -15984,7 +15986,7 @@ packages:
       debug: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       execa: 5.1.1
       fast-json-stable-stringify: 2.1.0
@@ -15992,7 +15994,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nock: 12.0.3
-      node-abort-controller: 3.0.1
+      node-abort-controller: 3.1.1
       prettier: 2.8.3
       priorityqueuejs: 1.0.0
       requirejs: 2.3.6
@@ -16001,7 +16003,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       universal-user-agent: 6.0.0
       uuid: 8.3.2
@@ -16017,7 +16019,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -16027,7 +16029,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -16047,7 +16049,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -16065,9 +16067,9 @@ packages:
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
-      '@_ts/max': /typescript/4.9.4
+      '@_ts/max': /typescript/4.9.5
       '@_ts/min': /typescript/4.2.4
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-multi-entry': 4.1.0_rollup@2.79.1
@@ -16089,7 +16091,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 16.0.3
       downlevel-dts: 0.7.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       fs-extra: 11.1.0
       karma: 6.4.1
       minimist: 1.2.7
@@ -16104,7 +16106,7 @@ packages:
       rollup-plugin-visualizer: 5.9.0_rollup@2.79.1
       semver: 7.3.8
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       yaml: 1.10.2
     transitivePeerDependencies:
@@ -16123,7 +16125,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 14.18.36
       autorest: 3.6.3
@@ -16150,7 +16152,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -16160,12 +16162,12 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-zpmdHAAYYxRxrTiSoRX+PAHpl6CVW7fgY2nbRTlj7GgQEtlDFlm7JrQ+0ASkEK2gPYHhT5YxoVof7MgLt9I8HA==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-FqZ2A3XNO3xKqf2l2ZNfrtWqnoG3SJwGYZhhvswH3eFedzAwsIUVqMdskRh/QlVLJTFJF0KCfIRuQDE1I9xVpg==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -16174,7 +16176,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -16193,7 +16195,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -16212,21 +16214,21 @@ packages:
       '@types/chai': 4.3.4
       '@types/eslint': 8.4.10
       '@types/estree': 1.0.0
-      '@types/glob': 8.0.0
+      '@types/glob': 8.0.1
       '@types/json-schema': 7.0.11
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
-      '@typescript-eslint/eslint-plugin': 5.46.1_9915f8eb2680b99db13ca80ed7b3a32e
-      '@typescript-eslint/experimental-utils': 5.46.1_eslint@8.32.0+typescript@4.8.4
-      '@typescript-eslint/parser': 5.46.1_eslint@8.32.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.46.1_d11dc6fd8031cdb46eb60587aa225b16
+      '@typescript-eslint/experimental-utils': 5.46.1_eslint@8.33.0+typescript@4.8.4
+      '@typescript-eslint/parser': 5.46.1_eslint@8.33.0+typescript@4.8.4
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.8.4
       chai: 4.3.7
-      eslint: 8.32.0
-      eslint-config-prettier: 8.6.0_eslint@8.32.0
-      eslint-plugin-import: 2.27.5_eslint@8.32.0
-      eslint-plugin-markdown: 3.0.0_eslint@8.32.0
+      eslint: 8.33.0
+      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint-plugin-import: 2.27.5_eslint@8.33.0
+      eslint-plugin-markdown: 3.0.0_eslint@8.33.0
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-promise: 6.1.1_eslint@8.32.0
+      eslint-plugin-promise: 6.1.1_eslint@8.33.0
       eslint-plugin-tsdoc: 0.2.17
       glob: 8.1.0
       json-schema: 0.4.0
@@ -16235,19 +16237,19 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-8Z/Lp4mVyIyb92vRhanHwLEvH1v94/qa08iKbBRpTwyyFau+hFu+/F70Gsigf1ZP8z2WjrT3X5MpTKGi9PkMiA==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-DBo5oyDRI7yy7Pxjll83Dsj+ADVwWES/6vQ1+Fu+sf3VsiM+qK951tnv2F1qQLnY5TQ5enM3v+jnG344vDNw4Q==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
@@ -16274,7 +16276,7 @@ packages:
       debug: 4.3.4
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       https-proxy-agent: 5.0.1
       is-buffer: 2.0.5
@@ -16296,7 +16298,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       process: 0.11.10
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rhea-promise: 2.1.0
       rimraf: 3.0.2
       rollup: 2.79.1
@@ -16304,7 +16306,7 @@ packages:
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
       ws: 8.12.0
@@ -16322,7 +16324,7 @@ packages:
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -16333,7 +16335,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -16353,7 +16355,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16370,7 +16372,7 @@ packages:
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/chai-string': 1.4.2
@@ -16383,7 +16385,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       guid-typescript: 1.0.9
@@ -16405,7 +16407,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16422,7 +16424,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/data-tables': 12.1.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/chai-string': 1.4.2
@@ -16435,7 +16437,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       guid-typescript: 1.0.9
       inherits: 2.0.4
@@ -16456,7 +16458,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16474,7 +16476,7 @@ packages:
     dependencies:
       '@azure/functions': 3.5.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -16482,7 +16484,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -16503,7 +16505,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16521,24 +16523,24 @@ packages:
       '@azure/identity': 2.1.0
       '@azure/msal-node': 1.14.6
       '@azure/msal-node-extensions': 1.0.0-alpha.25
-      '@microsoft/api-extractor': 7.33.7
-      '@types/jws': 3.2.4
+      '@microsoft/api-extractor': 7.34.0
+      '@types/jws': 3.2.5
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/qs': 6.9.7
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16554,8 +16556,8 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
-      '@types/jws': 3.2.4
+      '@microsoft/api-extractor': 7.34.0
+      '@types/jws': 3.2.5
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/qs': 6.9.7
@@ -16563,16 +16565,16 @@ packages:
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16589,12 +16591,12 @@ packages:
     dependencies:
       '@azure/keyvault-keys': 4.6.0
       '@azure/msal-browser': 2.32.2
-      '@azure/msal-common': 9.0.2
+      '@azure/msal-common': 9.1.1
       '@azure/msal-node': 1.14.6
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/jsonwebtoken': 9.0.1
-      '@types/jws': 3.2.4
+      '@types/jws': 3.2.5
       '@types/mocha': 7.0.2
       '@types/ms': 0.7.31
       '@types/node': 14.18.36
@@ -16604,7 +16606,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 16.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       jsonwebtoken: 9.0.0
@@ -16623,11 +16625,11 @@ packages:
       nyc: 15.1.0
       open: 8.4.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       stoppable: 1.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -16645,14 +16647,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       chai: 4.3.7
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -16673,7 +16675,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16688,14 +16690,14 @@ packages:
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       chai: 4.3.7
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -16717,7 +16719,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -16736,14 +16738,14 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/keyvault-keys': 4.6.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
@@ -16752,7 +16754,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -16767,13 +16769,13 @@ packages:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
       '@azure/keyvault-secrets': 4.6.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -16792,11 +16794,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -16811,19 +16813,19 @@ packages:
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -16839,14 +16841,14 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dayjs: 1.11.7
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -16865,11 +16867,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -16886,13 +16888,13 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       '@types/sinon': 9.0.11
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -16909,11 +16911,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -16930,7 +16932,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/node': 12.20.55
       '@types/uuid': 8.3.4
@@ -16959,7 +16961,7 @@ packages:
       process: 0.11.10
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.2.4
       uuid: 9.0.0
     transitivePeerDependencies:
@@ -16974,7 +16976,7 @@ packages:
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -16982,7 +16984,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -16998,11 +17000,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17019,9 +17021,9 @@ packages:
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       downlevel-dts: 0.8.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       typescript: 4.8.4
@@ -17037,7 +17039,7 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17045,7 +17047,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -17065,7 +17067,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -17082,7 +17084,7 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17090,7 +17092,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -17110,7 +17112,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -17127,7 +17129,7 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 12.20.55
@@ -17155,7 +17157,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -17170,7 +17172,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17180,7 +17182,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.8.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -17201,7 +17203,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -17219,7 +17221,7 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17227,7 +17229,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -17247,7 +17249,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -17262,7 +17264,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17271,7 +17273,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -17291,7 +17293,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -17308,7 +17310,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17318,7 +17320,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       inherits: 2.0.4
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -17337,7 +17339,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
       uuid: 8.3.2
@@ -17355,11 +17357,11 @@ packages:
     dependencies:
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rhea: 2.0.8
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - supports-color
@@ -17371,7 +17373,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17402,7 +17404,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -17417,21 +17419,21 @@ packages:
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/instrumentation': 0.35.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/instrumentation-http': 0.35.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/resources': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-metrics': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-base': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-node': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/semantic-conventions': 1.9.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/instrumentation-http': 0.35.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-metrics': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-node': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/semantic-conventions': 1.9.1
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
-      eslint-plugin-node: 11.1.0_eslint@8.32.0
+      eslint: 8.33.0
+      eslint-plugin-node: 11.1.0_eslint@8.33.0
       mocha: 7.2.0
       nock: 12.0.3
       nyc: 15.1.0
@@ -17439,7 +17441,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17453,10 +17455,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/sdk-trace-base': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-node': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-node': 1.9.1_@opentelemetry+api@1.4.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -17466,7 +17468,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -17485,7 +17487,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - bufferutil
@@ -17499,8 +17501,8 @@ packages:
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
-      '@rollup/plugin-typescript': 10.0.1_905125611895ceb1b1b2fc58dab912cd
+      '@microsoft/api-extractor': 7.34.0
+      '@rollup/plugin-typescript': 10.0.1_09c4cab51ef954b1bc178cd63b85c611
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17509,7 +17511,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 16.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -17527,14 +17529,14 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.6.3_7e8d81808a761355f6c3da2f25cfe887
-      ts-node: 10.9.1_7090bf76c41628793231709c04ba8879
-      tslib: 2.4.1
-      typescript: 4.9.4
+      ts-node: 10.9.1_fa30498cc56410e89ff0a3d53093f367
+      tslib: 2.5.0
+      typescript: 4.9.5
       util: 0.12.5
       uuid: 9.0.0
     transitivePeerDependencies:
@@ -17552,12 +17554,12 @@ packages:
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
-      '@opentelemetry/core': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/instrumentation': 0.35.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-base': 1.9.0_@opentelemetry+api@1.4.0
-      '@opentelemetry/sdk-trace-node': 1.9.0_@opentelemetry+api@1.4.0
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/instrumentation': 0.35.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.0
+      '@opentelemetry/sdk-trace-node': 1.9.1_@opentelemetry+api@1.4.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -17566,7 +17568,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -17586,7 +17588,7 @@ packages:
       rimraf: 3.0.2
       sinon: 12.0.1
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -17605,11 +17607,11 @@ packages:
       '@azure/identity': 2.1.0
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17626,11 +17628,11 @@ packages:
       '@azure/identity': 2.1.0
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17646,11 +17648,11 @@ packages:
       '@azure/ai-metrics-advisor': 1.0.0-beta.3
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17667,11 +17669,11 @@ packages:
       '@azure/identity': 2.1.0
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17687,11 +17689,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17707,11 +17709,11 @@ packages:
     dependencies:
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 9.1.1_typescript@4.6.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - supports-color
@@ -17722,7 +17724,7 @@ packages:
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@types/express': 4.17.15
+      '@types/express': 4.17.16
       '@types/node': 17.0.45
       '@types/uuid': 8.3.4
       concurrently: 6.5.1
@@ -17733,9 +17735,9 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_58215dfbed9856019847b52698b53c56
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
-      undici: 5.15.0
+      undici: 5.16.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -17750,11 +17752,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17771,12 +17773,12 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       moment: 2.29.4
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17792,11 +17794,11 @@ packages:
     dependencies:
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17813,11 +17815,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17835,11 +17837,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17858,11 +17860,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17881,11 +17883,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -17903,11 +17905,11 @@ packages:
       '@azure/monitor-ingestion': 1.0.0-beta.2
       '@types/node': 12.20.55
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_b5bd4a8e238709e15d0171692055b18b
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17923,11 +17925,11 @@ packages:
       '@azure/identity': 2.1.0
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17944,11 +17946,11 @@ packages:
       '@azure/schema-registry': 1.2.0
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17965,11 +17967,11 @@ packages:
       '@azure/search-documents': 11.3.0-beta.7
       '@types/node': 14.18.36
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -17985,11 +17987,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18007,12 +18009,12 @@ packages:
       '@types/node-fetch': 2.6.2
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
-      node-fetch: 2.6.8
+      eslint: 8.33.0
+      node-fetch: 2.6.9
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18030,11 +18032,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18051,11 +18053,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18073,11 +18075,11 @@ packages:
       '@types/node': 14.18.36
       '@types/uuid': 8.3.4
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18092,14 +18094,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18119,7 +18121,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -18135,14 +18137,14 @@ packages:
     dependencies:
       '@azure/core-lro': 2.2.4
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18162,7 +18164,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -18177,14 +18179,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18204,7 +18206,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -18220,7 +18222,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18228,7 +18230,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -18250,7 +18252,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18269,7 +18271,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
       '@azure/schema-registry': 1.2.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 21.1.0_rollup@2.79.1
       '@rollup/plugin-inject': 4.0.4_rollup@2.79.1
       '@types/chai': 4.3.4
@@ -18283,7 +18285,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18308,7 +18310,7 @@ packages:
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -18325,12 +18327,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18350,7 +18352,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -18365,7 +18367,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-http-compat': 1.3.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18373,7 +18375,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -18396,7 +18398,7 @@ packages:
       rimraf: 3.0.2
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18414,7 +18416,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/debug': 4.1.7
@@ -18432,7 +18434,7 @@ packages:
       debug: 4.3.4
       dotenv: 16.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       https-proxy-agent: 5.0.1
@@ -18457,13 +18459,13 @@ packages:
       prettier: 2.8.3
       process: 0.11.10
       promise: 8.3.0
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rhea-promise: 2.1.0
       rimraf: 3.0.2
       rollup: 2.79.1
       sinon: 9.2.4
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
       ws: 8.12.0
@@ -18483,7 +18485,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18493,7 +18495,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -18514,12 +18516,12 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18540,7 +18542,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18550,7 +18552,7 @@ packages:
       dotenv: 16.0.3
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -18571,11 +18573,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18596,7 +18598,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18605,7 +18607,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       execa: 6.1.0
@@ -18627,11 +18629,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18651,7 +18653,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18660,7 +18662,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -18681,11 +18683,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18703,7 +18705,7 @@ packages:
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18711,7 +18713,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -18729,11 +18731,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18754,7 +18756,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -18763,7 +18765,7 @@ packages:
       dotenv: 8.6.0
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -18783,11 +18785,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -18805,7 +18807,7 @@ packages:
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -18815,7 +18817,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18836,7 +18838,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -18854,7 +18856,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -18865,7 +18867,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18888,7 +18890,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_849fe26e242416846e0608b0d80cfc55
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       uglify-js: 3.17.4
       uuid: 8.3.2
@@ -18907,7 +18909,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -18917,7 +18919,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18940,7 +18942,7 @@ packages:
       sinon: 9.2.4
       source-map-support: 0.5.21
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -18957,7 +18959,7 @@ packages:
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -18965,7 +18967,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -18983,7 +18985,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -18998,15 +19000,15 @@ packages:
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@rollup/plugin-commonjs': 22.0.2_rollup@2.79.1
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.79.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-sourcemaps: 0.6.3_rollup@2.79.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -19021,7 +19023,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -19029,7 +19031,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -19049,7 +19051,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uglify-js: 3.17.4
     transitivePeerDependencies:
@@ -19066,7 +19068,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -19074,7 +19076,7 @@ packages:
       cross-env: 7.0.3
       dotenv: 16.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.1
@@ -19095,7 +19097,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -19113,7 +19115,7 @@ packages:
       '@azure-tools/test-recorder': 1.0.2
       '@azure/identity': 2.1.0
       '@types/node': 14.18.36
-      eslint: 8.32.0
+      eslint: 8.33.0
       prettier: 2.8.3
       rimraf: 3.0.2
       typescript: 4.6.4
@@ -19129,7 +19131,7 @@ packages:
     dependencies:
       '@azure/core-http': 2.3.1
       '@types/chai': 4.3.4
-      '@types/express': 4.17.15
+      '@types/express': 4.17.16
       '@types/fs-extra': 8.1.2
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -19138,7 +19140,7 @@ packages:
       concurrently: 7.6.0
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       express: 4.18.2
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
@@ -19157,7 +19159,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 10.9.1_325dbdcd45fb3439d2de9b2f3ddec5e4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -19178,17 +19180,17 @@ packages:
       '@types/minimist': 1.2.2
       '@types/node': 14.18.36
       '@types/node-fetch': 2.6.2
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
       karma-env-preprocessor: 0.1.1
       minimist: 1.2.7
-      node-fetch: 2.6.8
+      node-fetch: 2.6.9
       prettier: 2.8.3
       rimraf: 3.0.2
       ts-node: 8.10.2_typescript@4.8.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -19203,7 +19205,7 @@ packages:
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@opentelemetry/api': 1.4.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
@@ -19214,7 +19216,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       chai-exclude: 2.1.0_chai@4.3.7
       cross-env: 7.0.3
-      eslint: 8.32.0
+      eslint: 8.33.0
       karma: 6.4.1
       karma-chrome-launcher: 3.1.1
       karma-coverage: 2.2.0
@@ -19223,7 +19225,7 @@ packages:
       prettier: 2.8.3
       rimraf: 3.0.2
       sinon: 9.2.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -19237,7 +19239,7 @@ packages:
     name: '@rush-temp/video-analyzer-edge'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
       '@types/mocha': 7.0.2
@@ -19247,7 +19249,7 @@ packages:
       chai-as-promised: 7.1.1_chai@4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.1
@@ -19266,7 +19268,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.3
       rimraf: 3.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -19282,11 +19284,11 @@ packages:
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/chai-as-promised': 7.1.5
-      '@types/express': 4.17.15
-      '@types/express-serve-static-core': 4.17.32
+      '@types/express': 4.17.16
+      '@types/express-serve-static-core': 4.17.33
       '@types/jsonwebtoken': 9.0.1
       '@types/mocha': 7.0.2
       '@types/node': 12.20.55
@@ -19296,7 +19298,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       express: 4.18.2
       karma: 6.4.1
@@ -19317,11 +19319,11 @@ packages:
       mock-socket: 9.1.5
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.6.4
       util: 0.12.5
       ws: 7.5.9
@@ -19338,10 +19340,10 @@ packages:
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
-      '@types/express': 4.17.15
-      '@types/express-serve-static-core': 4.17.32
+      '@types/express': 4.17.16
+      '@types/express-serve-static-core': 4.17.33
       '@types/jsonwebtoken': 9.0.1
       '@types/mocha': 7.0.2
       '@types/node': 14.18.36
@@ -19349,18 +19351,18 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       express: 4.18.2
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -19374,7 +19376,7 @@ packages:
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.33.7
+      '@microsoft/api-extractor': 7.34.0
       '@types/chai': 4.3.4
       '@types/jsonwebtoken': 9.0.1
       '@types/mocha': 7.0.2
@@ -19384,7 +19386,7 @@ packages:
       chai: 4.3.7
       cross-env: 7.0.3
       dotenv: 8.6.0
-      eslint: 8.32.0
+      eslint: 8.33.0
       esm: 3.2.25
       jsonwebtoken: 9.0.0
       karma: 6.4.1
@@ -19402,11 +19404,11 @@ packages:
       mocha-junit-reporter: 2.2.0_mocha@7.2.0
       nyc: 15.1.0
       prettier: 2.8.3
-      puppeteer: 19.5.2
+      puppeteer: 19.6.2
       rimraf: 3.0.2
       sinon: 9.2.4
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.8.4
       ws: 8.12.0
     transitivePeerDependencies:


### PR DESCRIPTION
Making a counterpart PR in the feature branch for the one in main https://github.com/Azure/azure-sdk-for-js/pull/24636