### PR TITLE
[engsys] do not build the `ts-genapi`

### DIFF
--- a/eng/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/scripts/Generate-APIView-CodeFile.ps1
@@ -35,7 +35,6 @@ if (!(Test-Path -Path $installedPath))
 
 Write-Host "Setting working directory to $($installedPath)"
 Set-Location $installedPath
-npm run-script build
 
 $apiFiles = Get-ChildItem -Path $ArtifactPath -Recurse -Filter "*.api.json"
 foreach ($apiPkgFile in $apiFiles)


### PR DESCRIPTION
The installed one is ready for use. Trying to build it would result in compiler errors as its devDependencies are not installed.


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
