### PR TITLE
[engsys] upgrade load-testing dev dependency prettier to ^2.5.1

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7309,12 +7309,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: false
 
-  /prettier/2.2.1:
-    resolution: {integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: false
-
   /prettier/2.8.3:
     resolution: {integrity: sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==}
     engines: {node: '>=10.13.0'}
@@ -17504,7 +17498,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-dEMfZdZQA9IdCKED1XMgIbZPlzjkgkufRsv0nplKiTSquk/UW5owAY3RmTR5B3USaIv+Ik0ccFX6U067urILBg==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-W9vkfSJU9XQ0HIf6k71GlwNgqY3TtvJFUo6GMHJf0Y66MOw9beCLlqBlMncxn8YIQbDL83Zic7shxsWmX9KNDA==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -17535,7 +17529,7 @@ packages:
       mocha: 7.2.0
       mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
-      prettier: 2.2.1
+      prettier: 2.8.3
       rimraf: 3.0.2
       source-map-support: 0.5.21
       tslib: 2.5.0

--- a/sdk/loadtestservice/load-testing-rest/package.json
+++ b/sdk/loadtestservice/load-testing-rest/package.json
@@ -112,7 +112,7 @@
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "uuid": "^9.0.0",

--- a/sdk/loadtestservice/load-testing-rest/samples-dev/sample.ts
+++ b/sdk/loadtestservice/load-testing-rest/samples-dev/sample.ts
@@ -81,13 +81,14 @@ async function main() {
       body: {
         testId: testCreationResult.body.testId,
         components: {
-          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo": {
-            resourceId:
-              "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
-            resourceName: "App-Service-Sample-Demo",
-            resourceType: "Microsoft.Web/sites",
-            subscriptionId: SUBSCRIPTION_ID,
-          },
+          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo":
+            {
+              resourceId:
+                "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
+              resourceName: "App-Service-Sample-Demo",
+              resourceType: "Microsoft.Web/sites",
+              subscriptionId: SUBSCRIPTION_ID,
+            },
         },
       },
     });

--- a/sdk/loadtestservice/load-testing-rest/src/parameters.ts
+++ b/sdk/loadtestservice/load-testing-rest/src/parameters.ts
@@ -100,9 +100,10 @@ export interface TestCreateOrUpdateAppComponentsMediaTypesParam {
   contentType?: "application/merge-patch+json";
 }
 
-export type TestCreateOrUpdateAppComponentsParameters = TestCreateOrUpdateAppComponentsMediaTypesParam &
-  TestCreateOrUpdateAppComponentsBodyParam &
-  RequestParameters;
+export type TestCreateOrUpdateAppComponentsParameters =
+  TestCreateOrUpdateAppComponentsMediaTypesParam &
+    TestCreateOrUpdateAppComponentsBodyParam &
+    RequestParameters;
 export type TestListAppComponentsParameters = RequestParameters;
 
 export interface TestCreateOrUpdateServerMetricsConfigBodyParam {
@@ -115,9 +116,10 @@ export interface TestCreateOrUpdateServerMetricsConfigMediaTypesParam {
   contentType?: "application/merge-patch+json";
 }
 
-export type TestCreateOrUpdateServerMetricsConfigParameters = TestCreateOrUpdateServerMetricsConfigMediaTypesParam &
-  TestCreateOrUpdateServerMetricsConfigBodyParam &
-  RequestParameters;
+export type TestCreateOrUpdateServerMetricsConfigParameters =
+  TestCreateOrUpdateServerMetricsConfigMediaTypesParam &
+    TestCreateOrUpdateServerMetricsConfigBodyParam &
+    RequestParameters;
 export type TestListServerMetricsConfigParameters = RequestParameters;
 export type TestRunDeleteParameters = RequestParameters;
 
@@ -233,8 +235,8 @@ export interface TestRunListMetricDimensionValuesQueryParam {
   queryParameters: TestRunListMetricDimensionValuesQueryParamProperties;
 }
 
-export type TestRunListMetricDimensionValuesParameters = TestRunListMetricDimensionValuesQueryParam &
-  RequestParameters;
+export type TestRunListMetricDimensionValuesParameters =
+  TestRunListMetricDimensionValuesQueryParam & RequestParameters;
 
 export interface TestRunCreateOrUpdateAppComponentsBodyParam {
   /** App Component model. */
@@ -246,9 +248,10 @@ export interface TestRunCreateOrUpdateAppComponentsMediaTypesParam {
   contentType?: "application/merge-patch+json";
 }
 
-export type TestRunCreateOrUpdateAppComponentsParameters = TestRunCreateOrUpdateAppComponentsMediaTypesParam &
-  TestRunCreateOrUpdateAppComponentsBodyParam &
-  RequestParameters;
+export type TestRunCreateOrUpdateAppComponentsParameters =
+  TestRunCreateOrUpdateAppComponentsMediaTypesParam &
+    TestRunCreateOrUpdateAppComponentsBodyParam &
+    RequestParameters;
 export type TestRunListAppComponentsParameters = RequestParameters;
 
 export interface TestRunCreateOrUpdateServerMetricsConfigBodyParam {
@@ -261,7 +264,8 @@ export interface TestRunCreateOrUpdateServerMetricsConfigMediaTypesParam {
   contentType?: "application/merge-patch+json";
 }
 
-export type TestRunCreateOrUpdateServerMetricsConfigParameters = TestRunCreateOrUpdateServerMetricsConfigMediaTypesParam &
-  TestRunCreateOrUpdateServerMetricsConfigBodyParam &
-  RequestParameters;
+export type TestRunCreateOrUpdateServerMetricsConfigParameters =
+  TestRunCreateOrUpdateServerMetricsConfigMediaTypesParam &
+    TestRunCreateOrUpdateServerMetricsConfigBodyParam &
+    RequestParameters;
 export type TestRunListServerMetricsConfigParameters = RequestParameters;

--- a/sdk/loadtestservice/load-testing-rest/test/public/testAdministration.spec.ts
+++ b/sdk/loadtestservice/load-testing-rest/test/public/testAdministration.spec.ts
@@ -113,13 +113,14 @@ describe("Test Creation", () => {
       body: {
         testId: "abc",
         components: {
-          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo": {
-            resourceId:
-              "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
-            resourceName: "App-Service-Sample-Demo",
-            resourceType: "Microsoft.Web/sites",
-            subscriptionId: SUBSCRIPTION_ID,
-          },
+          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo":
+            {
+              resourceId:
+                "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
+              resourceName: "App-Service-Sample-Demo",
+              resourceType: "Microsoft.Web/sites",
+              subscriptionId: SUBSCRIPTION_ID,
+            },
         },
       },
     });

--- a/sdk/loadtestservice/load-testing-rest/test/public/testRun.spec.ts
+++ b/sdk/loadtestservice/load-testing-rest/test/public/testRun.spec.ts
@@ -150,13 +150,14 @@ describe("Test Run Creation", () => {
       contentType: "application/merge-patch+json",
       body: {
         components: {
-          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo": {
-            resourceId:
-              "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
-            resourceName: "App-Service-Sample-Demo",
-            resourceType: "Microsoft.Web/sites",
-            subscriptionId: SUBSCRIPTION_ID,
-          },
+          "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo":
+            {
+              resourceId:
+                "/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/App-Service-Sample-Demo-rg/providers/Microsoft.Web/sites/App-Service-Sample-Demo",
+              resourceName: "App-Service-Sample-Demo",
+              resourceType: "Microsoft.Web/sites",
+              subscriptionId: SUBSCRIPTION_ID,
+            },
         },
       },
     });


### PR DESCRIPTION
which is the version currently used by other packages.

Also include results of `rushx format`
