### PR TITLE
fix: comm-common: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-common/test/internal/cryptoUtils.spec.ts
+++ b/sdk/communication/communication-common/test/internal/cryptoUtils.spec.ts
@@ -4,23 +4,23 @@
 import { shaHMAC, shaHash } from "../../src/credential/cryptoUtils";
 import { assert } from "chai";
 
-describe("CryptoUtils", () => {
-  it("calculates correct hash", async () => {
+describe("CryptoUtils", function () {
+  it("calculates correct hash", async function () {
     const hash = await shaHash("banana");
     assert.equal(hash, "tJPUg2Sv5E0RwBZc9HCkFk0eJgmRHvmYvoaNRq3j3k4=");
   });
 
-  it("calculates correct hmac", async () => {
+  it("calculates correct hmac", async function () {
     const hmac = await shaHMAC("pw==", "banana");
     assert.equal(hmac, "88EC05aAS9iXnaimtNO78JLjiPtfWryQB/5QYEzEsu8=");
   });
 
-  it("hash handles encoding", async () => {
+  it("hash handles encoding", async function () {
     const hash = await shaHash("😀");
     assert.equal(hash, "8EQ6NCxe9UeDoRG1G6Vsk45HTDIyTZDDpgycjjo34tk=");
   });
 
-  it("hmac handles encoding", async () => {
+  it("hmac handles encoding", async function () {
     const hmac = await shaHMAC("pw==", "😀");
     assert.equal(hmac, "1rudJKjn2Zi+3hRrBG29wIF6pD6YyAeQR1ZcFtXoKAU=");
   });

--- a/sdk/communication/communication-common/test/public/clientArguments.spec.ts
+++ b/sdk/communication/communication-common/test/public/clientArguments.spec.ts
@@ -12,20 +12,20 @@ const host = "https://contoso.communicationservices.azure.com";
 const connectionString =
   "endpoint=https://contoso.communicationservices.azure.com:443/;accesskey=secret";
 
-describe("ClientArguments", () => {
-  it("accepts valid host URL", () => {
+describe("ClientArguments", function () {
+  it("accepts valid host URL", function () {
     const { url, credential } = parseClientArguments(host, mockCredential);
     assert.equal(url, host);
     assert.equal(credential, mockCredential);
   });
 
-  it("throws if invalid host URL", () => {
+  it("throws if invalid host URL", function () {
     assert.throws(() => {
       parseClientArguments("file://banana/fofana.txt", mockCredential);
     }, "Invalid endpoint");
   });
 
-  it("handles valid connection string", () => {
+  it("handles valid connection string", function () {
     const { url, credential } = parseClientArguments(connectionString);
     assert.equal(url, "https://contoso.communicationservices.azure.com:443/");
     /* Instead of 'instanceOf' check (as the AzureKeyCredential object might be referenced from different package version), 
@@ -34,7 +34,7 @@ describe("ClientArguments", () => {
     assertPropertyNames(AzureKeyCredential.prototype, Object.getPrototypeOf(credential));
   });
 
-  it("throws if invalid connection string", () => {
+  it("throws if invalid connection string", function () {
     assert.throws(() => {
       parseConnectionString("Lorem ipsum dolor connection string");
     }, "Invalid connection string");

--- a/sdk/communication/communication-common/test/public/communicationKeyCredentialPolicy.spec.ts
+++ b/sdk/communication/communication-common/test/public/communicationKeyCredentialPolicy.spec.ts
@@ -13,8 +13,8 @@ import { assert } from "chai";
 import { createCommunicationAccessKeyCredentialPolicy } from "../../src";
 import { isNode } from "@azure/core-util";
 
-describe("CommunicationKeyCredentialPolicy", () => {
-  it("signs the request", async () => {
+describe("CommunicationKeyCredentialPolicy", function () {
+  it("signs the request", async function () {
     const credential = new MockKeyCredential("pw==");
     const communicationKeyCredentialPolicy =
       createCommunicationAccessKeyCredentialPolicy(credential);

--- a/sdk/communication/communication-common/test/public/communicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/public/communicationTokenCredential.spec.ts
@@ -34,26 +34,26 @@ const exposeInternalUpdatePromise = async (
   }
 };
 
-describe("CommunicationTokenCredential", () => {
+describe("CommunicationTokenCredential", function () {
   let clock: sinon.SinonFakeTimers;
 
-  beforeEach(() => {
+  beforeEach(function () {
     clock = sinon.useFakeTimers();
   });
 
-  afterEach(() => {
+  afterEach(function () {
     clock.restore();
   });
 
-  it("handles valid JWT strings", async () => {
+  it("handles valid JWT strings", async function () {
     new AzureCommunicationTokenCredential(generateToken(60));
   });
 
-  it("throws if non-JWT token", async () => {
+  it("throws if non-JWT token", async function () {
     assert.throws(() => new AzureCommunicationTokenCredential("IAmNotAToken"), /Invalid token/);
   });
 
-  it("throws if non-JWT passed as lambda", async () => {
+  it("throws if non-JWT passed as lambda", async function () {
     await assert.isRejected(
       new AzureCommunicationTokenCredential({
         tokenRefresher: async () => "IAmNotAToken",
@@ -61,14 +61,14 @@ describe("CommunicationTokenCredential", () => {
     );
   });
 
-  it("returns token as expected", async () => {
+  it("returns token as expected", async function () {
     const token = generateToken(60);
     const tokenCredential = new AzureCommunicationTokenCredential(token);
     const tokenResult = (await tokenCredential.getToken()).token;
     assert.strictEqual(tokenResult, token);
   });
 
-  it("returns token as expected when using lambda", async () => {
+  it("returns token as expected when using lambda", async function () {
     const token = generateToken(60);
     const tokenRefresher = sinon.stub().resolves(token);
     const tokenCredential = new AzureCommunicationTokenCredential({
@@ -79,7 +79,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("uses initial token as expected", async () => {
+  it("uses initial token as expected", async function () {
     const token = generateToken(60);
     const tokenRefresher = sinon.stub().resolves(generateToken(120));
     const tokenCredential = new AzureCommunicationTokenCredential({
@@ -92,7 +92,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.notCalled(tokenRefresher);
   });
 
-  it("no proactive refresh, accepts expired token", async () => {
+  it("no proactive refresh, accepts expired token", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(-1));
     new AzureCommunicationTokenCredential({
       tokenRefresher,
@@ -101,7 +101,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.notCalled(tokenRefresher);
   });
 
-  it("with proactive refresh, passing an expired token to constructor triggers immediate refresh", async () => {
+  it("with proactive refresh, passing an expired token to constructor triggers immediate refresh", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(30));
     new AzureCommunicationTokenCredential({
       tokenRefresher,
@@ -113,7 +113,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("throws if tokenRefresher returns an expired token", async () => {
+  it("throws if tokenRefresher returns an expired token", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(-1));
     const credential = new AzureCommunicationTokenCredential({
       tokenRefresher: tokenRefresher,
@@ -127,14 +127,14 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("returns expired token when not using a lambda", async () => {
+  it("returns expired token when not using a lambda", async function () {
     const token = generateToken(-1);
     const tokenCredential = new AzureCommunicationTokenCredential(token);
     const tokenResult = (await tokenCredential.getToken()).token;
     assert.strictEqual(tokenResult, token);
   });
 
-  it("passes abortSignal through to tokenRefresher", async () => {
+  it("passes abortSignal through to tokenRefresher", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(60));
     const tokenCredential = new AzureCommunicationTokenCredential({
       tokenRefresher,
@@ -144,7 +144,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnceWithExactly(tokenRefresher, options.abortSignal);
   });
 
-  it("throws if disposed", async () => {
+  it("throws if disposed", async function () {
     const withStatic = new AzureCommunicationTokenCredential(generateToken(60));
     const withLambda = new AzureCommunicationTokenCredential({
       tokenRefresher: async () => generateToken(60),
@@ -155,7 +155,7 @@ describe("CommunicationTokenCredential", () => {
     await assert.isRejected(withLambda.getToken());
   });
 
-  it("doesn't swallow error from tokenRefresher", async () => {
+  it("doesn't swallow error from tokenRefresher", async function () {
     const tokenRefresher = sinon.stub().throws(new Error("No token for you!"));
     const tokenCredential = new AzureCommunicationTokenCredential({
       tokenRefresher,
@@ -163,7 +163,7 @@ describe("CommunicationTokenCredential", () => {
     await assert.isRejected(tokenCredential.getToken());
   });
 
-  it("requests new token when token is about to expire", async () => {
+  it("requests new token when token is about to expire", async function () {
     const token = generateToken(20);
     const newToken = generateToken(60);
     const tokenRefresher = sinon.stub().resolves(token);
@@ -188,7 +188,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledTwice(tokenRefresher);
   });
 
-  it("proactively refreshes token when it is about to expire", async () => {
+  it("proactively refreshes token when it is about to expire", async function () {
     const token = (): string => generateToken(20);
     const tokenRefresher = sinon.stub().resolves(token());
     new AzureCommunicationTokenCredential({
@@ -202,7 +202,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("repeats proactive refreshing", async () => {
+  it("repeats proactive refreshing", async function () {
     const token = (): string => generateToken(20);
     const tokenRefresher = sinon.stub().resolves(token());
     const tokenCredential = new AzureCommunicationTokenCredential({
@@ -223,7 +223,7 @@ describe("CommunicationTokenCredential", () => {
     assert.notEqual(internalTimeout, newInternalTimeout);
   });
 
-  it("dispose cancels timer", async () => {
+  it("dispose cancels timer", async function () {
     const token = (): string => generateToken(20);
     const tokenRefresher = sinon.stub().resolves(token());
     const tokenCredential = new AzureCommunicationTokenCredential({
@@ -238,7 +238,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.notCalled(tokenRefresher);
   });
 
-  it("multiple calls to getToken call tokenRefresher only once", async () => {
+  it("multiple calls to getToken call tokenRefresher only once", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(60));
     const tokenCredential = new AzureCommunicationTokenCredential({ tokenRefresher });
 
@@ -249,7 +249,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("calls tokenRefresher only once when proactive refreshing is in progress", async () => {
+  it("calls tokenRefresher only once when proactive refreshing is in progress", async function () {
     const tokenRefresher = sinon.stub().resolves(generateToken(20));
     const tokenCredential = new AzureCommunicationTokenCredential({
       tokenRefresher,
@@ -262,7 +262,7 @@ describe("CommunicationTokenCredential", () => {
     sinon.assert.calledOnce(tokenRefresher);
   });
 
-  it("applies fractional backoff when the token is about to expire", async () => {
+  it("applies fractional backoff when the token is about to expire", async function () {
     const defaultRefreshAfterLifetimePercentage = 0.5;
     const tokenExpirationMinutes = 20;
     const expectedPreBackOffCallCount = 1;

--- a/sdk/communication/communication-common/test/public/connectionString.spec.ts
+++ b/sdk/communication/communication-common/test/public/connectionString.spec.ts
@@ -9,8 +9,8 @@ import { assertPropertyNames } from "./utils/credentialUtils";
 const CONNECTION_STRING =
   "endpoint=https://contoso.communicationservices.azure.com:443/;accesskey=secret";
 
-describe("ConnectionString", () => {
-  it("handles valid connection string", () => {
+describe("ConnectionString", function () {
+  it("handles valid connection string", function () {
     const { endpoint, credential } = parseConnectionString(CONNECTION_STRING);
     assert.equal(endpoint, "https://contoso.communicationservices.azure.com:443/");
     /* Instead of 'instanceOf' check (as the AzureKeyCredential object might be referenced from different package version), 
@@ -19,7 +19,7 @@ describe("ConnectionString", () => {
     assertPropertyNames(AzureKeyCredential.prototype, Object.getPrototypeOf(credential));
   });
 
-  it("throws if invalid connection string", () => {
+  it("throws if invalid connection string", function () {
     assert.throws(() => {
       parseConnectionString("Lorem ipsum dolor connection string");
     }, "Invalid connection string");

--- a/sdk/communication/communication-common/test/public/identifierModelSerializer.spec.ts
+++ b/sdk/communication/communication-common/test/public/identifierModelSerializer.spec.ts
@@ -45,8 +45,8 @@ const assertThrowsTooManyProperties = (
   }, /^Only one of the properties in \[[\w,"\s]+\] should be present.$/);
 };
 
-describe("Identifier model serializer", () => {
-  it("can serialize", () => {
+describe("Identifier model serializer", function () {
+  it("can serialize", function () {
     assertSerialize(
       {
         communicationUserId:
@@ -141,13 +141,13 @@ describe("Identifier model serializer", () => {
     );
   });
 
-  it("serializes as unknown identifier if kind not understood", () => {
+  it("serializes as unknown identifier if kind not understood", function () {
     assertSerialize({ kind: "foobar", id: "42", someOtherProp: true } as any, {
       rawId: "42",
     });
   });
 
-  it("can deserialize", () => {
+  it("can deserialize", function () {
     assertDeserialize(
       {
         communicationUser: {
@@ -323,14 +323,14 @@ describe("Identifier model serializer", () => {
     );
   });
 
-  it("deserializes as unknown identifier if kind not understood", () => {
+  it("deserializes as unknown identifier if kind not understood", function () {
     assertDeserialize({ rawId: "42", someOtherProp: true } as any, {
       kind: "unknown",
       id: "42",
     });
   });
 
-  it("throws if property is missing", () => {
+  it("throws if property is missing", function () {
     assertThrowsMissingProperty(
       {
         communicationUser: {} as any,
@@ -380,7 +380,7 @@ describe("Identifier model serializer", () => {
     }, `Property rawId is required for identifier of type unknown.`);
   });
 
-  it("ignores additional properties", () => {
+  it("ignores additional properties", function () {
     assert.doesNotThrow(() => {
       deserializeCommunicationIdentifier({
         microsoftTeamsUser: {
@@ -394,7 +394,7 @@ describe("Identifier model serializer", () => {
     });
   });
 
-  it("throws if more than one nested model", () => {
+  it("throws if more than one nested model", function () {
     assertThrowsTooManyProperties({
       rawId: "rawId",
       microsoftTeamsUser: {

--- a/sdk/communication/communication-common/test/public/identifierModels.spec.ts
+++ b/sdk/communication/communication-common/test/public/identifierModels.spec.ts
@@ -15,8 +15,8 @@ import {
 } from "../../src";
 import { assert } from "chai";
 
-describe("Identifier models", () => {
-  it("type guards", () => {
+describe("Identifier models", function () {
+  it("type guards", function () {
     const communicationUser = { communicationUserId: "alice" };
     assert.isTrue(isCommunicationUserIdentifier(communicationUser));
     assert.isFalse(isPhoneNumberIdentifier(communicationUser));
@@ -24,7 +24,7 @@ describe("Identifier models", () => {
     assert.isFalse(isUnknownIdentifier(communicationUser));
   });
 
-  it("get kind", () => {
+  it("get kind", function () {
     const phoneNumber = { phoneNumber: "123" };
     const identifierKind = getIdentifierKind(phoneNumber);
     assert.strictEqual(identifierKind.kind, "phoneNumber");
@@ -34,7 +34,7 @@ describe("Identifier models", () => {
     );
   });
 
-  it("get raw id of identifier", () => {
+  it("get raw id of identifier", function () {
     const assertRawId = (identifier: CommunicationIdentifier, expectedRawId: string) =>
       assert.strictEqual(getIdentifierRawId(identifier), expectedRawId);
 
@@ -158,7 +158,7 @@ describe("Identifier models", () => {
     );
   });
 
-  it("create identifier from raw id", () => {
+  it("create identifier from raw id", function () {
     const assertIdentifier = (rawId: string, expectedIdentifier: CommunicationIdentifierKind) =>
       assert.deepStrictEqual(createIdentifierFromRawId(rawId), expectedIdentifier);
 
@@ -262,7 +262,7 @@ describe("Identifier models", () => {
     assert.throws(() => createIdentifierFromRawId(null as unknown as string));
   });
 
-  it("rawId stays the same after conversion to identifier and back", () => {
+  it("rawId stays the same after conversion to identifier and back", function () {
     const assertRoundtrip = (rawId: string) =>
       assert.strictEqual(getIdentifierRawId(createIdentifierFromRawId(rawId)), rawId);
 


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-common`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-common` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
