### PR TITLE
fix: comm-email: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-email/test/public/emailClient.spec.ts
+++ b/sdk/communication/communication-email/test/public/emailClient.spec.ts
@@ -7,7 +7,7 @@ import { Context } from "mocha";
 import { assert } from "chai";
 import { createRecordedEmailClientWithConnectionString } from "./utils/recordedClient";
 
-describe(`EmailClient [Playback/Live]`, () => {
+describe(`EmailClient [Playback/Live]`, function () {
   let recorder: Recorder;
   let client: EmailClient;
 


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-email`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-email` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package
#24746 - Same fix but for the `sdk\communication\communication-common` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
