### PR TITLE
[recorder] Remove host.docker.internal from recorder tests

### DIFF
--- a/sdk/test-utils/recorder/test/sanitizers.spec.ts
+++ b/sdk/test-utils/recorder/test/sanitizers.spec.ts
@@ -4,7 +4,7 @@
 import { ServiceClient } from "@azure/core-client";
 import { env, isPlaybackMode, Recorder } from "../src";
 import { TestMode } from "../src/utils/utils";
-import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./utils/utils";
+import { TEST_SERVER_URL, makeRequestAndVerifyResponse, setTestMode } from "./utils/utils";
 import { v4 as generateUuid } from "uuid";
 
 // These tests require the following to be running in parallel
@@ -24,7 +24,7 @@ import { v4 as generateUuid } from "uuid";
 
     beforeEach(async function () {
       recorder = new Recorder(this.currentTest);
-      client = new ServiceClient(recorder.configureClientOptions({ baseUri: getTestServerUrl() }));
+      client = new ServiceClient(recorder.configureClientOptions({ baseUri: TEST_SERVER_URL }));
       currentValue = isPlaybackMode() ? fakeSecretValue : secretValue;
     });
 
@@ -181,7 +181,7 @@ import { v4 as generateUuid } from "uuid";
           client,
           {
             url: isPlaybackMode()
-              ? getTestServerUrl().replace(secretEndpoint, fakeEndpoint) + pathToHit
+              ? TEST_SERVER_URL.replace(secretEndpoint, fakeEndpoint) + pathToHit
               : undefined,
             path: pathToHit,
             method: "POST",

--- a/sdk/test-utils/recorder/test/testProxyTests.spec.ts
+++ b/sdk/test-utils/recorder/test/testProxyTests.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import { expect } from "chai";
 import { CustomMatcherOptions, isPlaybackMode, Recorder } from "../src";
 import { isLiveMode, TestMode } from "../src/utils/utils";
-import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./utils/utils";
+import { TEST_SERVER_URL, makeRequestAndVerifyResponse, setTestMode } from "./utils/utils";
 
 // These tests require the following to be running in parallel
 // - utils/server.ts (to serve requests to act as a service)
@@ -23,7 +23,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
 
     beforeEach(async function () {
       recorder = new Recorder(this.currentTest);
-      client = new ServiceClient(recorder.configureClientOptions({ baseUri: getTestServerUrl() }));
+      client = new ServiceClient(recorder.configureClientOptions({ baseUri: TEST_SERVER_URL }));
     });
 
     afterEach(async () => {
@@ -98,7 +98,7 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
         it(`to a ${method} request`, async () => {
           await recorder.start({ envSetupForPlayback: {} });
           const req = createPipelineRequest({
-            url: getTestServerUrl() + "/content_length_test",
+            url: TEST_SERVER_URL + "/content_length_test",
             method,
             allowInsecureConnection: isLiveMode(),
           });
@@ -120,14 +120,14 @@ import { getTestServerUrl, makeRequestAndVerifyResponse, setTestMode } from "./u
     it("redirected request gets reverted", async () => {
       await recorder.start({ envSetupForPlayback: {} });
       const req = createPipelineRequest({
-        url: getTestServerUrl() + "/sample_response",
+        url: TEST_SERVER_URL + "/sample_response",
         method: "GET",
         allowInsecureConnection: isLiveMode(),
       });
       await client.sendRequest(req);
       assert.strictEqual(
         req.url,
-        getTestServerUrl() + "/sample_response",
+        TEST_SERVER_URL + "/sample_response",
         "Looks like the url is not the same"
       );
     });

--- a/sdk/test-utils/recorder/test/utils/utils.ts
+++ b/sdk/test-utils/recorder/test/utils/utils.ts
@@ -10,24 +10,7 @@ export const setTestMode = (mode: TestMode): TestMode => {
   return mode;
 };
 
-/**
- * Returns the test server url
- * Acts as the endpoint [ Works as a substitute to the actual Azure Services ]
- */
-export function getTestServerUrl(): string {
-  // utils/server.ts creates a localhost server at port 8080
-  // - In "live" mode, we are hitting directly the localhost endpoint
-  // - In "record" and "playback" modes, we need to hit the localhost of the host network
-  //   from the proxy tool running in the docker container.
-  //   `host.docker.internal` alias can be used in the docker container to access host's network(localhost)
-  //
-  // if PROXY_MANUAL_START=true, we start the proxy tool using the dotnet tool instead of the `docker run` command
-  //  - in this case, we don't need to hit the localhost using the alias
-  //  - needed for the CI since we have difficulties with the mac machines
-  return !isLiveMode() && !(env.PROXY_MANUAL_START === "true")
-    ? `http://host.docker.internal:8080` // Accessing host's network(localhost) through docker container
-    : `http://127.0.0.1:8080`;
-}
+export const TEST_SERVER_URL = "http://127.0.0.1:8080";
 
 export async function makeRequestAndVerifyResponse(
   client: ServiceClient,
@@ -42,7 +25,7 @@ export async function makeRequestAndVerifyResponse(
   expectedHeaders?: { [key: string]: string }
 ): Promise<PipelineResponse> {
   const req = createPipelineRequest({
-    url: request.url ?? getTestServerUrl() + request.path,
+    url: request.url ?? TEST_SERVER_URL + request.path,
     body: request.body,
     method: request.method,
     allowInsecureConnection: isLiveMode(),

--- a/sdk/test-utils/recorder/test/utils/utils.ts
+++ b/sdk/test-utils/recorder/test/utils/utils.ts
@@ -10,6 +10,10 @@ export const setTestMode = (mode: TestMode): TestMode => {
   return mode;
 };
 
+/**
+ * The test server url.
+ * This server acts as the endpoint [ Works as a substitute to the actual Azure Services ]
+ */
 export const TEST_SERVER_URL = "http://127.0.0.1:8080";
 
 export async function makeRequestAndVerifyResponse(


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Describe the problem that is addressed by this PR

Fixes tests broken by move to native test proxy binaries. These tests passed in CI (due to the test proxy being started separately) but weren't working locally.