### PR TITLE
[recorder] Rename RECORDING_ASSETS_PATH environment variable

### DIFF
--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -4,7 +4,7 @@ process.env.CHROME_BIN = require("puppeteer").executablePath();
 require("dotenv").config({ path: "../.env" });
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
-process.env.RECORDING_ASSETS_PATH = relativeAssetsPath();
+process.env.RECORDINGS_ASSETS_PATH = relativeAssetsPath();
 
 module.exports = function (config) {
   config.set({
@@ -50,7 +50,7 @@ module.exports = function (config) {
     // inject following environment values into browser testing with window.__env__
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
-    envPreprocessor: ["RECORDINGS_RELATIVE_PATH", "PROXY_MANUAL_START", "RECORDING_ASSETS_PATH"],
+    envPreprocessor: ["RECORDINGS_RELATIVE_PATH", "PROXY_MANUAL_START", "RECORDINGS_ASSETS_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/test-utils/recorder/src/utils/relativePathCalculator.browser.ts
+++ b/sdk/test-utils/recorder/src/utils/relativePathCalculator.browser.ts
@@ -21,22 +21,22 @@ export function relativeRecordingsPath(): string {
  *
  * Note for browser tests:
  *    1. Supposed to be called from karma.conf.js in the package for which the testing is being done.
- *    2. Set this `RECORDING_ASSETS_PATH` as an env variable
+ *    2. Set this `RECORDINGS_ASSETS_PATH` as an env variable
  *      ```js
  *        const { relativeRecordingsPathForBrowser } = require("@azure-tools/test-recorder-new");
- *        process.env.RECORDING_ASSETS_PATH = relativeRecordingsPathForBrowser();
+ *        process.env.RECORDINGS_ASSETS_PATH = relativeRecordingsPathForBrowser();
  *      ```
- *    3. Add "RECORDING_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
+ *    3. Add "RECORDINGS_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
  *      ```
- *        envPreprocessor: ["RECORDING_ASSETS_PATH"],
+ *        envPreprocessor: ["RECORDINGS_ASSETS_PATH"],
  *      ```
  *
- * `RECORDING_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
+ * `RECORDINGS_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
  * `x-recording-assets-file` to playback|record/Start. Doing so enables the proxy to auto-restore files from a remote location.
  *
  * @export
  * @returns {string} location of the relative path to discovered assets.json - `sdk/storage/storage-blob/assets.json` for example.
  */
 export function relativeAssetsPath(): string | undefined {
-  return env.RECORDING_ASSETS_PATH;
+  return env.RECORDINGS_ASSETS_PATH;
 }

--- a/sdk/test-utils/recorder/src/utils/relativePathCalculator.ts
+++ b/sdk/test-utils/recorder/src/utils/relativePathCalculator.ts
@@ -82,17 +82,17 @@ export function relativeRecordingsPath(): string {
  *
  * Note for browser tests:
  *    1. Supposed to be called from karma.conf.js in the package for which the testing is being done.
- *    2. Set this `RECORDING_ASSETS_PATH` as an env variable
+ *    2. Set this `RECORDINGS_ASSETS_PATH` as an env variable
  *      ```js
  *        const { relativeRecordingsPathForBrowser } = require("@azure-tools/test-recorder-new");
- *        process.env.RECORDING_ASSETS_PATH = relativeRecordingsPathForBrowser();
+ *        process.env.RECORDINGS_ASSETS_PATH = relativeRecordingsPathForBrowser();
  *      ```
- *    3. Add "RECORDING_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
+ *    3. Add "RECORDINGS_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
  *      ```
- *        envPreprocessor: ["RECORDING_ASSETS_PATH"],
+ *        envPreprocessor: ["RECORDINGS_ASSETS_PATH"],
  *      ```
  *
- * `RECORDING_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
+ * `RECORDINGS_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
  * `x-recording-assets-file` to playback|record/Start. Doing so enables the proxy to auto-restore files from a remote location.
  *
  * @export


### PR DESCRIPTION

### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Describe the problem addressed by this PR

Changing the variable name (adding a s at the end of "recording") for consistency with pre-existing `RECORDINGS_RELATIVE_PATH` variable.