### PR TITLE
Revert "Allow any version of @types/node to satisfy peer dependencies"

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -101,9 +101,7 @@
   "globalPeerDependencyRules": {
     // "ignoreMissing": ["@eslint/*"],
     // "allowedVersions": { "react": "17" },
-    "allowAny": [
-      "@types/node"
-    ]
+    // "allowAny": ["@babel/*"]
   },
   /**
    * The `globalPackageExtension` setting provides a way to patch arbitrary package.json fields


### PR DESCRIPTION
- Dependency requiring this workaround has been updated (microsoft/rushstack#3952)