### PR TITLE
[storage-blob-changefeed] Migrate to core-rest-pipeline

### DIFF
--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -93,9 +93,11 @@
   "dependencies": {
     "@azure/storage-blob": "^12.12.0",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^3.0.0",
+    "@azure/core-auth": "^1.4.0",
+    "@azure/core-http-compat": "^2.0.0",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.1.1",
+    "@azure/core-rest-pipeline": "^1.10.1",
     "@azure/core-tracing": "1.0.0-preview.13",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-blob-changefeed/review/storage-blob-changefeed.api.md
+++ b/sdk/storage/storage-blob-changefeed/review/storage-blob-changefeed.api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
-import { AbortSignalLike } from '@azure/core-http';
+import { AbortSignalLike } from '@azure/abort-controller';
 import { AnonymousCredential } from '@azure/storage-blob';
 import { CommonOptions } from '@azure/storage-blob';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { Pipeline } from '@azure/storage-blob';
 import { StoragePipelineOptions } from '@azure/storage-blob';
 import { StorageSharedKeyCredential } from '@azure/storage-blob';
-import { TokenCredential } from '@azure/core-http';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export type AccessTier = "P4" | "P6" | "P10" | "P15" | "P20" | "P30" | "P40" | "P50" | "P60" | "P70" | "P80" | "Hot" | "Cool" | "Archive";

--- a/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
+++ b/sdk/storage/storage-blob-changefeed/src/BlobChangeFeedClient.ts
@@ -14,7 +14,7 @@ import { ChangeFeedFactory } from "./ChangeFeedFactory";
 import { ChangeFeed } from "./ChangeFeed";
 import { CHANGE_FEED_MAX_PAGE_SIZE, SDK_VERSION } from "./utils/constants";
 import { BlobChangeFeedListChangesOptions } from "./models/models";
-import { TokenCredential } from "@azure/core-http";
+import { TokenCredential } from "@azure/core-auth";
 
 /**
  * Contains paged response data for the {@link BlobChangeFeedClient.listChanges} operation.

--- a/sdk/storage/storage-blob-changefeed/src/ChangeFeed.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChangeFeed.ts
@@ -7,7 +7,7 @@ import { SegmentFactory } from "./SegmentFactory";
 import { BlobChangeFeedEvent } from "./models/BlobChangeFeedEvent";
 import { ChangeFeedCursor } from "./models/ChangeFeedCursor";
 import { getSegmentsInYear, minDate, getHost } from "./utils/utils.common";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/Chunk.ts
+++ b/sdk/storage/storage-blob-changefeed/src/Chunk.ts
@@ -4,7 +4,7 @@
 import { AvroReader } from "../../storage-internal-avro/src";
 import { BlobChangeFeedEvent } from "./models/BlobChangeFeedEvent";
 import { CommonOptions } from "@azure/storage-blob";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { AvroParseOptions } from "../../storage-internal-avro/src/AvroReader";
 import { rawEventToBlobChangeFeedEvent } from "./utils/utils.common";
 

--- a/sdk/storage/storage-blob-changefeed/src/ChunkFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ChunkFactory.ts
@@ -6,7 +6,7 @@ import { ContainerClient, CommonOptions } from "@azure/storage-blob";
 import { Chunk } from "./Chunk";
 import { AvroReader } from "../../storage-internal-avro/src";
 import { streamToAvroReadable } from "./utils/utils.node";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { LazyLoadingBlobStreamFactory } from "./LazyLoadingBlobStreamFactory";
 import { CHANGE_FEED_CHUNK_BLOCK_DOWNLOAD_SIZE } from "./utils/constants";
 

--- a/sdk/storage/storage-blob-changefeed/src/LazyLoadingBlobStream.ts
+++ b/sdk/storage/storage-blob-changefeed/src/LazyLoadingBlobStream.ts
@@ -3,7 +3,7 @@
 
 import { Readable, ReadableOptions } from "stream";
 import { BlobClient, CommonOptions } from "@azure/storage-blob";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/Segment.ts
+++ b/sdk/storage/storage-blob-changefeed/src/Segment.ts
@@ -5,7 +5,7 @@ import { BlobChangeFeedEvent } from "./models/BlobChangeFeedEvent";
 import { Shard } from "./Shard";
 import { SegmentCursor, ShardCursor } from "./models/ChangeFeedCursor";
 import { CommonOptions } from "@azure/storage-blob";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/SegmentFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/SegmentFactory.ts
@@ -9,7 +9,7 @@ import { Segment } from "./Segment";
 import { SegmentCursor } from "./models/ChangeFeedCursor";
 import { bodyToString } from "./utils/utils.node";
 import { parseDateFromSegmentPath } from "./utils/utils.common";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/Shard.ts
+++ b/sdk/storage/storage-blob-changefeed/src/Shard.ts
@@ -6,7 +6,7 @@ import { ChunkFactory } from "./ChunkFactory";
 import { Chunk } from "./Chunk";
 import { BlobChangeFeedEvent } from "./models/BlobChangeFeedEvent";
 import { ShardCursor } from "./models/ChangeFeedCursor";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { createSpan } from "./utils/tracing";
 import { SpanStatusCode } from "@azure/core-tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/ShardFactory.ts
+++ b/sdk/storage/storage-blob-changefeed/src/ShardFactory.ts
@@ -6,7 +6,7 @@ import { ShardCursor } from "./models/ChangeFeedCursor";
 import { Shard } from "./Shard";
 import { ContainerClient, CommonOptions } from "@azure/storage-blob";
 import { Chunk } from "./Chunk";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { SpanStatusCode } from "@azure/core-tracing";
 import { createSpan } from "./utils/tracing";
 

--- a/sdk/storage/storage-blob-changefeed/src/models/models.ts
+++ b/sdk/storage/storage-blob-changefeed/src/models/models.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { CommonOptions } from "@azure/storage-blob";
-import { AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * Options to configure {@link BlobChangeFeedClient.listChanges} operation.

--- a/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
@@ -29,7 +29,7 @@ export function floorToNearestHour(date: Date | undefined): Date | undefined {
  * @param url - Source URL string
  */
 export function getHost(url: string): string | undefined {
-  const urlParsed = new URL(url)
+  const urlParsed = new URL(url);
   return urlParsed.hostname;
 }
 

--- a/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/utils.common.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { URLBuilder, AbortSignalLike } from "@azure/core-http";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { ContainerClient, CommonOptions } from "@azure/storage-blob";
 import { CHANGE_FEED_SEGMENT_PREFIX, CHANGE_FEED_INITIALIZATION_SEGMENT } from "./constants";
 import { createSpan } from "./tracing";
@@ -29,28 +29,8 @@ export function floorToNearestHour(date: Date | undefined): Date | undefined {
  * @param url - Source URL string
  */
 export function getHost(url: string): string | undefined {
-  const urlParsed = URLBuilder.parse(url);
-  return urlParsed.getHost();
-}
-
-/**
- * Get URI from an URL string.
- *
- * @param url - Source URL string
- */
-export function getURI(url: string): string {
-  const urlParsed = URLBuilder.parse(url);
-  return `${urlParsed.getHost()}${urlParsed.getPort()}${urlParsed.getPath()}`;
-}
-
-// s[0]*31^(n - 1) + s[1]*31^(n - 2) + ... + s[n - 1]
-export function hashString(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash << 5) - hash + str.charCodeAt(i);
-    hash |= 0; // Bit operation converts operands to 32-bit integers
-  }
-  return hash;
+  const urlParsed = new URL(url)
+  return urlParsed.hostname;
 }
 
 /**

--- a/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
@@ -7,7 +7,7 @@ import { recorderEnvSetup, getBlobChangeFeedClient, streamToString } from "./uti
 import { BlobChangeFeedClient, BlobChangeFeedEvent, BlobChangeFeedEventPage } from "../src";
 import { AbortController } from "@azure/abort-controller";
 import { setTracer } from "@azure/test-utils";
-import { BlobServiceClient } from "@azure/storage-blob";
+import { BlobServiceClient, RequestPolicy } from "@azure/storage-blob";
 import { SDK_VERSION } from "../src/utils/constants";
 import { setSpan, context } from "@azure/core-tracing";
 import * as fs from "fs";
@@ -15,7 +15,8 @@ import * as path from "path";
 
 import { Context } from "mocha";
 import { rawEventToBlobChangeFeedEvent } from "../src/utils/utils.common";
-import { HttpHeaders, RequestPolicy, RestError } from "@azure/core-http";
+import { createHttpHeaders, RestError } from "@azure/core-rest-pipeline";
+import { toHttpHeadersLike } from "@azure/core-http-compat";
 
 const timeoutForLargeFileUploadingTest = 20 * 60 * 1000;
 
@@ -148,7 +149,7 @@ describe("BlobChangeFeedClient", async () => {
       sendRequest(request) {
         return Promise.resolve({
           request,
-          headers: new HttpHeaders(),
+          headers: toHttpHeadersLike(createHttpHeaders()),
           status: 418,
         });
       },

--- a/sdk/storage/storage-blob-changefeed/test/utils/index.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/index.ts
@@ -9,7 +9,7 @@ import {
   StoragePipelineOptions,
 } from "@azure/storage-blob";
 import { BlobChangeFeedClient } from "../../src";
-import { TokenCredential } from "@azure/core-http";
+import { TokenCredential } from "@azure/core-auth";
 import { env } from "@azure-tools/test-recorder";
 
 config();

--- a/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-auth";
 import { isPlaybackMode, env, RecorderEnvironmentSetup } from "@azure-tools/test-recorder";
 import { Readable } from "stream";
 


### PR DESCRIPTION
### Packages impacted by this PR

storage-blob-changefeed

### Describe the problem that is addressed by this PR

Migrated to use `core-rest-pipeline` (coreV2). Since this package doesn't directly expose REST operations, there is very little change. `core-http` only provided a few common interfaces that have been moved to other packages.

