### PR TITLE
Add `keyvault` trigger when updating eng/common/testproxy

### DIFF
--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -25,6 +25,7 @@ pr:
   paths:
     include:
       - sdk/keyvault/
+      - eng/common/testproxy/
     exclude:
       - sdk/keyvault/ci.mgmt.yml
       - sdk/keyvault/arm-keyvault


### PR DESCRIPTION
We auto-target `test-utils`, which is a good barometer, but I am only comfortable with merging proxy changes if I can see that at least one real library in each repo really works.

