### PR TITLE
[recorder] Figure out assets.json from RELATIVE_RECORDINGS_PATH

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow mapping the test-proxy tool to ports other than just 5000(for HTTP) using the environment variable `TEST_PROXY_HTTP_PORT`(and `TEST_PROXY_HTTPS_PORT` for 5001(for HTTPS)).
   - If `TEST_PROXY_HTTP_PORT` is undefined, we'll try for 5000 as usual.
   - For browsers, this variable has to be added as part of the environment variables listed under `envPreprocessor` array in `karma.conf.js` so that the recorder knows the port to hit.
+- Added support for the asset sync tool. If an `assets.json` exists in the package directory, the recorder will fetch recordings from the external repo.
 
 ### Breaking Changes
 

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -4,7 +4,6 @@ process.env.CHROME_BIN = require("puppeteer").executablePath();
 require("dotenv").config({ path: "../.env" });
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
-process.env.RECORDING_ASSETS_PATH = relativeAssetsPath();
 
 module.exports = function (config) {
   config.set({
@@ -50,7 +49,7 @@ module.exports = function (config) {
     // inject following environment values into browser testing with window.__env__
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
-    envPreprocessor: ["RECORDINGS_RELATIVE_PATH", "PROXY_MANUAL_START", "RECORDING_ASSETS_PATH"],
+    envPreprocessor: ["RECORDINGS_RELATIVE_PATH", "PROXY_MANUAL_START"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
     // inject following environment values into browser testing with window.__env__
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
-    envPreprocessor: ["RECORDINGS_RELATIVE_PATH", "PROXY_MANUAL_START"],
+    envPreprocessor: ["RECORDINGS_RELATIVE_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/test-utils/recorder/src/index.ts
+++ b/sdk/test-utils/recorder/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export { Recorder } from "./recorder";
-export { relativeRecordingsPath, relativeAssetsPath } from "./utils/relativePathCalculator";
+export { relativeRecordingsPath } from "./utils/relativePathCalculator";
 export {
   SanitizerOptions,
   RecorderStartOptions,

--- a/sdk/test-utils/recorder/src/utils/relativePathCalculator.browser.ts
+++ b/sdk/test-utils/recorder/src/utils/relativePathCalculator.browser.ts
@@ -13,30 +13,3 @@ export function relativeRecordingsPath(): string {
     );
   }
 }
-
-/**
- * ONLY WORKS IN THE NODE.JS ENVIRONMENT
- *
- * Returns the potential assets.json for the project using `process.cwd()`.
- *
- * Note for browser tests:
- *    1. Supposed to be called from karma.conf.js in the package for which the testing is being done.
- *    2. Set this `RECORDING_ASSETS_PATH` as an env variable
- *      ```js
- *        const { relativeRecordingsPathForBrowser } = require("@azure-tools/test-recorder-new");
- *        process.env.RECORDING_ASSETS_PATH = relativeRecordingsPathForBrowser();
- *      ```
- *    3. Add "RECORDING_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
- *      ```
- *        envPreprocessor: ["RECORDING_ASSETS_PATH"],
- *      ```
- *
- * `RECORDING_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
- * `x-recording-assets-file` to playback|record/Start. Doing so enables the proxy to auto-restore files from a remote location.
- *
- * @export
- * @returns {string} location of the relative path to discovered assets.json - `sdk/storage/storage-blob/assets.json` for example.
- */
-export function relativeAssetsPath(): string | undefined {
-  return env.RECORDING_ASSETS_PATH;
-}

--- a/sdk/test-utils/recorder/src/utils/relativePathCalculator.ts
+++ b/sdk/test-utils/recorder/src/utils/relativePathCalculator.ts
@@ -76,30 +76,3 @@ function relativePackagePath() {
 export function relativeRecordingsPath(): string {
   return toSafePath(path.join(relativePackagePath(), "recordings"));
 }
-
-/**
- * Returns the potential assets.json for the project using `process.cwd()`.
- *
- * Note for browser tests:
- *    1. Supposed to be called from karma.conf.js in the package for which the testing is being done.
- *    2. Set this `RECORDING_ASSETS_PATH` as an env variable
- *      ```js
- *        const { relativeRecordingsPathForBrowser } = require("@azure-tools/test-recorder-new");
- *        process.env.RECORDING_ASSETS_PATH = relativeRecordingsPathForBrowser();
- *      ```
- *    3. Add "RECORDING_ASSETS_PATH" in the `envPreprocessor` array to let this be loaded in the browser environment.
- *      ```
- *        envPreprocessor: ["RECORDING_ASSETS_PATH"],
- *      ```
- *
- * `RECORDING_ASSETS_PATH` in the browser environment is used in the recorder to tell the proxy-tool about whether or not to pass additional body argument
- * `x-recording-assets-file` to playback|record/Start. Doing so enables the proxy to auto-restore files from a remote location.
- *
- * @export
- * @returns {string} location of the relative path to discovered assets.json - `sdk/storage/storage-blob/assets.json` for example, or undefined if the path does not exist
- */
-export function relativeAssetsPath(): string | undefined {
-  return fs.existsSync("assets.json")
-    ? toSafePath(path.join(relativePackagePath(), "assets.json"))
-    : undefined;
-}

--- a/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
+++ b/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
@@ -29,3 +29,12 @@ export function recordingFilePath(testContext: Mocha.Test): string {
     testContext.title
   );
 }
+
+export function assetsJsonPath(): string {
+  // Hacky solution using substring works around the fact that:
+  // 1) the relativeRecordingsPath may not exist on disk (so relativeRecordingsPath()/../assets.json might not exist either, can't use ..)
+  // 2) `path` (and therefore `path.dirname`) is not available in the browser.
+  const recordingsPath = relativeRecordingsPath();
+  const sdkDir = recordingsPath.substring(0, recordingsPath.lastIndexOf("/"));
+  return `${sdkDir}/assets.json`;
+}


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Describe the problem that is addressed by this PR

Remove additional `RECORDING_ASSETS_PATH` environment variable in Karma config by calculating the assets.json path relative to the existing `RECORDINGS_RELATIVE_PATH` variable. Includes a fix to the start method to retry in the event the `assets.json` does not exist.