### PR TITLE
fix: comm-identity: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
@@ -12,22 +12,22 @@ import { assert } from "chai";
 import { isNode } from "@azure/core-util";
 import sinon from "sinon";
 
-describe("CommunicationIdentityClient [Mocked]", () => {
+describe("CommunicationIdentityClient [Mocked]", function () {
   const dateHeader = "x-ms-date";
   const user: CommunicationUserIdentifier = { communicationUserId: "ACS_ID" };
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 
-  it("creates instance of CommunicationIdentityClient", () => {
+  it("creates instance of CommunicationIdentityClient", function () {
     const client = new CommunicationIdentityClient(
       "endpoint=https://contoso.spool.azure.local;accesskey=banana"
     );
     assert.instanceOf(client, CommunicationIdentityClient);
   });
 
-  it("sets correct headers", async () => {
+  it("sets correct headers", async function () {
     const client = new TestCommunicationIdentityClient();
     const spy = sinon.spy(getTokenHttpClient, "sendRequest");
 
@@ -48,7 +48,7 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     );
   });
 
-  it("sends scopes in issue token request", async () => {
+  it("sends scopes in issue token request", async function () {
     const client = new TestCommunicationIdentityClient();
     const spy = sinon.spy(getTokenHttpClient, "sendRequest");
     const response = await client.getTokenTest(user, ["chat"]);
@@ -61,14 +61,14 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     assert.deepEqual(JSON.parse(request.body as string), { scopes: ["chat"] });
   });
 
-  it("[getToken] excludes _response from results", async () => {
+  it("[getToken] excludes _response from results", async function () {
     const client = new TestCommunicationIdentityClient();
     const response = await client.getTokenTest(user, ["chat"]);
 
     assert.isFalse("_response" in response);
   });
 
-  it("[createUser] excludes _response from results", async () => {
+  it("[createUser] excludes _response from results", async function () {
     const client = new TestCommunicationIdentityClient();
     const newUser = await client.createUserTest();
 
@@ -77,7 +77,7 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     assert.isFalse("_response" in newUser);
   });
 
-  it("exchanges Teams token for ACS token", async () => {
+  it("exchanges Teams token for ACS token", async function () {
     const client = new TestCommunicationIdentityClient();
     const spy = sinon.spy(getTokenForTeamsUserHttpClient, "sendRequest");
     const response = await client.getTokenForTeamsUserTest("TeamsToken", "appId", "userId");
@@ -87,7 +87,7 @@ describe("CommunicationIdentityClient [Mocked]", () => {
     sinon.assert.calledOnce(spy);
   });
 
-  it("[getTokenForTeamsUser] excludes _response from results", async () => {
+  it("[getTokenForTeamsUser] excludes _response from results", async function () {
     const client = new TestCommunicationIdentityClient();
     const response = await client.getTokenForTeamsUserTest("TeamsToken", "appId", "userId");
 


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-identity`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-identity` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package
#24746 - Same fix but for the `sdk\communication\communication-common` package
#24747 - Same fix but for the `sdk\communication\communication-email` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
