### PR TITLE
fix: comm-job-router: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-job-router/test/internal/routerClient.mocked.spec.ts
+++ b/sdk/communication/communication-job-router/test/internal/routerClient.mocked.spec.ts
@@ -6,12 +6,12 @@ import { AzureCommunicationTokenCredential } from "@azure/communication-common";
 import { RouterClient } from "../../src";
 import { baseUri, generateToken } from "../public/utils/connectionUtils";
 
-describe("[Mocked] RouterClient", async () => {
-  afterEach(() => {
+describe("[Mocked] RouterClient", async function() {
+  afterEach(function() {
     sinon.restore();
   });
 
-  it("can instantiate", async () => {
+  it("can instantiate", async function() {
     new RouterClient(baseUri, new AzureCommunicationTokenCredential(generateToken()));
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-job-router`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-job-router` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package
#24746 - Same fix but for the `sdk\communication\communication-common` package
#24747 - Same fix but for the `sdk\communication\communication-email` package
#24797 - Same fix but for the `sdk\communication\communication-identity` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
