### PR TITLE
fix: comm-rooms: remove mocha arrow functions

### DIFF
--- a/sdk/communication/communication-rooms/test/internal/roomsClient.mocked.spec.ts
+++ b/sdk/communication/communication-rooms/test/internal/roomsClient.mocked.spec.ts
@@ -12,14 +12,14 @@ import {
   mockUpdateRoomsResult,
 } from "./utils/mockedClient";
 
-describe("[Mocked] RoomsClient", async () => {
+describe("[Mocked] RoomsClient", async function () {
   let roomsClient: RoomsClient;
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore();
   });
 
-  it("makes successful create Rooms request", async () => {
+  it("makes successful create Rooms request", async function () {
     const mockHttpClient = generateHttpClient(201, mockCreateRoomsResult);
 
     roomsClient = createRoomsClient(mockHttpClient);
@@ -42,7 +42,7 @@ describe("[Mocked] RoomsClient", async () => {
     assert.isNotEmpty(request.headers.get("repeatability-request-id"));
   });
 
-  it("makes update Rooms request", async () => {
+  it("makes update Rooms request", async function () {
     const mockHttpClient = generateHttpClient(200, mockUpdateRoomsResult);
     roomsClient = createRoomsClient(mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");
@@ -65,7 +65,7 @@ describe("[Mocked] RoomsClient", async () => {
     assert.deepEqual(request.body as string, JSON.stringify(sendOptions));
   });
 
-  it("makes add Participant request", async () => {
+  it("makes add Participant request", async function () {
     const mockHttpClient = generateHttpClient(200, mockUpdateRoomsResult);
     roomsClient = createRoomsClient(mockHttpClient);
     const spy = sinon.spy(mockHttpClient, "sendRequest");


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\communication\communication-rooms`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\communication\communication-rooms` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package
#24746 - Same fix but for the `sdk\communication\communication-common` package
#24747 - Same fix but for the `sdk\communication\communication-email` package
#24797 - Same fix but for the `sdk\communication\communication-identity` package
#24799 - Same fix but for the `sdk\communication\communication-job-router` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
