### PR TITLE
[core-rest-pipeline] Remove oscpu from OS sniffing

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.browser.ts
@@ -13,14 +13,15 @@ export function getHeaderName(): string {
 }
 
 interface NavigatorEx extends Navigator {
-  // oscpu is not yet standards-compliant, but can not be undefined in TypeScript 3.6.2
-  readonly oscpu: string;
+  userAgentData?: {
+    platform?: string;
+  };
 }
 
 /**
  * @internal
  */
 export function setPlatformSpecificData(map: Map<string, string>): void {
-  const navigator = self.navigator as NavigatorEx;
-  map.set("OS", (navigator.oscpu || navigator.platform).replace(" ", ""));
+  const localNavigator = globalThis.navigator as NavigatorEx;
+  map.set("OS", (localNavigator?.userAgentData?.platform ?? localNavigator?.platform ?? "unknown").replace(" ", ""));
 }

--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.browser.ts
@@ -23,5 +23,11 @@ interface NavigatorEx extends Navigator {
  */
 export function setPlatformSpecificData(map: Map<string, string>): void {
   const localNavigator = globalThis.navigator as NavigatorEx;
-  map.set("OS", (localNavigator?.userAgentData?.platform ?? localNavigator?.platform ?? "unknown").replace(" ", ""));
+  map.set(
+    "OS",
+    (localNavigator?.userAgentData?.platform ?? localNavigator?.platform ?? "unknown").replace(
+      " ",
+      ""
+    )
+  );
 }


### PR DESCRIPTION
### Packages impacted by this PR

- [@azure/core-rest-pipeline]

### Issues associated with this PR

#24758

### Describe the problem that is addressed by this PR

Relies on the deprecated `oscpu`.  This uses the non-standard `globalThis.navigator.userAgentData.platform` and falls back to the deprecated `globalThis.navigator.platform`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could have removed the OS checks overall, but we can get better telemetry to keep the OS detection.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
