### PR TITLE
[engsys] comment link to api ref docs that haven't been published

### DIFF
--- a/sdk/communication/communication-rooms/samples/v1-beta/javascript/README.md
+++ b/sdk/communication/communication-rooms/samples/v1-beta/javascript/README.md
@@ -59,7 +59,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 
 [participantoperations]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/communication/communication-rooms/samples/v1-beta/javascript/participantOperations.js
 [roomoperations]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/communication/communication-rooms/samples/v1-beta/javascript/roomOperations.js
-[apiref]: https://docs.microsoft.com/javascript/api/@azure/communication-rooms
+<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/communication-rooms -->
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azurecommunicationservicesaccount]: https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/communication/communication-rooms/README.md


### PR DESCRIPTION
The best practice is to put the link in comment and submit a follow-up PR to uncomment it after build pipeline passes and the doc is published.

