### PR TITLE
In `CODEOWNERS`, restore erroneously removed `/eng/pipelines/aggregate-reports.yml` path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1469,3 +1469,6 @@
 /**/tsconfig.json @witemple-msft @deyaaeldeen
 /**/tsconfig.strict.json @deyaaeldeen
 /.scripts/ @mikeharder @ckairen
+
+# Add owners for notifications for specific pipelines
+/eng/pipelines/aggregate-reports.yml         @xirzec @jeremymeng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,6 @@
 /documentation/ @jeremymeng
 /samples/       @jeremymeng
 
-# Add owners for notifications for specific pipelines
-/eng/pipelines/aggregate-reports.yml @jeremymeng @xirzec
-
 ################
 # Automation
 ################


### PR DESCRIPTION
For context, see:
- https://github.com/Azure/azure-sdk-for-js/pull/24621#pullrequestreview-1294287181

Related PR:
- https://github.com/Azure/azure-sdk-tools/pull/5088