### PR TITLE
Fix Issue-24493: Typecheck feedResponse in FetchResult

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
@@ -22,7 +22,7 @@ export class FetchResult {
    */
   constructor(feedResponse: unknown, error: unknown) {
     // TODO: feedResponse/error
-    if (feedResponse) {
+    if (feedResponse !== undefined) {
       this.feedResponse = feedResponse;
       this.fetchResultType = FetchResultType.Result;
     } else {


### PR DESCRIPTION
### Packages impacted by this PR
[@azure/cosmos](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cosmosdb/cosmos)

### Issues associated with this PR
#24493 

### Describe the problem that is addressed by this PR
The code was breaking for any parallel query where the result is `0` or `false` or array of them.
Eg. `SELECT value c['type'] from c where c['type']=0`. This fix enables typecheck of the `feedResponse`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
