### PR TITLE
[ServiceBus][Test] enable detailed logging in live test pipeline

### DIFF
--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -13,3 +13,4 @@ stages:
         AZURE_TENANT_ID: $(SERVICEBUS_TENANT_ID)
         AZURE_CLIENT_SECRET: $(SERVICEBUS_CLIENT_SECRET)
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)
+        DEBUG: azure:service-bus:*,azure:core-amqp:*,rhea-promise:error,rhea:events,rhea:frames,rhea:io,rhea:flow


### PR DESCRIPTION
There's little impact to the total running time of the pipeline. We get larger logs but it should provide big help on diagnosing failures.
