### PR TITLE
Revert "Temporarily pin dependency "puppeteer" (#24869)"

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,8 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@types/trusted-types": "2.0.2", // #24872
-    "puppeteer": "19.6.3"
+    "@types/trusted-types": "2.0.2" // #24872
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -327,7 +327,6 @@ specifiers:
   '@rush-temp/web-pubsub-client': file:./projects/web-pubsub-client.tgz
   '@rush-temp/web-pubsub-express': file:./projects/web-pubsub-express.tgz
   '@types/trusted-types': 2.0.2
-  puppeteer: 19.6.3
 
 dependencies:
   '@rush-temp/abort-controller': file:projects/abort-controller.tgz
@@ -656,7 +655,6 @@ dependencies:
   '@rush-temp/web-pubsub-client': file:projects/web-pubsub-client.tgz
   '@rush-temp/web-pubsub-express': file:projects/web-pubsub-express.tgz
   '@types/trusted-types': 2.0.2
-  puppeteer: 19.6.3
 
 packages:
 
@@ -3930,7 +3928,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 5.0.0-dev.20230215
+      typescript: 5.0.0-dev.20230216
     dev: false
 
   /downlevel-dts/0.7.0:
@@ -8714,8 +8712,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/5.0.0-dev.20230215:
-    resolution: {integrity: sha512-rbuBEuyaLltNQkRsBCxysSHGGEaizuGaVEMO+8bBmTXQRSzITTl1WOg2UFXr9p0pwz8l0KJtOem8MggaGz1/XA==}
+  /typescript/5.0.0-dev.20230216:
+    resolution: {integrity: sha512-yeZZGWiNc5pbGg4J/bgN7vq2Lrs4YTNzhG5dv8owIe1PyYX4tMDla8NnXipy9h4Cmw6+DQA8FG9XZbymgmzSbA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
@@ -17893,7 +17891,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-CtEBzCs8gADc56AozIehMF2iu7e7R/8YroShdvL2gjK6Hol5Tz+LRfNo4m9XoM17Mwsm1VtZe6Di0vA+WdiJ3g==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-zodipV0pcRnzrfWjHYqvU42+E4V7E6TqdSYdrmqk/W9isTlZ3lW7OQXvblPPmjo2gTxDBbq+MUcDJ1Bu4FPPYA==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -18798,7 +18796,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-kLU74faNZXQAJXMne2lL+AAKkVKmU8+obYvymA9G2IuJBpPraaTOxyIOypkQeZqLuWCdZgrgeCno39dVP0MLtg==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-mSZh1szK6lxMnczMO7kgXzef/o22kR6Ttc0voG7IKFLpMKRq6gwvWDAtPzvAEz9qjHzskrN9Me89DaPc7H7ccw==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -18850,7 +18848,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - debug
-      - encoding
       - supports-color
       - utf-8-validate
     dev: false
@@ -19021,7 +19018,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-TXNy2Pvp5CIqX4OIpz1VRsPRwAvygZolQrZt3CIw4omVh6NbThB567Ftu8TSOMz+1UiRyXdz80hCGgT5rYDCnQ==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-mYK6I+h0xzksiXIMd9/qOAU7QtVuQXfHFH7QcSSsTwkOFnNx967vIH40CRpeEXAUAjEXfKM0uaJPVw6W3saoEA==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
- Reverts commit 149223735921959652f1cc0968b5b1582636edc7
- Fixes #24870

I verified `rush update --full` works correctly after these changes and the release of `puppeteer-core@19.7.1`.