### PR TITLE
[web-pubsub-client][fix] Return correct `isDuplicated` #24901

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -591,8 +591,13 @@ export class WebPubSubClient {
           if (this._ackMap.has(message.ackId)) {
             const entity = this._ackMap.get(message.ackId)!;
             this._ackMap.delete(message.ackId);
-            if (message.success || (message.error && message.error.name === "Duplicate")) {
-              entity.resolve({ ackId: message.ackId, isDuplicated: true } as WebPubSubResult);
+            const isDuplicated: boolean =
+              message.error != null && message.error.name === 'Duplicate';
+            if (message.success || isDuplicated) {
+              entity.resolve({
+                ackId: message.ackId,
+                isDuplicated: isDuplicated,
+              } as WebPubSubResult);
             } else {
               entity.reject(
                 new SendMessageError("Failed to send message.", {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-client


### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/24901

### Describe the problem that is addressed by this PR
`isDuplicated` was always returned true regardless if operation was successful or duplicated

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
No, previous test cases cover this but more can be added.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [X] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
