### PR TITLE
Modified public interface, instead of getRoutes/trunks use listTrunks…

### DIFF
--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
+- Changed public methods getTrunks to listTrunks and getRoutes to ListRoutes.
 
 ### Bugs Fixed
 

--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-- Changed public methods getTrunks to listTrunks and getRoutes to ListRoutes.
+- Changed public methods getTrunks to listTrunks and getRoutes to listRoutes.
 
 ### Bugs Fixed
 

--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-- Changed public methods getTrunks to listTrunks and getRoutes to listRoutes.
+- Changed public methods `getTrunks` to `listTrunks` and `getRoutes` to `listRoutes`.
 
 ### Bugs Fixed
 

--- a/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
+++ b/sdk/communication/communication-phone-numbers/review/communication-phone-numbers.api.md
@@ -61,6 +61,14 @@ export interface ListPurchasedPhoneNumbersOptions extends OperationOptions {
 }
 
 // @public
+export interface ListSipRoutesOptions extends OperationOptions {
+}
+
+// @public
+export interface ListSipTrunksOptions extends OperationOptions {
+}
+
+// @public
 export interface ListTollFreeAreaCodesOptions extends Omit<PhoneNumbersListAreaCodesOptionalParams, "assignmentType" | "locality" | "administrativeDivision"> {
 }
 
@@ -207,9 +215,9 @@ export class SipRoutingClient {
     constructor(endpoint: string, credential: KeyCredential, options?: SipRoutingClientOptions);
     constructor(endpoint: string, credential: TokenCredential, options?: SipRoutingClientOptions);
     deleteTrunk(fqdn: string, options?: OperationOptions): Promise<void>;
-    getRoutes(options?: OperationOptions): Promise<SipTrunkRoute[]>;
     getTrunk(fqdn: string, options?: OperationOptions): Promise<SipTrunk>;
-    getTrunks(options?: OperationOptions): Promise<SipTrunk[]>;
+    listRoutes(options?: ListSipRoutesOptions): PagedAsyncIterableIterator<SipTrunkRoute>;
+    listTrunks(options?: ListSipTrunksOptions): PagedAsyncIterableIterator<SipTrunk>;
     setRoutes(routes: SipTrunkRoute[], options?: OperationOptions): Promise<SipTrunkRoute[]>;
     setTrunk(trunk: SipTrunk, options?: OperationOptions): Promise<SipTrunk>;
     setTrunks(trunks: SipTrunk[], options?: OperationOptions): Promise<SipTrunk[]>;

--- a/sdk/communication/communication-phone-numbers/samples-dev/siprouting/getSipRoutingConfiguration.ts
+++ b/sdk/communication/communication-phone-numbers/samples-dev/siprouting/getSipRoutingConfiguration.ts
@@ -18,13 +18,13 @@ export async function main() {
 
   // Get trunks
   const trunks = await client.listTrunks();
-  for await(const trunk of trunks) {
+  for await (const trunk of trunks) {
     console.log(`Trunk ${trunk.fqdn}:${trunk.sipSignalingPort}`);
   }
 
   // Get routes
   const routes = await client.listRoutes();
-  for await(const route of routes) {
+  for await (const route of routes) {
     console.log(`Route ${route.name} with pattern ${route.numberPattern}`);
     console.log(`Route's trunks: ${route.trunks?.join()}`);
   }

--- a/sdk/communication/communication-phone-numbers/samples-dev/siprouting/getSipRoutingConfiguration.ts
+++ b/sdk/communication/communication-phone-numbers/samples-dev/siprouting/getSipRoutingConfiguration.ts
@@ -17,14 +17,14 @@ export async function main() {
   const client = new SipRoutingClient(connectionString);
 
   // Get trunks
-  const trunks = await client.getTrunks();
-  for (const trunk of trunks) {
+  const trunks = await client.listTrunks();
+  for await(const trunk of trunks) {
     console.log(`Trunk ${trunk.fqdn}:${trunk.sipSignalingPort}`);
   }
 
   // Get routes
-  const routes = await client.getRoutes();
-  for (const route of routes) {
+  const routes = await client.listRoutes();
+  for await(const route of routes) {
     console.log(`Route ${route.name} with pattern ${route.numberPattern}`);
     console.log(`Route's trunks: ${route.trunks?.join()}`);
   }

--- a/sdk/communication/communication-phone-numbers/samples-dev/siprouting/manageSipRoutingConfiguration.ts
+++ b/sdk/communication/communication-phone-numbers/samples-dev/siprouting/manageSipRoutingConfiguration.ts
@@ -64,14 +64,14 @@ export async function main() {
   });
 
   // Get trunks
-  const trunks = await client.getTrunks();
-  for (const trunk of trunks) {
+  const trunks = await client.listTrunks();
+  for await(const trunk of trunks) {
     console.log(`Trunk ${trunk.fqdn}:${trunk.sipSignalingPort}`);
   }
 
   // Get routes
-  const routes = await client.getRoutes();
-  for (const route of routes) {
+  const routes = await client.listRoutes();
+  for await(const route of routes) {
     console.log(`Route ${route.name} with pattern ${route.numberPattern}`);
     console.log(`Route's trunks: ${route.trunks?.join()}`);
   }

--- a/sdk/communication/communication-phone-numbers/samples-dev/siprouting/manageSipRoutingConfiguration.ts
+++ b/sdk/communication/communication-phone-numbers/samples-dev/siprouting/manageSipRoutingConfiguration.ts
@@ -65,13 +65,13 @@ export async function main() {
 
   // Get trunks
   const trunks = await client.listTrunks();
-  for await(const trunk of trunks) {
+  for await (const trunk of trunks) {
     console.log(`Trunk ${trunk.fqdn}:${trunk.sipSignalingPort}`);
   }
 
   // Get routes
   const routes = await client.listRoutes();
-  for await(const route of routes) {
+  for await (const route of routes) {
     console.log(`Route ${route.name} with pattern ${route.numberPattern}`);
     console.log(`Route's trunks: ${route.trunks?.join()}`);
   }

--- a/sdk/communication/communication-phone-numbers/src/models.ts
+++ b/sdk/communication/communication-phone-numbers/src/models.ts
@@ -67,6 +67,16 @@ export interface ListLocalitiesOptions extends OperationOptions {
 }
 
 /**
+ * Additional options that can be passed to list SIP routes.
+ */
+export interface ListSipRoutesOptions extends OperationOptions {}
+
+/**
+ * Additional options that can be passed to list SIP trunks.
+ */
+export interface ListSipTrunksOptions extends OperationOptions {}
+
+/**
  * Additional options that can be passed to the available offerings request.
  */
 export interface ListOfferingsOptions extends OperationOptions {

--- a/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
@@ -258,12 +258,12 @@ export class SipRoutingClient {
     );
   }
 
-  private async getRoutesInternal(options: OperationOptions) {
+  private async getRoutesInternal(options: OperationOptions): Promise<SipTrunkRoute[]> {
     const config = await this.client.getSipConfiguration(options);
     return config.routes || [];
   }
 
-  private async getTrunksInternal(options: OperationOptions) {
+  private async getTrunksInternal(options: OperationOptions): Promise<SipTrunk[]> {
     const config = await this.client.getSipConfiguration(options);
     return transformFromRestModel(config.trunks);
   }
@@ -287,14 +287,14 @@ export class SipRoutingClient {
   private async *listTrunksPagingPage(
     options: ListSipTrunksOptions = {}
   ): AsyncIterableIterator<SipTrunk[]> {
-    let apiResult = await this.getTrunksInternal(options as OperationOptions);
+    const apiResult = await this.getTrunksInternal(options as OperationOptions);
     yield apiResult;
   }
 
   private async *listRoutesPagingPage(
     options: ListSipRoutesOptions = {}
   ): AsyncIterableIterator<SipTrunkRoute[]> {
-    let apiResult = await this.getRoutesInternal(options as OperationOptions);
+    const apiResult = await this.getRoutesInternal(options as OperationOptions);
     yield apiResult;
   }
 }

--- a/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
@@ -104,18 +104,33 @@ export class SipRoutingClient {
    * @param options - The options parameters.
    */
   public listTrunks(options: ListSipTrunksOptions = {}): PagedAsyncIterableIterator<SipTrunk> {
-    const iter = this.listTrunksPagingAll(options);
-    return {
-      next() {
-        return iter.next();
-      },
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-      byPage: () => {
-        return this.listTrunksPagingPage(options);
-      },
-    };
+    const { span, updatedOptions } = tracingClient.startSpan(
+      "SipRoutingClient-listTrunks",
+      options
+    );
+
+    try {
+      const iter = this.listTrunksPagingAll({ ...updatedOptions });
+      return {
+        next() {
+          return iter.next();
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        byPage: () => {
+          return this.listTrunksPagingPage({ ...updatedOptions });
+        },
+      };
+    } catch (e: any) {
+      span.setStatus({
+        status: "error",
+        error: e,
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -139,18 +154,33 @@ export class SipRoutingClient {
    * @param options - The options parameters.
    */
   public listRoutes(options: ListSipRoutesOptions = {}): PagedAsyncIterableIterator<SipTrunkRoute> {
-    const iter = this.listRoutesPagingAll(options);
-    return {
-      next() {
-        return iter.next();
-      },
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-      byPage: () => {
-        return this.listRoutesPagingPage(options);
-      },
-    };
+    const { span, updatedOptions } = tracingClient.startSpan(
+      "SipRoutingClient-listRoutes",
+      options
+    );
+
+    try {
+      const iter = this.listRoutesPagingAll({ ...updatedOptions });
+      return {
+        next() {
+          return iter.next();
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        byPage: () => {
+          return this.listRoutesPagingPage({ ...updatedOptions });
+        },
+      };
+    } catch (e: any) {
+      span.setStatus({
+        status: "error",
+        error: e,
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**

--- a/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/sipRoutingClient.ts
@@ -11,10 +11,11 @@ import { InternalPipelineOptions } from "@azure/core-rest-pipeline";
 import { logger } from "./utils";
 import { SipRoutingClient as SipRoutingGeneratedClient } from "./generated/src/siprouting/sipRoutingClient";
 import { SipConfigurationPatch, SipRoutingError } from "./generated/src/siprouting/models";
-import { SipTrunk, SipTrunkRoute } from "./models";
+import { ListSipRoutesOptions, ListSipTrunksOptions, SipTrunk, SipTrunkRoute } from "./models";
 import { transformFromRestModel, transformIntoRestModel } from "./mappers";
 import { CommonClientOptions, OperationOptions } from "@azure/core-client";
 import { tracingClient } from "./generated/src/tracing";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
 export * from "./models";
 
@@ -102,11 +103,19 @@ export class SipRoutingClient {
    * Gets the SIP trunks.
    * @param options - The options parameters.
    */
-  public async getTrunks(options: OperationOptions = {}): Promise<SipTrunk[]> {
-    return tracingClient.withSpan("SipRoutingClient-getTrunks", options, async (updatedOptions) => {
-      const config = await this.client.getSipConfiguration(updatedOptions);
-      return transformFromRestModel(config.trunks);
-    });
+  public listTrunks(options: ListSipTrunksOptions = {}): PagedAsyncIterableIterator<SipTrunk> {
+    const iter = this.listTrunksPagingAll(options);
+    return {
+      next() {
+        return iter.next();
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      byPage: () => {
+        return this.listTrunksPagingPage(options);
+      },
+    };
   }
 
   /**
@@ -116,25 +125,34 @@ export class SipRoutingClient {
    */
   public async getTrunk(fqdn: string, options: OperationOptions = {}): Promise<SipTrunk> {
     return tracingClient.withSpan("SipRoutingClient-getTrunk", options, async (updatedOptions) => {
-      const trunks = await this.getTrunks(updatedOptions);
-      const trunk = trunks.find((value: SipTrunk) => value.fqdn === fqdn);
-      if (trunk) {
-        return trunk;
+      for await(const trunk of this.listTrunks(updatedOptions))
+      {
+        if(trunk.fqdn === fqdn)
+        {
+          return trunk;
+        }
       }
-
       throw { code: "NotFound", message: "Not Found" } as SipRoutingError;
     });
   }
 
   /**
-   * Gets the SIP trunk routes.
+   * Lists the SIP trunk routes.
    * @param options - The options parameters.
    */
-  public async getRoutes(options: OperationOptions = {}): Promise<SipTrunkRoute[]> {
-    return tracingClient.withSpan("SipRoutingClient-getRoutes", options, async (updatedOptions) => {
-      const config = await this.client.getSipConfiguration(updatedOptions);
-      return config.routes || [];
-    });
+  public listRoutes(options: ListSipRoutesOptions = {}): PagedAsyncIterableIterator<SipTrunkRoute> {
+    const iter = this.listRoutesPagingAll(options);
+    return {
+      next() {
+        return iter.next();
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      byPage: () => {
+        return this.listRoutesPagingPage(options);
+      },
+    };
   }
 
   /**
@@ -212,7 +230,16 @@ export class SipRoutingClient {
         ...patch,
       };
       const config = await this.client.patchSipConfiguration(payload);
-      const storedRoutes = config.routes || (await this.getRoutes(updatedOptions));
+      let storedRoutes = config.routes;
+
+      if(!storedRoutes)
+      {
+        storedRoutes = [];
+        for await(const route of this.listRoutes(updatedOptions))
+        {
+          storedRoutes.push(route);
+        }
+      }
       return storedRoutes;
     });
   }
@@ -240,5 +267,89 @@ export class SipRoutingClient {
         await this.client.patchSipConfiguration(payload);
       }
     );
+  }
+
+  private async getRoutesInternal(options: OperationOptions) {
+    return await tracingClient.withSpan(
+      "SipRoutingClient-getRoutes",
+      options,
+      async (updatedOptions) => {
+        const config = await this.client.getSipConfiguration(updatedOptions);
+        return config.routes || [];
+      }
+    );
+  }
+
+  private async getTrunksInternal(options: OperationOptions) {
+    return tracingClient.withSpan("SipRoutingClient-getTrunks", options, async (updatedOptions) => {
+      const config = await this.client.getSipConfiguration(updatedOptions);
+      return transformFromRestModel(config.trunks);
+    });
+  }
+
+  private async *listRoutesPagingAll(
+    options?: ListSipRoutesOptions
+  ): AsyncIterableIterator<SipTrunkRoute> {
+    for await (const page of this.listRoutesPagingPage(options)) {
+      yield* page;
+    }
+  }
+
+  private async *listTrunksPagingAll(
+    options?: ListSipTrunksOptions
+  ): AsyncIterableIterator<SipTrunk> {
+    for await (const page of this.listTrunksPagingPage(options)) {
+      yield* page;
+    }
+  }
+
+  private async *listTrunksPagingPage(
+    options: ListSipTrunksOptions = {}
+  ): AsyncIterableIterator<SipTrunk[]> {
+    let apiResult = await this.getTrunksInternal(options as OperationOptions);
+
+    // const pageSize = options.maxPageSize ?? 100;
+    // const offset = options.skip ?? 0;
+    const pageSize = 256;
+    const offset = 0;
+
+    if (offset > apiResult.length) {
+        yield [];
+    }
+
+    const pageCount = Math.ceil((apiResult.length - offset) / pageSize);
+
+    for (let j = 0; j < pageCount; j++) {
+      let page = [];
+      for (let k = offset + j * pageSize; k < apiResult.length; k++) {
+        page.push(apiResult[k]);
+      }
+      yield page;
+    }
+  }
+
+  private async *listRoutesPagingPage(
+    options: ListSipRoutesOptions = {}
+  ): AsyncIterableIterator<SipTrunkRoute[]> {
+    let apiResult = await this.getRoutesInternal(options as OperationOptions);
+
+    // const pageSize = options.maxPageSize ?? 100;
+    // const offset = options.skip ?? 0;
+    const pageSize = 256;
+    const offset = 0;
+
+    if (offset > apiResult.length) {
+      yield [];
+    }
+
+    const pageCount = Math.ceil((apiResult.length - offset) / pageSize);
+
+    for (let j = 0; j < pageCount; j++) {
+      let page = [];
+      for (let k = offset + j * pageSize; k <= apiResult.length; k++) {
+        page.push(apiResult[k]);
+      }
+      yield page;
+    }
   }
 }

--- a/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
@@ -27,7 +27,7 @@ describe("SipRoutingClient - headers", function () {
 
   it("calls the spy", async function () {
     const spy = sinon.spy(getTrunksHttpClient, "sendRequest");
-    const iter= await client.listTrunks();
+    const iter = await client.listTrunks();
     await iter.next();
     sinon.assert.calledOnce(spy);
 

--- a/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
@@ -27,7 +27,8 @@ describe("SipRoutingClient - headers", function () {
 
   it("calls the spy", async function () {
     const spy = sinon.spy(getTrunksHttpClient, "sendRequest");
-    await client.getTrunks();
+    const iter= await client.listTrunks();
+    await iter.next();
     sinon.assert.calledOnce(spy);
 
     request = spy.getCall(0).args[0];
@@ -67,7 +68,8 @@ describe("SipRoutingClient - headers", function () {
     });
 
     const spy = sinon.spy(getTrunksHttpClient, "sendRequest");
-    await client.getTrunks();
+    const iter = await client.listTrunks();
+    await iter.next();
     sinon.assert.calledOnce(spy);
 
     request = spy.getCall(0).args[0];
@@ -86,7 +88,8 @@ describe("SipRoutingClient - headers", function () {
     });
 
     const spy = sinon.spy(getTrunksHttpClient, "sendRequest");
-    await client.getTrunks();
+    const iter = await client.listTrunks();
+    await iter.next();
     sinon.assert.calledOnce(spy);
 
     request = spy.getCall(0).args[0];
@@ -103,7 +106,8 @@ describe("SipRoutingClient - headers", function () {
     });
 
     const spy = sinon.spy(getTrunksHttpClient, "sendRequest");
-    await client.getTrunks();
+    const iter = await client.listTrunks();
+    await iter.next();
     sinon.assert.calledOnce(spy);
 
     request = spy.getCall(0).args[0];

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/deleteTrunk.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/deleteTrunk.spec.ts
@@ -13,6 +13,7 @@ import {
   createRecordedClient,
   createRecordedClientWithToken,
   getUniqueFqdn,
+  listAllTrunks,
   resetUniqueFqdns,
 } from "./utils/recordedClient";
 import { matrix } from "@azure/test-utils";
@@ -50,11 +51,11 @@ matrix([[true, false]], async function (useAad) {
       };
       const storedTrunk = await client.setTrunk(trunk);
       assert.deepEqual(storedTrunk, trunk);
-      assert.exists((await client.getTrunks()).find((value) => value.fqdn === trunk.fqdn));
+      assert.exists((await listAllTrunks(client)).find((value) => value.fqdn === trunk.fqdn));
 
       await client.deleteTrunk(testFqdn);
 
-      assert.notExists((await client.getTrunks()).find((value) => value.fqdn === trunk.fqdn));
+      assert.notExists((await listAllTrunks(client)).find((value) => value.fqdn === trunk.fqdn));
     });
 
     it("cannot delete a not existing trunk but succeeds", async () => {
@@ -62,7 +63,7 @@ matrix([[true, false]], async function (useAad) {
 
       await client.deleteTrunk("notExisting.fqdn.com");
 
-      const storedTrunks = await client.getTrunks();
+      const storedTrunks = await listAllTrunks(client);
       assert.isNotNull(storedTrunks);
       assert.isArray(storedTrunks);
       assert.isEmpty(storedTrunks);

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/deleteTrunk.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/deleteTrunk.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 
 import { SipRoutingClient } from "../../../src";
 
-import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import { SipTrunk } from "../../../src/models";
 import {
   clearSipConfiguration,

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/getRoutes.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/getRoutes.spec.ts
@@ -7,7 +7,7 @@ import { Context } from "mocha";
 import { SipRoutingClient } from "../../../src";
 
 import { matrix } from "@azure/test-utils";
-import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import {
   clearSipConfiguration,
   createRecordedClient,

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/getRoutes.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/getRoutes.spec.ts
@@ -12,6 +12,7 @@ import {
   clearSipConfiguration,
   createRecordedClient,
   createRecordedClientWithToken,
+  listAllRoutes,
 } from "./utils/recordedClient";
 
 matrix([[true, false]], async function (useAad) {
@@ -38,13 +39,13 @@ matrix([[true, false]], async function (useAad) {
     });
 
     it("can retrieve routes", async () => {
-      assert.isArray(await client.getRoutes());
+      assert.isArray(await listAllRoutes(client));
     });
 
     it("can retrieve empty routes", async () => {
       await client.setRoutes([]);
 
-      const routes = await client.getRoutes();
+      const routes = await listAllRoutes(client);
 
       assert.isNotNull(routes);
       assert.isArray(routes);
@@ -68,7 +69,7 @@ matrix([[true, false]], async function (useAad) {
       ];
       await client.setRoutes(expectedRoutes);
 
-      const routes = await client.getRoutes();
+      const routes = await listAllRoutes(client);
 
       assert.isNotNull(routes);
       assert.isArray(routes);

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/getTrunks.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/getTrunks.spec.ts
@@ -13,6 +13,7 @@ import {
   createRecordedClient,
   createRecordedClientWithToken,
   getUniqueFqdn,
+  listAllTrunks,
   resetUniqueFqdns,
 } from "./utils/recordedClient";
 import { matrix } from "@azure/test-utils";
@@ -69,13 +70,13 @@ matrix([[true, false]], async function (useAad) {
     });
 
     it("can retrieve trunks", async () => {
-      assert.isArray(await client.getTrunks());
+      assert.isArray(await listAllTrunks(client));
     });
 
     it("can retrieve empty trunks", async () => {
       await client.setTrunks([]);
 
-      const trunks = await client.getTrunks();
+      const trunks = await listAllTrunks(client);
 
       assert.isNotNull(trunks);
       assert.isArray(trunks);
@@ -90,7 +91,7 @@ matrix([[true, false]], async function (useAad) {
       ];
       await client.setTrunks(expectedTrunks);
 
-      const trunks = await client.getTrunks();
+      const trunks = await listAllTrunks(client);
 
       assert.isNotNull(trunks);
       assert.isArray(trunks);

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/getTrunks.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/getTrunks.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 
 import { SipRoutingClient } from "../../../src";
 
-import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import { SipTrunk } from "../../../src/models";
 import {
   clearSipConfiguration,

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/setRoutes.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/setRoutes.spec.ts
@@ -13,6 +13,8 @@ import {
   createRecordedClient,
   createRecordedClientWithToken,
   getUniqueFqdn,
+  listAllRoutes,
+  listAllTrunks,
   resetUniqueFqdns,
 } from "./utils/recordedClient";
 import { matrix } from "@azure/test-utils";
@@ -66,7 +68,7 @@ matrix([[true, false]], async function (useAad) {
       const setRoutes = await client.setRoutes(routes);
       assert.deepEqual(setRoutes, routes);
 
-      const storedRoutes = await client.getRoutes();
+      const storedRoutes = await listAllRoutes(client);
       assert.deepEqual(storedRoutes, routes);
     });
 
@@ -99,7 +101,7 @@ matrix([[true, false]], async function (useAad) {
       const setRoutes = await client.setRoutes(expectedRoutes);
       assert.deepEqual(setRoutes, expectedRoutes);
 
-      const storedRoutes = await client.getRoutes();
+      const storedRoutes = await listAllRoutes(client);
       assert.deepEqual(storedRoutes, expectedRoutes);
     });
 
@@ -117,7 +119,7 @@ matrix([[true, false]], async function (useAad) {
         trunks: [firstFqdn],
       };
       assert.deepEqual(await client.setRoutes([route]), [route]);
-      assert.deepEqual(await client.getRoutes(), [route]);
+      assert.deepEqual(await listAllRoutes(client), [route]);
     });
 
     it("can set empty routes when empty before", async () => {
@@ -125,7 +127,7 @@ matrix([[true, false]], async function (useAad) {
 
       await client.setRoutes([]);
 
-      const storedRoutes = await client.getRoutes();
+      const storedRoutes = await listAllRoutes(client);
       assert.isNotNull(storedRoutes);
       assert.isArray(storedRoutes);
       assert.isEmpty(storedRoutes);
@@ -150,7 +152,7 @@ matrix([[true, false]], async function (useAad) {
 
       await client.setRoutes([]);
 
-      const storedRoutes = await client.getRoutes();
+      const storedRoutes = await listAllRoutes(client);
       assert.isNotNull(storedRoutes);
       assert.isArray(storedRoutes);
       assert.isEmpty(storedRoutes);
@@ -167,7 +169,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setRoutes([invalidRoute]);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedRoutes = await client.getRoutes();
+        const storedRoutes = await listAllRoutes(client);
         assert.isUndefined(storedRoutes.find((item) => item.name === ""));
         return;
       }
@@ -184,7 +186,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setRoutes([invalidRoute]);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedRoutes = await client.getRoutes();
+        const storedRoutes = await listAllRoutes(client);
         assert.isUndefined(storedRoutes.find((item) => item.name === "invalidNumberPatternRoute"));
         return;
       }
@@ -207,7 +209,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setRoutes(invalidRoutes);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedRoutes = await client.getRoutes();
+        const storedRoutes = await listAllRoutes(client);
         assert.isUndefined(storedRoutes.find((item) => item.name === "sameNameRoute"));
         return;
       }
@@ -231,7 +233,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setRoutes([invalidRoute]);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedRoutes = await client.getRoutes();
+        const storedRoutes = await listAllRoutes(client);
         assert.isUndefined(
           storedRoutes.find((item) => item.name === "invalidDuplicatedRoutingTrunksRoute")
         );
@@ -251,7 +253,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setRoutes([invalidRoute]);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedRoutes = await client.getRoutes();
+        const storedRoutes = await listAllRoutes(client);
         assert.isUndefined(storedRoutes.find((item) => item.name === "invalidRoutingTrunkRoute"));
         return;
       }
@@ -287,8 +289,8 @@ matrix([[true, false]], async function (useAad) {
       ];
       await client.setRoutes(routes);
 
-      assert.deepEqual(await client.getTrunks(), trunks);
-      assert.deepEqual(await client.getRoutes(), routes);
+      assert.deepEqual(await listAllTrunks(client), trunks);
+      assert.deepEqual(await listAllRoutes(client), routes);
     });
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/setRoutes.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/setRoutes.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 
 import { SipRoutingClient } from "../../../src";
 
-import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import { SipTrunk, SipTrunkRoute } from "../../../src/models";
 import {
   clearSipConfiguration,

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/setTrunks.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/setTrunks.spec.ts
@@ -13,6 +13,8 @@ import {
   createRecordedClient,
   createRecordedClientWithToken,
   getUniqueFqdn,
+  listAllRoutes,
+  listAllTrunks,
   resetUniqueFqdns,
 } from "./utils/recordedClient";
 import { matrix } from "@azure/test-utils";
@@ -79,7 +81,7 @@ matrix([[true, false]], async function (useAad) {
       const setTrunks = await client.setTrunks(trunks);
       assert.deepEqual(setTrunks, trunks);
 
-      const storedTrunks = await client.getTrunks();
+      const storedTrunks = await listAllTrunks(client);
       assert.deepEqual(storedTrunks, trunks);
     });
 
@@ -96,7 +98,7 @@ matrix([[true, false]], async function (useAad) {
       const setTrunks = await client.setTrunks(trunks);
       assert.deepEqual(setTrunks, trunks);
 
-      const storedTrunks = await client.getTrunks();
+      const storedTrunks = await listAllTrunks(client);
       assert.deepEqual(storedTrunks, trunks);
     });
 
@@ -105,7 +107,7 @@ matrix([[true, false]], async function (useAad) {
 
       await client.setTrunks([]);
 
-      const storedTrunks = await client.getTrunks();
+      const storedTrunks = await listAllTrunks(client);
       assert.isNotNull(storedTrunks);
       assert.isArray(storedTrunks);
       assert.isEmpty(storedTrunks);
@@ -120,7 +122,7 @@ matrix([[true, false]], async function (useAad) {
 
       await client.setTrunks([]);
 
-      const storedTrunks = await client.getTrunks();
+      const storedTrunks = await listAllTrunks(client);
       assert.isNotNull(storedTrunks);
       assert.isArray(storedTrunks);
       assert.isEmpty(storedTrunks);
@@ -192,7 +194,7 @@ matrix([[true, false]], async function (useAad) {
         await client.setTrunks([{ fqdn: firstFqdn, sipSignalingPort: 1234 }]);
       } catch (error: any) {
         assert.equal(error.code, "UnprocessableConfiguration");
-        const storedTrunks = await client.getTrunks();
+        const storedTrunks = await listAllTrunks(client);
         assert.isNotNull(storedTrunks);
         assert.isArray(storedTrunks);
         assert.deepEqual(storedTrunks, expectedTrunks);
@@ -230,8 +232,8 @@ matrix([[true, false]], async function (useAad) {
       ];
       await client.setTrunks(trunks);
 
-      assert.deepEqual(await client.getTrunks(), trunks);
-      assert.deepEqual(await client.getRoutes(), routes);
+      assert.deepEqual(await listAllTrunks(client), trunks);
+      assert.deepEqual(await listAllRoutes(client), routes);
     });
   });
 });

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/setTrunks.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/setTrunks.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 
 import { SipRoutingClient } from "../../../src";
 
-import { isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import { SipTrunk, SipTrunkRoute } from "../../../src/models";
 import {
   clearSipConfiguration,

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
@@ -163,3 +163,4 @@ export async function listAllRoutes(client: SipRoutingClient) : Promise<SipTrunk
       }
       return result;
     }
+    

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
@@ -7,10 +7,10 @@ import * as dotenv from "dotenv";
 import {
   Recorder,
   RecorderStartOptions,
-  env,
-  assertEnvironmentVariable,
-  isPlaybackMode,
   SanitizerOptions,
+  assertEnvironmentVariable,
+  env,
+  isPlaybackMode,
 } from "@azure-tools/test-recorder";
 import { SipRoutingClient, SipTrunk, SipTrunkRoute } from "../../../../src";
 import { parseConnectionString } from "@azure/communication-common";
@@ -139,7 +139,7 @@ export function resetUniqueFqdns(): void {
 
 export async function listAllTrunks(client: SipRoutingClient) : Promise<SipTrunk[]>
     {
-      let result: SipTrunk[] = [];
+      const result: SipTrunk[] = [];
 
       for await (const trunk of client.listTrunks())
       {
@@ -153,7 +153,7 @@ export async function listAllTrunks(client: SipRoutingClient) : Promise<SipTrunk
 
 export async function listAllRoutes(client: SipRoutingClient) : Promise<SipTrunkRoute[]>
     {
-      let result: SipTrunkRoute[] = [];
+      const result: SipTrunkRoute[] = [];
       for await (const route of client.listRoutes())
       {
         if(route)
@@ -163,4 +163,3 @@ export async function listAllRoutes(client: SipRoutingClient) : Promise<SipTrunk
       }
       return result;
     }
-    

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
@@ -12,7 +12,7 @@ import {
   isPlaybackMode,
   SanitizerOptions,
 } from "@azure-tools/test-recorder";
-import { SipRoutingClient } from "../../../../src";
+import { SipRoutingClient, SipTrunk, SipTrunkRoute } from "../../../../src";
 import { parseConnectionString } from "@azure/communication-common";
 import { TokenCredential } from "@azure/identity";
 import { isNode } from "@azure/test-utils";
@@ -136,3 +136,30 @@ export function getUniqueFqdn(recorder: Recorder): string {
 export function resetUniqueFqdns(): void {
   fqdnNumber = 1;
 }
+
+export async function listAllTrunks(client: SipRoutingClient) : Promise<SipTrunk[]>
+    {
+      let result: SipTrunk[] = [];
+
+      for await (const trunk of client.listTrunks())
+      {
+        if(trunk)
+        {
+          result.push(trunk);
+        }
+      }
+      return result;
+    }
+
+export async function listAllRoutes(client: SipRoutingClient) : Promise<SipTrunkRoute[]>
+    {
+      let result: SipTrunkRoute[] = [];
+      for await (const route of client.listRoutes())
+      {
+        if(route)
+        {
+          result.push(route);
+        }
+      }
+      return result;
+    }

--- a/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/siprouting/utils/recordedClient.ts
@@ -137,29 +137,23 @@ export function resetUniqueFqdns(): void {
   fqdnNumber = 1;
 }
 
-export async function listAllTrunks(client: SipRoutingClient) : Promise<SipTrunk[]>
-    {
-      const result: SipTrunk[] = [];
+export async function listAllTrunks(client: SipRoutingClient): Promise<SipTrunk[]> {
+  const result: SipTrunk[] = [];
 
-      for await (const trunk of client.listTrunks())
-      {
-        if(trunk)
-        {
-          result.push(trunk);
-        }
-      }
-      return result;
+  for await (const trunk of client.listTrunks()) {
+    if (trunk) {
+      result.push(trunk);
     }
+  }
+  return result;
+}
 
-export async function listAllRoutes(client: SipRoutingClient) : Promise<SipTrunkRoute[]>
-    {
-      const result: SipTrunkRoute[] = [];
-      for await (const route of client.listRoutes())
-      {
-        if(route)
-        {
-          result.push(route);
-        }
-      }
-      return result;
+export async function listAllRoutes(client: SipRoutingClient): Promise<SipTrunkRoute[]> {
+  const result: SipTrunkRoute[] = [];
+  for await (const route of client.listRoutes()) {
+    if (route) {
+      result.push(route);
     }
+  }
+  return result;
+}


### PR DESCRIPTION
### Packages impacted by this PR
Communication Phone-Numbers

### Issues associated with this PR
https://skype.visualstudio.com/SPOOL/_workitems/edit/3149585/

### Describe the problem that is addressed by this PR
On the latest Internal Board Review, we got the feedback to change naming of functions retrieving the trunks and routes from "get" to "list". This PR aims to solve this.

We don't provide options to set page size or skip, because:
1) The collections returned by ListTrunks and ListRoutes are short (usually 1~5 items), bigger collections don't make sense from use case perspective.
2) Underlying API doesnt support paging, therefore no cost would be saved with setting the page size.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
