### PR TITLE
Check for unpartitioned container

### DIFF
--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -286,7 +286,9 @@ export function deepFind<T, P extends string>(document: T, path: P): string | JS
   for (const p of apath) {
     if (p in h) h = h[p];
     else {
+      if (p !== "_partitionKey") {
       console.warn(`Partition key not found, using undefined: ${path} at ${p}`);
+      }
       return "{}";
     }
   }

--- a/sdk/cosmosdb/cosmos/src/utils/batch.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/batch.ts
@@ -287,7 +287,7 @@ export function deepFind<T, P extends string>(document: T, path: P): string | JS
     if (p in h) h = h[p];
     else {
       if (p !== "_partitionKey") {
-      console.warn(`Partition key not found, using undefined: ${path} at ${p}`);
+        console.warn(`Partition key not found, using undefined: ${path} at ${p}`);
       }
       return "{}";
     }


### PR DESCRIPTION
### Packages impacted by this PR
[@azure/cosmos](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/cosmosdb/cosmos)

### Issues associated with this PR
#24287 

### Describe the problem that is addressed by this PR
A warning is logged on console if partition key is not present in resource body for bulk operations. This fix checks for a non-partitioned container, and skips logging a warning for it.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
