### PR TITLE
[storage]Added createdOn in BlobDownloadResponseParsed and FileReadResponse in datalake package

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.13.0 (Unreleased)
+
+### Features Added
+
+- Added BlobDownloadHeaders.createdOn property for interface BlobClient.Download().
+
 ## 12.13.0-beta.1 (2023-02-09)
 
 ### Features Added

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -2313,7 +2313,7 @@ export { IHttpClient }
 export function isPipelineLike(pipeline: unknown): pipeline is PipelineLike;
 
 // @public
-export const enum KnownEncryptionAlgorithmType {
+export enum KnownEncryptionAlgorithmType {
     // (undocumented)
     AES256 = "AES256"
 }

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -569,6 +569,7 @@ export interface BlobDownloadHeaders {
     copySource?: string;
     copyStatus?: CopyStatusType;
     copyStatusDescription?: string;
+    createdOn?: Date;
     date?: Date;
     encryptionKeySha256?: string;
     encryptionScope?: string;
@@ -2310,6 +2311,12 @@ export { IHttpClient }
 
 // @public
 export function isPipelineLike(pipeline: unknown): pipeline is PipelineLike;
+
+// @public
+export const enum KnownEncryptionAlgorithmType {
+    // (undocumented)
+    AES256 = "AES256"
+}
 
 // @public
 export interface Lease {

--- a/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
@@ -340,6 +340,15 @@ export class BlobDownloadResponse implements BlobDownloadResponseParsed {
   }
 
   /**
+   * Returns the date and time the blob was created.
+   *
+   * @readonly
+   */
+  public get createdOn(): Date | undefined {
+    return this.originalResponse.createdOn;
+  }
+
+  /**
    * A name-value pair
    * to associate with a file storage object.
    *

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -979,6 +979,8 @@ export interface ContainerGetAccountInfoExceptionHeaders {
 export interface BlobDownloadHeaders {
   /** Returns the date and time the container was last modified. Any operation that modifies the blob, including an update of the blob's metadata or properties, changes the last-modified time of the blob. */
   lastModified?: Date;
+  /** Returns the date and time the blob was created. */
+  createdOn?: Date;
   metadata?: { [propertyName: string]: string };
   /** Optional. Only valid when Object Replication is enabled for the storage container and on the destination blob of the replication. */
   objectReplicationPolicyId?: string;

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -3872,6 +3872,13 @@ export const BlobDownloadHeaders: coreHttp.CompositeMapper = {
           name: "DateTimeRfc1123"
         }
       },
+      createdOn: {
+        serializedName: "x-ms-creation-time",
+        xmlName: "x-ms-creation-time",
+        type: {
+          name: "DateTimeRfc1123"
+        }
+      },
       metadata: {
         serializedName: "x-ms-meta",
         xmlName: "x-ms-meta",

--- a/sdk/storage/storage-blob/src/generatedModels.ts
+++ b/sdk/storage/storage-blob/src/generatedModels.ts
@@ -92,6 +92,7 @@ export {
   EncryptionAlgorithmType,
   GeoReplication,
   GeoReplicationStatusType,
+  KnownEncryptionAlgorithmType,
   LeaseAccessConditions,
   LeaseDurationType,
   LeaseStateType,

--- a/sdk/storage/storage-blob/src/generatedModels.ts
+++ b/sdk/storage/storage-blob/src/generatedModels.ts
@@ -92,7 +92,6 @@ export {
   EncryptionAlgorithmType,
   GeoReplication,
   GeoReplicationStatusType,
-  KnownEncryptionAlgorithmType,
   LeaseAccessConditions,
   LeaseDurationType,
   LeaseStateType,
@@ -256,4 +255,9 @@ export interface PageRangeInfo {
   start: number;
   end: number;
   isClear: boolean;
+}
+
+/** Known values of {@link EncryptionAlgorithmType} that the service accepts. */
+export enum KnownEncryptionAlgorithmType {
+  AES256 = "AES256",
 }

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -12,7 +12,7 @@ enable-xml: true
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/080b332b7572514a2e100dd2fa1fb86cb8edcb08/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/3e6f238a1f74d77ba6970f297c77995a9f1f374e/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json
 model-date-time-as-string: true
 optional-response-headers: true
 v3: true

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -202,6 +202,7 @@ describe("BlobClient", () => {
   it("download with with default parameters", async () => {
     const result = await blobClient.download();
     assert.deepStrictEqual(await bodyToString(result, content.length), content);
+    assert.exists(result.createdOn);
   });
 
   it("download with progress report", async () => {

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added FileReadHeaders.CreatedOn property for interface DataLakeFileClient.read().
 
+### Bugs Fixed
+
+- Renamed option 'leaseDuration' to 'leaseDurationInSeconds' in methods DataLakeFileClient.append() and flush(), the option was added in 12.12.0-beta.1.
+
 ## 12.12.0-beta.1 (2023-02-09)
 
 ### Features Added

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.12.0 (Unreleased)
+
+### Features Added
+
+- Added FileReadHeaders.CreatedOn property for interface DataLakeFileClient.read().
+
 ## 12.12.0-beta.1 (2023-02-09)
 
 ### Features Added

--- a/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
+++ b/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
@@ -524,7 +524,7 @@ export interface FileAppendOptions extends CommonOptions {
     flush?: boolean;
     // Warning: (ae-forgotten-export) The symbol "LeaseAction" needs to be exported by the entry point index.d.ts
     leaseAction?: LeaseAction;
-    leaseDuration?: number;
+    leaseDurationInSeconds?: number;
     // (undocumented)
     onProgress?: (progress: TransferProgressEvent) => void;
     proposedLeaseId?: string;
@@ -568,7 +568,7 @@ export interface FileFlushOptions extends CommonOptions {
     conditions?: DataLakeRequestConditions;
     customerProvidedKey?: CpkInfo;
     leaseAction?: LeaseAction;
-    leaseDuration?: number;
+    leaseDurationInSeconds?: number;
     // (undocumented)
     pathHttpHeaders?: PathHttpHeaders;
     proposedLeaseId?: string;
@@ -676,6 +676,7 @@ export interface FileReadHeaders {
     copyStatus?: CopyStatusType;
     // (undocumented)
     copyStatusDescription?: string;
+    createdOn?: Date;
     // (undocumented)
     date?: Date;
     // (undocumented)

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -1411,7 +1411,7 @@ export class DataLakeFileClient extends DataLakePathClient {
         cpkInfo: options.customerProvidedKey,
         flush: options.flush,
         proposedLeaseId: options.proposedLeaseId,
-        leaseDuration: options.leaseDuration,
+        leaseDuration: options.leaseDurationInSeconds,
         leaseAction: options.leaseAction,
         ...convertTracingToRequestOptionsBase(updatedOptions),
       });
@@ -1451,7 +1451,7 @@ export class DataLakeFileClient extends DataLakePathClient {
         modifiedAccessConditions: options.conditions,
         cpkInfo: options.customerProvidedKey,
         proposedLeaseId: options.proposedLeaseId,
-        leaseDuration: options.leaseDuration,
+        leaseDuration: options.leaseDurationInSeconds,
         leaseAction: options.leaseAction,
         ...convertTracingToRequestOptionsBase(updatedOptions),
       });

--- a/sdk/storage/storage-file-datalake/src/models.ts
+++ b/sdk/storage/storage-file-datalake/src/models.ts
@@ -1169,6 +1169,10 @@ export interface FileReadOptions extends CommonOptions {
 
 export interface FileReadHeaders {
   lastModified?: Date;
+  /**
+   * Returns the date and time the file was created.
+   */
+  createdOn?: Date;
   metadata?: Metadata;
   contentLength?: number;
   contentType?: string;
@@ -1229,7 +1233,7 @@ export interface FileAppendOptions extends CommonOptions {
   /**
    * The lease duration is required to acquire a lease, and specifies the duration of the lease in seconds.  The lease duration must be between 15 and 60 seconds or -1 for infinite lease.
    * */
-  leaseDuration?: number;
+  leaseDurationInSeconds?: number;
   /**
    * Optional. If "acquire" it will acquire the lease. If "auto-renew" it will renew the lease. If "release" it will release the lease only on flush. If "acquire-release" it will acquire & complete the operation & release the lease once operation is done.
    * */
@@ -1253,7 +1257,7 @@ export interface FileFlushOptions extends CommonOptions {
   /**
    * The lease duration is required to acquire a lease, and specifies the duration of the lease in seconds.  The lease duration must be between 15 and 60 seconds or -1 for infinite lease.
    */
-  leaseDuration?: number;
+  leaseDurationInSeconds?: number;
   /**
    * Optional. If "acquire" it will acquire the lease. If "auto-renew" it will renew the lease. If "release" it will release the lease only on flush. If "acquire-release" it will acquire & complete the operation & release the lease once operation is done.
    */

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -630,6 +630,7 @@ describe("DataLakePathClient", () => {
   it("read with with default parameters", async () => {
     const result = await fileClient.read();
     assert.deepStrictEqual(await bodyToString(result, content.length), content);
+    assert.exists(result.createdOn);
   });
 
   it("read should not have aborted error after read finishes", async () => {
@@ -809,7 +810,7 @@ describe("DataLakePathClient", () => {
 
     await tempFileClient.append(body, 0, body.length, {
       proposedLeaseId: leaseId,
-      leaseDuration: 15,
+      leaseDurationInSeconds: 15,
       leaseAction: "acquire",
     });
 
@@ -870,7 +871,7 @@ describe("DataLakePathClient", () => {
     }
     await tempFileClient.append(body, 0, body.length, {
       conditions: { leaseId: leaseId },
-      leaseDuration: 15,
+      leaseDurationInSeconds: 15,
       leaseAction: "auto-renew",
     });
 
@@ -939,7 +940,7 @@ describe("DataLakePathClient", () => {
 
     await tempFileClient.flush(body.length * 2, {
       proposedLeaseId: leaseId,
-      leaseDuration: 15,
+      leaseDurationInSeconds: 15,
       leaseAction: "acquire",
     });
 
@@ -994,7 +995,7 @@ describe("DataLakePathClient", () => {
 
     await tempFileClient.flush(body.length * 2, {
       conditions: { leaseId: leaseId },
-      leaseDuration: 15,
+      leaseDurationInSeconds: 15,
       leaseAction: "auto-renew",
     });
 


### PR DESCRIPTION
1. Added createdOn in BlobDownloadResponseParsed and FileReadResponse in datalake package 
2. Renamed new added option `leaseDuration` to `leaseDurationInSeconds`
3. Expose `KnownEncryptionAlgorithmType` to describe extendable enum type  `EncryptionAlgorithmType`'s available value.

### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
