### PR TITLE
Migration @azure/cosmos ci pipeline to run on windows-2022 agent pool.

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -39,7 +39,7 @@ stages:
         - TestType=node
         - DependencyVersion=^$
         - NodeTestVersion=14.x
-        - Pool=.*mms-win-2019.*
+        - Pool=.*mms-win-2020.*
       PreSteps:
         - template: /eng/pipelines/templates/steps/cosmos-integration-public.yml
       PostSteps:

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -39,7 +39,7 @@ stages:
         - TestType=node
         - DependencyVersion=^$
         - NodeTestVersion=14.x
-        - Pool=.*mms-win-2020.*
+        - Pool=.*mms-win-2022.*
       PreSteps:
         - template: /eng/pipelines/templates/steps/cosmos-integration-public.yml
       PostSteps:


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Agent pool in `eng\pipelines\templates\stages\platform-matrix.json` has been migrated to windows-2022, from windows-2019. This caused tests to skip for @azure/cosmos which uses non standard file `eng\pipelines\templates\stages\cosmos-sdk-client.yml` instead of `eng\pipelines\templates\stages\archetype-sdk-client.yml`. We are currently planning to move to `archetype-sdk-client.yml`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
NA

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
