### PR TITLE
[ServiceBus] pass `skipParsingBodyAsJson` and `skipConvertingDate` options to peek operations

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Pass `skipParsingBodyAsJson` and `skipConvertingDate` options to peek operations. (PR #24950)[https://github.com/Azure/azure-sdk-for-js/pull/24950]
+
 ### Other Changes
 
 ## 7.8.0 (2023-02-07)

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -439,6 +439,8 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
           associatedLinkName: this._getAssociatedReceiverName(),
           requestName: "receiveDeferredMessages",
           timeoutInMs: this._retryOptions.timeoutInMs,
+          skipParsingBodyAsJson: this.skipParsingBodyAsJson,
+          skipConvertingDate: this.skipConvertingDate,
         });
       return deferredMessages;
     };
@@ -465,6 +467,8 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
       associatedLinkName: this._getAssociatedReceiverName(),
       requestName: "peekMessages",
       timeoutInMs: this._retryOptions?.timeoutInMs,
+      skipParsingBodyAsJson: this.skipParsingBodyAsJson,
+      skipConvertingDate: this.skipConvertingDate,
     };
     const peekOperationPromise = async (): Promise<ServiceBusReceivedMessage[]> => {
       if (options.fromSequenceNumber !== undefined) {

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -133,6 +133,8 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
     private _context: ConnectionContext,
     public entityPath: string,
     public receiveMode: "peekLock" | "receiveAndDelete",
+    private _skipParsingBodyAsJson: boolean,
+    private _skipConvertingDate: boolean,
     private _retryOptions: RetryOptions = {}
   ) {
     throwErrorIfConnectionClosed(_context);
@@ -322,6 +324,8 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
       associatedLinkName: this._messageSession.name,
       requestName: "peekMessages",
       timeoutInMs: this._retryOptions?.timeoutInMs,
+      skipParsingBodyAsJson: this._skipParsingBodyAsJson,
+      skipConvertingDate: this._skipConvertingDate,
     };
     const peekOperationPromise = async (): Promise<ServiceBusReceivedMessage[]> => {
       if (options.fromSequenceNumber !== undefined) {
@@ -385,6 +389,8 @@ export class ServiceBusSessionReceiverImpl implements ServiceBusSessionReceiver 
           associatedLinkName: this._messageSession.name,
           requestName: "receiveDeferredMessages",
           timeoutInMs: this._retryOptions.timeoutInMs,
+          skipParsingBodyAsJson: this._skipParsingBodyAsJson,
+          skipConvertingDate: this._skipConvertingDate,
         });
       return deferredMessages;
     };

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -372,6 +372,8 @@ export class ServiceBusClient {
       this._connectionContext,
       entityPath,
       receiveMode,
+      options?.skipParsingBodyAsJson ?? false,
+      options?.skipConvertingDate ?? false,
       this._clientOptions.retryOptions
     );
 
@@ -460,6 +462,8 @@ export class ServiceBusClient {
       this._connectionContext,
       entityPath,
       receiveMode,
+      options?.skipParsingBodyAsJson ?? false,
+      options?.skipConvertingDate ?? false,
       this._clientOptions.retryOptions
     );
 

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -15,6 +15,7 @@ import {
   ServiceBusError,
   ServiceBusSessionReceiver,
   ServiceBusSender,
+  ServiceBusReceiverOptions,
 } from "../../src";
 import { DispositionType, ServiceBusReceivedMessage } from "../../src/serviceBusMessage";
 import { getReceiverClosedErrorMsg, getSenderClosedErrorMsg } from "../../src/util/errors";
@@ -230,6 +231,52 @@ describe("ServiceBusClient live tests", () => {
             peekedMsgs[0]._rawAmqpMessage.deliveryAnnotations!["omitted-message-body-size"],
             "Not expecting omitted-message-body-size"
           );
+
+          await receiver.receiveMessages(2);
+          await testPeekMsgsLength(receiver, 0);
+        } finally {
+          // Clean up
+          await sbClient.test.after();
+          await sender.close();
+          await receiver.close();
+          await sbClientWithRelaxedEndPoint.close();
+        }
+      }
+    );
+
+    it(
+      noSessionTestClientType + ": respect receiver options when peeking",
+      async function (): Promise<void> {
+        // Create a test client to get the entity types
+        const sbClient = createServiceBusClientForTests();
+        const entities = await sbClient.test.createTestEntities(noSessionTestClientType);
+        await sbClient.close();
+
+        // Create a sb client, sender, receiver with relaxed endpoint
+        const sbClientWithRelaxedEndPoint = new ServiceBusClient(
+          getEnvVars().SERVICEBUS_CONNECTION_STRING.replace("sb://", "CheeseBurger://")
+        );
+        const sender = sbClientWithRelaxedEndPoint.createSender(entities.queue || entities.topic!);
+        const receiverOptions: ServiceBusReceiverOptions = {
+          skipParsingBodyAsJson: true
+        };
+        const receiver = entities.queue
+          ? sbClientWithRelaxedEndPoint.createReceiver(entities.queue, receiverOptions)
+          : sbClientWithRelaxedEndPoint.createReceiver(entities.topic!, entities.subscription!, receiverOptions);
+        try {
+          // Send and receive messages
+          const testMessages = [ {
+            // body: Long.fromString("12345678901234567890"),
+            body: { id: 123456789 },
+          }];
+          await sender.sendMessages(testMessages);
+
+          let peekedMsgs = await receiver.peekMessages(2, {
+            fromSequenceNumber: Long.ZERO,
+          });
+          should.equal(peekedMsgs.length, 1, "expecting one peeked message 1");
+          peekedMsgs[0].body.should.not.deep.equal({ id: 123456789 });
+          peekedMsgs[0].body.constructor.name.should.equal("Buffer");
 
           await receiver.receiveMessages(2);
           await testPeekMsgsLength(receiver, 0);

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -400,7 +400,9 @@ describe("AbortSignal", () => {
         messageSession,
         connectionContext,
         "entityPath",
-        "peekLock"
+        "peekLock",
+        false,
+        false,
       );
 
       try {

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -402,7 +402,7 @@ describe("AbortSignal", () => {
         "entityPath",
         "peekLock",
         false,
-        false,
+        false
       );
 
       try {

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -279,6 +279,8 @@ describe("Receiver unit tests", () => {
         connectionContext,
         "entity path",
         "peekLock",
+        false,
+        false,
         undefined
       );
 


### PR DESCRIPTION
Currently the two options only affect `receiveMessages()`.  This PR pass them to peek operations as well so the received messages are consistent.

