### PR TITLE
[core-xml] port https://github.com/Azure/ms-rest-js/pull/475

### DIFF
--- a/sdk/core/core-xml/src/xml.browser.ts
+++ b/sdk/core/core-xml/src/xml.browser.ts
@@ -17,10 +17,14 @@ if (!document || !DOMParser || !Node || !XMLSerializer) {
 // according to the spec.  There are no HTML/XSS security concerns on the usage of
 // parseFromString() here.
 let ttPolicy: Pick<TrustedTypePolicy, "createHTML"> | undefined;
-if (typeof self.trustedTypes !== "undefined") {
-  ttPolicy = self.trustedTypes.createPolicy("@azure/core-xml#xml.browser", {
-    createHTML: (s) => s,
-  });
+try {
+  if (typeof self.trustedTypes !== "undefined") {
+    ttPolicy = self.trustedTypes.createPolicy("@azure/core-xml#xml.browser", {
+      createHTML: (s: any) => s,
+    });
+  }
+} catch (e: any) {
+  console.warn('Could not create trusted types policy "@azure/core-xml#xml.browser"');
 }
 
 const doc = document.implementation.createDocument(null, null, null);


### PR DESCRIPTION
Original PR description:

>Zlatkovsky commented on Nov 15, 2022
In our use-case of the ms-rest-js library, we have a large existing application (complete with caching, service-workers, etc) that we dynamically load additional JavaScript code into. The additional JS is what brings in the ms-rest-js.
>
>The application has Trusted Types enabled (e.g., CSP rule `'trusted-types LibraryA LibraryB etc`). But, interestingly, its `require-trusted-types-for 'script'` is currently under "report only" (`Content-Security-Policy-Report-Only`). In those cases, a call to `trustedTypes.createPolicy` will fail because the policy isn't on the allowed-list, even though _skipping_ the `createPolicy` would be OK. So in effect, https://github.com/Azure/ms-rest-js/commit/531aea9bfbbe6ef6c06984ab06f99775b90923ca introduced a regression.
>
>We are working on extending the allow-list of our application to include `@azure/ms-rest-js#xml.browser`, but that change takes time. In the meantime, we'd like to wrap the policy-creation in a `try/catch`. There is no security risk to it, since for host applications that DO have strict enforcement of trusted-types, the code will simply fail when the dangerous sink is used (e.g., when doing `parseFromString`). And likewise, wrapping in `try/catch` and doing nothing on `catch` is OK, because the code already deals with the possibility of the trustedTypes API not being available on the browser.


### Packages impacted by this PR
`@azure/core-xml`
