### PR TITLE
Add permission for `Azure/azure-sdk-assets` to `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,8 +37,20 @@
     "MS-vsliveshare.vsliveshare",
     "VisualStudioExptTeam.vscodeintellicode"
   ],
-  "postCreateCommand": "npm install -g @microsoft/rush" // This both overrides Oryx build which will run npm install and create a phantom node_modules directory and ensures that rush is available for use.
+  "postCreateCommand": "npm install -g @microsoft/rush", // This both overrides Oryx build which will run npm install and create a phantom node_modules directory and ensures that rush is available for use.
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
+
+  "customizations": {
+    "codespaces": {
+      "repositories": {
+        "Azure/azure-sdk-assets": {
+          "permissions": {
+            "contents": "write" 
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

GitHub grants minimal permissions to a Codespace when it is created through creating a personal access token (PAT). By default, this PAT only grants write access to the repo that the Codespace was created from. This causes permissions issues when pushing assets to the `Azure/azure-sdk-assets` repo since the PAT does not grant write permission to that repo. Fortunately, we can request additional permissions through the `devcontainer.json`, which will give the Codespace write access to the `Azure/azure-sdk-assets` repo.

Reference: https://docs.github.com/codespaces/managing-your-codespaces/managing-repository-access-for-your-codespaces