### PR TITLE
[storage-blob][test] remove x-ms-encryption-key from recordings

### DIFF
--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_rethrows_error_from_getproperties.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_rethrows_error_from_getproperties.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "d209c52d-9b34-4c19-a0d2-3c2c44c6c21f",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "dde862d9-76d2-41b1-8221-3420e7e244ee",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E4812FFB57\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF1AC1CC\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d209c52d-9b34-4c19-a0d2-3c2c44c6c21f",
-        "x-ms-request-id": "1d207ab5-101e-005d-46cd-357536000000",
+        "x-ms-client-request-id": "dde862d9-76d2-41b1-8221-3420e7e244ee",
+        "x-ms-request-id": "612a0cb2-901e-005e-04e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275/blob167520841582207800?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547/blob167719878238806775?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "65444b56-2a9b-49da-be41-94a5f71742f3",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "df3cb123-d200-418f-921a-999244fe1eff",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E4813A68E2\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF245E79\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "65444b56-2a9b-49da-be41-94a5f71742f3",
+        "x-ms-client-request-id": "df3cb123-d200-418f-921a-999244fe1eff",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d207b01-101e-005d-0bcd-357536000000",
+        "x-ms-request-id": "612a0cb5-901e-005e-06e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.8572770Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275/blobCPK167520841588902716?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547/blobCPK167719878244906142?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,41 +105,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "9a99d9e5-eee9-4b03-9617-cd6d975cd884",
+        "x-ms-client-request-id": "78bc9867-d690-4a8b-922f-5d3964f62e6d",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:15 GMT",
-        "ETag": "\u00220x8DB03E48144C79B\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF2BA940\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9a99d9e5-eee9-4b03-9617-cd6d975cd884",
+        "x-ms-client-request-id": "78bc9867-d690-4a8b-922f-5d3964f62e6d",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d207b4d-101e-005d-55cd-357536000000",
+        "x-ms-request-id": "612a0cb7-901e-005e-08e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.9252379Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275/blobCPK167520841588902716?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547/blobCPK167719878244906142?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -156,39 +153,37 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "6a84ff42-a5c5-4264-8cb9-66ae897b391c",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "61ce894d-c5eb-45e5-93e9-341d7c905e77",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:15 GMT",
-        "ETag": "\u00220x8DB03E4814EFF5C\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF351480\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6a84ff42-a5c5-4264-8cb9-66ae897b391c",
+        "x-ms-client-request-id": "61ce894d-c5eb-45e5-93e9-341d7c905e77",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d207b97-101e-005d-18cd-357536000000",
+        "x-ms-request-id": "612a0cb8-901e-005e-09e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.9932012Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275/blobCPK167520841588902716?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547/blobCPK167719878244906142?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -203,9 +198,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "60d62119-356d-4ccf-9a69-c410b799af96",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "d3d4cfb5-0929-4a2f-a894-ac95820e2472",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -213,22 +208,22 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,WWW-Authenticate,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "WWW-Authenticate": "Bearer authorization_uri=https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/authorize resource_id=https://storage.azure.com",
-        "x-ms-client-request-id": "60d62119-356d-4ccf-9a69-c410b799af96",
+        "x-ms-client-request-id": "d3d4cfb5-0929-4a2f-a894-ac95820e2472",
         "x-ms-error-code": "NoAuthenticationInformation",
-        "x-ms-request-id": "1d207bdb-101e-005d-5acd-357536000000",
+        "x-ms-request-id": "612a0cb9-901e-005e-0ae7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841575603275?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878233700547?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -243,9 +238,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "428a0b3d-89e3-4964-8212-9a57ae76a226",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "9a91baf4-1a6a-4743-9c9d-e1f07a3f2a8c",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -254,21 +249,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "428a0b3d-89e3-4964-8212-9a57ae76a226",
-        "x-ms-request-id": "1d207c32-101e-005d-2acd-357536000000",
+        "x-ms-client-request-id": "9a91baf4-1a6a-4743-9c9d-e1f07a3f2a8c",
+        "x-ms-request-id": "612a0cbb-901e-005e-0be7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841582207800",
-    "blobCPK": "blobCPK167520841588902716",
-    "container": "container167520841575603275"
+    "blob": "blob167719878238806775",
+    "blobCPK": "blobCPK167719878244906142",
+    "container": "container167719878233700547"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_against_blob_uploaded_with_customer_provided_key.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_against_blob_uploaded_with_customer_provided_key.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "c14d24be-5482-400a-89fa-267045e0ed0b",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "c3a86ef1-a782-4254-87b7-05f5eaeccb4c",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E480E89C77\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEDFA919\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c14d24be-5482-400a-89fa-267045e0ed0b",
-        "x-ms-request-id": "1d2078a7-101e-005d-5bcd-357536000000",
+        "x-ms-client-request-id": "c3a86ef1-a782-4254-87b7-05f5eaeccb4c",
+        "x-ms-request-id": "612a0ca3-901e-005e-76e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449/blob167520841535507435?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758/blob167719878199704832?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d8feab43-7906-4505-8220-b989406de309",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "515fd004-33b2-431f-ba52-3aba61db8ac6",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E480F33125\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEE662D4\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d8feab43-7906-4505-8220-b989406de309",
+        "x-ms-client-request-id": "515fd004-33b2-431f-ba52-3aba61db8ac6",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d2078ee-101e-005d-1ecd-357536000000",
+        "x-ms-request-id": "612a0ca9-901e-005e-7be7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.3905445Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449/blobCPK167520841542209367?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758/blobCPK167719878204709647?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,41 +105,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "cf528f4c-cf9c-4661-b509-707c0de0d39a",
+        "x-ms-client-request-id": "cbf95fbf-4ca6-48a2-8d65-0e3c4e23a380",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E480FD68D1\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEEE492D\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "cf528f4c-cf9c-4661-b509-707c0de0d39a",
+        "x-ms-client-request-id": "cbf95fbf-4ca6-48a2-8d65-0e3c4e23a380",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d207934-101e-005d-62cd-357536000000",
+        "x-ms-request-id": "612a0cab-901e-005e-7de7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.4585051Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449/blobCPK167520841542209367?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758/blobCPK167719878204709647?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -156,39 +153,37 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "44b0daf8-d708-41e1-9011-b33d8cde393e",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "d1cd1a9f-abf9-49ac-b792-55ec93888c8a",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E48107C78F\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:15 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEF4AA99\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "44b0daf8-d708-41e1-9011-b33d8cde393e",
+        "x-ms-client-request-id": "d1cd1a9f-abf9-49ac-b792-55ec93888c8a",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d20797a-101e-005d-22cd-357536000000",
+        "x-ms-request-id": "612a0cad-901e-005e-7fe7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:15.5264671Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449/blobCPK167520841542209367?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758/blobCPK167719878204709647?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -203,9 +198,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "21f2da12-2b55-43f2-acd1-99a70f593cc6",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "8548a3db-3666-437b-a174-3ebd71f2897b",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -213,21 +208,21 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "21f2da12-2b55-43f2-acd1-99a70f593cc6",
+        "x-ms-client-request-id": "8548a3db-3666-437b-a174-3ebd71f2897b",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d2079d5-101e-005d-78cd-357536000000",
+        "x-ms-request-id": "612a0cae-901e-005e-80e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841528707449?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878195908758?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -242,9 +237,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "b490ded5-f7f7-4b1d-ac09-94596c95e6be",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "8e9cb772-422b-4f90-a206-a1bf33925fb1",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -253,21 +248,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b490ded5-f7f7-4b1d-ac09-94596c95e6be",
-        "x-ms-request-id": "1d207a15-101e-005d-2fcd-357536000000",
+        "x-ms-client-request-id": "8e9cb772-422b-4f90-a206-a1bf33925fb1",
+        "x-ms-request-id": "612a0caf-901e-005e-01e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841535507435",
-    "blobCPK": "blobCPK167520841542209367",
-    "container": "container167520841528707449"
+    "blob": "blob167719878199704832",
+    "blobCPK": "blobCPK167719878204709647",
+    "container": "container167719878195908758"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_with_customer_provided_key.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_with_customer_provided_key.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "6ffb5a32-ca06-4643-a500-7e4482b50a7d",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "9fcd54f3-8fc6-4ae2-810d-cdcd6f7295a7",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E480523E8A\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE690315\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6ffb5a32-ca06-4643-a500-7e4482b50a7d",
-        "x-ms-request-id": "1d207467-101e-005d-79cd-357536000000",
+        "x-ms-client-request-id": "9fcd54f3-8fc6-4ae2-810d-cdcd6f7295a7",
+        "x-ms-request-id": "612a0c8e-901e-005e-65e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507/blob167520841437107365?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415/blob167719878122508091?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "201db3e1-5ae1-44e6-a6f5-67811b856fcc",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "efcd6ed7-d607-45f3-968e-40545742f073",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E4805D21A2\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE70584E\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "201db3e1-5ae1-44e6-a6f5-67811b856fcc",
+        "x-ms-client-request-id": "efcd6ed7-d607-45f3-968e-40545742f073",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d2074ad-101e-005d-37cd-357536000000",
+        "x-ms-request-id": "612a0c90-901e-005e-66e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.4071074Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507/blobCPK167520841443909855?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415/blobCPK167719878127500395?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,41 +105,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c73f4766-e694-422e-9b79-b418d0402f16",
+        "x-ms-client-request-id": "f0abbc78-74e8-4779-a08c-d23ccec61705",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E48067805C\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAE783EA5\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c73f4766-e694-422e-9b79-b418d0402f16",
+        "x-ms-client-request-id": "f0abbc78-74e8-4779-a08c-d23ccec61705",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d207507-101e-005d-7acd-357536000000",
+        "x-ms-request-id": "612a0c92-901e-005e-68e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.4750684Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507/blobCPK167520841443909855?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415/blobCPK167719878127500395?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -156,39 +153,37 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "b44e6f36-2445-4992-82c9-967ce863d876",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "57fe1c39-26eb-4d4a-bfaf-0223ce9f23a3",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E48071B80C\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAE8024FD\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b44e6f36-2445-4992-82c9-967ce863d876",
+        "x-ms-client-request-id": "57fe1c39-26eb-4d4a-bfaf-0223ce9f23a3",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d20754c-101e-005d-37cd-357536000000",
+        "x-ms-request-id": "612a0c93-901e-005e-69e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.5440298Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507/blobCPK167520841443909855?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415/blobCPK167719878127500395?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -203,12 +198,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "b10d7829-b9fd-42ce-b325-f06b10089111",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "844e1933-b673-466b-a142-0f9b8a3b6134",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -216,13 +210,13 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-a,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-a,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "11",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
         "Content-Type": "application/octet-stream",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E48071B80C\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAE8024FD\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -230,22 +224,20 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b10d7829-b9fd-42ce-b325-f06b10089111",
-        "x-ms-creation-time": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "x-ms-client-request-id": "844e1933-b673-466b-a142-0f9b8a3b6134",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:59 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-a": "a",
-        "x-ms-request-id": "1d207594-101e-005d-7ccd-357536000000",
+        "x-ms-request-id": "612a0c94-901e-005e-6ae7-47cf23000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.5440298Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841430201507?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878117308415?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -260,9 +252,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "d2b870e2-a54a-481c-904b-28484ac8b728",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "5d7f4076-8a38-43b3-96f6-f0935443f2a7",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -271,21 +263,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d2b870e2-a54a-481c-904b-28484ac8b728",
-        "x-ms-request-id": "1d2075cd-101e-005d-32cd-357536000000",
+        "x-ms-client-request-id": "5d7f4076-8a38-43b3-96f6-f0935443f2a7",
+        "x-ms-request-id": "612a0c95-901e-005e-6be7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841437107365",
-    "blobCPK": "blobCPK167520841443909855",
-    "container": "container167520841430201507"
+    "blob": "blob167719878122508091",
+    "blobCPK": "blobCPK167719878127500395",
+    "container": "container167719878117308415"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_without_customer_provided_key_on_a_blob_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_exists_works_without_customer_provided_key_on_a_blob_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841478702610?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878159900265?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "fdc56ac6-8e29-449c-b769-0660b692a76a",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "238a7d67-6239-4fbb-8e34-a3b4a620ce73",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E4809C352D\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEA91F26\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "fdc56ac6-8e29-449c-b769-0660b692a76a",
-        "x-ms-request-id": "1d20766f-101e-005d-4ccd-357536000000",
+        "x-ms-client-request-id": "238a7d67-6239-4fbb-8e34-a3b4a620ce73",
+        "x-ms-request-id": "612a0c99-901e-005e-6de7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841478702610/blob167520841485405790?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878159900265/blob167719878164404970?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "1ae53915-53dc-4809-98a3-ff834fc7e703",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "e10aadfa-6b01-4143-9b9e-d210dac60dd1",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:13 GMT",
-        "ETag": "\u00220x8DB03E480A73F28\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEB11000\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "1ae53915-53dc-4809-98a3-ff834fc7e703",
+        "x-ms-client-request-id": "e10aadfa-6b01-4143-9b9e-d210dac60dd1",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d2076bb-101e-005d-11cd-357536000000",
+        "x-ms-request-id": "612a0c9b-901e-005e-6ee7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.8928296Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841478702610/blobCPK167520841492406965?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878159900265/blobCPK167719878169503881?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,41 +105,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "bf59013e-d6b6-4709-b5c3-785fce06666f",
+        "x-ms-client-request-id": "93d4f508-5b95-4651-b750-9e3e08d93f4a",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
-        "ETag": "\u00220x8DB03E480B19DE0\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
+        "ETag": "\u00220x8DB15FEAEB8F65C\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "bf59013e-d6b6-4709-b5c3-785fce06666f",
+        "x-ms-client-request-id": "93d4f508-5b95-4651-b750-9e3e08d93f4a",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d207719-101e-005d-64cd-357536000000",
+        "x-ms-request-id": "612a0c9c-901e-005e-6fe7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:14.9607904Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841478702610/blobCPK167520841492406965?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878159900265/blobCPK167719878169503881?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -155,9 +152,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "b1d95e80-f35a-48d5-9942-2308ad1700cb",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "a9d31e6e-dd6a-42db-979d-91148f0d72b7",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -165,21 +162,21 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b1d95e80-f35a-48d5-9942-2308ad1700cb",
+        "x-ms-client-request-id": "a9d31e6e-dd6a-42db-979d-91148f0d72b7",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d207775-101e-005d-3dcd-357536000000",
+        "x-ms-request-id": "612a0c9f-901e-005e-72e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841478702610?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878159900265?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -194,9 +191,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "63a378f9-efcc-4981-9735-ec33d80f86a7",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "2b137987-155a-4641-909c-9c0515a72d13",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -205,21 +202,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:14 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "63a378f9-efcc-4981-9735-ec33d80f86a7",
-        "x-ms-request-id": "1d2077c3-101e-005d-08cd-357536000000",
+        "x-ms-client-request-id": "2b137987-155a-4641-909c-9c0515a72d13",
+        "x-ms-request-id": "612a0ca2-901e-005e-75e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841485405790",
-    "blobCPK": "blobCPK167520841492406965",
-    "container": "container167520841478702610"
+    "blob": "blob167719878164404970",
+    "blobCPK": "blobCPK167719878169503881",
+    "container": "container167719878159900265"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_setmetadata_sethttpheaders_getproperties_and_createsnapshot_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_setmetadata_sethttpheaders_getproperties_and_createsnapshot_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "af1789d1-a0c2-4a88-a6f4-0831c9a7a07d",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "c20e3783-f201-40da-8d4a-258b8a49a070",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47E68B6B9\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE0202D3\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "af1789d1-a0c2-4a88-a6f4-0831c9a7a07d",
-        "x-ms-request-id": "1d206677-101e-005d-0fcd-357536000000",
+        "x-ms-client-request-id": "c20e3783-f201-40da-8d4a-258b8a49a070",
+        "x-ms-request-id": "612a0c72-901e-005e-4ce7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blob167520841116206675?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blob167719878054705088?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f1c5bb33-cdc3-4dfb-a2c2-cf2c53ae444d",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "2b30bc71-b6c4-4bb1-af8a-602805563190",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47E734CA7\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE09580B\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f1c5bb33-cdc3-4dfb-a2c2-cf2c53ae444d",
+        "x-ms-client-request-id": "2b30bc71-b6c4-4bb1-af8a-602805563190",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d2066b6-101e-005d-43cd-357536000000",
+        "x-ms-request-id": "612a0c74-901e-005e-4de7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:11.1969447Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,41 +105,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "29ef3c9b-98db-4bed-8516-ff5927da9ebe",
+        "x-ms-client-request-id": "b280b547-323a-4be6-a893-1ca241cd62cb",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47E7DF97E\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE0FE05F\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "29ef3c9b-98db-4bed-8516-ff5927da9ebe",
+        "x-ms-client-request-id": "b280b547-323a-4be6-a893-1ca241cd62cb",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d20670e-101e-005d-14cd-357536000000",
+        "x-ms-request-id": "612a0c75-901e-005e-4ee7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:11.2669054Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -156,40 +153,38 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "01ab8e7f-b5a7-4add-a3ad-4410ada95fb1",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "f85ee16a-a0c7-4e91-a398-2544186f24e6",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47E8CEB61\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE18B009\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "01ab8e7f-b5a7-4add-a3ad-4410ada95fb1",
+        "x-ms-client-request-id": "f85ee16a-a0c7-4e91-a398-2544186f24e6",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d206756-101e-005d-57cd-357536000000",
+        "x-ms-request-id": "612a0c7a-901e-005e-53e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:11.3658481Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -204,9 +199,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "b47ffeb2-7fc8-4224-8cd2-48d73cbf08b9",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "fae6ae86-bd20-4be0-9c5f-fdc05bd15077",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -214,21 +209,21 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b47ffeb2-7fc8-4224-8cd2-48d73cbf08b9",
+        "x-ms-client-request-id": "fae6ae86-bd20-4be0-9c5f-fdc05bd15077",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d20679e-101e-005d-1ecd-357536000000",
+        "x-ms-request-id": "612a0c7d-901e-005e-56e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?comp=properties",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?comp=properties",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -244,15 +239,15 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-cache-control": "blobCacheControl",
         "x-ms-blob-content-disposition": "blobContentDisposition",
         "x-ms-blob-content-encoding": "blobContentEncoding",
         "x-ms-blob-content-language": "blobContentLanguage",
         "x-ms-blob-content-md5": "AQIDBA==",
         "x-ms-blob-content-type": "blobContentType",
-        "x-ms-client-request-id": "4eabba35-5a55-4ca4-b6ef-bed842258c03",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "a67f8d0e-880c-4577-bb09-e126a6bfb372",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -261,21 +256,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47EA0E5A6\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE26AA09\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "4eabba35-5a55-4ca4-b6ef-bed842258c03",
-        "x-ms-request-id": "1d2067e2-101e-005d-5ecd-357536000000",
+        "x-ms-client-request-id": "a67f8d0e-880c-4577-bb09-e126a6bfb372",
+        "x-ms-request-id": "612a0c7f-901e-005e-57e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -290,12 +285,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "a9d694ea-7bc9-4fe6-835f-299a6072a539",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "215674b9-5490-4029-9847-d283c561588f",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -303,7 +297,7 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-a,x-ms-meta-b,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-a,x-ms-meta-b,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Cache-Control": "blobCacheControl",
         "Content-Disposition": "blobContentDisposition",
         "Content-Encoding": "blobContentEncoding",
@@ -311,9 +305,9 @@
         "Content-Length": "11",
         "Content-MD5": "AQIDBA==",
         "Content-Type": "blobContentType",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47EA0E5A6\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE26AA09\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -321,23 +315,21 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "a9d694ea-7bc9-4fe6-835f-299a6072a539",
-        "x-ms-creation-time": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "x-ms-client-request-id": "215674b9-5490-4029-9847-d283c561588f",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:58 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
-        "x-ms-request-id": "1d206819-101e-005d-11cd-357536000000",
+        "x-ms-request-id": "612a0c82-901e-005e-59e7-47cf23000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:11.3658481Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?comp=snapshot",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?comp=snapshot",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -353,38 +345,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "83500b63-40d3-41d4-860e-a5fba7d1bf57",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "2e9b2a4d-9a17-43d1-9ef8-6e90d4431952",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-snapshot,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-snapshot,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47EA0E5A6\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE26AA09\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "83500b63-40d3-41d4-860e-a5fba7d1bf57",
-        "x-ms-request-id": "1d20685a-101e-005d-52cd-357536000000",
+        "x-ms-client-request-id": "2e9b2a4d-9a17-43d1-9ef8-6e90d4431952",
+        "x-ms-request-id": "612a0c86-901e-005e-5de7-47cf23000000",
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2023-01-31T23:40:11.6286987Z",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:11.6296987Z"
+        "x-ms-snapshot": "2023-02-24T00:32:59.1648956Z",
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?snapshot=2023-01-31T23%3A40%3A11.6286987Z\u0026",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?snapshot=2023-02-24T00%3A32%3A59.1648956Z\u0026",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -399,12 +389,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "dded3e2b-4a34-46f6-b780-e5e2de3ecb3f",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "cb58dfb9-17ed-4c23-88eb-f0b175509fab",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -420,9 +409,9 @@
         "Content-Length": "11",
         "Content-MD5": "AQIDBA==",
         "Content-Type": "blobContentType",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
-        "ETag": "\u00220x8DB03E47EA0E5A6\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
+        "ETag": "\u00220x8DB15FEAE26AA09\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -430,19 +419,19 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "dded3e2b-4a34-46f6-b780-e5e2de3ecb3f",
-        "x-ms-creation-time": "Tue, 31 Jan 2023 23:40:11 GMT",
+        "x-ms-client-request-id": "cb58dfb9-17ed-4c23-88eb-f0b175509fab",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:58 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
-        "x-ms-request-id": "1d206899-101e-005d-0bcd-357536000000",
+        "x-ms-request-id": "612a0c88-901e-005e-5fe7-47cf23000000",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610/blobCPK167520841123100923?snapshot=2023-01-31T23%3A40%3A11.6286987Z\u0026",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758/blobCPK167719878059203604?snapshot=2023-02-24T00%3A32%3A59.1648956Z\u0026",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -457,9 +446,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "ba532067-1437-4c69-8d2c-af6fc5c8180e",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "4835c537-d54e-40d7-b850-ecccce6b986b",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -467,21 +456,21 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "ba532067-1437-4c69-8d2c-af6fc5c8180e",
+        "x-ms-client-request-id": "4835c537-d54e-40d7-b850-ecccce6b986b",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d2068d7-101e-005d-48cd-357536000000",
+        "x-ms-request-id": "612a0c8a-901e-005e-61e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841109401610?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878050303758?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -496,9 +485,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "e2ca47fd-40e0-47aa-91b2-80822f59fce6",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "7106eca9-f0ef-4317-bd98-19645b2ca97a",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -507,21 +496,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e2ca47fd-40e0-47aa-91b2-80822f59fce6",
-        "x-ms-request-id": "1d20691b-101e-005d-0ccd-357536000000",
+        "x-ms-client-request-id": "7106eca9-f0ef-4317-bd98-19645b2ca97a",
+        "x-ms-request-id": "612a0c8c-901e-005e-63e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841116206675",
-    "blobCPK": "blobCPK167520841123100923",
-    "container": "container167520841109401610"
+    "blob": "blob167719878054705088",
+    "blobCPK": "blobCPK167719878059203604",
+    "container": "container167719878050303758"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_setmetadata_with_cpk_on_a_blob_uploaded_without_cpk_should_fail.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_setmetadata_with_cpk_on_a_blob_uploaded_without_cpk_should_fail.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841073001950?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877977705688?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "6ecfb887-ac28-40e2-9d35-df033a410696",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "a5427a41-c701-4ab6-b622-ce861456bbe4",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:09 GMT",
-        "ETag": "\u00220x8DB03E47E324549\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:57 GMT",
+        "ETag": "\u00220x8DB15FEADC17201\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6ecfb887-ac28-40e2-9d35-df033a410696",
-        "x-ms-request-id": "1d2064d9-101e-005d-21cd-357536000000",
+        "x-ms-client-request-id": "a5427a41-c701-4ab6-b622-ce861456bbe4",
+        "x-ms-request-id": "612a0c65-901e-005e-41e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841073001950/blob167520841080509180?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877977705688/blob167719878013601708?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "906f8e72-8950-4a72-b5d8-74ebfef18561",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "47addb15-c0f7-427f-86ee-5be91b3f1e0c",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Tue, 31 Jan 2023 23:40:09 GMT",
-        "ETag": "\u00220x8DB03E47E3CDB53\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:57 GMT",
+        "ETag": "\u00220x8DB15FEADCA99EB\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "906f8e72-8950-4a72-b5d8-74ebfef18561",
+        "x-ms-client-request-id": "47addb15-c0f7-427f-86ee-5be91b3f1e0c",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "1d206521-101e-005d-62cd-357536000000",
+        "x-ms-request-id": "612a0c69-901e-005e-43e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:40:10.8401491Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841073001950/blob167520841080509180?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877977705688/blob167719878013601708?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -105,13 +104,12 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "1cd2982e-a713-40a6-a4fb-a08cbdcd9fe5",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "3a2b9c10-480d-452a-990f-1091ef33bc51",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -121,24 +119,24 @@
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "308",
         "Content-Type": "application/xml",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "1cd2982e-a713-40a6-a4fb-a08cbdcd9fe5",
+        "x-ms-client-request-id": "3a2b9c10-480d-452a-990f-1091ef33bc51",
         "x-ms-error-code": "BlobDoesNotUseCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d206597-101e-005d-44cd-357536000000",
+        "x-ms-request-id": "612a0c6b-901e-005e-45e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobDoesNotUseCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is not encrypted with customer specified encryption, but one was provided in the request.\n",
-        "RequestId:1d206597-101e-005d-44cd-357536000000\n",
-        "Time:2023-01-31T23:40:10.9376780Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:612a0c6b-901e-005e-45e7-47cf23000000\n",
+        "Time:2023-02-24T00:32:58.5284279Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520841073001950?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877977705688?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -153,9 +151,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "ceaabc46-efd4-410d-a1d5-a1434d468239",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "818fc3ca-50a9-4bc4-93c3-6c56dc7b4d67",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -164,20 +162,20 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:40:10 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ceaabc46-efd4-410d-a1d5-a1434d468239",
-        "x-ms-request-id": "1d2065ef-101e-005d-18cd-357536000000",
+        "x-ms-client-request-id": "818fc3ca-50a9-4bc4-93c3-6c56dc7b4d67",
+        "x-ms-request-id": "612a0c6c-901e-005e-46e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520841080509180",
-    "container": "container167520841073001950"
+    "blob": "blob167719878013601708",
+    "container": "container167719877977705688"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_download_without_cpk_should_fail_if_upload_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_download_without_cpk_should_fail_if_upload_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520849043608261?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878377209594?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "8b23d44f-9e17-4948-b1c0-1a7e1df7569d",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "dd1f8343-ef01-4430-8e89-11e923d99be8",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
-        "ETag": "\u00220x8DB03E4ADB336BF\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:30 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEAFF49BCF\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "8b23d44f-9e17-4948-b1c0-1a7e1df7569d",
-        "x-ms-request-id": "1d21cf30-101e-005d-78cd-357536000000",
+        "x-ms-client-request-id": "dd1f8343-ef01-4430-8e89-11e923d99be8",
+        "x-ms-request-id": "612a0cd7-901e-005e-23e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520849043608261/blob167520849050405328?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878377209594/blob167719878381405699?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,41 +59,39 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6cca865b-9e31-4ca8-915d-66ee1adcc3fe",
+        "x-ms-client-request-id": "298945eb-4fae-4a77-81da-093106a5f9c2",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
-      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NTIwODQ5MDUwNDA5MDQ1",
+      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc4MzgxNTAwODU1",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Content-MD5": "lgWr3\u002Bvy9x7pTciJvXHayA==",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
-        "ETag": "\u00220x8DB03E4ADBE0465\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:30 GMT",
+        "Content-MD5": "i9ZDr1J7Lddq3/eWqNEmEA==",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEAFFD016B\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6cca865b-9e31-4ca8-915d-66ee1adcc3fe",
-        "x-ms-content-crc64": "DTKCxZ0gNwU=",
+        "x-ms-client-request-id": "298945eb-4fae-4a77-81da-093106a5f9c2",
+        "x-ms-content-crc64": "jtuJdTMwpVM=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21cf83-101e-005d-43cd-357536000000",
+        "x-ms-request-id": "612a0cdc-901e-005e-27e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:30.5395301Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520849043608261/blob167520849050405328?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878377209594/blob167719878381405699?",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -108,9 +106,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "11d3b0c4-2a5f-4b05-bee0-5286fb7e9d50",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "32482508-568b-450b-9f5f-b53d0940da3d",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -120,24 +118,24 @@
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "301",
         "Content-Type": "application/xml",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "11d3b0c4-2a5f-4b05-bee0-5286fb7e9d50",
+        "x-ms-client-request-id": "32482508-568b-450b-9f5f-b53d0940da3d",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "1d21cfe7-101e-005d-19cd-357536000000",
+        "x-ms-request-id": "612a0cdd-901e-005e-28e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobUsesCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is encrypted with customer specified encryption, but it was not provided in the request.\n",
-        "RequestId:1d21cfe7-101e-005d-19cd-357536000000\n",
-        "Time:2023-01-31T23:41:30.6056532Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:612a0cdd-901e-005e-28e7-47cf23000000\n",
+        "Time:2023-02-24T00:33:02.2112110Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520849043608261?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878377209594?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -152,9 +150,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "75f43974-ed30-403b-88fc-15ec4617f7ee",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "a1da3418-baf5-43d8-a023-5b5a3f7ff4ec",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -163,21 +161,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "75f43974-ed30-403b-88fc-15ec4617f7ee",
-        "x-ms-request-id": "1d21d035-101e-005d-60cd-357536000000",
+        "x-ms-client-request-id": "a1da3418-baf5-43d8-a023-5b5a3f7ff4ec",
+        "x-ms-request-id": "612a0cde-901e-005e-29e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520849050405328",
-    "container": "container167520849043608261",
-    "randomstring": "randomstring167520849050409045"
+    "blob": "blob167719878381405699",
+    "container": "container167719878377209594",
+    "randomstring": "randomstring167719878381500855"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_stageblock_stageblockurl_and_commitblocklist_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_stageblock_stageblockurl_and_commitblocklist_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "5adfe552-714b-4b91-b854-a41630345f5f",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "30d69e83-f95d-498d-af9b-c57794feff76",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
-        "ETag": "\u00220x8DB03E4AD44585F\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF907E83\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "5adfe552-714b-4b91-b854-a41630345f5f",
-        "x-ms-request-id": "1d21cb7b-101e-005d-2bcd-357536000000",
+        "x-ms-client-request-id": "30d69e83-f95d-498d-af9b-c57794feff76",
+        "x-ms-request-id": "612a0cc6-901e-005e-14e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/blob167520848978905263?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/blob167719878315608786?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,37 +59,36 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "84b0e4da-0e69-4c01-a467-fa713cc3100d",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-client-request-id": "a20676f9-1838-47ef-9b07-b8e3c521b2a4",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG9Xb3JsZA==",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "aOEJ8PQMpyoV4FzCJ4b45g==",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
-        "ETag": "\u00220x8DB03E4AD5121C2\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF973844\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "84b0e4da-0e69-4c01-a467-fa713cc3100d",
+        "x-ms-client-request-id": "a20676f9-1838-47ef-9b07-b8e3c521b2a4",
         "x-ms-content-crc64": "8R2aIe9T07E=",
-        "x-ms-request-id": "1d21cbe5-101e-005d-05cd-357536000000",
+        "x-ms-request-id": "612a0cc8-901e-005e-15e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:29.8259394Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?comp=block\u0026blockid=MQ%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?comp=block\u0026blockid=MQ%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -106,12 +105,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "d4b06697-433d-4630-872f-f79df082b10b",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "97546194-7b23-4c30-8326-53a9c4ae1403",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbA==",
@@ -120,22 +118,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d4b06697-433d-4630-872f-f79df082b10b",
+        "x-ms-client-request-id": "97546194-7b23-4c30-8326-53a9c4ae1403",
         "x-ms-content-crc64": "nuXQFtc8BqA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21cc6e-101e-005d-80cd-357536000000",
+        "x-ms-request-id": "612a0cc9-901e-005e-16e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?comp=block\u0026blockid=Mg%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?comp=block\u0026blockid=Mg%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -151,13 +149,12 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "73db8789-4ddf-4b6f-b474-bb70d7481b8a",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "a6d0191c-86da-43fb-8940-194845478923",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-source-range": "bytes=4-7",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -166,22 +163,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "73db8789-4ddf-4b6f-b474-bb70d7481b8a",
+        "x-ms-client-request-id": "a6d0191c-86da-43fb-8940-194845478923",
         "x-ms-content-crc64": "n6BouArmEbQ=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21ccd9-101e-005d-62cd-357536000000",
+        "x-ms-request-id": "612a0ccc-901e-005e-18e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?comp=block\u0026blockid=Mw%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?comp=block\u0026blockid=Mw%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -197,13 +194,12 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "77329bd8-2c1b-446e-b881-e348f7454a1f",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "c2287bcf-3586-45fd-afe6-d19e589372b5",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-source-range": "bytes=8-9",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -212,22 +208,22 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "77329bd8-2c1b-446e-b881-e348f7454a1f",
+        "x-ms-client-request-id": "c2287bcf-3586-45fd-afe6-d19e589372b5",
         "x-ms-content-crc64": "sMJJw3kkP8c=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21cd36-101e-005d-37cd-357536000000",
+        "x-ms-request-id": "612a0ccf-901e-005e-1be7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?comp=blocklist\u0026blocklisttype=uncommitted\u0026",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?comp=blocklist\u0026blocklisttype=uncommitted\u0026",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -242,9 +238,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "a652f98d-dd00-4fdb-99f7-72e4d4ef41de",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "d176a840-cf88-4661-b187-18a8f21e72fe",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -253,20 +249,20 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding",
         "Content-Type": "application/xml",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "a652f98d-dd00-4fdb-99f7-72e4d4ef41de",
-        "x-ms-request-id": "1d21cd95-101e-005d-0acd-357536000000",
+        "x-ms-client-request-id": "d176a840-cf88-4661-b187-18a8f21e72fe",
+        "x-ms-request-id": "612a0cd0-901e-005e-1ce7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CBlockList\u003E\u003CUncommittedBlocks\u003E\u003CBlock\u003E\u003CName\u003EMQ==\u003C/Name\u003E\u003CSize\u003E4\u003C/Size\u003E\u003C/Block\u003E\u003CBlock\u003E\u003CName\u003EMg==\u003C/Name\u003E\u003CSize\u003E4\u003C/Size\u003E\u003C/Block\u003E\u003CBlock\u003E\u003CName\u003EMw==\u003C/Name\u003E\u003CSize\u003E2\u003C/Size\u003E\u003C/Block\u003E\u003C/UncommittedBlocks\u003E\u003C/BlockList\u003E"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?comp=blocklist",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?comp=blocklist",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -283,39 +279,37 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "f6ef9333-ec97-42af-bd95-55c1e4d99972",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "ab563721-b4fc-429a-90c6-6dc35783e98b",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "\u003C?xml version=\u00221.0\u0022 encoding=\u0022UTF-8\u0022 standalone=\u0022yes\u0022?\u003E\u003CBlockList\u003E\u003CLatest\u003EMQ==\u003C/Latest\u003E\u003CLatest\u003EMg==\u003C/Latest\u003E\u003CLatest\u003EMw==\u003C/Latest\u003E\u003C/BlockList\u003E",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Last-Modified,ETag,x-ms-version-id,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
-        "ETag": "\u00220x8DB03E4AD8C4D55\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:30 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEAFC7AE96\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f6ef9333-ec97-42af-bd95-55c1e4d99972",
+        "x-ms-client-request-id": "ab563721-b4fc-429a-90c6-6dc35783e98b",
         "x-ms-content-crc64": "AviKeNGq9Po=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21cdec-101e-005d-58cd-357536000000",
+        "x-ms-request-id": "612a0cd1-901e-005e-1de7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:30.2137173Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897/newblockblob167520848989608306?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613/newblockblob167719878320207422?",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -330,12 +324,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "f09a131c-c62d-48f6-bcdf-0a666535b2cc",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "9f72922b-0e31-4714-9d23-4db8fa59ff24",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -343,32 +336,30 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "10",
         "Content-Type": "application/octet-stream",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
-        "ETag": "\u00220x8DB03E4AD8C4D55\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:30 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEAFC7AE96\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f09a131c-c62d-48f6-bcdf-0a666535b2cc",
-        "x-ms-creation-time": "Tue, 31 Jan 2023 23:41:30 GMT",
+        "x-ms-client-request-id": "9f72922b-0e31-4714-9d23-4db8fa59ff24",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:33:01 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "1d21ce56-101e-005d-37cd-357536000000",
+        "x-ms-request-id": "612a0cd2-901e-005e-1ee7-47cf23000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:30.2137173Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "SGVsbG9Xb3JsZA=="
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848970801897?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878311500613?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -383,9 +374,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "a2a5a56e-8a49-4b50-a285-9c9091ccdafd",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "5e54f30e-81b0-4ad3-a64a-bbf82b7174ae",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -394,21 +385,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a2a5a56e-8a49-4b50-a285-9c9091ccdafd",
-        "x-ms-request-id": "1d21cea7-101e-005d-7ecd-357536000000",
+        "x-ms-client-request-id": "5e54f30e-81b0-4ad3-a64a-bbf82b7174ae",
+        "x-ms-request-id": "612a0cd3-901e-005e-1fe7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520848978905263",
-    "container": "container167520848970801897",
-    "newblockblob": "newblockblob167520848989608306"
+    "blob": "blob167719878315608786",
+    "container": "container167719878311500613",
+    "newblockblob": "newblockblob167719878320207422"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_upload_and_download_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blockblobclient/recording_upload_and_download_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848938007617?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878277205514?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "293efa85-3b79-44b0-b4da-29487fcc0a76",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "201e4b65-bb2b-4158-b19d-a2b4dc01c70c",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
-        "ETag": "\u00220x8DB03E4AD122C18\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF5DC0DB\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "293efa85-3b79-44b0-b4da-29487fcc0a76",
-        "x-ms-request-id": "1d21c9e5-101e-005d-40cd-357536000000",
+        "x-ms-client-request-id": "201e4b65-bb2b-4158-b19d-a2b4dc01c70c",
+        "x-ms-request-id": "612a0cbd-901e-005e-0de7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848938007617/blob167520848944600580?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878277205514/blob167719878282505096?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,48 +59,46 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-cache-control": "blobCacheControl",
         "x-ms-blob-content-disposition": "blobContentDisposition",
         "x-ms-blob-content-encoding": "blobContentEncoding",
         "x-ms-blob-content-language": "blobContentLanguage",
         "x-ms-blob-content-type": "blobContentType",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "9bdcc90f-dec0-4964-aceb-88eeba18001a",
+        "x-ms-client-request-id": "f8d2f9ce-a56e-4cc6-821c-2ad9e61c5f71",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "vala",
         "x-ms-meta-keyb": "valb",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
-      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NTIwODQ4OTQ0NzA0NTAw",
+      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc4MjgyNTAyNDAw",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Content-MD5": "iU\u002BrJ5dn1G\u002BkhzsfeTBIHQ==",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
-        "ETag": "\u00220x8DB03E4AD1D210A\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Content-MD5": "/CoKZGm9/jIUt7AtoUAKgg==",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF65B1B5\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9bdcc90f-dec0-4964-aceb-88eeba18001a",
-        "x-ms-content-crc64": "B\u002B/IPZ8V0FA=",
+        "x-ms-client-request-id": "f8d2f9ce-a56e-4cc6-821c-2ad9e61c5f71",
+        "x-ms-content-crc64": "NP8tH2F5L8c=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d21ca26-101e-005d-7dcd-357536000000",
+        "x-ms-request-id": "612a0cc1-901e-005e-0fe7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:29.4861332Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848938007617/blob167520848944600580?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878277205514/blob167719878282505096?",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -115,12 +113,11 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "6b43741a-02e1-4dce-82bc-8e61461e2f3a",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "0aa790ca-b377-45b6-b9eb-259c9a6b1af7",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -128,39 +125,37 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-keya,x-ms-meta-keyb,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-keya,x-ms-meta-keyb,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Cache-Control": "blobCacheControl",
         "Content-Disposition": "blobContentDisposition",
         "Content-Encoding": "blobContentEncoding",
         "Content-Language": "blobContentLanguage",
         "Content-Length": "30",
-        "Content-MD5": "iU\u002BrJ5dn1G\u002BkhzsfeTBIHQ==",
+        "Content-MD5": "/CoKZGm9/jIUt7AtoUAKgg==",
         "Content-Type": "blobContentType",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
-        "ETag": "\u00220x8DB03E4AD1D210A\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
+        "ETag": "\u00220x8DB15FEAF65B1B5\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6b43741a-02e1-4dce-82bc-8e61461e2f3a",
-        "x-ms-creation-time": "Tue, 31 Jan 2023 23:41:29 GMT",
+        "x-ms-client-request-id": "0aa790ca-b377-45b6-b9eb-259c9a6b1af7",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:33:01 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-keya": "vala",
         "x-ms-meta-keyb": "valb",
-        "x-ms-request-id": "1d21ca98-101e-005d-5ecd-357536000000",
+        "x-ms-request-id": "612a0cc3-901e-005e-11e7-47cf23000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:29.4861332Z"
+        "x-ms-version": "2021-12-02"
       },
-      "ResponseBody": "cmFuZG9tc3RyaW5nMTY3NTIwODQ4OTQ0NzA0NTAw"
+      "ResponseBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc4MjgyNTAyNDAw"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520848938007617?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878277205514?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -175,9 +170,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "347a4b04-dbf0-4def-af18-d61668a50746",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "bf80d24a-4ce8-475c-bbfd-2bd5abbfc23c",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -186,21 +181,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:28 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "347a4b04-dbf0-4def-af18-d61668a50746",
-        "x-ms-request-id": "1d21caf1-101e-005d-30cd-357536000000",
+        "x-ms-client-request-id": "bf80d24a-4ce8-475c-bbfd-2bd5abbfc23c",
+        "x-ms-request-id": "612a0cc4-901e-005e-12e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167520848944600580",
-    "container": "container167520848938007617",
-    "randomstring": "randomstring167520848944704500"
+    "blob": "blob167719878282505096",
+    "container": "container167719878277205514",
+    "randomstring": "randomstring167719878282502400"
   }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520850960500839?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878410004133?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -17,9 +17,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "74fc7b65-b558-421a-a28f-ccd1606871ac",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "55f61ac4-be5e-406c-8485-7097a4eb8894",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -28,21 +28,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Last-Modified,ETag,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:48 GMT",
-        "ETag": "\u00220x8DB03E4B9205941\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:49 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEB0269710\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "74fc7b65-b558-421a-a28f-ccd1606871ac",
-        "x-ms-request-id": "1d221ef1-101e-005d-5ccd-357536000000",
+        "x-ms-client-request-id": "55f61ac4-be5e-406c-8485-7097a4eb8894",
+        "x-ms-request-id": "612a0ce7-901e-005e-32e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520850960500839/blockblob/0167520850967405264?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878410004133/blockblob/0167719878414206549?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -59,43 +59,41 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "22074153-bf90-423a-980c-c245f009fe6c",
+        "x-ms-client-request-id": "450b1bf6-acd3-4d16-8801-db15b3d9ef6a",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "a",
         "x-ms-meta-keyb": "c",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "Date": "Tue, 31 Jan 2023 23:41:48 GMT",
-        "ETag": "\u00220x8DB03E4B92B48A6\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:49 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEB02D9E9F\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "22074153-bf90-423a-980c-c245f009fe6c",
+        "x-ms-client-request-id": "450b1bf6-acd3-4d16-8801-db15b3d9ef6a",
         "x-ms-content-crc64": "AAAAAAAAAAA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d221f2b-101e-005d-13cd-357536000000",
+        "x-ms-request-id": "612a0ce9-901e-005e-33e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:49.7105574Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520850960500839/blockblob/1167520850974201156?",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878410004133/blockblob/1167719878418502172?",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -112,43 +110,41 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "acb264ca-51f1-4c7d-8a1e-e6cb54ca6db7",
+        "x-ms-client-request-id": "2bfd59ad-644a-41ac-b6da-d1dc6312a8fb",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "a",
         "x-ms-meta-keyb": "c",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,x-ms-version-id,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-content-crc64,Content-MD5,Last-Modified,ETag,x-ms-request-server-encrypted,x-ms-encryption-key-sha256,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
         "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "Date": "Tue, 31 Jan 2023 23:41:48 GMT",
-        "ETag": "\u00220x8DB03E4B935806D\u0022",
-        "Last-Modified": "Tue, 31 Jan 2023 23:41:49 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
+        "ETag": "\u00220x8DB15FEB0353732\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "acb264ca-51f1-4c7d-8a1e-e6cb54ca6db7",
+        "x-ms-client-request-id": "2bfd59ad-644a-41ac-b6da-d1dc6312a8fb",
         "x-ms-content-crc64": "AAAAAAAAAAA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "1d221f5c-101e-005d-3fcd-357536000000",
+        "x-ms-request-id": "612a0cea-901e-005e-34e7-47cf23000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-31T23:41:49.7775213Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520850960500839?comp=list\u0026prefix=blockblob\u0026maxresults=1\u0026restype=container\u0026include=copy,deleted,metadata,snapshots,uncommittedblobs\u0026",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878410004133?comp=list\u0026prefix=blockblob\u0026maxresults=1\u0026restype=container\u0026include=copy,deleted,metadata,snapshots,uncommittedblobs\u0026",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -163,9 +159,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "551313bd-ce6d-4474-9548-24a85b59ca94",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "e5eb85ca-be25-43a3-bcf8-2a81feaee4d6",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -174,20 +170,20 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding",
         "Content-Type": "application/xml",
-        "Date": "Tue, 31 Jan 2023 23:41:48 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:01 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "551313bd-ce6d-4474-9548-24a85b59ca94",
-        "x-ms-request-id": "1d221f9e-101e-005d-7fcd-357536000000",
+        "x-ms-client-request-id": "e5eb85ca-be25-43a3-bcf8-2a81feaee4d6",
+        "x-ms-request-id": "612a0cec-901e-005e-36e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://fakestorageaccount.blob.core.windows.net/\u0022 ContainerName=\u0022container167520850960500839\u0022\u003E\u003CPrefix\u003Eblockblob\u003C/Prefix\u003E\u003CMaxResults\u003E1\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblockblob/0167520850967405264\u003C/Name\u003E\u003CVersionId\u003E2023-01-31T23:41:49.7105574Z\u003C/VersionId\u003E\u003CIsCurrentVersion\u003Etrue\u003C/IsCurrentVersion\u003E\u003CProperties\u003E\u003CCreation-Time\u003ETue, 31 Jan 2023 23:41:49 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003ETue, 31 Jan 2023 23:41:49 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB03E4B92B48A6\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E1B2M2Y8AsgTpgAmY7PhCfg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CCustomerProvidedKeySha256\u003E3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=\u003C/CustomerProvidedKeySha256\u003E\u003C/Properties\u003E\u003CMetadata Encrypted=\u0022true\u0022 /\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY3NTIwODUwOTc0MjAxMTU2ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://fakestorageaccount.blob.core.windows.net/\u0022 ContainerName=\u0022container167719878410004133\u0022\u003E\u003CPrefix\u003Eblockblob\u003C/Prefix\u003E\u003CMaxResults\u003E1\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblockblob/0167719878414206549\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 24 Feb 2023 00:33:02 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 24 Feb 2023 00:33:02 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB15FEB02D9E9F\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E1B2M2Y8AsgTpgAmY7PhCfg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CCustomerProvidedKeySha256\u003E3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=\u003C/CustomerProvidedKeySha256\u003E\u003C/Properties\u003E\u003CMetadata Encrypted=\u0022true\u0022 /\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY3NzE5ODc4NDE4NTAyMTcyITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167520850960500839?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719878410004133?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -202,9 +198,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/109.0.5412.0 Safari/537.36",
-        "x-ms-client-request-id": "482387c4-3b0c-4b29-a012-0d8c74685a07",
-        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS/Linuxx86_64",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "5bb3595d-8469-4fad-8380-41f93b52737a",
+        "x-ms-useragent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 OS",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -213,21 +209,21 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "0",
-        "Date": "Tue, 31 Jan 2023 23:41:48 GMT",
+        "Date": "Fri, 24 Feb 2023 00:33:02 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "482387c4-3b0c-4b29-a012-0d8c74685a07",
-        "x-ms-request-id": "1d221fc8-101e-005d-28cd-357536000000",
+        "x-ms-client-request-id": "5bb3595d-8469-4fad-8380-41f93b52737a",
+        "x-ms-request-id": "612a0ced-901e-005e-37e7-47cf23000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blockblob/0": "blockblob/0167520850967405264",
-    "blockblob/1": "blockblob/1167520850974201156",
-    "container": "container167520850960500839"
+    "blockblob/0": "blockblob/0167719878414206549",
+    "blockblob/1": "blockblob/1167719878418502172",
+    "container": "container167719878410004133"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/appendblobclient_nodejs_only/recording_create_appendblock_appendblockfromurl_and_download_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/appendblobclient_nodejs_only/recording_create_appendblock_appendblockfromurl_and_download_with_cpk.json
@@ -1,49 +1,48 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "72580a06-2b53-4b43-a4b0-067b954d65c4",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "5fb62dab-1f83-43be-b776-ace6ac13c05b",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF4D0AB3\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA7021935\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "72580a06-2b53-4b43-a4b0-067b954d65c4",
-        "x-ms-request-id": "9837b5f9-301e-000f-66ee-34bcdd000000",
+        "x-ms-client-request-id": "5fb62dab-1f83-43be-b776-ace6ac13c05b",
+        "x-ms-request-id": "86b6e454-301e-001a-52e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991/blob167511274227108805",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971/blob167719876880704699",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-client-request-id": "b277faf4-6cc0-4c68-80d9-2761c8574956",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "x-ms-client-request-id": "684090f1-c82d-4b33-a12c-16ed38f356d8",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -51,24 +50,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF599107\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA70A1101\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b277faf4-6cc0-4c68-80d9-2761c8574956",
+        "x-ms-client-request-id": "684090f1-c82d-4b33-a12c-16ed38f356d8",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "9837b67e-301e-000f-64ee-34bcdd000000",
+        "x-ms-request-id": "86b6e457-301e-001a-54e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:05:42.3095047Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991/blockblob167511274234603695",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971/blockblob167719876885402085",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -76,10 +74,10 @@
         "Connection": "keep-alive",
         "Content-Length": "12",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "7c1c2d92-b917-43b4-95ae-deb8f3651ac5",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "x-ms-client-request-id": "818fbd28-1ecf-4d73-8037-a774428c85a6",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQh",
@@ -87,24 +85,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "7Qdih1MuhjZehB6Sv8UNjA==",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF64DA08\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA70FFDC4\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "7c1c2d92-b917-43b4-95ae-deb8f3651ac5",
+        "x-ms-client-request-id": "818fbd28-1ecf-4d73-8037-a774428c85a6",
         "x-ms-content-crc64": "peH8Xsgc5QI=",
-        "x-ms-request-id": "9837b6f8-301e-000f-52ee-34bcdd000000",
+        "x-ms-request-id": "86b6e458-301e-001a-55e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:05:42.3834632Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991/blob167511274227108805?comp=appendblock",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971/blob167719876880704699?comp=appendblock",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -112,11 +109,10 @@
         "Connection": "keep-alive",
         "Content-Length": "12",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "a84d3081-643d-4fa2-8c73-0234657394b5",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "62951b0d-6945-4332-a343-70570f297fe0",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -124,37 +120,36 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF704A18\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA71831E6\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-append-offset": "0",
         "x-ms-blob-committed-block-count": "1",
-        "x-ms-client-request-id": "a84d3081-643d-4fa2-8c73-0234657394b5",
+        "x-ms-client-request-id": "62951b0d-6945-4332-a343-70570f297fe0",
         "x-ms-content-crc64": "peH8Xsgc5QI=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "9837b786-301e-000f-59ee-34bcdd000000",
+        "x-ms-request-id": "86b6e459-301e-001a-56e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991/blob167511274227108805?comp=appendblock",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971/blob167719876880704699?comp=appendblock",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "7cc872e3-03ba-4538-954b-a5f32a0ada1d",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "c6de838d-4412-4661-96fe-fca5b65a16ec",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-source-range": "bytes=0-11",
         "x-ms-version": "2021-12-02"
@@ -164,35 +159,34 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "7Qdih1MuhjZehB6Sv8UNjA==",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF7C5640\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA7210197\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-append-offset": "12",
         "x-ms-blob-committed-block-count": "2",
-        "x-ms-client-request-id": "7cc872e3-03ba-4538-954b-a5f32a0ada1d",
+        "x-ms-client-request-id": "c6de838d-4412-4661-96fe-fca5b65a16ec",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "9837b809-301e-000f-51ee-34bcdd000000",
+        "x-ms-request-id": "86b6e45a-301e-001a-57e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991/blob167511274227108805",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971/blob167719876880704699",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "ee9e7d95-71a1-4543-8b0c-466c9a1494cf",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "bf0d4a47-e53e-4770-bab8-8e8534af91f6",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -201,63 +195,61 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-committed-block-count,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-committed-block-count,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "24",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
-        "ETag": "\u00220x8DB0305BF7C5640\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA7210197\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-committed-block-count": "2",
         "x-ms-blob-type": "AppendBlob",
-        "x-ms-client-request-id": "ee9e7d95-71a1-4543-8b0c-466c9a1494cf",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "x-ms-client-request-id": "bf0d4a47-e53e-4770-bab8-8e8534af91f6",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "9837b88a-301e-000f-4dee-34bcdd000000",
+        "x-ms-request-id": "86b6e45b-301e-001a-58e7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:05:42.3095047Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "SGVsbG8gV29ybGQhSGVsbG8gV29ybGQh"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511274219109991?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876876303971?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "9134e16c-1194-4a51-bf21-0a7b0c3a06d1",
-        "x-ms-date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "aae69df2-93cb-44e1-842b-ba2b012c7925",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:05:42 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9134e16c-1194-4a51-bf21-0a7b0c3a06d1",
-        "x-ms-request-id": "9837b905-301e-000f-40ee-34bcdd000000",
+        "x-ms-client-request-id": "aae69df2-93cb-44e1-842b-ba2b012c7925",
+        "x-ms-request-id": "86b6e45f-301e-001a-5ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167511274227108805",
-    "blockblob": "blockblob167511274234603695",
-    "container": "container167511274219109991",
-    "expiry": "2023-01-30T21:05:42.421Z"
+    "blob": "blob167719876880704699",
+    "blockblob": "blockblob167719876885402085",
+    "container": "container167719876876303971",
+    "expiry": "2023-02-24T00:32:48.902Z"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_rethrows_error_from_getproperties.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_rethrows_error_from_getproperties.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "bc6ba470-fb0a-41a6-9305-19d7e43f46c4",
-        "x-ms-date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "5ef5a040-279a-499a-8aa2-c9d102cca397",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
-        "ETag": "\u00220x8DB03169C14CF70\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5F22979\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "bc6ba470-fb0a-41a6-9305-19d7e43f46c4",
-        "x-ms-request-id": "91d30cc7-b01e-0063-1bff-34574a000000",
+        "x-ms-client-request-id": "5ef5a040-279a-499a-8aa2-c9d102cca397",
+        "x-ms-request-id": "86b6e3f8-301e-001a-10e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477/blob167511998462307818",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185/blob167719876702409358",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ebe6ced0-f391-4feb-9dc8-b6381da61294",
-        "x-ms-date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "x-ms-client-request-id": "90f69156-ba6b-46d7-88fe-190d1e8c13fa",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
-        "ETag": "\u00220x8DB03169C203C97\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5F95F2D\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ebe6ced0-f391-4feb-9dc8-b6381da61294",
+        "x-ms-client-request-id": "90f69156-ba6b-46d7-88fe-190d1e8c13fa",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "91d30d2a-b01e-0063-76ff-34574a000000",
+        "x-ms-request-id": "86b6e3fa-301e-001a-11e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T23:06:24.6589349Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477/blobCPK167511998469304246",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185/blobCPK167719876707102754",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f1e89153-fb58-43f2-8853-4425251c3631",
-        "x-ms-date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "x-ms-client-request-id": "e868675d-2bb6-42fe-b856-a6bb587863f7",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,36 +87,34 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
-        "ETag": "\u00220x8DB03169C2B107F\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA600A9F3\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f1e89153-fb58-43f2-8853-4425251c3631",
+        "x-ms-client-request-id": "e868675d-2bb6-42fe-b856-a6bb587863f7",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "91d30d85-b01e-0063-49ff-34574a000000",
+        "x-ms-request-id": "86b6e3fd-301e-001a-13e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T23:06:24.7288959Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477/blobCPK167511998469304246?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185/blobCPK167719876707102754?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "72480980-3873-41a1-858a-5026cd95b939",
-        "x-ms-date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "4c7d5a43-f7c9-40cf-8bbf-7f801c2b929b",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-version": "2021-12-02"
@@ -127,30 +123,29 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
-        "ETag": "\u00220x8DB03169C359641\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA607A6F3\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "72480980-3873-41a1-858a-5026cd95b939",
+        "x-ms-client-request-id": "4c7d5a43-f7c9-40cf-8bbf-7f801c2b929b",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "91d30ddd-b01e-0063-1cff-34574a000000",
+        "x-ms-request-id": "86b6e3fe-301e-001a-14e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T23:06:24.7988561Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477/blobCPK167511998469304246",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185/blobCPK167719876707102754",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "74d10806-e6b7-47fe-b038-6d61665060ea",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "a161b6ad-4b71-4946-b3e9-be15e97aeb05",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -158,51 +153,51 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,WWW-Authenticate,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "WWW-Authenticate": "Bearer authorization_uri=https://login.microsoftonline.com/aaaaa/oauth2/authorize resource_id=https://storage.azure.com",
-        "x-ms-client-request-id": "74d10806-e6b7-47fe-b038-6d61665060ea",
+        "x-ms-client-request-id": "a161b6ad-4b71-4946-b3e9-be15e97aeb05",
         "x-ms-error-code": "NoAuthenticationInformation",
-        "x-ms-request-id": "91d30e51-b01e-0063-06ff-34574a000000",
+        "x-ms-request-id": "86b6e3ff-301e-001a-15e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511998430900477?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876698201185?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "70bc684d-41a2-4eb7-8876-d5d4e05ef1b6",
-        "x-ms-date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "db9f5f8b-caaf-4c69-878e-dea01b9722ca",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 23:06:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "70bc684d-41a2-4eb7-8876-d5d4e05ef1b6",
-        "x-ms-request-id": "91d30eb6-b01e-0063-5eff-34574a000000",
+        "x-ms-client-request-id": "db9f5f8b-caaf-4c69-878e-dea01b9722ca",
+        "x-ms-request-id": "86b6e400-301e-001a-16e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167511998462307818",
-    "blobCPK": "blobCPK167511998469304246",
-    "container": "container167511998430900477"
+    "blob": "blob167719876702409358",
+    "blobCPK": "blobCPK167719876707102754",
+    "container": "container167719876698201185"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_against_blob_uploaded_with_customer_provided_key.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_against_blob_uploaded_with_customer_provided_key.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "171cec17-7234-4442-ae03-cd970b1be4d1",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "40042c75-c64f-4402-a822-0897c19a2038",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
-        "ETag": "\u00220x8DB00BD6C4195EA\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5C07BF7\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "171cec17-7234-4442-ae03-cd970b1be4d1",
-        "x-ms-request-id": "d8ba8bce-001e-0076-51a6-3240f9000000",
+        "x-ms-client-request-id": "40042c75-c64f-4402-a822-0897c19a2038",
+        "x-ms-request-id": "86b6e3e4-301e-001a-7ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808/blob167486177684403809",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179/blob167719876670102614",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3f064936-6a90-4c2c-8a84-091a96d46e42",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "7af4d233-7fff-4642-a3d2-12d889491fdc",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
-        "ETag": "\u00220x8DB00BD6C4B7A4D\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5C7B1B9\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "3f064936-6a90-4c2c-8a84-091a96d46e42",
+        "x-ms-client-request-id": "7af4d233-7fff-4642-a3d2-12d889491fdc",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "d8ba8c59-001e-0076-53a6-3240f9000000",
+        "x-ms-request-id": "86b6e3eb-301e-001a-04e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.8761933Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808/blobCPK167486177691407332",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179/blobCPK167719876674202585",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e0e539e3-338f-49c8-8b09-c45049aad67c",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "ad893d8a-ce44-4764-9ace-babc211455d0",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,36 +87,34 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
-        "ETag": "\u00220x8DB00BD6C564E34\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5CDEC43\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e0e539e3-338f-49c8-8b09-c45049aad67c",
+        "x-ms-client-request-id": "ad893d8a-ce44-4764-9ace-babc211455d0",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba8ce2-001e-0076-56a6-3240f9000000",
+        "x-ms-request-id": "86b6e3f0-301e-001a-08e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.9471540Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808/blobCPK167486177691407332?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179/blobCPK167719876674202585?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "f9c9b83c-21b0-4d89-acfb-5236a07cb23d",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "1b53faa4-1f46-4356-a971-2e61d8b190e1",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-version": "2021-12-02"
@@ -127,32 +123,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
-        "ETag": "\u00220x8DB00BD6C612219\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA5D6BBF5\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f9c9b83c-21b0-4d89-acfb-5236a07cb23d",
+        "x-ms-client-request-id": "1b53faa4-1f46-4356-a971-2e61d8b190e1",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba8d70-001e-0076-5fa6-3240f9000000",
+        "x-ms-request-id": "86b6e3f1-301e-001a-09e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:57.0201134Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808/blobCPK167486177691407332",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179/blobCPK167719876674202585",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "66e827c2-4957-4f23-b4f9-9a077ee121e8",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "269e6082-607d-468b-82ef-fcc2f8283c74",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -160,50 +155,50 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "66e827c2-4957-4f23-b4f9-9a077ee121e8",
+        "x-ms-client-request-id": "269e6082-607d-468b-82ef-fcc2f8283c74",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8ba8dc6-001e-0076-31a6-3240f9000000",
+        "x-ms-request-id": "86b6e3f2-301e-001a-0ae7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177677303808?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876665105179?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "53ffd7ee-e79d-4ba5-bd13-bcfc553e6373",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "41769065-7b29-4e32-a4d8-5c9988dbccdf",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "53ffd7ee-e79d-4ba5-bd13-bcfc553e6373",
-        "x-ms-request-id": "d8ba8e1c-001e-0076-7fa6-3240f9000000",
+        "x-ms-client-request-id": "41769065-7b29-4e32-a4d8-5c9988dbccdf",
+        "x-ms-request-id": "86b6e3f5-301e-001a-0de7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486177684403809",
-    "blobCPK": "blobCPK167486177691407332",
-    "container": "container167486177677303808"
+    "blob": "blob167719876670102614",
+    "blobCPK": "blobCPK167719876674202585",
+    "container": "container167719876665105179"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_with_customer_provided_key.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_with_customer_provided_key.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "b49eee4b-66b4-4e3f-aa82-125ec729fb83",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:55 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3b9d5d22-4528-4860-839f-968fbffa7783",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6BC2DC3F\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:55 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA562E6D5\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b49eee4b-66b4-4e3f-aa82-125ec729fb83",
-        "x-ms-request-id": "d8ba85e0-001e-0076-66a6-3240f9000000",
+        "x-ms-client-request-id": "3b9d5d22-4528-4860-839f-968fbffa7783",
+        "x-ms-request-id": "86b6e3c5-301e-001a-62e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597/blob167486177601304979",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045/blob167719876608605507",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "54cbe635-9978-4c7a-bcbd-54066f36bd3a",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "d0e83702-68f4-4201-a9f8-ac17eae76815",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6BCC9891\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA56A439C\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "54cbe635-9978-4c7a-bcbd-54066f36bd3a",
+        "x-ms-client-request-id": "d0e83702-68f4-4201-a9f8-ac17eae76815",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "d8ba8667-001e-0076-66a6-3240f9000000",
+        "x-ms-request-id": "86b6e3c8-301e-001a-64e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.0446609Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597/blobCPK167486177608109666",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045/blobCPK167719876612900188",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b5618909-1750-41c6-b112-d8f72928fbc1",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "cf5d3e28-6cc6-42db-8c72-83a85ee4b6fe",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,36 +87,34 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6BD74565\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA57119B2\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b5618909-1750-41c6-b112-d8f72928fbc1",
+        "x-ms-client-request-id": "cf5d3e28-6cc6-42db-8c72-83a85ee4b6fe",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba86d6-001e-0076-49a6-3240f9000000",
+        "x-ms-request-id": "86b6e3c9-301e-001a-65e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.1156222Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597/blobCPK167486177608109666?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045/blobCPK167719876612900188?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "6fe5cc41-c523-49ed-9f6a-c947e0f43a0b",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "365b91bb-aac4-423b-89ac-b12ce331d5d8",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-version": "2021-12-02"
@@ -127,34 +123,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6BE1F249\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA577543D\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6fe5cc41-c523-49ed-9f6a-c947e0f43a0b",
+        "x-ms-client-request-id": "365b91bb-aac4-423b-89ac-b12ce331d5d8",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba875b-001e-0076-46a6-3240f9000000",
+        "x-ms-request-id": "86b6e3ca-301e-001a-66e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.1855833Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597/blobCPK167486177608109666",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045/blobCPK167719876612900188",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "0d5ec3f6-503c-4a6f-a6f0-a711671ddc7a",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "5935c304-f883-4742-9242-a2c01a1781c1",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -163,13 +157,13 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-a,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-a,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "11",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
         "Content-Type": "application/octet-stream",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6BE1F249\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA577543D\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -177,51 +171,49 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "0d5ec3f6-503c-4a6f-a6f0-a711671ddc7a",
-        "x-ms-creation-time": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "5935c304-f883-4742-9242-a2c01a1781c1",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:44 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-a": "a",
-        "x-ms-request-id": "d8ba87f5-001e-0076-53a6-3240f9000000",
+        "x-ms-request-id": "86b6e3ce-301e-001a-6ae7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.1855833Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177594405597?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876604801045?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "6b0c83fa-567d-40fd-ba65-956d443fd0ac",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "b6b8ac86-d8f5-407d-ba8b-206f624a3940",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6b0c83fa-567d-40fd-ba65-956d443fd0ac",
-        "x-ms-request-id": "d8ba8875-001e-0076-45a6-3240f9000000",
+        "x-ms-client-request-id": "b6b8ac86-d8f5-407d-ba8b-206f624a3940",
+        "x-ms-request-id": "86b6e3d0-301e-001a-6ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486177601304979",
-    "blobCPK": "blobCPK167486177608109666",
-    "container": "container167486177594405597"
+    "blob": "blob167719876608605507",
+    "blobCPK": "blobCPK167719876612900188",
+    "container": "container167719876604801045"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_without_customer_provided_key_on_a_blob_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_exists_works_without_customer_provided_key_on_a_blob_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177638508279?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876636100981?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "d6bb7cea-0fb8-4206-a40f-28b00718c42f",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "0cd4cd49-5cf6-45d4-99a9-f2444b4eca3f",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6C06439F\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA593F8C4\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d6bb7cea-0fb8-4206-a40f-28b00718c42f",
-        "x-ms-request-id": "d8ba8920-001e-0076-5fa6-3240f9000000",
+        "x-ms-client-request-id": "0cd4cd49-5cf6-45d4-99a9-f2444b4eca3f",
+        "x-ms-request-id": "86b6e3d2-301e-001a-6ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177638508279/blob167486177645503832",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876636100981/blob167719876640600321",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "a0715e9b-464e-494e-9afd-b2d0307959fd",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "e185f70e-7a2d-47a8-a139-69ebd457acae",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:55 GMT",
-        "ETag": "\u00220x8DB00BD6C104E97\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA59AE0D1\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a0715e9b-464e-494e-9afd-b2d0307959fd",
+        "x-ms-client-request-id": "e185f70e-7a2d-47a8-a139-69ebd457acae",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "d8ba8992-001e-0076-4ba6-3240f9000000",
+        "x-ms-request-id": "86b6e3d4-301e-001a-6fe7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.4884119Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177638508279/blobCPK167486177652508146",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876636100981/blobCPK167719876645001350",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "9750410f-f8c6-42ff-ab08-b2b93c0f3f8a",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "x-ms-client-request-id": "9b6822b0-0497-4783-af31-547ff1a9437f",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,33 +87,32 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
-        "ETag": "\u00220x8DB00BD6C1AD460\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA5A204AF\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9750410f-f8c6-42ff-ab08-b2b93c0f3f8a",
+        "x-ms-client-request-id": "9b6822b0-0497-4783-af31-547ff1a9437f",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba8a18-001e-0076-45a6-3240f9000000",
+        "x-ms-request-id": "86b6e3d9-301e-001a-73e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:56.5573728Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177638508279/blobCPK167486177652508146",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876636100981/blobCPK167719876645001350",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "4ea61898-ef0f-43df-85a9-a0e9d95a6812",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "4ed22b2e-efed-4657-98f2-d6e2324bc59d",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -123,50 +120,50 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "4ea61898-ef0f-43df-85a9-a0e9d95a6812",
+        "x-ms-client-request-id": "4ed22b2e-efed-4657-98f2-d6e2324bc59d",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8ba8aad-001e-0076-41a6-3240f9000000",
+        "x-ms-request-id": "86b6e3e2-301e-001a-7ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177638508279?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876636100981?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "c2295680-ca9f-4da9-b1f9-0ff6bc135afc",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "bfed85d4-a654-4dfe-9205-aa82f8b60edc",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:56 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c2295680-ca9f-4da9-b1f9-0ff6bc135afc",
-        "x-ms-request-id": "d8ba8b1c-001e-0076-28a6-3240f9000000",
+        "x-ms-client-request-id": "bfed85d4-a654-4dfe-9205-aa82f8b60edc",
+        "x-ms-request-id": "86b6e3e3-301e-001a-7de7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486177645503832",
-    "blobCPK": "blobCPK167486177652508146",
-    "container": "container167486177638508279"
+    "blob": "blob167719876640600321",
+    "blobCPK": "blobCPK167719876645001350",
+    "container": "container167719876636100981"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_setmetadata_sethttpheaders_getproperties_and_createsnapshot_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_setmetadata_sethttpheaders_getproperties_and_createsnapshot_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "ec366c01-29e8-4701-8cda-526534165c9e",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "9de9108c-ef24-4c0f-b24f-5a4c28168a4a",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69C202FE\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
+        "ETag": "\u00220x8DB15FEA509B983\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ec366c01-29e8-4701-8cda-526534165c9e",
-        "x-ms-request-id": "d8ba70df-001e-0076-12a6-3240f9000000",
+        "x-ms-client-request-id": "9de9108c-ef24-4c0f-b24f-5a4c28168a4a",
+        "x-ms-request-id": "86b6e3b2-301e-001a-50e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blob167486177265100343",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blob167719876550302232",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "99a96f39-281a-4e44-8267-9754f629745b",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "4dd2c3c9-63c0-45b0-897c-5ae761fd9659",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69CBBB25\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
+        "ETag": "\u00220x8DB15FEA510A1BC\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "99a96f39-281a-4e44-8267-9754f629745b",
+        "x-ms-client-request-id": "4dd2c3c9-63c0-45b0-897c-5ae761fd9659",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "d8ba715f-001e-0076-08a6-3240f9000000",
+        "x-ms-request-id": "86b6e3b6-301e-001a-53e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:52.6835493Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8169965d-1e02-4c8d-8bc8-167576c0dbb0",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "e8cdb873-6767-40a9-96ee-648806d748de",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,36 +87,34 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69D640F1\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
+        "ETag": "\u00220x8DB15FEA5179EBD\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "8169965d-1e02-4c8d-8bc8-167576c0dbb0",
+        "x-ms-client-request-id": "e8cdb873-6767-40a9-96ee-648806d748de",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba71dd-001e-0076-80a6-3240f9000000",
+        "x-ms-request-id": "86b6e3b8-301e-001a-55e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:52.7535100Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "b840a193-cdb1-4b18-be45-dbf0e66b8f6f",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "4e9c439b-7d85-4333-a082-4b0932265604",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
@@ -128,32 +124,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69E0C6C0\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA51FABFE\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b840a193-cdb1-4b18-be45-dbf0e66b8f6f",
+        "x-ms-client-request-id": "4e9c439b-7d85-4333-a082-4b0932265604",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8ba7262-001e-0076-7fa6-3240f9000000",
+        "x-ms-request-id": "86b6e3ba-301e-001a-57e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:52.8224720Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "ad4f55ef-e4d6-446b-9ef1-394012c25634",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "8aecd573-2f63-46b2-b6e4-e9232ecf7fd8",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -161,67 +156,66 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "ad4f55ef-e4d6-446b-9ef1-394012c25634",
+        "x-ms-client-request-id": "8aecd573-2f63-46b2-b6e4-e9232ecf7fd8",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8ba7300-001e-0076-13a6-3240f9000000",
+        "x-ms-request-id": "86b6e3bb-301e-001a-58e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529?comp=properties",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362?comp=properties",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-cache-control": "blobCacheControl",
         "x-ms-blob-content-disposition": "blobContentDisposition",
         "x-ms-blob-content-encoding": "blobContentEncoding",
         "x-ms-blob-content-language": "blobContentLanguage",
         "x-ms-blob-content-md5": "AQIDBA==",
         "x-ms-blob-content-type": "blobContentType",
-        "x-ms-client-request-id": "a9e3dbfd-91b4-41e2-94f2-3bd5bda7ffe0",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "a782acf7-46d4-43bb-91fb-25fbd044757b",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69F50F1D\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA52BD346\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a9e3dbfd-91b4-41e2-94f2-3bd5bda7ffe0",
-        "x-ms-request-id": "d8ba7377-001e-0076-02a6-3240f9000000",
+        "x-ms-client-request-id": "a782acf7-46d4-43bb-91fb-25fbd044757b",
+        "x-ms-request-id": "86b6e3bc-301e-001a-59e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "4654a242-d394-4c75-af34-a58123dd85eb",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "5d811d47-0c04-41e0-be5b-c4447f16ebda",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -230,7 +224,7 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-a,x-ms-meta-b,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-a,x-ms-meta-b,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Cache-Control": "blobCacheControl",
         "Content-Disposition": "blobContentDisposition",
         "Content-Encoding": "blobContentEncoding",
@@ -238,9 +232,9 @@
         "Content-Length": "11",
         "Content-MD5": "AQIDBA==",
         "Content-Type": "blobContentType",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69F50F1D\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA52BD346\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -248,34 +242,31 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "4654a242-d394-4c75-af34-a58123dd85eb",
-        "x-ms-creation-time": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "5d811d47-0c04-41e0-be5b-c4447f16ebda",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:43 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
-        "x-ms-request-id": "d8ba73ff-001e-0076-7fa6-3240f9000000",
+        "x-ms-request-id": "86b6e3bd-301e-001a-5ae7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:52.8224720Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529?comp=snapshot",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362?comp=snapshot",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "db1d9ff8-008a-42e9-845c-4e4b9926fb7d",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:53 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3fd5a547-2273-4139-91ba-e67be0525182",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -283,34 +274,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69F50F1D\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA52BD346\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "db1d9ff8-008a-42e9-845c-4e4b9926fb7d",
-        "x-ms-request-id": "d8ba7473-001e-0076-68a6-3240f9000000",
+        "x-ms-client-request-id": "3fd5a547-2273-4139-91ba-e67be0525182",
+        "x-ms-request-id": "86b6e3be-301e-001a-5be7-47451c000000",
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2023-01-27T23:22:53.0893221Z",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:53.0903221Z"
+        "x-ms-snapshot": "2023-02-24T00:32:44.0932505Z",
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529?snapshot=2023-01-27T23%3A22%3A53.0893221Z",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362?snapshot=2023-02-24T00%3A32%3A44.0932505Z",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "5d1a598b-2d5e-4f5a-83c9-6e4b41a968a5",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:53 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "2de0bc93-77b8-4e9b-881b-6f3e73ba34e1",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -327,9 +316,9 @@
         "Content-Length": "11",
         "Content-MD5": "AQIDBA==",
         "Content-Type": "blobContentType",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
-        "ETag": "\u00220x8DB00BD69F50F1D\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
+        "ETag": "\u00220x8DB15FEA52BD346\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -337,27 +326,27 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "5d1a598b-2d5e-4f5a-83c9-6e4b41a968a5",
-        "x-ms-creation-time": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "2de0bc93-77b8-4e9b-881b-6f3e73ba34e1",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:43 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-meta-b": "b",
-        "x-ms-request-id": "d8ba751b-001e-0076-08a6-3240f9000000",
+        "x-ms-request-id": "86b6e3bf-301e-001a-5ce7-47451c000000",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176/blobCPK167486177272106529?snapshot=2023-01-27T23%3A22%3A53.0893221Z",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903/blobCPK167719876554503362?snapshot=2023-02-24T00%3A32%3A44.0932505Z",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "68cfc100-1015-43b1-857c-a9ecd3ab41e9",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:53 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "a5ca2211-a956-4674-9fa4-7397e21b2f0d",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -365,50 +354,50 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "68cfc100-1015-43b1-857c-a9ecd3ab41e9",
+        "x-ms-client-request-id": "a5ca2211-a956-4674-9fa4-7397e21b2f0d",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8ba758f-001e-0076-79a6-3240f9000000",
+        "x-ms-request-id": "86b6e3c0-301e-001a-5de7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177258303176?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876546309903?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "cd3a1908-c453-47f4-955e-e9fadf2806ae",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:53 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "33752298-f6e4-4c58-af87-2c8f2da67d92",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "cd3a1908-c453-47f4-955e-e9fadf2806ae",
-        "x-ms-request-id": "d8ba760e-001e-0076-5aa6-3240f9000000",
+        "x-ms-client-request-id": "33752298-f6e4-4c58-af87-2c8f2da67d92",
+        "x-ms-request-id": "86b6e3c3-301e-001a-60e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486177265100343",
-    "blobCPK": "blobCPK167486177272106529",
-    "container": "container167486177258303176"
+    "blob": "blob167719876550302232",
+    "blobCPK": "blobCPK167719876554503362",
+    "container": "container167719876546309903"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_setmetadata_with_cpk_on_a_blob_uploaded_without_cpk_should_fail.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_setmetadata_with_cpk_on_a_blob_uploaded_without_cpk_should_fail.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177228702172?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876478701231?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "3d1155d7-351b-40b9-9a0e-0f017d1718a7",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "920911e2-3cc0-4aec-94b6-6772b6b6e843",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:51 GMT",
-        "ETag": "\u00220x8DB00BD6994B848\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
+        "ETag": "\u00220x8DB15FEA4D8CE7D\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "3d1155d7-351b-40b9-9a0e-0f017d1718a7",
-        "x-ms-request-id": "d8ba6e73-001e-0076-5aa6-3240f9000000",
+        "x-ms-client-request-id": "920911e2-3cc0-4aec-94b6-6772b6b6e843",
+        "x-ms-request-id": "86b6e3a7-301e-001a-47e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177228702172/blob167486177235504054",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876478701231/blob167719876519307684",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "affb3ab5-0ea8-4185-84da-bf6964b66c40",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "x-ms-client-request-id": "a2cc7b5c-5030-495c-bdc2-c2f9045b05ae",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,35 +50,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Fri, 27 Jan 2023 23:22:51 GMT",
-        "ETag": "\u00220x8DB00BD699E971F\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
+        "ETag": "\u00220x8DB15FEA4E1FE21\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "affb3ab5-0ea8-4185-84da-bf6964b66c40",
+        "x-ms-client-request-id": "a2cc7b5c-5030-495c-bdc2-c2f9045b05ae",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "d8ba6ef9-001e-0076-4ca6-3240f9000000",
+        "x-ms-request-id": "86b6e3aa-301e-001a-48e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:22:52.3877151Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177228702172/blob167486177235504054?comp=metadata",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876478701231/blob167719876519307684?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "68cef849-a3c3-44bb-ab0e-33e41d16b393",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "c9e035f4-049a-497c-aa12-b634039d42bd",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-a": "a",
         "x-ms-version": "2021-12-02"
@@ -88,52 +86,52 @@
       "ResponseHeaders": {
         "Content-Length": "308",
         "Content-Type": "application/xml",
-        "Date": "Fri, 27 Jan 2023 23:22:51 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "68cef849-a3c3-44bb-ab0e-33e41d16b393",
+        "x-ms-client-request-id": "c9e035f4-049a-497c-aa12-b634039d42bd",
         "x-ms-error-code": "BlobDoesNotUseCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8ba6fa2-001e-0076-6da6-3240f9000000",
+        "x-ms-request-id": "86b6e3ac-301e-001a-4ae7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobDoesNotUseCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is not encrypted with customer specified encryption, but one was provided in the request.\n",
-        "RequestId:d8ba6fa2-001e-0076-6da6-3240f9000000\n",
-        "Time:2023-01-27T23:22:52.4629459Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:86b6e3ac-301e-001a-4ae7-47451c000000\n",
+        "Time:2023-02-24T00:32:43.5740696Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486177228702172?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876478701231?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "baa17138-5fc9-416e-82b1-05e55d6a0e01",
-        "x-ms-date": "Fri, 27 Jan 2023 23:22:52 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "86977dec-ae5e-4e4d-8570-d01fa988d502",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:22:51 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:42 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "baa17138-5fc9-416e-82b1-05e55d6a0e01",
-        "x-ms-request-id": "d8ba702e-001e-0076-6fa6-3240f9000000",
+        "x-ms-client-request-id": "86977dec-ae5e-4e4d-8570-d01fa988d502",
+        "x-ms-request-id": "86b6e3ae-301e-001a-4ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486177235504054",
-    "container": "container167486177228702172"
+    "blob": "blob167719876519307684",
+    "container": "container167719876478701231"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient_nodejs_only/recording_query_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blobclient_nodejs_only/recording_query_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511305935107463?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876912404131?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "f9c55c05-9ec5-48fe-84a5-22d49c0787a2",
-        "x-ms-date": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "59907253-14ae-49a8-b667-2e5c570f2508",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:10:58 GMT",
-        "ETag": "\u00220x8DB03067C57009C\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA738F107\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f9c55c05-9ec5-48fe-84a5-22d49c0787a2",
-        "x-ms-request-id": "e3d65e97-401e-003a-40ef-34d0c9000000",
+        "x-ms-client-request-id": "59907253-14ae-49a8-b667-2e5c570f2508",
+        "x-ms-request-id": "86b6e462-301e-001a-5ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511305935107463/blob167511305941708075",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876912404131/blob167719876916700960",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "0f13d2d8-a826-4a67-93e7-9bb82dfc5569",
-        "x-ms-date": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "x-ms-client-request-id": "1fa4f1ac-b8e3-43b6-bdcb-6b0e2b1926b8",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG8gV29ybGQ=",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Mon, 30 Jan 2023 21:10:58 GMT",
-        "ETag": "\u00220x8DB03067C6199D7\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA741D216\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0f13d2d8-a826-4a67-93e7-9bb82dfc5569",
+        "x-ms-client-request-id": "1fa4f1ac-b8e3-43b6-bdcb-6b0e2b1926b8",
         "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "e3d65edc-401e-003a-80ef-34d0c9000000",
+        "x-ms-request-id": "86b6e465-301e-001a-60e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:10:59.4515415Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511305935107463/blob167511305941708075",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876912404131/blob167719876916700960",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,12 +74,11 @@
         "Connection": "keep-alive",
         "Content-Length": "32",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "70b07026-d4a1-4c44-a077-de242af54b5b",
-        "x-ms-date": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "x-ms-client-request-id": "77cf5101-d392-42d7-81e6-67705c9bbef9",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -89,25 +87,24 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "v9C7YWQTetukQaGSOQcgRQ==",
-        "Date": "Mon, 30 Jan 2023 21:10:58 GMT",
-        "ETag": "\u00220x8DB03067C6C1FA2\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA7485A6F\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "70b07026-d4a1-4c44-a077-de242af54b5b",
+        "x-ms-client-request-id": "77cf5101-d392-42d7-81e6-67705c9bbef9",
         "x-ms-content-crc64": "gema9E3\u002BzEY=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "e3d65f15-401e-003a-2eef-34d0c9000000",
+        "x-ms-request-id": "86b6e468-301e-001a-63e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:10:59.5215026Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511305935107463/blob167511305941708075?comp=query",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876912404131/blob167719876916700960?comp=query",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -115,11 +112,10 @@
         "Connection": "keep-alive",
         "Content-Length": "160",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "13a04a5c-e353-4d00-a861-835ed6f76f6d",
-        "x-ms-date": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "663a6592-a040-46d4-a965-006d86ef961d",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -128,58 +124,56 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Content-Type": "avro/binary",
-        "Date": "Mon, 30 Jan 2023 21:10:58 GMT",
-        "ETag": "\u00220x8DB03067C6C1FA2\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
+        "ETag": "\u00220x8DB15FEA7485A6F\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:47 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "13a04a5c-e353-4d00-a861-835ed6f76f6d",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "x-ms-client-request-id": "663a6592-a040-46d4-a965-006d86ef961d",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "e3d65f61-401e-003a-75ef-34d0c9000000",
+        "x-ms-request-id": "86b6e46a-301e-001a-65e7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:10:59.5215026Z"
+        "x-ms-version": "2021-12-02"
       },
-      "ResponseBody": "T2JqAQIWYXZyby5zY2hlbWHOHlsKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLnJlc3VsdERhdGEiLAogICAgImRvYyI6ICJIb2xkcyByZXN1bHQgZGF0YSBpbiB0aGUgZm9ybWF0IHNwZWNpZmllZCBmb3IgdGhpcyBxdWVyeSAoQ1NWLCBKU09OLCBldGMuKS4iLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImRhdGEiLAogICAgICAgICJ0eXBlIjogImJ5dGVzIgogICAgICB9CiAgICBdCiAgfSwKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLmVycm9yIiwKICAgICJkb2MiOiAiQW4gZXJyb3IgdGhhdCBvY2N1cnJlZCB3aGlsZSBwcm9jZXNzaW5nIHRoZSBxdWVyeS4iLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImZhdGFsIiwKICAgICAgICAidHlwZSI6ICJib29sZWFuIiwKICAgICAgICAiZG9jIjogIklmIHRydWUsIHRoaXMgZXJyb3IgcHJldmVudHMgZnVydGhlciBxdWVyeSBwcm9jZXNzaW5nLiAgTW9yZSByZXN1bHQgZGF0YSBtYXkgYmUgcmV0dXJuZWQsIGJ1dCB0aGVyZSBpcyBubyBndWFyYW50ZWUgdGhhdCBhbGwgb2YgdGhlIG9yaWdpbmFsIGRhdGEgd2lsbCBiZSBwcm9jZXNzZWQuICBJZiBmYWxzZSwgdGhpcyBlcnJvciBkb2VzIG5vdCBwcmV2ZW50IGZ1cnRoZXIgcXVlcnkgcHJvY2Vzc2luZy4iCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJuYW1lIiwKICAgICAgICAidHlwZSI6ICJzdHJpbmciLAogICAgICAgICJkb2MiOiAiVGhlIG5hbWUgb2YgdGhlIGVycm9yIgogICAgICB9LAogICAgICB7CiAgICAgICAgIm5hbWUiOiAiZGVzY3JpcHRpb24iLAogICAgICAgICJ0eXBlIjogInN0cmluZyIsCiAgICAgICAgImRvYyI6ICJBIGRlc2NyaXB0aW9uIG9mIHRoZSBlcnJvciIKICAgICAgfSwKICAgICAgewogICAgICAgICJuYW1lIjogInBvc2l0aW9uIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSByZWNvcmQgb2Zmc2V0IGluIHRoZSBibG9iIGF0IHdoaWNoIHRoZSBlcnJvciBvY2N1cnJlZCIKICAgICAgfQogICAgXQogIH0sCiAgewogICAgInR5cGUiOiAicmVjb3JkIiwKICAgICJuYW1lIjogImNvbS5taWNyb3NvZnQuYXp1cmUuc3RvcmFnZS5xdWVyeUJsb2JDb250ZW50cy5wcm9ncmVzcyIsCiAgICAiZG9jIjogIkluZm9ybWF0aW9uIGFib3V0IHRoZSBwcm9ncmVzcyBvZiB0aGUgcXVlcnkiLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImJ5dGVzU2Nhbm5lZCIsCiAgICAgICAgInR5cGUiOiAibG9uZyIsCiAgICAgICAgImRvYyI6ICJUaGUgbnVtYmVyIG9mIGJ5dGVzIHRoYXQgaGF2ZSBiZWVuIHNjYW5uZWQiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJ0b3RhbEJ5dGVzIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSB0b3RhbCBudW1iZXIgb2YgYnl0ZXMgdG8gYmUgc2Nhbm5lZCBpbiB0aGlzIHF1ZXJ5IgogICAgICB9CiAgICBdCiAgfSwKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLmVuZCIsCiAgICAiZG9jIjogIlNlbnQgYXMgdGhlIGZpbmFsIG1lc3NhZ2Ugb2YgdGhlIHJlc3BvbnNlLCBpbmRpY2F0aW5nIHRoYXQgYWxsIHJlc3VsdHMgaGF2ZSBiZWVuIHNlbnQuIiwKICAgICJmaWVsZHMiOiBbCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJ0b3RhbEJ5dGVzIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSB0b3RhbCBudW1iZXIgb2YgYnl0ZXMgc2Nhbm5lZCBpbiB0aGlzIHF1ZXJ5IgogICAgICB9CiAgICBdCiAgfQpdCgB8mi\u002BSy7O1TLIT0JmerwQ6AkQAQDEwMCwyMDAsMzAwLDQwMAoxNTAsMjUwLDM1MCw0NTAKfJovksuztUyyE9CZnq8EOgIGBEBAfJovksuztUyyE9CZnq8EOgIEBkB8mi\u002BSy7O1TLIT0JmerwQ6"
+      "ResponseBody": "T2JqAQIWYXZyby5zY2hlbWHOHlsKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLnJlc3VsdERhdGEiLAogICAgImRvYyI6ICJIb2xkcyByZXN1bHQgZGF0YSBpbiB0aGUgZm9ybWF0IHNwZWNpZmllZCBmb3IgdGhpcyBxdWVyeSAoQ1NWLCBKU09OLCBldGMuKS4iLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImRhdGEiLAogICAgICAgICJ0eXBlIjogImJ5dGVzIgogICAgICB9CiAgICBdCiAgfSwKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLmVycm9yIiwKICAgICJkb2MiOiAiQW4gZXJyb3IgdGhhdCBvY2N1cnJlZCB3aGlsZSBwcm9jZXNzaW5nIHRoZSBxdWVyeS4iLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImZhdGFsIiwKICAgICAgICAidHlwZSI6ICJib29sZWFuIiwKICAgICAgICAiZG9jIjogIklmIHRydWUsIHRoaXMgZXJyb3IgcHJldmVudHMgZnVydGhlciBxdWVyeSBwcm9jZXNzaW5nLiAgTW9yZSByZXN1bHQgZGF0YSBtYXkgYmUgcmV0dXJuZWQsIGJ1dCB0aGVyZSBpcyBubyBndWFyYW50ZWUgdGhhdCBhbGwgb2YgdGhlIG9yaWdpbmFsIGRhdGEgd2lsbCBiZSBwcm9jZXNzZWQuICBJZiBmYWxzZSwgdGhpcyBlcnJvciBkb2VzIG5vdCBwcmV2ZW50IGZ1cnRoZXIgcXVlcnkgcHJvY2Vzc2luZy4iCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJuYW1lIiwKICAgICAgICAidHlwZSI6ICJzdHJpbmciLAogICAgICAgICJkb2MiOiAiVGhlIG5hbWUgb2YgdGhlIGVycm9yIgogICAgICB9LAogICAgICB7CiAgICAgICAgIm5hbWUiOiAiZGVzY3JpcHRpb24iLAogICAgICAgICJ0eXBlIjogInN0cmluZyIsCiAgICAgICAgImRvYyI6ICJBIGRlc2NyaXB0aW9uIG9mIHRoZSBlcnJvciIKICAgICAgfSwKICAgICAgewogICAgICAgICJuYW1lIjogInBvc2l0aW9uIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSByZWNvcmQgb2Zmc2V0IGluIHRoZSBibG9iIGF0IHdoaWNoIHRoZSBlcnJvciBvY2N1cnJlZCIKICAgICAgfQogICAgXQogIH0sCiAgewogICAgInR5cGUiOiAicmVjb3JkIiwKICAgICJuYW1lIjogImNvbS5taWNyb3NvZnQuYXp1cmUuc3RvcmFnZS5xdWVyeUJsb2JDb250ZW50cy5wcm9ncmVzcyIsCiAgICAiZG9jIjogIkluZm9ybWF0aW9uIGFib3V0IHRoZSBwcm9ncmVzcyBvZiB0aGUgcXVlcnkiLAogICAgImZpZWxkcyI6IFsKICAgICAgewogICAgICAgICJuYW1lIjogImJ5dGVzU2Nhbm5lZCIsCiAgICAgICAgInR5cGUiOiAibG9uZyIsCiAgICAgICAgImRvYyI6ICJUaGUgbnVtYmVyIG9mIGJ5dGVzIHRoYXQgaGF2ZSBiZWVuIHNjYW5uZWQiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJ0b3RhbEJ5dGVzIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSB0b3RhbCBudW1iZXIgb2YgYnl0ZXMgdG8gYmUgc2Nhbm5lZCBpbiB0aGlzIHF1ZXJ5IgogICAgICB9CiAgICBdCiAgfSwKICB7CiAgICAidHlwZSI6ICJyZWNvcmQiLAogICAgIm5hbWUiOiAiY29tLm1pY3Jvc29mdC5henVyZS5zdG9yYWdlLnF1ZXJ5QmxvYkNvbnRlbnRzLmVuZCIsCiAgICAiZG9jIjogIlNlbnQgYXMgdGhlIGZpbmFsIG1lc3NhZ2Ugb2YgdGhlIHJlc3BvbnNlLCBpbmRpY2F0aW5nIHRoYXQgYWxsIHJlc3VsdHMgaGF2ZSBiZWVuIHNlbnQuIiwKICAgICJmaWVsZHMiOiBbCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJ0b3RhbEJ5dGVzIiwKICAgICAgICAidHlwZSI6ICJsb25nIiwKICAgICAgICAiZG9jIjogIlRoZSB0b3RhbCBudW1iZXIgb2YgYnl0ZXMgc2Nhbm5lZCBpbiB0aGlzIHF1ZXJ5IgogICAgICB9CiAgICBdCiAgfQpdCgAA1wIbQGEARokvVS8phMI\u002BAkQAQDEwMCwyMDAsMzAwLDQwMAoxNTAsMjUwLDM1MCw0NTAKANcCG0BhAEaJL1UvKYTCPgIGBEBAANcCG0BhAEaJL1UvKYTCPgIEBkAA1wIbQGEARokvVS8phMI\u002B"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511305935107463?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876912404131?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "ee56b493-b869-4dca-9c12-13e2717764fa",
-        "x-ms-date": "Mon, 30 Jan 2023 21:10:59 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "7e3ccc28-b3e9-4f66-8007-41b161571863",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:10:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ee56b493-b869-4dca-9c12-13e2717764fa",
-        "x-ms-request-id": "e3d65fb8-401e-003a-40ef-34d0c9000000",
+        "x-ms-client-request-id": "7e3ccc28-b3e9-4f66-8007-41b161571863",
+        "x-ms-request-id": "86b6e473-301e-001a-6ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167511305941708075",
-    "container": "container167511305935107463"
+    "blob": "blob167719876916700960",
+    "container": "container167719876912404131"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_download_without_cpk_should_fail_if_upload_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_download_without_cpk_should_fail_if_upload_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180518109100?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876823407896?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "6d13a7fa-c0af-4688-9340-1c9e7a408536",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "8a850194-b698-4846-94ba-6d66a31bcee6",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:23:24 GMT",
-        "ETag": "\u00220x8DB00BD7D302C6B\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6B0D243\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6d13a7fa-c0af-4688-9340-1c9e7a408536",
-        "x-ms-request-id": "d8bb44c6-001e-0076-06a6-3240f9000000",
+        "x-ms-client-request-id": "8a850194-b698-4846-94ba-6d66a31bcee6",
+        "x-ms-request-id": "86b6e440-301e-001a-40e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180518109100/blob167486180526308008",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876823407896/blob167719876827308317",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,47 +39,45 @@
         "Connection": "keep-alive",
         "Content-Length": "30",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3509f592-42e1-4ccf-a302-43f34d6a4799",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "x-ms-client-request-id": "5d24fcf4-b6f4-4880-8aaf-dccc54b0a998",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
-      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NDg2MTgwNTI2NDA5ODcw",
+      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc2ODI3NDA4MzM2",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Content-MD5": "rshLfzkRsnutsq8oirJU6g==",
-        "Date": "Fri, 27 Jan 2023 23:23:24 GMT",
-        "ETag": "\u00220x8DB00BD7D3C2E86\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "Content-MD5": "JKUJeTsYx5vmpD4gutgNxA==",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6B7B9EE\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "3509f592-42e1-4ccf-a302-43f34d6a4799",
-        "x-ms-content-crc64": "zkNB/c2FwM8=",
+        "x-ms-client-request-id": "5d24fcf4-b6f4-4880-8aaf-dccc54b0a998",
+        "x-ms-content-crc64": "HlAu2sOTWmI=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8bb455c-001e-0076-0ea6-3240f9000000",
+        "x-ms-request-id": "86b6e443-301e-001a-42e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:23:25.2972166Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180518109100/blob167486180526308008",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876823407896/blob167719876827308317",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "ab5b31a2-a545-4d19-adc4-1ec3997f459e",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "a79ae491-f472-4a77-9f86-412ddb8c8110",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -89,53 +87,53 @@
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "301",
         "Content-Type": "application/xml",
-        "Date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ab5b31a2-a545-4d19-adc4-1ec3997f459e",
+        "x-ms-client-request-id": "a79ae491-f472-4a77-9f86-412ddb8c8110",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "d8bb45f1-001e-0076-13a6-3240f9000000",
+        "x-ms-request-id": "86b6e444-301e-001a-43e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobUsesCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is encrypted with customer specified encryption, but it was not provided in the request.\n",
-        "RequestId:d8bb45f1-001e-0076-13a6-3240f9000000\n",
-        "Time:2023-01-27T23:23:25.3724289Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:86b6e444-301e-001a-43e7-47451c000000\n",
+        "Time:2023-02-24T00:32:46.6326199Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180518109100?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876823407896?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "c3282f69-d436-4466-a1a5-0996ff350cf5",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:25 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "908bb491-8adc-47be-89a9-060a5586f69a",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c3282f69-d436-4466-a1a5-0996ff350cf5",
-        "x-ms-request-id": "d8bb4650-001e-0076-6ca6-3240f9000000",
+        "x-ms-client-request-id": "908bb491-8adc-47be-89a9-060a5586f69a",
+        "x-ms-request-id": "86b6e446-301e-001a-45e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486180526308008",
-    "container": "container167486180518109100",
-    "randomstring": "randomstring167486180526409870"
+    "blob": "blob167719876827308317",
+    "container": "container167719876823407896",
+    "randomstring": "randomstring167719876827408336"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_stageblock_stageblockurl_and_commitblocklist_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_stageblock_stageblockurl_and_commitblocklist_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "43b69535-0fce-4890-9a4b-2e87ce4b77d3",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:04 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3530fb77-2b9a-4561-ab3f-6ce65d0ad0fb",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:04 GMT",
-        "ETag": "\u00220x8DB048687932F9B\u0022",
-        "Last-Modified": "Wed, 01 Feb 2023 19:00:04 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6500C6E\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "43b69535-0fce-4890-9a4b-2e87ce4b77d3",
-        "x-ms-request-id": "044a1f24-601e-0025-636f-36d6ce000000",
+        "x-ms-client-request-id": "3530fb77-2b9a-4561-ab3f-6ce65d0ad0fb",
+        "x-ms-request-id": "86b6e419-301e-001a-20e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/blob167527800501501912",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/blob167719876763900088",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,10 +39,10 @@
         "Connection": "keep-alive",
         "Content-Length": "10",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "173c14ab-8a39-467d-b6d7-5bc15423b69c",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "x-ms-client-request-id": "70b6c79d-39c5-4b11-bf82-c0e4dd6dc564",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "SGVsbG9Xb3JsZA==",
@@ -50,24 +50,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "aOEJ8PQMpyoV4FzCJ4b45g==",
-        "Date": "Wed, 01 Feb 2023 19:00:04 GMT",
-        "ETag": "\u00220x8DB0486879EA2CB\u0022",
-        "Last-Modified": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA656A66F\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "173c14ab-8a39-467d-b6d7-5bc15423b69c",
+        "x-ms-client-request-id": "70b6c79d-39c5-4b11-bf82-c0e4dd6dc564",
         "x-ms-content-crc64": "8R2aIe9T07E=",
-        "x-ms-request-id": "044a1f9b-601e-0025-526f-36d6ce000000",
+        "x-ms-request-id": "86b6e41c-301e-001a-22e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-02-01T19:00:05.0506443Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619?restype=container\u0026comp=acl",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786?restype=container\u0026comp=acl",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -75,31 +74,31 @@
         "Connection": "keep-alive",
         "Content-Length": "75",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "0a4a9c5f-42e6-4d1c-9dff-7beadd3993f3",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "x-ms-client-request-id": "c90cd570-e0af-4b6b-b411-b8baeea72987",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "\u003C?xml version=\u00221.0\u0022 encoding=\u0022UTF-8\u0022 standalone=\u0022yes\u0022?\u003E\u003CSignedIdentifiers/\u003E",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
-        "ETag": "\u00220x8DB048687AA5FB0\u0022",
-        "Last-Modified": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA65E9B85\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0a4a9c5f-42e6-4d1c-9dff-7beadd3993f3",
-        "x-ms-request-id": "044a2032-601e-0025-626f-36d6ce000000",
+        "x-ms-client-request-id": "c90cd570-e0af-4b6b-b411-b8baeea72987",
+        "x-ms-request-id": "86b6e41d-301e-001a-23e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175?comp=block\u0026blockid=MQ%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854?comp=block\u0026blockid=MQ%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -107,11 +106,10 @@
         "Connection": "keep-alive",
         "Content-Length": "4",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "52eebaae-ce73-4082-a278-fafecc5297fa",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "9f56e982-9eba-456d-a258-96cf7594c889",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -119,33 +117,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "52eebaae-ce73-4082-a278-fafecc5297fa",
+        "x-ms-client-request-id": "9f56e982-9eba-456d-a258-96cf7594c889",
         "x-ms-content-crc64": "nuXQFtc8BqA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "044a20bc-601e-0025-616f-36d6ce000000",
+        "x-ms-request-id": "86b6e41e-301e-001a-24e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175?comp=block\u0026blockid=Mg%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854?comp=block\u0026blockid=Mg%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "f9ac42f4-7bbe-46d1-82cf-e6717814638e",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "bbfe84f1-66d1-4712-acc3-ccf831e281ef",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-source-range": "bytes=4-7",
         "x-ms-version": "2021-12-02"
@@ -154,33 +151,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f9ac42f4-7bbe-46d1-82cf-e6717814638e",
+        "x-ms-client-request-id": "bbfe84f1-66d1-4712-acc3-ccf831e281ef",
         "x-ms-content-crc64": "n6BouArmEbQ=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "044a2131-601e-0025-516f-36d6ce000000",
+        "x-ms-request-id": "86b6e422-301e-001a-28e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175?comp=block\u0026blockid=Mw%3D%3D",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854?comp=block\u0026blockid=Mw%3D%3D",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "c73bf751-f99a-4ba6-b0b5-b2aa13626ef9",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "7320a05a-2751-4f1e-8442-606049424882",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-source-range": "bytes=8-9",
         "x-ms-version": "2021-12-02"
@@ -189,30 +185,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c73bf751-f99a-4ba6-b0b5-b2aa13626ef9",
+        "x-ms-client-request-id": "7320a05a-2751-4f1e-8442-606049424882",
         "x-ms-content-crc64": "sMJJw3kkP8c=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "044a21e9-601e-0025-7c6f-36d6ce000000",
+        "x-ms-request-id": "86b6e42d-301e-001a-30e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175?comp=blocklist\u0026blocklisttype=uncommitted",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854?comp=blocklist\u0026blocklisttype=uncommitted",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "72a274a8-b211-496d-a164-5bc44e098964",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "9bb6d585-b821-402e-bbd2-a6eca1a49983",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -221,20 +217,20 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding",
         "Content-Type": "application/xml",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "72a274a8-b211-496d-a164-5bc44e098964",
-        "x-ms-request-id": "044a2257-601e-0025-5f6f-36d6ce000000",
+        "x-ms-client-request-id": "9bb6d585-b821-402e-bbd2-a6eca1a49983",
+        "x-ms-request-id": "86b6e42f-301e-001a-32e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CBlockList\u003E\u003CUncommittedBlocks\u003E\u003CBlock\u003E\u003CName\u003EMQ==\u003C/Name\u003E\u003CSize\u003E4\u003C/Size\u003E\u003C/Block\u003E\u003CBlock\u003E\u003CName\u003EMg==\u003C/Name\u003E\u003CSize\u003E4\u003C/Size\u003E\u003C/Block\u003E\u003CBlock\u003E\u003CName\u003EMw==\u003C/Name\u003E\u003CSize\u003E2\u003C/Size\u003E\u003C/Block\u003E\u003C/UncommittedBlocks\u003E\u003C/BlockList\u003E"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175?comp=blocklist",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854?comp=blocklist",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -242,11 +238,10 @@
         "Connection": "keep-alive",
         "Content-Length": "141",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "0d162c6b-83f6-4c63-9cfc-c348409baf04",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "ebfbe550-6e1b-473a-a080-5b37afb4dae0",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -254,35 +249,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
-        "ETag": "\u00220x8DB048687EFC428\u0022",
-        "Last-Modified": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6906119\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0d162c6b-83f6-4c63-9cfc-c348409baf04",
+        "x-ms-client-request-id": "ebfbe550-6e1b-473a-a080-5b37afb4dae0",
         "x-ms-content-crc64": "AviKeNGq9Po=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "044a22b1-601e-0025-306f-36d6ce000000",
+        "x-ms-request-id": "86b6e431-301e-001a-34e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-02-01T19:00:05.5823400Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619/newblockblob167527800515904175",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786/newblockblob167719876773303854",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "d01911e9-acb4-4357-b1dc-20e0c41d72e5",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "a484782e-9bcd-449a-a12b-fec76ba1e02f",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -291,61 +284,59 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "10",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
-        "ETag": "\u00220x8DB048687EFC428\u0022",
-        "Last-Modified": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6906119\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d01911e9-acb4-4357-b1dc-20e0c41d72e5",
-        "x-ms-creation-time": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "x-ms-client-request-id": "a484782e-9bcd-449a-a12b-fec76ba1e02f",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:46 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "044a230f-601e-0025-0a6f-36d6ce000000",
+        "x-ms-request-id": "86b6e434-301e-001a-37e7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-02-01T19:00:05.5823400Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "SGVsbG9Xb3JsZA=="
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167527800494100619?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876753908786?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "678153d5-cd07-45ea-b948-8c2d15e714be",
-        "x-ms-date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "221f84df-071d-4bc9-97f8-a4316f4b0eec",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 01 Feb 2023 19:00:05 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "678153d5-cd07-45ea-b948-8c2d15e714be",
-        "x-ms-request-id": "044a236e-601e-0025-646f-36d6ce000000",
+        "x-ms-client-request-id": "221f84df-071d-4bc9-97f8-a4316f4b0eec",
+        "x-ms-request-id": "86b6e438-301e-001a-3be7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167527800501501912",
-    "container": "container167527800494100619",
-    "newblockblob": "newblockblob167527800515904175"
+    "blob": "blob167719876763900088",
+    "container": "container167719876753908786",
+    "newblockblob": "newblockblob167719876773303854"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_upload_and_download_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/blockblobclient/recording_upload_and_download_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180405407926?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876730904602?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "fa5db9bf-393d-4cf5-b842-d251f6bbcdf7",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "b322ac97-9e19-4586-8e5c-163646fcf9d5",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:23:23 GMT",
-        "ETag": "\u00220x8DB00BD7C847612\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA623D705\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "fa5db9bf-393d-4cf5-b842-d251f6bbcdf7",
-        "x-ms-request-id": "d8bb3d7a-001e-0076-4ba6-3240f9000000",
+        "x-ms-client-request-id": "b322ac97-9e19-4586-8e5c-163646fcf9d5",
+        "x-ms-request-id": "86b6e404-301e-001a-1ae7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180405407926/blob167486180412807631",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876730904602/blob167719876735006002",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,56 +39,53 @@
         "Connection": "keep-alive",
         "Content-Length": "30",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-cache-control": "blobCacheControl",
         "x-ms-blob-content-disposition": "blobContentDisposition",
         "x-ms-blob-content-encoding": "blobContentEncoding",
         "x-ms-blob-content-language": "blobContentLanguage",
         "x-ms-blob-content-type": "blobContentType",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "683a1398-3bc6-429e-9a85-0a3eabf13c2d",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "x-ms-client-request-id": "dfb7ad5f-79b6-4289-bb47-30c162cee70b",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "vala",
         "x-ms-meta-keyb": "valb",
         "x-ms-version": "2021-12-02"
       },
-      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NDg2MTgwNDEyODA1MDQw",
+      "RequestBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc2NzM1MTA2NTYw",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Content-MD5": "fRmpzxE/yIShsk3DxmCxcA==",
-        "Date": "Fri, 27 Jan 2023 23:23:23 GMT",
-        "ETag": "\u00220x8DB00BD7C8FDAB3\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "Content-MD5": "/8AeJJxzqyRGZrsaFNDiMw==",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA62A7115\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "683a1398-3bc6-429e-9a85-0a3eabf13c2d",
-        "x-ms-content-crc64": "EM2AqCB9JlI=",
+        "x-ms-client-request-id": "dfb7ad5f-79b6-4289-bb47-30c162cee70b",
+        "x-ms-content-crc64": "Z4JuY4AuwZs=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "d8bb3e31-001e-0076-6ea6-3240f9000000",
+        "x-ms-request-id": "86b6e406-301e-001a-1be7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:23:24.1678515Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180405407926/blob167486180412807631",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876730904602/blob167719876735006002",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "fd13300c-2594-4744-8984-03f40bef020c",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "70ee9d70-2025-45b5-99b4-5aefd84303a4",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -97,68 +94,66 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,x-ms-meta-keya,x-ms-meta-keyb,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-keya,x-ms-meta-keyb,Content-Type,Content-Encoding,Content-Language,Cache-Control,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,Content-Disposition,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Cache-Control": "blobCacheControl",
         "Content-Disposition": "blobContentDisposition",
         "Content-Encoding": "blobContentEncoding",
         "Content-Language": "blobContentLanguage",
         "Content-Length": "30",
-        "Content-MD5": "fRmpzxE/yIShsk3DxmCxcA==",
+        "Content-MD5": "/8AeJJxzqyRGZrsaFNDiMw==",
         "Content-Type": "blobContentType",
-        "Date": "Fri, 27 Jan 2023 23:23:23 GMT",
-        "ETag": "\u00220x8DB00BD7C8FDAB3\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
+        "ETag": "\u00220x8DB15FEA62A7115\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "fd13300c-2594-4744-8984-03f40bef020c",
-        "x-ms-creation-time": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "x-ms-client-request-id": "70ee9d70-2025-45b5-99b4-5aefd84303a4",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:45 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
         "x-ms-meta-keya": "vala",
         "x-ms-meta-keyb": "valb",
-        "x-ms-request-id": "d8bb3eb3-001e-0076-62a6-3240f9000000",
+        "x-ms-request-id": "86b6e415-301e-001a-1ce7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T23:23:24.1678515Z"
+        "x-ms-version": "2021-12-02"
       },
-      "ResponseBody": "cmFuZG9tc3RyaW5nMTY3NDg2MTgwNDEyODA1MDQw"
+      "ResponseBody": "cmFuZG9tc3RyaW5nMTY3NzE5ODc2NzM1MTA2NTYw"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167486180405407926?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876730904602?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "fd4e7104-e2c8-4cc9-ab57-3d12fdee2374",
-        "x-ms-date": "Fri, 27 Jan 2023 23:23:24 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "5eaa8446-7ada-4d56-933c-30392a4d9ee2",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:47 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 23:23:23 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:44 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "fd4e7104-e2c8-4cc9-ab57-3d12fdee2374",
-        "x-ms-request-id": "d8bb3f25-001e-0076-4da6-3240f9000000",
+        "x-ms-client-request-id": "5eaa8446-7ada-4d56-933c-30392a4d9ee2",
+        "x-ms-request-id": "86b6e416-301e-001a-1de7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167486180412807631",
-    "container": "container167486180405407926",
-    "randomstring": "randomstring167486180412805040"
+    "blob": "blob167719876735006002",
+    "container": "container167719876730904602",
+    "randomstring": "randomstring167719876735106560"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/containerclient/recording_listblobflat_with_blobs_encrypted_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167485778727206251?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876846208819?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "eda5f08b-972a-444e-90f4-6ede82eef3de",
-        "x-ms-date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3665d5af-b9a8-4e92-b3ef-6d6ffdb64235",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 22:16:27 GMT",
-        "ETag": "\u00220x8DB00B422531C10\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6D485CA\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "eda5f08b-972a-444e-90f4-6ede82eef3de",
-        "x-ms-request-id": "346c53cd-001e-002b-699c-324a7d000000",
+        "x-ms-client-request-id": "3665d5af-b9a8-4e92-b3ef-6d6ffdb64235",
+        "x-ms-request-id": "86b6e449-301e-001a-48e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167485778727206251/blockblob/0167485778735509314",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876846208819/blockblob/0167719876850804208",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,12 +39,11 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "485838e1-c106-4314-bc89-4b1ec162ebf8",
-        "x-ms-date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "x-ms-client-request-id": "5542b721-96e1-40a1-8068-5943f6d610f1",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "a",
         "x-ms-meta-keyb": "c",
@@ -55,25 +54,24 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "Date": "Fri, 27 Jan 2023 22:16:27 GMT",
-        "ETag": "\u00220x8DB00B4225FE661\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6DB4680\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "485838e1-c106-4314-bc89-4b1ec162ebf8",
+        "x-ms-client-request-id": "5542b721-96e1-40a1-8068-5943f6d610f1",
         "x-ms-content-crc64": "AAAAAAAAAAA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "346c546a-001e-002b-7b9c-324a7d000000",
+        "x-ms-request-id": "86b6e44c-301e-001a-4ae7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T22:16:27.3880673Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167485778727206251/blockblob/1167485778742603843",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876846208819/blockblob/1167719876854800549",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -81,12 +79,11 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "cf038248-6358-478c-8c60-2b138dc7efb7",
-        "x-ms-date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "x-ms-client-request-id": "00c7d93d-efca-40c2-b542-3ac499d9b33e",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-meta-keya": "a",
         "x-ms-meta-keyb": "c",
@@ -97,33 +94,32 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "Date": "Fri, 27 Jan 2023 22:16:27 GMT",
-        "ETag": "\u00220x8DB00B4226AE152\u0022",
-        "Last-Modified": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:45 GMT",
+        "ETag": "\u00220x8DB15FEA6E1810C\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "cf038248-6358-478c-8c60-2b138dc7efb7",
+        "x-ms-client-request-id": "00c7d93d-efca-40c2-b542-3ac499d9b33e",
         "x-ms-content-crc64": "AAAAAAAAAAA=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "346c54f5-001e-002b-7f9c-324a7d000000",
+        "x-ms-request-id": "86b6e44d-301e-001a-4be7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-27T22:16:27.4600274Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167485778727206251?comp=list\u0026prefix=blockblob\u0026maxresults=1\u0026restype=container\u0026include=copy,deleted,metadata,snapshots,uncommittedblobs",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876846208819?comp=list\u0026prefix=blockblob\u0026maxresults=1\u0026restype=container\u0026include=copy,deleted,metadata,snapshots,uncommittedblobs",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "07792a65-39d7-414b-88e0-9e5a21314a0d",
-        "x-ms-date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "9228e568-0879-4c40-a7e6-796d98a24c2e",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -132,49 +128,49 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding",
         "Content-Type": "application/xml",
-        "Date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "07792a65-39d7-414b-88e0-9e5a21314a0d",
-        "x-ms-request-id": "346c5566-001e-002b-659c-324a7d000000",
+        "x-ms-client-request-id": "9228e568-0879-4c40-a7e6-796d98a24c2e",
+        "x-ms-request-id": "86b6e44e-301e-001a-4ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://fakestorageaccount.blob.core.windows.net/\u0022 ContainerName=\u0022container167485778727206251\u0022\u003E\u003CPrefix\u003Eblockblob\u003C/Prefix\u003E\u003CMaxResults\u003E1\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblockblob/0167485778735509314\u003C/Name\u003E\u003CVersionId\u003E2023-01-27T22:16:27.3880673Z\u003C/VersionId\u003E\u003CIsCurrentVersion\u003Etrue\u003C/IsCurrentVersion\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 27 Jan 2023 22:16:27 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 27 Jan 2023 22:16:27 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB00B4225FE661\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E1B2M2Y8AsgTpgAmY7PhCfg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CCustomerProvidedKeySha256\u003E3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=\u003C/CustomerProvidedKeySha256\u003E\u003C/Properties\u003E\u003CMetadata Encrypted=\u0022true\u0022 /\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY3NDg1Nzc4NzQyNjAzODQzITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://fakestorageaccount.blob.core.windows.net/\u0022 ContainerName=\u0022container167719876846208819\u0022\u003E\u003CPrefix\u003Eblockblob\u003C/Prefix\u003E\u003CMaxResults\u003E1\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblockblob/0167719876850804208\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 24 Feb 2023 00:32:46 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 24 Feb 2023 00:32:46 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB15FEA6DB4680\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E1B2M2Y8AsgTpgAmY7PhCfg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CCustomerProvidedKeySha256\u003E3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=\u003C/CustomerProvidedKeySha256\u003E\u003C/Properties\u003E\u003CMetadata Encrypted=\u0022true\u0022 /\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!100!MDAwMDI5IWJsb2NrYmxvYi8xMTY3NzE5ODc2ODU0ODAwNTQ5ITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167485778727206251?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719876846208819?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "166f2b44-c4ac-4e21-a8a4-661255a4d262",
-        "x-ms-date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "d1bd544f-3492-4317-a4c7-32c116d56fce",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 27 Jan 2023 22:16:27 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:46 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "166f2b44-c4ac-4e21-a8a4-661255a4d262",
-        "x-ms-request-id": "346c55c5-001e-002b-3c9d-324a7d000000",
+        "x-ms-client-request-id": "d1bd544f-3492-4317-a4c7-32c116d56fce",
+        "x-ms-request-id": "86b6e450-301e-001a-4ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blockblob/0": "blockblob/0167485778735509314",
-    "blockblob/1": "blockblob/1167485778742603843",
-    "container": "container167485778727206251"
+    "blockblob/0": "blockblob/0167719876850804208",
+    "blockblob/1": "blockblob/1167719876854800549",
+    "container": "container167719876846208819"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/highlevel/recording_downloadtobuffer_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/highlevel/recording_downloadtobuffer_with_cpk.json
@@ -1,37 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "59d9d6c3-d0f6-4deb-93e2-2b852e6bbcda",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "6536c749-71ab-4964-84fa-da587bfa5959",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
-        "ETag": "\u00220x8DB03098DFD37F8\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA82C0360\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "59d9d6c3-d0f6-4deb-93e2-2b852e6bbcda",
-        "x-ms-request-id": "6d749cd2-701e-0053-10f2-34e985000000",
+        "x-ms-client-request-id": "6536c749-71ab-4964-84fa-da587bfa5959",
+        "x-ms-request-id": "86b6e48f-301e-001a-06e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809/blobCPK167511437751703649",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273/blobCPK167719877076507426",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -39,12 +39,11 @@
         "Connection": "keep-alive",
         "Content-Length": "11",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "0bfe953c-89fc-4b24-b023-a33dec68d6ff",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "x-ms-client-request-id": "c717e8b2-0595-40c9-aebc-674dcf546ce7",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -53,35 +52,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
-        "ETag": "\u00220x8DB03098E080673\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA8346F7A\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0bfe953c-89fc-4b24-b023-a33dec68d6ff",
+        "x-ms-client-request-id": "c717e8b2-0595-40c9-aebc-674dcf546ce7",
         "x-ms-content-crc64": "YeJLfssylmU=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "6d749d4a-701e-0053-7af2-34e985000000",
+        "x-ms-request-id": "86b6e491-301e-001a-07e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:32:57.5536755Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809/blobCPK167511437751703649",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273/blobCPK167719877076507426",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "8e349885-4bdc-4f40-b24f-ff3e95f09345",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3fa34d1a-6354-478d-a943-58c635e8ff62",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -90,13 +87,13 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "11",
         "Content-MD5": "sQqNsWTgdUEFt6mb5y4/5Q==",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
-        "ETag": "\u00220x8DB03098E080673\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA8346F7A\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -104,31 +101,28 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8e349885-4bdc-4f40-b24f-ff3e95f09345",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "x-ms-client-request-id": "3fa34d1a-6354-478d-a943-58c635e8ff62",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "6d749db7-701e-0053-5ff2-34e985000000",
+        "x-ms-request-id": "86b6e493-301e-001a-09e7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:32:57.5536755Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809/blobCPK167511437751703649",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273/blobCPK167719877076507426",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "059014d2-aa24-4d9c-92a6-f799d3bb4b21",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "62669ba8-81ea-426a-ad75-838fada7b58c",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-range": "bytes=0-10",
         "x-ms-version": "2021-12-02"
@@ -138,42 +132,40 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-blob-content-md5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-blob-content-md5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "11",
         "Content-Range": "bytes 0-10/11",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
-        "ETag": "\u00220x8DB03098E080673\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA8346F7A\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "059014d2-aa24-4d9c-92a6-f799d3bb4b21",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "x-ms-client-request-id": "62669ba8-81ea-426a-ad75-838fada7b58c",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "6d749e36-701e-0053-49f2-34e985000000",
+        "x-ms-request-id": "86b6e495-301e-001a-0be7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:32:57.5536755Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "SGVsbG8gV29ybGQ="
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809/blobCPK167511437751703649",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273/blobCPK167719877076507426",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "d8723cfb-68aa-4a61-aa1d-4ac080814914",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "af10b99e-a003-44a8-bd03-df71712af1ae",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -181,50 +173,50 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "d8723cfb-68aa-4a61-aa1d-4ac080814914",
+        "x-ms-client-request-id": "af10b99e-a003-44a8-bd03-df71712af1ae",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "6d749ea4-701e-0053-2bf2-34e985000000",
+        "x-ms-request-id": "86b6e496-301e-001a-0ce7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511437744809809?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877070004273?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "026a69d9-6dc5-4945-a3fe-995b2631e1fa",
-        "x-ms-date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "42624520-3691-45b0-8df0-721a2965b564",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:50 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:32:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "026a69d9-6dc5-4945-a3fe-995b2631e1fa",
-        "x-ms-request-id": "6d749f2c-701e-0053-25f2-34e985000000",
+        "x-ms-client-request-id": "42624520-3691-45b0-8df0-721a2965b564",
+        "x-ms-request-id": "86b6e498-301e-001a-0ee7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167511437751600466",
-    "blobCPK": "blobCPK167511437751703649",
-    "container": "container167511437744809809"
+    "blob": "blob167719877076308983",
+    "blobCPK": "blobCPK167719877076507426",
+    "container": "container167719877070004273"
   }
 }

--- a/sdk/storage/storage-blob/recordings/node/pageblobclient_nodejs_only/recording_create_uploadpages_uploadpagesfromurl_download_clearpages_and_resize_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/node/pageblobclient_nodejs_only/recording_create_uploadpages_uploadpagesfromurl_download_clearpages_and_resize_with_cpk.json
@@ -1,50 +1,49 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "12dcbb5d-14bd-4310-8230-2868c9f12502",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:57 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "e3fc21ec-82bc-43e6-a5c9-53f63208a96c",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:14:57 GMT",
-        "ETag": "\u00220x8DB03070A93F1A6\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA86659B7\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "12dcbb5d-14bd-4310-8230-2868c9f12502",
-        "x-ms-request-id": "983fd5e6-301e-000f-4eef-34bcdd000000",
+        "x-ms-client-request-id": "e3fc21ec-82bc-43e6-a5c9-53f63208a96c",
+        "x-ms-request-id": "86b6e49a-301e-001a-10e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
-        "x-ms-client-request-id": "c5b684d3-ade7-486f-a291-38c7443a7251",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "e2186a86-70ed-4c0a-bc2d-eb40f918d11a",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -52,32 +51,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:14:57 GMT",
-        "ETag": "\u00220x8DB03070AA021B9\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA86D67B4\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c5b684d3-ade7-486f-a291-38c7443a7251",
+        "x-ms-client-request-id": "e2186a86-70ed-4c0a-bc2d-eb40f918d11a",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "983fd62a-301e-000f-0aef-34bcdd000000",
+        "x-ms-request-id": "86b6e49c-301e-001a-11e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:14:58.0978105Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "b8edcc38-dc80-43fb-966d-6e6137987736",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "383b2b7a-59a5-459f-8a79-f7f787865216",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
@@ -87,24 +85,24 @@
         "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "301",
         "Content-Type": "application/xml",
-        "Date": "Mon, 30 Jan 2023 21:14:57 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b8edcc38-dc80-43fb-966d-6e6137987736",
+        "x-ms-client-request-id": "383b2b7a-59a5-459f-8a79-f7f787865216",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "983fd651-301e-000f-2def-34bcdd000000",
+        "x-ms-request-id": "86b6e49d-301e-001a-12e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobUsesCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is encrypted with customer specified encryption, but it was not provided in the request.\n",
-        "RequestId:983fd651-301e-000f-2def-34bcdd000000\n",
-        "Time:2023-01-30T21:14:58.1748476Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:86b6e49d-301e-001a-12e7-47451c000000\n",
+        "Time:2023-02-24T00:32:49.5049873Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blockblob167511329821102073",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blockblob167719877124108065",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -112,10 +110,10 @@
         "Connection": "keep-alive",
         "Content-Length": "512",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "bb8e978d-4afa-49e9-9b13-38b37dc80677",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "4fa11bcd-6bd6-4717-a07f-9197ec65c4d2",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": "YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=",
@@ -123,24 +121,23 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "uk9S5NXZfBvPq4jGr\u002BLM5g==",
-        "Date": "Mon, 30 Jan 2023 21:14:57 GMT",
-        "ETag": "\u00220x8DB03070AB74FE0\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA87D8230\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "bb8e978d-4afa-49e9-9b13-38b37dc80677",
+        "x-ms-client-request-id": "4fa11bcd-6bd6-4717-a07f-9197ec65c4d2",
         "x-ms-content-crc64": "zGf3rvhKPeA=",
-        "x-ms-request-id": "983fd690-301e-000f-69ef-34bcdd000000",
+        "x-ms-request-id": "86b6e49e-301e-001a-13e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:14:58.2497248Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658?comp=page",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017?comp=page",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -148,11 +145,10 @@
         "Connection": "keep-alive",
         "Content-Length": "512",
         "Content-Type": "application/octet-stream",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "7ef24f91-bec8-4be1-b512-6ef23617b07e",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "71ae8fe9-1fe9-414f-abdd-2b02829a36f4",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=0-511",
@@ -162,36 +158,35 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:14:57 GMT",
-        "ETag": "\u00220x8DB03070AC271CF\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA883BCB6\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
-        "x-ms-client-request-id": "7ef24f91-bec8-4be1-b512-6ef23617b07e",
+        "x-ms-client-request-id": "71ae8fe9-1fe9-414f-abdd-2b02829a36f4",
         "x-ms-content-crc64": "u661BimQ84c=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "983fd6d1-301e-000f-1eef-34bcdd000000",
+        "x-ms-request-id": "86b6e4a0-301e-001a-15e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658?comp=page",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017?comp=page",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "232b8985-2763-4251-b598-610d2149e863",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "d9cad72a-f57f-4dfa-8017-1ebaf95f1278",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=512-1023",
@@ -203,34 +198,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "uk9S5NXZfBvPq4jGr\u002BLM5g==",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
-        "ETag": "\u00220x8DB03070ACF684F\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA88AB9BE\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
-        "x-ms-client-request-id": "232b8985-2763-4251-b598-610d2149e863",
+        "x-ms-client-request-id": "d9cad72a-f57f-4dfa-8017-1ebaf95f1278",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-request-id": "983fd72c-301e-000f-76ef-34bcdd000000",
+        "x-ms-request-id": "86b6e4a4-301e-001a-19e7-47451c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "e3b15797-913a-49bb-a63c-2c4bf698876d",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "cd16bc39-b6e1-4e7b-98b3-7c91607cbbb9",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-range": "bytes=0-511",
         "x-ms-version": "2021-12-02"
@@ -240,44 +234,41 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "512",
         "Content-Range": "bytes 0-511/1024",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
-        "ETag": "\u00220x8DB03070ACF684F\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA88AB9BE\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
         "x-ms-blob-type": "PageBlob",
-        "x-ms-client-request-id": "e3b15797-913a-49bb-a63c-2c4bf698876d",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "cd16bc39-b6e1-4e7b-98b3-7c91607cbbb9",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "983fd78c-301e-000f-48ef-34bcdd000000",
+        "x-ms-request-id": "86b6e4a5-301e-001a-1ae7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:14:58.0978105Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "5b7c8b06-aa30-4101-8e35-71121875a45f",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "19bd1843-590e-4d78-892f-ca267ffe45bf",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-range": "bytes=512-1023",
         "x-ms-version": "2021-12-02"
@@ -287,43 +278,41 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "512",
         "Content-Range": "bytes 512-1023/1024",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
-        "ETag": "\u00220x8DB03070ACF684F\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA88AB9BE\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
         "x-ms-blob-type": "PageBlob",
-        "x-ms-client-request-id": "5b7c8b06-aa30-4101-8e35-71121875a45f",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "19bd1843-590e-4d78-892f-ca267ffe45bf",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "983fd7c3-301e-000f-7cef-34bcdd000000",
+        "x-ms-request-id": "86b6e4a6-301e-001a-1be7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:14:58.0978105Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": "YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI="
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658?comp=page",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017?comp=page",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "a2aadcb4-c419-4fb9-9c93-90e2ff9ce2d2",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "90ed049f-b029-4663-9bd7-d25e462a2be3",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-page-write": "clear",
         "x-ms-range": "bytes=0-511",
         "x-ms-version": "2021-12-02"
@@ -333,66 +322,65 @@
       "ResponseHeaders": {
         "Content-Length": "301",
         "Content-Type": "application/xml",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a2aadcb4-c419-4fb9-9c93-90e2ff9ce2d2",
+        "x-ms-client-request-id": "90ed049f-b029-4663-9bd7-d25e462a2be3",
         "x-ms-error-code": "BlobUsesCustomerSpecifiedEncryption",
-        "x-ms-request-id": "983fd7ef-301e-000f-23ef-34bcdd000000",
+        "x-ms-request-id": "86b6e4ac-301e-001a-21e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobUsesCustomerSpecifiedEncryption\u003C/Code\u003E\u003CMessage\u003EThe blob is encrypted with customer specified encryption, but it was not provided in the request.\n",
-        "RequestId:983fd7ef-301e-000f-23ef-34bcdd000000\n",
-        "Time:2023-01-30T21:14:58.6235953Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:86b6e4ac-301e-001a-21e7-47451c000000\n",
+        "Time:2023-02-24T00:32:49.7877444Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658?comp=properties",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017?comp=properties",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
         "x-ms-blob-content-length": "2048",
-        "x-ms-client-request-id": "b4a6fbd1-51df-417d-8d90-2cb6648fa6b3",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "73df3dd2-c425-44dd-95f1-5b93fe438ab9",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
-        "ETag": "\u00220x8DB03070AFB53D7\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA8A501EA\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
-        "x-ms-client-request-id": "b4a6fbd1-51df-417d-8d90-2cb6648fa6b3",
-        "x-ms-request-id": "983fd82f-301e-000f-5aef-34bcdd000000",
+        "x-ms-client-request-id": "73df3dd2-c425-44dd-95f1-5b93fe438ab9",
+        "x-ms-request-id": "86b6e4b0-301e-001a-24e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951/blob167511329805900658",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937/blob167719877114109017",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "a5b113bf-54bd-4c5e-84ae-2319ef12048a",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "764c31e7-1cf6-4b12-9ff2-321501b48510",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-encryption-algorithm": "AES256",
-        "x-ms-encryption-key": "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
         "x-ms-version": "2021-12-02"
       },
@@ -401,63 +389,61 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
+        "Access-Control-Expose-Headers": "x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-blob-sequence-number,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges,Content-Length,Date,Transfer-Encoding",
         "Content-Length": "2048",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
-        "ETag": "\u00220x8DB03070AFB53D7\u0022",
-        "Last-Modified": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:48 GMT",
+        "ETag": "\u00220x8DB15FEA8A501EA\u0022",
+        "Last-Modified": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
         "x-ms-blob-type": "PageBlob",
-        "x-ms-client-request-id": "a5b113bf-54bd-4c5e-84ae-2319ef12048a",
-        "x-ms-creation-time": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "x-ms-client-request-id": "764c31e7-1cf6-4b12-9ff2-321501b48510",
+        "x-ms-creation-time": "Fri, 24 Feb 2023 00:32:49 GMT",
         "x-ms-encryption-key-sha256": "3QFFFpRA5\u002BXANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
-        "x-ms-is-current-version": "true",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "983fd86f-301e-000f-16ef-34bcdd000000",
+        "x-ms-request-id": "86b6e4b3-301e-001a-27e7-47451c000000",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-12-02",
-        "x-ms-version-id": "2023-01-30T21:14:58.0978105Z"
+        "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167511329798307951?restype=container",
+      "RequestUri": "https://fakestorageaccount.blob.core.windows.net/container167719877109205937?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v16.18.0 OS/(x64-Linux-5.4.0-1100-azure)",
-        "x-ms-client-request-id": "9a83ab21-67bf-4522-a3ac-a87d852e2bc6",
-        "x-ms-date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "User-Agent": "azsdk-js-azure-storage-blob/12.13.0 core-rest-pipeline/1.10.2 Node/v14.20.1 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "8605469c-b541-4bf4-a9b7-fff4c8c1af23",
+        "x-ms-date": "Fri, 24 Feb 2023 00:32:51 GMT",
         "x-ms-version": "2021-12-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 30 Jan 2023 21:14:58 GMT",
+        "Date": "Fri, 24 Feb 2023 00:32:49 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9a83ab21-67bf-4522-a3ac-a87d852e2bc6",
-        "x-ms-request-id": "983fd8a0-301e-000f-44ef-34bcdd000000",
+        "x-ms-client-request-id": "8605469c-b541-4bf4-a9b7-fff4c8c1af23",
+        "x-ms-request-id": "86b6e4b5-301e-001a-29e7-47451c000000",
         "x-ms-version": "2021-12-02"
       },
       "ResponseBody": null
     }
   ],
   "Variables": {
-    "blob": "blob167511329805900658",
-    "blockblob": "blockblob167511329821102073",
-    "container": "container167511329798307951",
-    "expiry": "2023-01-30T21:14:58.287Z"
+    "blob": "blob167719877114109017",
+    "blockblob": "blockblob167719877124108065",
+    "container": "container167719877109205937",
+    "expiry": "2023-02-24T00:32:51.289Z"
   }
 }

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -643,7 +643,7 @@ describe("BlobClient", () => {
     }
   });
 
-  it.only("setMetadata with CPK on a blob uploaded without CPK should fail", async function () {
+  it("setMetadata with CPK on a blob uploaded without CPK should fail", async function () {
     let exceptionCaught = false;
     try {
       await blobClient.setMetadata({ a: "a" }, { customerProvidedKey: Test_CPK_INFO });
@@ -653,7 +653,7 @@ describe("BlobClient", () => {
     assert.ok(exceptionCaught);
   });
 
-  it.only("setMetadata, setHTTPHeaders, getProperties and createSnapshot with CPK", async () => {
+  it("setMetadata, setHTTPHeaders, getProperties and createSnapshot with CPK", async () => {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -817,7 +817,7 @@ describe("BlobClient", () => {
     assert.ok(result === false, "exists() should return true for an existing blob");
   });
 
-  it.only("exists works with customer provided key", async function () {
+  it("exists works with customer provided key", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -837,7 +837,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it.only("exists works without customer provided key on a blob with CPK", async function () {
+  it("exists works without customer provided key on a blob with CPK", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -849,7 +849,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it.only("exists works against blob uploaded with customer provided key", async function () {
+  it("exists works against blob uploaded with customer provided key", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -867,7 +867,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it.only("exists re-throws error from getProperties", async () => {
+  it("exists re-throws error from getProperties", async () => {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -49,7 +49,7 @@ describe("BlobClient", () => {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
     await recorder.addSanitizers(
-      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source"] } },
+      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] } },
       ["record", "playback"]
     );
     blobServiceClient = getBSU(recorder);
@@ -653,7 +653,7 @@ describe("BlobClient", () => {
     assert.ok(exceptionCaught);
   });
 
-  it("setMetadata, setHTTPHeaders, getProperties and createSnapshot with CPK", async () => {
+  it.only("setMetadata, setHTTPHeaders, getProperties and createSnapshot with CPK", async () => {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -817,7 +817,7 @@ describe("BlobClient", () => {
     assert.ok(result === false, "exists() should return true for an existing blob");
   });
 
-  it("exists works with customer provided key", async function () {
+  it.only("exists works with customer provided key", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -837,7 +837,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it("exists works without customer provided key on a blob with CPK", async function () {
+  it.only("exists works without customer provided key on a blob with CPK", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -849,7 +849,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it("exists works against blob uploaded with customer provided key", async function () {
+  it.only("exists works against blob uploaded with customer provided key", async function () {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();
@@ -867,7 +867,7 @@ describe("BlobClient", () => {
     assert.ok(result, "exists() should return true");
   });
 
-  it("exists re-throws error from getProperties", async () => {
+  it.only("exists re-throws error from getProperties", async () => {
     blobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     blobClient = containerClient.getBlobClient(blobName);
     blockBlobClient = blobClient.getBlockBlobClient();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -643,7 +643,7 @@ describe("BlobClient", () => {
     }
   });
 
-  it("setMetadata with CPK on a blob uploaded without CPK should fail", async function () {
+  it.only("setMetadata with CPK on a blob uploaded without CPK should fail", async function () {
     let exceptionCaught = false;
     try {
       await blobClient.setMetadata({ a: "a" }, { customerProvidedKey: Test_CPK_INFO });

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -49,7 +49,10 @@ describe("BlobClient", () => {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
     await recorder.addSanitizers(
-      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] } },
+      {
+        uriSanitizers,
+        removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] },
+      },
       ["record", "playback"]
     );
     blobServiceClient = getBSU(recorder);

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -317,7 +317,7 @@ describe("BlockBlobClient", () => {
     }
   });
 
-  it.only("upload and download with CPK", async function () {
+  it("upload and download with CPK", async function () {
     const body: string = recorder.variable("randomstring", getUniqueName("randomstring"));
     const options = {
       blobCacheControl: "blobCacheControl",
@@ -348,7 +348,7 @@ describe("BlockBlobClient", () => {
     assert.deepStrictEqual(result.metadata, options.metadata);
   });
 
-  it.only("stageBlock, stageBlockURL and commitBlockList with CPK", async () => {
+  it("stageBlock, stageBlockURL and commitBlockList with CPK", async () => {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 
@@ -400,7 +400,7 @@ describe("BlockBlobClient", () => {
     assert.equal(await bodyToString(downloadResponse, 10), body);
   });
 
-  it.only("download without CPK should fail, if upload with CPK", async () => {
+  it("download without CPK should fail, if upload with CPK", async () => {
     const body: string = recorder.variable("randomstring", getUniqueName("randomstring"));
     await blockBlobClient.upload(body, body.length, {
       customerProvidedKey: Test_CPK_INFO,

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -33,7 +33,10 @@ describe("BlockBlobClient", () => {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
     await recorder.addSanitizers(
-      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] } },
+      {
+        uriSanitizers,
+        removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] },
+      },
       ["playback", "record"]
     );
     const blobServiceClient = getBSU(recorder);

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -33,7 +33,7 @@ describe("BlockBlobClient", () => {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
     await recorder.addSanitizers(
-      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source"] } },
+      { uriSanitizers, removeHeaderSanitizer: { headersForRemoval: ["x-ms-copy-source", "x-ms-encryption-key"] } },
       ["playback", "record"]
     );
     const blobServiceClient = getBSU(recorder);
@@ -317,7 +317,7 @@ describe("BlockBlobClient", () => {
     }
   });
 
-  it("upload and download with CPK", async function () {
+  it.only("upload and download with CPK", async function () {
     const body: string = recorder.variable("randomstring", getUniqueName("randomstring"));
     const options = {
       blobCacheControl: "blobCacheControl",
@@ -348,7 +348,7 @@ describe("BlockBlobClient", () => {
     assert.deepStrictEqual(result.metadata, options.metadata);
   });
 
-  it("stageBlock, stageBlockURL and commitBlockList with CPK", async () => {
+  it.only("stageBlock, stageBlockURL and commitBlockList with CPK", async () => {
     const body = "HelloWorld";
     await blockBlobClient.upload(body, body.length);
 
@@ -400,7 +400,7 @@ describe("BlockBlobClient", () => {
     assert.equal(await bodyToString(downloadResponse, 10), body);
   });
 
-  it("download without CPK should fail, if upload with CPK", async () => {
+  it.only("download without CPK should fail, if upload with CPK", async () => {
     const body: string = recorder.variable("randomstring", getUniqueName("randomstring"));
     await blockBlobClient.upload(body, body.length, {
       customerProvidedKey: Test_CPK_INFO,

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -317,7 +317,7 @@ describe("ContainerClient", () => {
     assert.ok(result.segment.blobItems![0].hasVersionsOnly);
   });
 
-  it.only("listBlobFlat with blobs encrypted with CPK", async function () {
+  it("listBlobFlat with blobs encrypted with CPK", async function () {
     const blobURLs = [];
     const prefix = "blockblob";
     const metadata = {

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -37,7 +37,15 @@ describe("ContainerClient", () => {
   beforeEach(async function (this: Context) {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
-    await recorder.addSanitizers({ uriSanitizers }, ["record", "playback"]);
+    await recorder.addSanitizers(
+      {
+        uriSanitizers,
+        removeHeaderSanitizer: {
+          headersForRemoval: ["x-ms-encryption-key"],
+        },
+      },
+      ["playback", "record"]
+    );
     blobServiceClient = getBSU(recorder);
     containerName = recorder.variable("container", getUniqueName("container"));
     containerClient = blobServiceClient.getContainerClient(containerName);
@@ -309,7 +317,7 @@ describe("ContainerClient", () => {
     assert.ok(result.segment.blobItems![0].hasVersionsOnly);
   });
 
-  it("listBlobFlat with blobs encrypted with CPK", async function () {
+  it.only("listBlobFlat with blobs encrypted with CPK", async function () {
     const blobURLs = [];
     const prefix = "blockblob";
     const metadata = {

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -43,7 +43,7 @@ describe("AppendBlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization"],
+          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
         },
       },
       ["playback", "record"]
@@ -291,7 +291,7 @@ describe("AppendBlobClient Node.js only", () => {
     });
   });
 
-  it("create, appendBlock, appendBlockFromURL and download with CPK", async () => {
+  it.only("create, appendBlock, appendBlockFromURL and download with CPK", async () => {
     const cResp = await appendBlobClient.create({
       customerProvidedKey: Test_CPK_INFO,
     });

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -291,7 +291,7 @@ describe("AppendBlobClient Node.js only", () => {
     });
   });
 
-  it.only("create, appendBlock, appendBlockFromURL and download with CPK", async () => {
+  it("create, appendBlock, appendBlockFromURL and download with CPK", async () => {
     const cResp = await appendBlobClient.create({
       customerProvidedKey: Test_CPK_INFO,
     });

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -43,7 +43,11 @@ describe("AppendBlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
+          headersForRemoval: [
+            "x-ms-copy-source",
+            "x-ms-copy-source-authorization",
+            "x-ms-encryption-key",
+          ],
         },
       },
       ["playback", "record"]

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -929,7 +929,7 @@ describe("BlobClient Node.js only", () => {
     assert.deepStrictEqual(await bodyToString(response), "0,mdifjt55.ea3,mdifjt55.ea3\n");
   });
 
-  it.only("query with CPK", async function () {
+  it("query with CPK", async function () {
     const csvContent = "100,200,300,400\n150,250,350,450\n";
     await blockBlobClient.upload(csvContent, csvContent.length, {
       customerProvidedKey: Test_CPK_INFO,

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -58,7 +58,7 @@ describe("BlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization"],
+          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
         },
       },
       ["playback", "record"]
@@ -929,7 +929,7 @@ describe("BlobClient Node.js only", () => {
     assert.deepStrictEqual(await bodyToString(response), "0,mdifjt55.ea3,mdifjt55.ea3\n");
   });
 
-  it("query with CPK", async function () {
+  it.only("query with CPK", async function () {
     const csvContent = "100,200,300,400\n150,250,350,450\n";
     await blockBlobClient.upload(csvContent, csvContent.length, {
       customerProvidedKey: Test_CPK_INFO,

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -58,7 +58,11 @@ describe("BlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
+          headersForRemoval: [
+            "x-ms-copy-source",
+            "x-ms-copy-source-authorization",
+            "x-ms-encryption-key",
+          ],
         },
       },
       ["playback", "record"]

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -223,7 +223,7 @@ describe("syncUploadFromURL", () => {
       {
         uriSanitizers,
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization"],
+          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
         },
       },
       ["playback", "record"]

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -223,7 +223,11 @@ describe("syncUploadFromURL", () => {
       {
         uriSanitizers,
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
+          headersForRemoval: [
+            "x-ms-copy-source",
+            "x-ms-copy-source-authorization",
+            "x-ms-encryption-key",
+          ],
         },
       },
       ["playback", "record"]

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -45,6 +45,14 @@ describe("Highlevel", () => {
   beforeEach(async function (this: Context) {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
+    await recorder.addSanitizers(
+      {
+        removeHeaderSanitizer: {
+          headersForRemoval: ["x-ms-encryption-key"],
+        },
+      },
+      ["playback", "record"]
+    );
     blobServiceClient = getBSU(recorder, {
       keepAliveOptions: {
         enable: true,
@@ -553,7 +561,7 @@ describe("Highlevel", () => {
     assert.ok(eventTriggered);
   });
 
-  it("downloadToBuffer with CPK", async function () {
+  it.only("downloadToBuffer with CPK", async function () {
     const content = "Hello World";
     const CPKblobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     const CPKblobClient = containerClient.getBlobClient(CPKblobName);

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -561,7 +561,7 @@ describe("Highlevel", () => {
     assert.ok(eventTriggered);
   });
 
-  it.only("downloadToBuffer with CPK", async function () {
+  it("downloadToBuffer with CPK", async function () {
     const content = "Hello World";
     const CPKblobName = recorder.variable("blobCPK", getUniqueName("blobCPK"));
     const CPKblobClient = containerClient.getBlobClient(CPKblobName);

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -47,7 +47,11 @@ describe("PageBlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
+          headersForRemoval: [
+            "x-ms-copy-source",
+            "x-ms-copy-source-authorization",
+            "x-ms-encryption-key",
+          ],
         },
       },
       ["playback", "record"]

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -47,7 +47,7 @@ describe("PageBlobClient Node.js only", () => {
     await recorder.addSanitizers(
       {
         removeHeaderSanitizer: {
-          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization"],
+          headersForRemoval: ["x-ms-copy-source", "x-ms-copy-source-authorization", "x-ms-encryption-key"],
         },
       },
       ["playback", "record"]
@@ -393,7 +393,7 @@ describe("PageBlobClient Node.js only", () => {
     assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
   });
 
-  it("create, uploadPages, uploadPagesFromURL, download, clearPages and resize with CPK", async () => {
+  it.only("create, uploadPages, uploadPagesFromURL, download, clearPages and resize with CPK", async () => {
     const cResp = await pageBlobClient.create(1024, {
       customerProvidedKey: Test_CPK_INFO,
     });

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -393,7 +393,7 @@ describe("PageBlobClient Node.js only", () => {
     assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
   });
 
-  it.only("create, uploadPages, uploadPagesFromURL, download, clearPages and resize with CPK", async () => {
+  it("create, uploadPages, uploadPagesFromURL, download, clearPages and resize with CPK", async () => {
     const cResp = await pageBlobClient.create(1024, {
       customerProvidedKey: Test_CPK_INFO,
     });


### PR DESCRIPTION
use `removeHeaderSanitizer` to remove the `x-ms-encryption-key` header from the recordings. The header value contains test resource keys that made credscan unhappy.