### PR TITLE
[core-client-rest] Set comma as parametrized path delimiter

### DIFF
--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -103,7 +103,7 @@ function buildRoutePath(
       value = encodeURIComponent(pathParam);
     }
 
-    routePath = routePath.replace(/{([^/]+)}/, value);
+    routePath = routePath.replace(/{([^/,]+)}/, value);
   }
   return routePath;
 }

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -89,6 +89,14 @@ describe("urlHelpers", () => {
     assert.equal(result, `https://example.org/foo?existing=hey&foo=1&bar=two`);
   });
 
+  it("should build url with parenthesis", () => {
+    const path = "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})";
+    const parameters = ["foo", "bar"];
+    const result = buildRequestUrl(mockBaseUrl, path, parameters);
+
+    assert.equal(result, `${mockBaseUrl}/certificates(thumbprintAlgorithm=foo,thumbprint=bar)`);
+  });
+
   it("should build url with array queries", () => {
     const testArray = ["ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", null as any, ""] as string[];
     let result = buildRequestUrl(mockBaseUrl, "/foo?existing=hey", [], {


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/core-client

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/24982

### Describe the problem that is addressed by this PR
Currently core-client-rest fills in parameterized paths assuming that there will be only one parametrized element in a given path part. As surfaced in the linked issue, there are scenarios where a single path part can have more than one parameter.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Currently we only consider `/` as a delimiter to look for the next path parameter. Adding `,` as a delimiter addresses this issue.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
N/A
