### PR TITLE
[Event Hubs] Bump core-util version

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -110,7 +110,7 @@
     "@azure/core-amqp": "^3.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.1.0",
+    "@azure/core-util": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "buffer": "^6.0.0",
     "is-buffer": "^2.0.3",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The library uses `createAbortablePromise` that is part of v1.2.0 and not v1.1.0.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/24731

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
