### PR TITLE
[identity] Add WorkloadIdentityCredential to DefaultAzureCredential

### DIFF
--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -52,6 +52,7 @@ export class DefaultManagedIdentityCredential extends ManagedIdentityCredential 
     const managedResourceId = (options as DefaultAzureCredentialResourceIdOptions)
       ?.managedIdentityResourceId;
     const workloadFile = process.env.AZURE_FEDERATED_TOKEN_FILE;
+    const tenantId = options?.tenantId ?? process.env.AZURE_TENANT_ID;
 
     // ManagedIdentityCredential throws if both the resourceId and the clientId are provided.
     if (managedResourceId) {
@@ -63,6 +64,7 @@ export class DefaultManagedIdentityCredential extends ManagedIdentityCredential 
     } else if (workloadFile) {
       const workloadIdentityCredentialOptions: WorkloadIdentityCredentialOptions = {
         ...options,
+        tenantId,
         clientId: managedIdentityClientId,
         federatedTokenFilePath: workloadFile,
       };


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/identity

### Issues associated with this PR

- #23326

### Describe the problem that is addressed by this PR

Ensuring `tenantId` is supported for the `WorkloadIdentityCredential` and being passed through from the `DefaultAzureCredential`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- #24830
- #25010

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
