### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,13 @@
 
 /.devcontainer/ @jeremymeng
 /documentation/ @jeremymeng
-/samples/       @jeremymeng
+/samples/       @jeremymeng @witemple-msft
+
+################
+# Architecture
+################
+
+/design/ @bterlson @mpodwysocki @joheredi @jeremymeng @witemple-msft
 
 ################
 # Automation
@@ -1463,8 +1469,8 @@
 # Config
 ###########
 /.vscode/ @mikeharder @ckairen @deyaaeldeen
-/common/ @mikeharder @ckairen @witemple-msft @deyaaeldeen
-/common/config/rush/pnpm-lock.yaml @ckairen @witemple-msft @deyaaeldeen @jeremymeng
+/common/ @mikeharder @ckairen @deyaaeldeen
+/common/config/rush/pnpm-lock.yaml @ckairen @deyaaeldeen @jeremymeng
 /common/smoke-test/ @mikeharder @ckairen @witemple-msft @deyaaeldeen @benbp
 
 /rush.json @mikeharder @ckairen


### PR DESCRIPTION
Adds all JS arch team members to the /design/ folder. Also adds me to /samples/ and removes me from pnpm-lock.yaml and /common/ as these are extremely noisy ownerships that I can't (don't) actually pay attention to.

FYI @xirzec 

CC @mikeharder , @ckairen & @deyaaeldeen , since I imagine you all also get all the noisiness from churn in the lockfiles and such.