### PR TITLE
[storage-file-datalake] [Bug Fix] Fix the date property(createdOn, expiresOn) in some of the returned responses

### DIFF
--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Bugs Fixed
 
+- Fixes the date properties(`createdOn` and `expiresOn`) in the returned responses of `DataLakeFileSystemClient` to calculate the date more accurately. [#25072](https://github.com/Azure/azure-sdk-for-js/pull/25072)
+
 ### Other Changes
 
 - Update dependency `@azure/core-http` version to `^3.0.0`.

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Bugs Fixed
 
-- Fixes the date properties(`createdOn` and `expiresOn`) in the returned responses of `DataLakeFileSystemClient` to calculate the date more accurately. [#25072](https://github.com/Azure/azure-sdk-for-js/pull/25072)
+- Fixes the date properties(`createdOn` and `expiresOn`) in the returned responses of `DataLakeFileSystemClient` by calculating the date more accurately. [#25072](https://github.com/Azure/azure-sdk-for-js/pull/25072)
 
 ### Other Changes
 

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -571,7 +571,7 @@ export function windowsFileTimeTicksToTime(timeNumber: string | undefined): Date
   // So, we'll handle the calculations in milliseconds from here
 
   // Time in milliseconds since "12:00 A.M. January 1, 1601"
-  const timeElapsed = parseInt(timeNumber.substring(0, timeNumber.length - 4));
+  const timeElapsed = parseInt(timeNumber)/10000;
 
   if (timeElapsed === 0) return undefined;
 
@@ -580,7 +580,7 @@ export function windowsFileTimeTicksToTime(timeNumber: string | undefined): Date
   // Milliseconds calculated relative to "12:00 A.M. January 1, 1970" (will be negative)
   const initialFrameOfReference = Date.UTC(1601, 0, 1);
 
-  // (TimeAt1601 - TimeAt1970) + (Current - TimeAt1601) = (Current - TimeAt1970)
+  // TimeRelativeTo1970 = (TimeAt1601 - TimeAt1970) + (Current - TimeAt1601) = (Current - TimeAt1970)
   return new Date(initialFrameOfReference + timeElapsed);
 }
 

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -565,17 +565,23 @@ export function isIpEndpointStyle(parsedUrl: URL): boolean {
  */
 export function windowsFileTimeTicksToTime(timeNumber: string | undefined): Date | undefined {
   if (!timeNumber) return undefined;
-  const timeNumberInternal = parseInt(timeNumber!);
-
-  if (timeNumberInternal === 0) return undefined;
-
   // A windows file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
   // since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
-  // Date accepts a value that represents miliseconds from 12:00 A.M. January 1, 1970
-  // Here should correct the year number after converting.
-  const date = new Date(timeNumberInternal / 10000);
-  date.setUTCFullYear(date.getUTCFullYear() - 369);
-  return date;
+  // JS Date accepts a value that represents milliseconds from 12:00 A.M. January 1, 1970
+  // So, we'll handle the calculations in milliseconds from here
+
+  // Time in milliseconds since "12:00 A.M. January 1, 1601"
+  const timeElapsed = parseInt(timeNumber.substring(0, timeNumber.length - 4));
+
+  if (timeElapsed === 0) return undefined;
+
+  // Reference - https://stackoverflow.com/a/24188106/4137356
+
+  // Milliseconds calculated relative to "12:00 A.M. January 1, 1970" (will be negative)
+  const initialFrameOfReference = Date.UTC(1601, 0, 1);
+
+  // (TimeAt1601 - TimeAt1970) + (Current - TimeAt1601) = (Current - TimeAt1970)
+  return new Date(initialFrameOfReference + timeElapsed);
 }
 
 export function ensureCpkIfSpecified(cpk: CpkInfo | undefined, isHttps: boolean): void {

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -571,7 +571,7 @@ export function windowsFileTimeTicksToTime(timeNumber: string | undefined): Date
   // So, we'll handle the calculations in milliseconds from here
 
   // Time in milliseconds since "12:00 A.M. January 1, 1601"
-  const timeElapsed = parseInt(timeNumber)/10000;
+  const timeElapsed = parseInt(timeNumber) / 10000;
 
   if (timeElapsed === 0) return undefined;
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/storage-file-datalake`

### Issues associated with this PR
Fixes #25068 

### Describe the problem that is addressed by this PR
`windowsFileTimeTicksToTime` calculation somehow went wrong since 2023 with a 1-day difference, perhaps due to miscalculation w.r.t leap days.

This PR attempts to fix the bug and fix the tests.

The new implementation makes use of the JS Date object to do most of the calculation instead of relying on the numbers/constants to account for the leap days.  
```js
// Existing Code - Straight from the storage-file-datalake code
function windowsFileTimeTicksToTime(timeNumber: string | undefined): Date | undefined {
  if (!timeNumber) return undefined;
  const timeNumberInternal = parseInt(timeNumber!);

  if (timeNumberInternal === 0) return undefined;

  const date = new Date(timeNumberInternal / 10000);
  date.setUTCFullYear(date.getUTCFullYear() - 369);
  return date;
}

// New Implementation - Alternative algo from stackoverflow that works as expected
// Reference https://stackoverflow.com/a/24188106
function windowsFileTimeTicksToTime2(timeNumber: string | undefined): Date | undefined {
  if (!timeNumber) return undefined;
  const timeElapsed = parseInt(timeNumber)/10000;

  if (timeElapsed === 0) return undefined;

  // Milliseconds calculated relative to "12:00 A.M. January 1, 1970" (will be negative)
  const initialFrameOfReference = Date.UTC(1601, 0, 1);

  // TimeRelativeTo1970 = (TimeAt1601 - TimeAt1970) + (Current - TimeAt1601) = (Current - TimeAt1970)
  return new Date(initialFrameOfReference + timeElapsed);
}

// Value from a saved recording 
const olderTicks = "132934495529749313"; // April 3rd, 2022
console.log(windowsFileTimeTicksToTime(olderTicks))  // "2022-04-03T08:52:32.974Z" 
console.log(windowsFileTimeTicksToTime2(olderTicks)) // "2022-04-03T08:52:32.974Z" 

// Current time (At about the time of this PR) 
const newerTicks = "133222649014464202"; // March 2nd, 2023
console.log(windowsFileTimeTicksToTime(newerTicks))  // "2023-03-01T21:08:21.446Z"
console.log(windowsFileTimeTicksToTime2(newerTicks)) // "2023-03-02T21:08:21.446Z"
```

## Playground if you want to play with
[windows filetime to JS date - TS playground](https://www.typescriptlang.org/play?#code/PTAEGUBcCcEMEsDmALSoBm0D2BbUlkBTUAZ0izkUIFp14AbGgE1klntgGtiBjLJwgCh0AVwB2PSPCxjQAd3himWOSQBiDQgBV4ObfB6cSWrDr0AKKXoByInACNC0AFykYixKAA+ocQLpihEwAlK4AIqzEPn6EAUGgAN6CoKDw6KDmAIRWhLYOTsGg0ISQItCyMXFMANzJoHxiZPi6uXaO0ACSYpBOYuygALygAA6w0CSEXZCWLXntmcG1dWkZOXNOU739AzugAAyFxaXlvkqxikFLKSCgAILyisqqGJrNeqkkoLCgAGwALNR7PA0AA3dgiYgEVhFQjDYoTbqfAjEMRtJygLDpACMez21D6YiwEwaTFS3ScYPoSOQ0JpIOIhA4wwmTDqNxIih4xCxACZnLi7gA6ACygtAAClYKixgBPUBYgA08p+eyxoAAwlgKExFJFSQBVMTwenjfpmYjmfVadXBQVssARHpfHhc4aQT7fSkQ-A0tDFOGEBHu0A4BjwYkyJifTC4eV8gW3EViyXS6ByxXygCcAHY9vbQAAJJzEEjILAieikvjQYqSH3EGWEMagVH5aBfdA9dsNE1SMSIO0pBpNFhOoaBOSgR2EGY2NGdcnlfpgHG4g61FKjwiCiaQK3qtQV+gATSb0HMW8FVD31sP9BPZ-MhWooAAzD9M4s6kcyrIt7UAF9BEEG5bnoLs+ikekvnoRAsAwbA8DIWBDCwE10HoFQfWhOQKCML5PkIAAPYZCEkIIQLAAAlWJiwkYhUEgZlnBAZDUPQzC5EFPgcGAWBgB5P4sQADmEnEfmEcRJGkWQFCUFR1E0c0dEMYxTBaHlZ1aNtXDIaAPG8U5-AuEJwkiQzKhMxI6hSFYsjWedDhKX8jPOQIahs0BQIeeTnjoRg3mIcMvl+AEgVBcFIV9GEAyDakUXnDFsVxfEpSJMjIzJLtKWpWlYGgxlYGZCiUmuMAOXouN+T2IVRQlKURFleUlSxFU1U1bVdR6A0jRNEgzRaDJ91tTybnFcAp3MlDXWDT1Iuwv1YXhQhERDBh6HDDKlGjRCqoTJN6tTdMWpzPNSq8sBwCwJU5EIABye9QBpJQAuRep2B4CtWBkz5FDW+9NpJHbYyIYpPOHNAcgAUSZFlBhGMYJimLT1mgYJgFXXFqgu0BzTJf6NojbbSE5YgACJeWq2rkwapqM1a1UyeA867Oh2H4h2IYDhhY4KjOKorlKiGyWBeB2DUOA9AAeXQGj0Dorl4enQV93MBnFT2BUsUWMrQGFdbAcjT4eA+r7uphDgoMheCKfjGrEzqlNGrTZqs1zMmMgUR7HBbQhEG++lgk8n8TgnSaenMRRRfFyXCBluWFeIABqQKYaKlkdZucxzVuSB1dAF8c7z07ChT8x1TKYpugL3GWlz9XCiGcvK5WtBC7r4vcyDoDKNAAA1eaYzwb5+vpUla06-tQEEYWsErJwVPwoYKdfHlM1fP4-kzABWbe1+zLfXyxV8yex0C4QYN9oCYJUeT2HkeRnmQSDn7dMMQcw5KeRTGGUgwjBMOacwc8BDQEXiQYIhQcZkzvg-agewAR7FfFoPYwlnB72cKvQUOY-gAC0PZP0aK-QU79P6PAUhoX+LRwGAI0sA+eYD-4QMKDcGB98eTwMQcg1B6C+RYJwfg6evcK41lboFDIucvj2HLJDIg4jMQ+mCgABSooUQhTQJwLyYfDFeq8H7-EzKqTe-xYGnxxsKMYPBkCgB5EoW+99XzqOIaQr+FClLUKYbQiwmjGGqUgbrNhPJXzwOCaqLQPIsT8jQREwUxj8FOMYCQrAH9XGqEofoPQND1J6E0j48B-jWGwNCaEnk4TIk8JiXEpmgggA)