### PR TITLE
Resolving promises before returning from the method in Storage SDK

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -32,13 +32,13 @@ export async function streamToBuffer(
 
     stream.on("readable", () => {
       if (pos >= count) {
+        clearTimeout(timeout);
+        resolve();
         return;
       }
 
       let chunk = stream.read();
       if (!chunk) {
-        clearTimeout(timeout);
-        resolve();
         return;
       }
       if (typeof chunk === "string") {

--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -39,6 +39,8 @@ export async function streamToBuffer(
 
       let chunk = stream.read();
       if (!chunk) {
+        clearTimeout(timeout);
+        resolve();
         return;
       }
       if (typeof chunk === "string") {
@@ -50,6 +52,12 @@ export async function streamToBuffer(
 
       buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
       pos += chunkLength;
+      
+      // Resolving streamToBuffer as we have read all necessary content.
+      if (pos >= count) { 
+        clearTimeout(timeout);
+        resolve();
+      }
     });
 
     stream.on("end", () => {

--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -32,8 +32,6 @@ export async function streamToBuffer(
 
     stream.on("readable", () => {
       if (pos >= count) {
-        clearTimeout(timeout);
-        resolve();
         return;
       }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/storage-blob

### Issues associated with this PR
- https://github.com/Azure/azure-sdk-for-js/issues/22321
- https://github.com/actions/cache/issues/810

### Describe the problem that is addressed by this PR
Sometimes download gets hanged when trying to download a file from the Azure blob storage using the SDK. This is intermittent but we noticed the promises were not resolved at places and suspecting some corner case when concurrency is enabled that could be causing this. Hence resolving promises and added corner conditions just to be extra cautious.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Used the existing design pattern to fix the bug

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
