### PR TITLE
[core-http-compat] Fix issue with disable keep alive policy being added multiple times

### DIFF
--- a/sdk/core/core-http-compat/src/extendedClient.ts
+++ b/sdk/core/core-http-compat/src/extendedClient.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { KeepAliveOptions } from "./policies/keepAliveOptions";
-import { createDisableKeepAlivePolicy } from "./policies/disableKeepAlivePolicy";
+import {
+  createDisableKeepAlivePolicy,
+  pipelineContainsDisableKeepAlivePolicy,
+} from "./policies/disableKeepAlivePolicy";
 import { RedirectOptions } from "./policies/redirectOptions";
 import { redirectPolicyName } from "@azure/core-rest-pipeline";
 import {
@@ -47,7 +50,10 @@ export class ExtendedServiceClient extends ServiceClient {
   constructor(options: ExtendedServiceClientOptions) {
     super(options);
 
-    if (options.keepAliveOptions?.enable === false) {
+    if (
+      options.keepAliveOptions?.enable === false &&
+      !pipelineContainsDisableKeepAlivePolicy(this.pipeline)
+    ) {
       this.pipeline.addPolicy(createDisableKeepAlivePolicy());
     }
 

--- a/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
+++ b/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  Pipeline,
   PipelinePolicy,
   PipelineRequest,
   PipelineResponse,
@@ -18,4 +19,11 @@ export function createDisableKeepAlivePolicy(): PipelinePolicy {
       return next(request);
     },
   };
+}
+
+/**
+ * @internal
+ */
+export function pipelineContainsDisableKeepAlivePolicy(pipeline: Pipeline): boolean {
+  return pipeline.getOrderedPolicies().some((policy) => policy.name === disableKeepAlivePolicyName);
 }

--- a/sdk/core/core-http-compat/test/extendedClient.spec.ts
+++ b/sdk/core/core-http-compat/test/extendedClient.spec.ts
@@ -12,25 +12,38 @@ import {
   serializationPolicy,
 } from "@azure/core-client";
 import { ExtendedServiceClient, disableKeepAlivePolicyName } from "../src/index";
+import {
+  pipelineContainsDisableKeepAlivePolicy,
+  createDisableKeepAlivePolicy,
+} from "../src/policies/disableKeepAlivePolicy";
 
 describe("Extended Client", () => {
   it("should add the disable keep alive policy", () => {
-    const extendedClient: ExtendedServiceClient = new ExtendedServiceClient({
+    const extendedClient = new ExtendedServiceClient({
       keepAliveOptions: {
         enable: false,
       },
     });
 
-    const pipelinePolicies: PipelinePolicy[] = extendedClient.pipeline.getOrderedPolicies();
-    let disableKeepAlivePolicyFound: boolean = false;
+    const disableKeepAlivePolicyFound = pipelineContainsDisableKeepAlivePolicy(
+      extendedClient.pipeline
+    );
 
-    for (const pipelinePolicy of pipelinePolicies) {
-      if (pipelinePolicy.name === disableKeepAlivePolicyName) {
-        disableKeepAlivePolicyFound = true;
-      }
-    }
+    assert.isTrue(disableKeepAlivePolicyFound);
+  });
 
-    assert.deepStrictEqual(disableKeepAlivePolicyFound, true);
+  it("should not add the disable keep alive policy twice", () => {
+    const pipeline = createEmptyPipeline();
+    pipeline.addPolicy(createDisableKeepAlivePolicy());
+    assert.doesNotThrow(() => {
+      const extendedClient = new ExtendedServiceClient({
+        keepAliveOptions: {
+          enable: false,
+        },
+        pipeline,
+      });
+      extendedClient.pipeline.getOrderedPolicies();
+    });
   });
 
   it("should remove the redirect policy", () => {
@@ -133,7 +146,7 @@ describe("Extended Client", () => {
 
     let counter = 0;
 
-    function onResponse() {
+    function onResponse(): void {
       counter++;
     }
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-http-compat`

### Issues associated with this PR

Fixes #25073

### Describe the problem that is addressed by this PR

In the case that the consumer provides a pipeline that already has the disableKeepAlivePolicy added, we don't want to add it a second time. This can happen in situations like Storage where the same pipeline might be re-used by multiple clients.


### Are there test cases added in this PR? _(If not, why?)_

Yes