### PR TITLE
[Communication][alpha-ids] enable code coverage tab for alpha ids

### DIFF
--- a/sdk/communication/communication-alpha-ids/.nycrc
+++ b/sdk/communication/communication-alpha-ids/.nycrc
@@ -1,0 +1,10 @@
+{
+  "include": ["dist-esm/src/**/*.js"],
+  "exclude": ["**/*.d.ts", "dist-esm/src/generated/*"],
+  "reporter": ["text-summary", "html", "cobertura"],
+  "exclude-after-remap": false,
+  "sourceMap": true,
+  "produce-source-map": true,
+  "instrument": true,
+  "all": true
+}

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -21,7 +21,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "dev-tool run test:browser",
-    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 300000 'dist-esm/test/public/*.spec.js'",
+    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 300000 'dist-esm/test/**/*.spec.js'",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js",

--- a/sdk/communication/communication-alpha-ids/tests.yml
+++ b/sdk/communication/communication-alpha-ids/tests.yml
@@ -11,10 +11,14 @@ stages:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
+        PPE:
+          SubscriptionConfigurations:
+            - $(sub-config-communication-ppe-test-resources-common)
+            - $(sub-config-communication-ppe-test-resources-js)
         Int:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-js)
           MatrixFilters:
             - TestType=^(?!(browser|sample)).*
-      Clouds: Public,Int
+      Clouds: Public,PPE,Int


### PR DESCRIPTION
### Packages impacted by this PR
communication-alpha-ids

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Test coverage tab was not getting generated in pipeline runs.
- Internal tests not being run as part of the pipeline.
- PPE cloud missing from tests configuration

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
