### PR TITLE
[keyvault] Add support for 7.4 API version

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Release History
 
-## 4.4.0-beta.2 (Unreleased)
+## 4.4.0 (Unreleased)
 
 ### Features Added
+
+- Added `KeyVaultSettingsClient` to get and update Managed HSM settings.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 ### Other Changes
+
+- `KeyVaultAccessControlClient`, `KeyVaultBackupClient`, and `KeyVaultSettingsClient` now support service version 7.4 by default.
 
 ## 4.4.0-beta.1 (2022-11-10)
 

--- a/sdk/keyvault/keyvault-admin/assets.json
+++ b/sdk/keyvault/keyvault-admin/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-admin",
-  "Tag": "js/keyvault/keyvault-admin_6f3115fff2"
+  "Tag": "js/keyvault/keyvault-admin_f36e9a0ef6"
 }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.5.0",
+  "version": "4.4.0",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.4.0-beta.2",
+  "version": "4.5.0",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -238,7 +238,7 @@ export enum KnownKeyVaultRoleScope {
 }
 
 // @public
-export const LATEST_API_VERSION = "7.4-preview.1";
+export const LATEST_API_VERSION = "7.4";
 
 // @public
 export interface ListRoleAssignmentsOptions extends OperationOptions {
@@ -286,7 +286,7 @@ export interface SettingsClientOptions extends CommonClientOptions {
 }
 
 // @public
-export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4-preview.1";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4";
 
 // @public
 export interface UnknownKeyVaultSetting extends KeyVaultSettingCommon {

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/tsconfig.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.5.0";
+export const SDK_VERSION: string = "4.4.0";
 
 /**
  * The latest supported Key Vault service API version.

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,14 +4,14 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.4.0-beta.2";
+export const SDK_VERSION: string = "4.5.0";
 
 /**
  * The latest supported Key Vault service API version.
  */
-export const LATEST_API_VERSION = "7.4-preview.1";
+export const LATEST_API_VERSION = "7.4";
 
 /**
  * Supported API versions
  */
-export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4-preview.1";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4";

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
@@ -14,7 +14,7 @@ import * as Mappers from "./models/mappers";
 import { KeyVaultClientContext } from "./keyVaultClientContext";
 import {
   KeyVaultClientOptionalParams,
-  ApiVersion74Preview1,
+  ApiVersion74,
   FullBackupOptionalParams,
   FullBackupResponse,
   FullBackupStatusOptionalParams,
@@ -40,7 +40,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion74Preview1,
+    apiVersion: ApiVersion74,
     options?: KeyVaultClientOptionalParams
   ) {
     super(apiVersion, options);

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -7,10 +7,10 @@
  */
 
 import * as coreClient from "@azure/core-client";
-import { ApiVersion74Preview1, KeyVaultClientOptionalParams } from "./models";
+import { ApiVersion74, KeyVaultClientOptionalParams } from "./models";
 
 export class KeyVaultClientContext extends coreClient.ServiceClient {
-  apiVersion: ApiVersion74Preview1;
+  apiVersion: ApiVersion74;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
@@ -18,7 +18,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion74Preview1,
+    apiVersion: ApiVersion74,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -33,7 +33,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/4.4.0-beta.2`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.5.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -33,7 +33,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/4.5.0`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.4.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
@@ -287,20 +287,20 @@ export interface KeyVaultClientSelectiveKeyRestoreOperationHeaders {
   azureAsyncOperation?: string;
 }
 
-/** Known values of {@link ApiVersion74Preview1} that the service accepts. */
-export enum KnownApiVersion74Preview1 {
-  /** Api Version '7.4-preview.1' */
-  Seven4Preview1 = "7.4-preview.1"
+/** Known values of {@link ApiVersion74} that the service accepts. */
+export enum KnownApiVersion74 {
+  /** Api Version '7.4' */
+  Seven4 = "7.4"
 }
 
 /**
- * Defines values for ApiVersion74Preview1. \
- * {@link KnownApiVersion74Preview1} can be used interchangeably with ApiVersion74Preview1,
+ * Defines values for ApiVersion74. \
+ * {@link KnownApiVersion74} can be used interchangeably with ApiVersion74,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.4-preview.1**: Api Version '7.4-preview.1'
+ * **7.4**: Api Version '7.4'
  */
-export type ApiVersion74Preview1 = string;
+export type ApiVersion74 = string;
 
 /** Known values of {@link RoleType} that the service accepts. */
 export enum KnownRoleType {

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -11,12 +11,12 @@ generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file:
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d78681a9d322bbd8d33ecaad7e6aaa2d513513b4/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/rbac.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d78681a9d322bbd8d33ecaad7e6aaa2d513513b4/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/backuprestore.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d78681a9d322bbd8d33ecaad7e6aaa2d513513b4/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/settings.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/rbac.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/backuprestore.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/settings.json
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 4.4.0-beta.2
+package-version: 4.5.0
 use-extension:
   "@autorest/typescript": "6.0.0-beta.15"
 ```
@@ -78,16 +78,4 @@ directive:
   - rename-operation:
       from: GetSettingValue
       to: GetSetting
-```
-
-### Fix listSettings response based on actual response
-
-See https://github.com/Azure/azure-rest-api-specs/issues/21334
-
-```yaml
-directive:
-  - where-model: SettingsListResult
-    rename-property:
-      from: value
-      to: settings
 ```

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -16,7 +16,7 @@ input-file:
   - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/settings.json
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 4.5.0
+package-version: 4.4.0
 use-extension:
   "@autorest/typescript": "6.0.0-beta.15"
 ```

--- a/sdk/keyvault/keyvault-admin/test/public/settingsClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/settingsClient.spec.ts
@@ -4,7 +4,7 @@ import { KeyVaultSettingsClient } from "../../src/settingsClient";
 import { authenticate } from "./utils/authentication";
 import { getServiceVersion, onVersions } from "./utils/common";
 
-onVersions({ minVer: "7.4-preview.1" }).describe("KeyVaultSettingsClient", () => {
+onVersions({ minVer: "7.4" }).describe("KeyVaultSettingsClient", () => {
   let client: KeyVaultSettingsClient;
   let recorder: Recorder;
 

--- a/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
@@ -62,7 +62,7 @@ export function getSasToken() {
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.2", "7.3", "7.4-preview.1"] as const;
+export const serviceVersions = ["7.2", "7.3", "7.4"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.7.0-beta.1 (Unreleased)
+## 4.7.0 (Unreleased)
 
 ### Features Added
 
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `CertificateClient` to support service version 7.4-preview.1 by default.
+- Updated `CertificateClient` to support service version 7.4 by default.
 
 ## 4.6.0 (2022-09-20)
 

--- a/sdk/keyvault/keyvault-certificates/assets.json
+++ b/sdk/keyvault/keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-certificates",
-  "Tag": "js/keyvault/keyvault-certificates_98ccd3fc69"
+  "Tag": "js/keyvault/keyvault-certificates_43821e21b3"
 }

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-certificates",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.7.0-beta.1",
+  "version": "4.7.0",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-certificates/README.md",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -89,7 +89,7 @@ export class CertificateClient {
 // @public
 export interface CertificateClientOptions extends ExtendedCommonClientOptions {
     disableChallengeResourceVerification?: boolean;
-    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4-preview.1";
+    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -15,7 +15,7 @@ import {
 /**
  * The latest supported KeyVault service API version
  */
-export const LATEST_API_VERSION = "7.4-preview.1";
+export const LATEST_API_VERSION = "7.4";
 
 /**
  * The optional parameters accepted by the KeyVault's CertificateClient
@@ -24,7 +24,7 @@ export interface CertificateClientOptions extends ExtendedCommonClientOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4-preview.1";
+  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4";
 
   /**
    * Whether to disable verification that the authentication challenge resource matches the Key Vault domain.

--- a/sdk/keyvault/keyvault-certificates/src/constants.ts
+++ b/sdk/keyvault/keyvault-certificates/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.7.0-beta.1";
+export const SDK_VERSION: string = "4.7.0";

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
@@ -11,7 +11,7 @@ import * as coreHttpCompat from "@azure/core-http-compat";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import {
-  ApiVersion74Preview1,
+  ApiVersion74,
   KeyVaultClientOptionalParams,
   GetCertificatesOptionalParams,
   GetCertificatesResponse,
@@ -80,7 +80,7 @@ import {
 
 /** @internal */
 export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
-  apiVersion: ApiVersion74Preview1;
+  apiVersion: ApiVersion74;
 
   /**
    * Initializes a new instance of the KeyVaultClient class.
@@ -88,7 +88,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion74Preview1,
+    apiVersion: ApiVersion74,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -103,7 +103,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-certificates/4.7.0-beta.1`;
+    const packageDetails = `azsdk-js-keyvault-certificates/4.7.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
@@ -504,20 +504,20 @@ export type DeletedCertificateBundle = CertificateBundle & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion74Preview1} that the service accepts. */
-export enum KnownApiVersion74Preview1 {
-  /** Api Version '7.4-preview.1' */
-  Seven4Preview1 = "7.4-preview.1"
+/** Known values of {@link ApiVersion74} that the service accepts. */
+export enum KnownApiVersion74 {
+  /** Api Version '7.4' */
+  Seven4 = "7.4"
 }
 
 /**
- * Defines values for ApiVersion74Preview1. \
- * {@link KnownApiVersion74Preview1} can be used interchangeably with ApiVersion74Preview1,
+ * Defines values for ApiVersion74. \
+ * {@link KnownApiVersion74} can be used interchangeably with ApiVersion74,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.4-preview.1**: Api Version '7.4-preview.1'
+ * **7.4**: Api Version '7.4'
  */
-export type ApiVersion74Preview1 = string;
+export type ApiVersion74 = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export enum KnownDeletionRecoveryLevel {
@@ -559,9 +559,7 @@ export enum KnownJsonWebKeyType {
   RSA = "RSA",
   RSAHSM = "RSA-HSM",
   Oct = "oct",
-  OctHSM = "oct-HSM",
-  OKP = "OKP",
-  OKPHSM = "OKP-HSM"
+  OctHSM = "oct-HSM"
 }
 
 /**
@@ -574,9 +572,7 @@ export enum KnownJsonWebKeyType {
  * **RSA** \
  * **RSA-HSM** \
  * **oct** \
- * **oct-HSM** \
- * **OKP** \
- * **OKP-HSM**
+ * **oct-HSM**
  */
 export type JsonWebKeyType = string;
 
@@ -585,8 +581,7 @@ export enum KnownJsonWebKeyCurveName {
   P256 = "P-256",
   P384 = "P-384",
   P521 = "P-521",
-  P256K = "P-256K",
-  Ed25519 = "Ed25519"
+  P256K = "P-256K"
 }
 
 /**
@@ -597,8 +592,7 @@ export enum KnownJsonWebKeyCurveName {
  * **P-256** \
  * **P-384** \
  * **P-521** \
- * **P-256K** \
- * **Ed25519**
+ * **P-256K**
  */
 export type JsonWebKeyCurveName = string;
 

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -16,10 +16,22 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/fead0dec636e7554fb8401370418085136d4f052/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/certificates.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/certificates.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.7.0-beta.1
+package-version: 4.7.0
 openapi-type: data-plane
+```
+
+## Rename certain models back to what they were before 7.4
+
+```yaml
+directive:
+  - from: certificates.json
+    where: $.definitions.Action
+    transform: $.properties.action_type["x-ms-enum"].name = "ActionType";
+  - from: keys.json
+    where: $.definitions.LifetimeActionsType
+    transform: $.properties.type["x-ms-enum"].name = "ActionType";
 ```

--- a/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/serviceVersionParameter.spec.ts
@@ -57,10 +57,10 @@ describe("The Certificates client should set the serviceVersion", () => {
   });
 
   // Adding this to the source would change the public API.
-  type ApiVersions = "7.0" | "7.1" | "7.2" | "7.3" | "7.4-preview.1";
+  type ApiVersions = "7.0" | "7.1" | "7.2" | "7.3" | "7.4";
 
   it("it should allow us to specify an API version from a specific set of versions", async function () {
-    const versions: ApiVersions[] = ["7.0", "7.1", "7.2", "7.3", "7.4-preview.1"];
+    const versions: ApiVersions[] = ["7.0", "7.1", "7.2", "7.3", "7.4"];
     for (const serviceVersion in versions) {
       const client = new CertificateClient(keyVaultUrl, credential, {
         serviceVersion: serviceVersion as ApiVersions,

--- a/sdk/keyvault/keyvault-certificates/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/utils/common.ts
@@ -35,7 +35,7 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4-preview.1"] as const;
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 ### Breaking Changes
 
-- Removed support for OKP key types as introduced in 4.7.0-beta.1.
-  - Removed `KeyClient.createOkpKey`.
+- Removed support for OKP key types as introduced in 4.7.0-beta.1. These changes are only breaking for those consuming the 4.7.0-beta.1 API and are not breaking for customers consuming a stable release such as 4.6.0.
   - Removed `OKP` and `OKP-HSM` from `KnownKeyTypes`.
   - Removed `EdDSA` from `KnownSignatureAlgorithms`.
   - Removed `Ed25519` from `KnownKeyCurveNames`.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-- Removed support for OKP key types as introduced in 4.7.0-beta.1. These changes are only breaking for those consuming the 4.7.0-beta.1 API and are not breaking for customers consuming a stable release such as 4.6.0.
+- Removed support for OKP key types as introduced in 4.7.0-beta.1. These changes are only breaking for customers consuming the 4.7.0-beta.1 API, and do not affect those consuming a stable release such as 4.6.0.
   - Removed `OKP` and `OKP-HSM` from `KnownKeyTypes`.
   - Removed `EdDSA` from `KnownSignatureAlgorithms`.
   - Removed `Ed25519` from `KnownKeyCurveNames`.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.7.0-beta.2 (Unreleased)
+## 4.7.0 (Unreleased)
 
 ### Features Added
 
@@ -15,6 +15,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- `KeyClient` and `CryptographyClient` now support service version 7.4 by default.
 
 ## 4.7.0-beta.1 (2022-11-10)
 

--- a/sdk/keyvault/keyvault-keys/assets.json
+++ b/sdk/keyvault/keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-keys",
-  "Tag": "js/keyvault/keyvault-keys_d82b96ffe0"
+  "Tag": "js/keyvault/keyvault-keys_b69a5239e9"
 }

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.7.0-beta.2",
+  "version": "4.7.0",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/constants.ts
+++ b/sdk/keyvault/keyvault-keys/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.7.0-beta.2";
+export const SDK_VERSION: string = "4.7.0";

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -98,7 +98,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-keys/4.7.0-beta.2`;
+    const packageDetails = `azsdk-js-keyvault-keys/4.7.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -18,7 +18,7 @@ export { KeyType, KnownKeyTypes, KeyOperation };
 /**
  * The latest supported Key Vault service API version
  */
-export const LATEST_API_VERSION = "7.4-preview.1";
+export const LATEST_API_VERSION = "7.4";
 
 /**
  * The optional parameters accepted by the KeyVault's KeyClient

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -10,12 +10,12 @@ add-credentials: false
 core-http-compat-mode: true
 use-core-v2: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/204cfa94e4ab94cc209c58984554411d6ab0e9e5/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true
 api-version-parameter: choice
-package-version: 4.7.0-beta.2
+package-version: 4.7.0
 use-extension:
   "@autorest/typescript": "6.0.0-beta.19"
 ```
@@ -58,4 +58,16 @@ directive:
     where: $.definitions.KeyReleasePolicy.properties.data
     transform: >
       $["x-ms-client-name"] = "encodedPolicy";
+```
+
+## Rename certain models back to what they were before 7.4
+
+```yaml
+directive:
+  - from: certificates.json
+    where: $.definitions.Action
+    transform: $.properties.action_type["x-ms-enum"].name = "ActionType";
+  - from: keys.json
+    where: $.definitions.LifetimeActionsType
+    transform: $.properties.type["x-ms-enum"].name = "ActionType";
 ```

--- a/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
@@ -22,7 +22,7 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4-preview.1"] as const;
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.7.0-beta.1 (Unreleased)
+## 4.7.0 (Unreleased)
 
 ### Features Added
 
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `SecretClient` to support service version 7.4-preview.1 by default.
+- Updated `SecretClient` to support service version 7.4 by default.
 
 ## 4.6.0 (2022-09-20)
 

--- a/sdk/keyvault/keyvault-secrets/assets.json
+++ b/sdk/keyvault/keyvault-secrets/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-secrets",
-  "Tag": "js/keyvault/keyvault-secrets_2ad682e4b9"
+  "Tag": "js/keyvault/keyvault-secrets_1a3f6657bd"
 }

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-secrets",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.7.0-beta.1",
+  "version": "4.7.0",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's secrets.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-secrets/README.md",

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -134,7 +134,7 @@ export class SecretClient {
 // @public
 export interface SecretClientOptions extends ExtendedCommonClientOptions {
     disableChallengeResourceVerification?: boolean;
-    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4-preview.1";
+    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-secrets/src/constants.ts
+++ b/sdk/keyvault/keyvault-secrets/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.7.0-beta.1";
+export const SDK_VERSION: string = "4.7.0";

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
@@ -12,7 +12,7 @@ import * as coreRestPipeline from "@azure/core-rest-pipeline";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import {
-  ApiVersion74Preview1,
+  ApiVersion74,
   KeyVaultClientOptionalParams,
   SetSecretOptionalParams,
   SetSecretResponse,
@@ -47,7 +47,7 @@ import {
 
 /** @internal */
 export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
-  apiVersion: ApiVersion74Preview1;
+  apiVersion: ApiVersion74;
 
   /**
    * Initializes a new instance of the KeyVaultClient class.
@@ -55,7 +55,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion74Preview1,
+    apiVersion: ApiVersion74,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -70,7 +70,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-secrets/4.7.0-beta.1`;
+    const packageDetails = `azsdk-js-keyvault-secrets/4.7.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
@@ -215,20 +215,20 @@ export type DeletedSecretItem = SecretItem & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion74Preview1} that the service accepts. */
-export enum KnownApiVersion74Preview1 {
-  /** Api Version '7.4-preview.1' */
-  Seven4Preview1 = "7.4-preview.1"
+/** Known values of {@link ApiVersion74} that the service accepts. */
+export enum KnownApiVersion74 {
+  /** Api Version '7.4' */
+  Seven4 = "7.4"
 }
 
 /**
- * Defines values for ApiVersion74Preview1. \
- * {@link KnownApiVersion74Preview1} can be used interchangeably with ApiVersion74Preview1,
+ * Defines values for ApiVersion74. \
+ * {@link KnownApiVersion74} can be used interchangeably with ApiVersion74,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.4-preview.1**: Api Version '7.4-preview.1'
+ * **7.4**: Api Version '7.4'
  */
-export type ApiVersion74Preview1 = string;
+export type ApiVersion74 = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -8,7 +8,7 @@ import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
 /**
  * The latest supported KeyVault service API version
  */
-export const LATEST_API_VERSION = "7.4-preview.1";
+export const LATEST_API_VERSION = "7.4";
 
 /**
  * The optional parameters accepted by the KeyVault's KeyClient
@@ -17,7 +17,7 @@ export interface SecretClientOptions extends ExtendedCommonClientOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4-preview.1";
+  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4";
 
   /**
    * Whether to disable verification that the authentication challenge resource matches the Key Vault domain.

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -16,9 +16,9 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/fead0dec636e7554fb8401370418085136d4f052/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/secrets.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/551275acb80e1f8b39036b79dfc35a8f63b601a7/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/secrets.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.7.0-beta.1
+package-version: 4.7.0
 ```

--- a/sdk/keyvault/keyvault-secrets/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/utils/common.ts
@@ -31,7 +31,7 @@ export const serviceVersions: readonly NonNullable<ServiceVersion>[] = [
   "7.1",
   "7.2",
   "7.3",
-  "7.4-preview.1",
+  "7.4",
 ] as const;
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-keys`
- `@azure/keyvault-admin`
- `@azure/keyvault-certificates`
- `@azure/keyvault-secrets`

### Describe the problem that is addressed by this PR

Regenerate, rerecord, and create changelog entries for adding support to the 7.4 API version.
