### PR TITLE
Set skip for azure-tools-communication-short-cdoes

### DIFF
--- a/sdk/communication/ci.yml
+++ b/sdk/communication/ci.yml
@@ -50,6 +50,8 @@ extends:
         skipPublishDocMs: true
         skipPublishDocGithubIo: true
       - name: azure-tools-communication-alpha-ids
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true
         safeName: azuretoolscommunicationalphaids
       - name: azure-communication-rooms
         safeName: azurecommunicationrooms

--- a/sdk/communication/ci.yml
+++ b/sdk/communication/ci.yml
@@ -47,6 +47,8 @@ extends:
         safeName: azurecommunicationnetworktraversal
       - name: azure-tools-communication-short-codes
         safeName: azuretoolscommunicationshortcodes
+        skipPublishDocMs: true
+        skipPublishDocGithubIo: true
       - name: azure-tools-communication-alpha-ids
         safeName: azuretoolscommunicationalphaids
       - name: azure-communication-rooms


### PR DESCRIPTION
This prevents publishing of docs for packages which do not require documentation. 