### PR TITLE
fix: confidential-ledger-rest: remove mocha arrow functions

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/colderEndpoints.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/colderEndpoints.spec.ts
@@ -3,12 +3,12 @@
 import { ConfidentialLedgerClient, isUnexpected } from "../../src";
 import { createClient, createRecorder } from "./utils/recordedClient";
 
-import { Context } from "mocha";
-import { EnclaveQuoteOutput } from "../../src";
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
+import { EnclaveQuoteOutput } from "../../src";
 
-describe("Colder endpoints", () => {
+describe("Colder endpoints", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/getCollections.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/getCollections.spec.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 import {
   ConfidentialLedgerClient,
-  CreateLedgerEntryParameters, isUnexpected, LedgerEntry
+  CreateLedgerEntryParameters,
+  isUnexpected,
+  LedgerEntry,
 } from "../../src";
 import { createClient, createRecorder } from "./utils/recordedClient";
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/getCollections.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/getCollections.spec.ts
@@ -2,17 +2,15 @@
 // Licensed under the MIT license.
 import {
   ConfidentialLedgerClient,
-  CreateLedgerEntryParameters,
-  LedgerEntry,
-  isUnexpected,
+  CreateLedgerEntryParameters, isUnexpected, LedgerEntry
 } from "../../src";
 import { createClient, createRecorder } from "./utils/recordedClient";
 
-import { Context } from "mocha";
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 
-describe("Get Collections", () => {
+describe("Get Collections", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/historicalRangeQuery.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/historicalRangeQuery.spec.ts
@@ -2,19 +2,16 @@
 // Licensed under the MIT license.
 import {
   ConfidentialLedgerClient,
-  CreateLedgerEntryParameters,
-  LedgerEntry,
-  isUnexpected,
-  paginate,
+  CreateLedgerEntryParameters, isUnexpected, LedgerEntry, paginate
 } from "../../src";
 
 import { createClient, createRecorder } from "./utils/recordedClient";
 
-import { Context } from "mocha";
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 
-describe("Range query should be successful", () => {
+describe("Range query should be successful", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/historicalRangeQuery.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/historicalRangeQuery.spec.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 import {
   ConfidentialLedgerClient,
-  CreateLedgerEntryParameters, isUnexpected, LedgerEntry, paginate
+  CreateLedgerEntryParameters,
+  isUnexpected,
+  LedgerEntry,
+  paginate,
 } from "../../src";
 
 import { createClient, createRecorder } from "./utils/recordedClient";

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/ledgerHistory.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/ledgerHistory.spec.ts
@@ -8,7 +8,7 @@ import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 import { env } from "process";
 
-describe("Get ledger history", () => {
+describe("Get ledger history", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/listEnclaveQuotes.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/listEnclaveQuotes.spec.ts
@@ -3,11 +3,11 @@
 import { ConfidentialLedgerClient, isUnexpected } from "../../src";
 import { createClient, createRecorder } from "./utils/recordedClient";
 
-import { Context } from "mocha";
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
+import { Context } from "mocha";
 
-describe("List Enclaves", () => {
+describe("List Enclaves", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/postTransaction.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/postTransaction.spec.ts
@@ -12,7 +12,7 @@ import { Context } from "mocha";
 import { Recorder } from "@azure-tools/test-recorder";
 import { assert } from "chai";
 
-describe("Post transaction", () => {
+describe("Post transaction", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
   let contentBody: string;

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/testUserAuth.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/testUserAuth.spec.ts
@@ -9,7 +9,7 @@ import { createClient, createRecorder } from "./utils/recordedClient";
 import { Context } from "mocha";
 import { DefaultAzureCredential } from "@azure/identity";
 
-describe("Test user authentications", () => {
+describe("Test user authentications", function () {
   let recorder: Recorder;
 
   beforeEach(async function (this: Context) {

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/usersEndpoint.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/usersEndpoint.spec.ts
@@ -7,7 +7,7 @@ import { createClient, createRecorder } from "./utils/recordedClient";
 import { Context } from "mocha";
 import { assert } from "chai";
 
-describe("Get user", () => {
+describe("Get user", function () {
   let recorder: Recorder;
   let client: ConfidentialLedgerClient;
 


### PR DESCRIPTION
### Packages impacted by this PR

`sdk\confidentialledger\confidential-ledger-rest`

### Issues associated with this PR

#13005 

### Describe the problem that is addressed by this PR

The existing mocha tests for the `sdk\confidentialledger\confidential-ledger-rest` made use of the arrow syntax for callback functions. Mocha recommends not to do this because you lose access to the mocha context (https://mochajs.org/#arrow-functions).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The reason for utilizing the function keyword instead of an arrow syntax to write the callback functions in these mocha tests is to maintain access to the mocha context.

### Are there test cases added in this PR? _(If not, why?)_

No additional test cases were added in this PR as the change only required modifying existing test cases.

### Provide a list of related PRs _(if any)_

#23761 - Same fix, but for the `sdk\search\search-documents` package
#23789 - Same fix but for the `sdk\attestation\attestation` package
#23835 - Same fix but for the `sdk\batch\batch` package
#23850 - Same fix but for the `sdk\cognitivelanguage\ai-language-conversations` package
#23881 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-authoring` package
#24126 - Same fix but for the `sdk\cognitiveservices\cognitiveservices-luis-runtime` package
#21470 - Same fix but for the `sdk\communication\communication-chat` package
#24746 - Same fix but for the `sdk\communication\communication-common` package
#24747 - Same fix but for the `sdk\communication\communication-email` package
#24797 - Same fix but for the `sdk\communication\communication-identity` package
#24865 - Same fix but for the `sdk\communication\communication-job-router` package

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

**_Not applicable_**

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
   - **_I don't believe this is relevant._**
- [ ] Added a changelog (if necessary)
  - **_I don't believe this is necessary_**
