### PR TITLE
[identity] Re-export WorkloadIdentityCredential options

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check. Related issue [#25089](https://github.com/Azure/azure-sdk-for-js/issues/25089) with the fix [#25119](https://github.com/Azure/azure-sdk-for-js/pull/25119).
+- Exported `WorkloadIdentityDefaultCredentialOptions` which was previously not publicly exported in `index.ts`.
+
 ### Other Changes
 
 ## 3.2.0-beta.1 (2023-02-28)

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -380,18 +380,24 @@ export interface VisualStudioCodeCredentialOptions extends MultiTenantTokenCrede
 // @public
 export class WorkloadIdentityCredential implements TokenCredential {
     constructor(options: WorkloadIdentityCredentialOptions);
-    // Warning: (ae-forgotten-export) The symbol "WorkloadIdentityDefaultCredentialOptions" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     constructor(options?: WorkloadIdentityDefaultCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "WorkloadIdentityCredentialOptions" is marked as @public, but its signature references "WorkloadIdentityDefaultCredentialOptions" which is marked as @internal
+//
 // @public
 export interface WorkloadIdentityCredentialOptions extends WorkloadIdentityDefaultCredentialOptions {
     clientId: string;
     federatedTokenFilePath: string;
     tenantId: string;
+}
+
+// Warning: (ae-internal-missing-underscore) The name "WorkloadIdentityDefaultCredentialOptions" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export interface WorkloadIdentityDefaultCredentialOptions extends MultiTenantTokenCredentialOptions, AuthorityValidationOptions {
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -385,8 +385,6 @@ export class WorkloadIdentityCredential implements TokenCredential {
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "WorkloadIdentityCredentialOptions" is marked as @public, but its signature references "WorkloadIdentityDefaultCredentialOptions" which is marked as @internal
-//
 // @public
 export interface WorkloadIdentityCredentialOptions extends WorkloadIdentityDefaultCredentialOptions {
     clientId: string;
@@ -394,9 +392,7 @@ export interface WorkloadIdentityCredentialOptions extends WorkloadIdentityDefau
     tenantId: string;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "WorkloadIdentityDefaultCredentialOptions" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
+// @public
 export interface WorkloadIdentityDefaultCredentialOptions extends MultiTenantTokenCredentialOptions, AuthorityValidationOptions {
 }
 

--- a/sdk/identity/identity/src/credentials/workloadIdentityCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/workloadIdentityCredentialOptions.ts
@@ -3,7 +3,6 @@
 
 import { AuthorityValidationOptions } from "./authorityValidationOptions";
 import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions";
-import { WorkloadIdentityCredential } from "./workloadIdentityCredential";
 
 /**
  * Options for the {@link WorkloadIdentityCredential}

--- a/sdk/identity/identity/src/credentials/workloadIdentityCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/workloadIdentityCredentialOptions.ts
@@ -24,8 +24,7 @@ export interface WorkloadIdentityCredentialOptions
 }
 
 /**
- * @internal
- * @hidden
+ * Internal Options for the {@link WorkloadIdentityCredential}, not meant to be used directly.
  */
 export interface WorkloadIdentityDefaultCredentialOptions
   extends MultiTenantTokenCredentialOptions,

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -90,7 +90,10 @@ export { VisualStudioCodeCredential } from "./credentials/visualStudioCodeCreden
 export { VisualStudioCodeCredentialOptions } from "./credentials/visualStudioCodeCredentialOptions";
 export { OnBehalfOfCredential } from "./credentials/onBehalfOfCredential";
 export { WorkloadIdentityCredential } from "./credentials/workloadIdentityCredential";
-export { WorkloadIdentityCredentialOptions } from "./credentials/workloadIdentityCredentialOptions";
+export { 
+  WorkloadIdentityCredentialOptions,
+  WorkloadIdentityDefaultCredentialOptions,
+} from "./credentials/workloadIdentityCredentialOptions";
 
 export { TokenCachePersistenceOptions } from "./msal/nodeFlows/tokenCachePersistenceOptions";
 

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -90,7 +90,7 @@ export { VisualStudioCodeCredential } from "./credentials/visualStudioCodeCreden
 export { VisualStudioCodeCredentialOptions } from "./credentials/visualStudioCodeCredentialOptions";
 export { OnBehalfOfCredential } from "./credentials/onBehalfOfCredential";
 export { WorkloadIdentityCredential } from "./credentials/workloadIdentityCredential";
-export { 
+export {
   WorkloadIdentityCredentialOptions,
   WorkloadIdentityDefaultCredentialOptions,
 } from "./credentials/workloadIdentityCredentialOptions";


### PR DESCRIPTION
### Packages impacted by this PR

- [@azure/identity]

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Customer reported issue with non-exported `WorkloadIdentityDefaultCredentialOptions`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
