### PR TITLE
[notification hubs] Adding Xiaomi support

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -127,7 +127,8 @@
     "Usuk",
     "USUK",
     "Vertica",
-    "westus"
+    "westus",
+    "Xiaomi"
   ],
   "allowCompoundWords": true,
   "overrides": [

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (Unreleased)
+## 1.0.0-beta.9 (Unreleased)
 
 ### Features Added
 

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Release History
 
-## 1.0.0 (2023-02-16)
+## 1.0.0-beta.8 (Unreleased)
+
+### Features Added
+
+- Added Xiaomi support with the following:
+  - `XiaomiRegistrationDescription` and `XiaomiTemplateRegistrationDescription` for registrations with associated factory methods.
+  - `XiaomiInstallation` for installation operations and associated factory methods.
+  - `XiaomiNotification` for notification send support and associated factory methods.
 
 ### Bugs Fixed
 

--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -1,6 +1,6 @@
 # Azure Notification Hubs SDK for JavaScript
 
-Azure Notification Hubs provide a scaled-out push engine that enables you to send notifications to any platform (Apple, Amazon Kindle, Android, Baidu, Web, Windows, etc.) from any back-end (cloud or on-premises). Notification Hubs works well for both enterprise and consumer scenarios. Here are a few example scenarios:
+Azure Notification Hubs provide a scaled-out push engine that enables you to send notifications to any platform (Apple, Amazon Kindle, Android, Baidu, Xiaomi, Web, Windows, etc.) from any back-end (cloud or on-premises). Notification Hubs works well for both enterprise and consumer scenarios. Here are a few example scenarios:
 
 - Send breaking news notifications to millions with low latency.
 - Send location-based coupons to interested user segments.

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/notification-hubs",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "Azure Notification Hubs SDK for JavaScript",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/notification-hubs",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.8",
   "description": "Azure Notification Hubs SDK for JavaScript",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -368,6 +368,18 @@ export function createWindowsTileNotification(notification: NotificationCommon):
 export function createWindowsToastNotification(notification: NotificationCommon): WindowsNotification;
 
 // @public
+export function createXiaomiInstallation(installation: DeviceTokenInstallation): XiaomiInstallation;
+
+// @public
+export function createXiaomiNotification(notification: NotificationCommon): XiaomiNotification;
+
+// @public
+export function createXiaomiRegistrationDescription(description: XiaomiRegistrationDescriptionCommon): XiaomiRegistrationDescription;
+
+// @public
+export function createXiaomiTemplateRegistrationDescription(description: XiaomiTemplateRegistrationDescriptionCommon): XiaomiTemplateRegistrationDescription;
+
+// @public
 export interface DeviceTokenInstallation extends InstallationCommon {
     pushChannel: string;
 }
@@ -472,7 +484,7 @@ export interface GcmTemplateRegistrationDescriptionCommon extends GcmRegistratio
 }
 
 // @public
-export type Installation = AppleInstallation | AdmInstallation | BaiduInstallation | BrowserInstallation | FcmLegacyInstallation | WindowsInstallation;
+export type Installation = AppleInstallation | AdmInstallation | BaiduInstallation | BrowserInstallation | FcmLegacyInstallation | XiaomiInstallation | WindowsInstallation;
 
 // @public
 export interface InstallationCommon {
@@ -533,7 +545,7 @@ export interface MpnsTemplateRegistrationDescriptionCommon extends MpnsRegistrat
 }
 
 // @public
-export type Notification = AppleNotification | AdmNotification | BaiduNotification | BrowserNotification | FcmLegacyNotification | WindowsNotification | TemplateNotification;
+export type Notification = AppleNotification | AdmNotification | BaiduNotification | BrowserNotification | FcmLegacyNotification | XiaomiNotification | WindowsNotification | TemplateNotification;
 
 // @public
 export interface NotificationCommon {
@@ -559,6 +571,7 @@ export interface NotificationDetails {
     tags?: string;
     targetPlatforms?: string;
     wnsOutcomeCounts?: NotificationOutcome[];
+    xiaomiOutcomeCounts?: NotificationOutcome[];
 }
 
 // @public
@@ -690,10 +703,10 @@ export interface PolledOperationOptions extends OperationOptions {
 export type PushHandle = BrowserPushChannel | string;
 
 // @public
-export type RegistrationChannel = AdmRegistrationChannel | AppleRegistrationChannel | BaiduRegistrationChannel | BrowserRegistrationChannel | FirebaseLegacyRegistrationChannel | WindowsRegistrationChannel;
+export type RegistrationChannel = AdmRegistrationChannel | AppleRegistrationChannel | BaiduRegistrationChannel | BrowserRegistrationChannel | FirebaseLegacyRegistrationChannel | XiaomiRegistrationChannel | WindowsRegistrationChannel;
 
 // @public
-export type RegistrationDescription = AdmRegistrationDescription | AdmTemplateRegistrationDescription | AppleRegistrationDescription | AppleTemplateRegistrationDescription | BaiduRegistrationDescription | BaiduTemplateRegistrationDescription | BrowserRegistrationDescription | BrowserTemplateRegistrationDescription | GcmRegistrationDescription | GcmTemplateRegistrationDescription | MpnsRegistrationDescription | MpnsTemplateRegistrationDescription | WindowsRegistrationDescription | WindowsTemplateRegistrationDescription;
+export type RegistrationDescription = AdmRegistrationDescription | AdmTemplateRegistrationDescription | AppleRegistrationDescription | AppleTemplateRegistrationDescription | BaiduRegistrationDescription | BaiduTemplateRegistrationDescription | BrowserRegistrationDescription | BrowserTemplateRegistrationDescription | GcmRegistrationDescription | GcmTemplateRegistrationDescription | MpnsRegistrationDescription | MpnsTemplateRegistrationDescription | XiaomiRegistrationDescription | XiaomiTemplateRegistrationDescription | WindowsRegistrationDescription | WindowsTemplateRegistrationDescription;
 
 // @public
 export interface RegistrationDescriptionCommon {
@@ -729,7 +742,7 @@ export interface RegistrationResult {
 }
 
 // @public
-export type RegistrationType = "Adm" | "AdmTemplate" | "Apple" | "AppleTemplate" | "Baidu" | "BaiduTemplate" | "Browser" | "BrowserTemplate" | "Gcm" | "GcmTemplate" | "Mpns" | "MpnsTemplate" | "Windows" | "WindowsTemplate";
+export type RegistrationType = "Adm" | "AdmTemplate" | "Apple" | "AppleTemplate" | "Baidu" | "BaiduTemplate" | "Browser" | "BrowserTemplate" | "Gcm" | "GcmTemplate" | "Mpns" | "MpnsTemplate" | "Xiaomi" | "XiaomiTemplate" | "Windows" | "WindowsTemplate";
 
 // @public
 export interface ScheduleNotificationOptions extends OperationOptions {
@@ -799,6 +812,41 @@ export interface WindowsTemplateRegistrationDescription extends WindowsTemplateR
 // @public
 export interface WindowsTemplateRegistrationDescriptionCommon extends WindowsRegistrationDescriptionCommon, TemplateRegistrationDescription {
     wnsHeaders?: Record<string, string>;
+}
+
+// @public
+export interface XiaomiInstallation extends DeviceTokenInstallation {
+    platform: "xiaomi";
+}
+
+// @public
+export interface XiaomiNotification extends JsonNotification {
+    platform: "xiaomi";
+}
+
+// @public
+export interface XiaomiRegistrationChannel {
+    kind: "xiaomi";
+    xiaomiRegistrationId: string;
+}
+
+// @public
+export interface XiaomiRegistrationDescription extends XiaomiRegistrationDescriptionCommon {
+    kind: "Xiaomi";
+}
+
+// @public
+export interface XiaomiRegistrationDescriptionCommon extends RegistrationDescriptionCommon {
+    xiaomiRegistrationId: string;
+}
+
+// @public
+export interface XiaomiTemplateRegistrationDescription extends XiaomiTemplateRegistrationDescriptionCommon {
+    kind: "XiaomiTemplate";
+}
+
+// @public
+export interface XiaomiTemplateRegistrationDescriptionCommon extends XiaomiRegistrationDescriptionCommon, TemplateRegistrationDescription {
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/notificationhubs/notification-hubs/src/models/installation.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/installation.ts
@@ -137,6 +137,30 @@ export function createFcmLegacyInstallation(
 }
 
 /**
+ * Represents a Xiaomi based installation.
+ */
+export interface XiaomiInstallation extends DeviceTokenInstallation {
+  /**
+   * The platform for the installation.
+   */
+  platform: "xiaomi";
+}
+
+/**
+ * Creates a Xiaomi based installation.
+ * @param installation - A partial installation used to create the Xiaomi installation.
+ * @returns The newly created Xiaomi installation.
+ */
+export function createXiaomiInstallation(
+  installation: DeviceTokenInstallation
+): XiaomiInstallation {
+  return {
+    ...installation,
+    platform: "xiaomi",
+  };
+}
+
+/**
  * Represents a Windows Notification Services (WNS) based installation.
  */
 export interface WindowsInstallation extends DeviceTokenInstallation {
@@ -223,6 +247,7 @@ export type Installation =
   | BaiduInstallation
   | BrowserInstallation
   | FcmLegacyInstallation
+  | XiaomiInstallation
   | WindowsInstallation;
 
 /**

--- a/sdk/notificationhubs/notification-hubs/src/models/notification.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notification.ts
@@ -133,7 +133,7 @@ export interface FcmLegacyNotification extends JsonNotification {
 /**
  * Creates a notification to send to Firebase.
  * @param notification - A partial message used to create a message for Firebase.
- * @returns A newly created Firebase.
+ * @returns A newly created Firebase notification.
  */
 export function createFcmLegacyNotification(
   notification: NotificationCommon
@@ -141,6 +141,29 @@ export function createFcmLegacyNotification(
   return {
     ...notification,
     platform: "gcm",
+    contentType: Constants.JSON_CONTENT_TYPE,
+  };
+}
+
+/**
+ * Represents a Xiaomi push notification.
+ */
+export interface XiaomiNotification extends JsonNotification {
+  /**
+   * The platform for the push notification.
+   */
+  platform: "xiaomi";
+}
+
+/**
+ * Creates a notification to send to Xiaomi.
+ * @param notification - A partial message used to create a message for Xiaomi.
+ * @returns A newly created Xiaomi notification.
+ */
+export function createXiaomiNotification(notification: NotificationCommon): XiaomiNotification {
+  return {
+    ...notification,
+    platform: "xiaomi",
     contentType: Constants.JSON_CONTENT_TYPE,
   };
 }
@@ -289,5 +312,6 @@ export type Notification =
   | BaiduNotification
   | BrowserNotification
   | FcmLegacyNotification
+  | XiaomiNotification
   | WindowsNotification
   | TemplateNotification;

--- a/sdk/notificationhubs/notification-hubs/src/models/notificationDetails.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notificationDetails.ts
@@ -112,6 +112,11 @@ export interface NotificationDetails {
    * Web Push outcome counts per state.
    */
   browserOutcomeCounts?: NotificationOutcome[];
+
+  /**
+   * Xiaomi outcome counts per state.
+   */
+  xiaomiOutcomeCounts?: NotificationOutcome[];
 }
 
 /**

--- a/sdk/notificationhubs/notification-hubs/src/models/registration.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/registration.ts
@@ -17,6 +17,8 @@ export type RegistrationType =
   | "GcmTemplate"
   | "Mpns"
   | "MpnsTemplate"
+  | "Xiaomi"
+  | "XiaomiTemplate"
   | "Windows"
   | "WindowsTemplate";
 
@@ -559,6 +561,72 @@ export function createWindowsTemplateRegistrationDescription(
 }
 
 /**
+ * Represents a Xiaomi registration description.
+ */
+export interface XiaomiRegistrationDescriptionCommon extends RegistrationDescriptionCommon {
+  /**
+   * The Xiaomi registration ID.
+   */
+  xiaomiRegistrationId: string;
+}
+
+/**
+ * Represents a Xiaomi registration description.
+ */
+export interface XiaomiRegistrationDescription extends XiaomiRegistrationDescriptionCommon {
+  /**
+   * The kind of the registration.
+   */
+  kind: "Xiaomi";
+}
+
+/**
+ * Creates a Xiaomi registration description.
+ * @param description - A partial Xiaomi registration description.
+ * @returns A created Xiaomi registration description.
+ */
+export function createXiaomiRegistrationDescription(
+  description: XiaomiRegistrationDescriptionCommon
+): XiaomiRegistrationDescription {
+  return {
+    ...description,
+    kind: "Xiaomi",
+  };
+}
+
+/**
+ * Represents a Xiaomi template registration.
+ */
+export interface XiaomiTemplateRegistrationDescriptionCommon
+  extends XiaomiRegistrationDescriptionCommon,
+    TemplateRegistrationDescription {}
+
+/**
+ * Represents a Windows Notification Services (WNS) template registration.
+ */
+export interface XiaomiTemplateRegistrationDescription
+  extends XiaomiTemplateRegistrationDescriptionCommon {
+  /**
+   * The kind of the registration.
+   */
+  kind: "XiaomiTemplate";
+}
+
+/**
+ * Creates a Xiaomi template registration description.
+ * @param description - A partial Xiaomi template registration description.
+ * @returns A created Xiaomi template registration description.
+ */
+export function createXiaomiTemplateRegistrationDescription(
+  description: XiaomiTemplateRegistrationDescriptionCommon
+): XiaomiTemplateRegistrationDescription {
+  return {
+    ...description,
+    kind: "XiaomiTemplate",
+  };
+}
+
+/**
  * Describes the types of registration descriptions.
  */
 export type RegistrationDescription =
@@ -574,6 +642,8 @@ export type RegistrationDescription =
   | GcmTemplateRegistrationDescription
   | MpnsRegistrationDescription
   | MpnsTemplateRegistrationDescription
+  | XiaomiRegistrationDescription
+  | XiaomiTemplateRegistrationDescription
   | WindowsRegistrationDescription
   | WindowsTemplateRegistrationDescription;
 
@@ -674,6 +744,20 @@ export interface WindowsRegistrationChannel {
 }
 
 /**
+ * Describes an Xiaomi Registration channel query.
+ */
+export interface XiaomiRegistrationChannel {
+  /**
+   * The Xiaomi registration ID.
+   */
+  xiaomiRegistrationId: string;
+  /**
+   * The kind of the registration channel.
+   */
+  kind: "xiaomi";
+}
+
+/**
  * Describes a Registration query.
  */
 export type RegistrationChannel =
@@ -682,4 +766,5 @@ export type RegistrationChannel =
   | BaiduRegistrationChannel
   | BrowserRegistrationChannel
   | FirebaseLegacyRegistrationChannel
+  | XiaomiRegistrationChannel
   | WindowsRegistrationChannel;

--- a/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
@@ -39,6 +39,11 @@ export async function parseNotificationDetails(bodyText: string): Promise<Notifi
     fcmOutcomeCounts = parseOutcomeCounts(notificationDetails["GcmOutcomeCounts"]["Outcome"]);
   }
 
+  let xiaomiOutcomeCounts: NotificationOutcome[] | undefined;
+  if (isDefined(notificationDetails["XiaomiOutcomeCounts"])) {
+    xiaomiOutcomeCounts = parseOutcomeCounts(notificationDetails["XiaomiOutcomeCounts"]["Outcome"]);
+  }
+
   let wnsOutcomeCounts: NotificationOutcome[] | undefined;
   if (isDefined(notificationDetails["WnsOutcomeCounts"])) {
     wnsOutcomeCounts = parseOutcomeCounts(notificationDetails["WnsOutcomeCounts"]["Outcome"]);
@@ -58,6 +63,7 @@ export async function parseNotificationDetails(bodyText: string): Promise<Notifi
     admOutcomeCounts,
     baiduOutcomeCounts,
     fcmOutcomeCounts,
+    xiaomiOutcomeCounts,
     wnsOutcomeCounts,
   };
 }

--- a/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
@@ -17,6 +17,8 @@ import {
   RegistrationDescription,
   RegistrationDescriptionCommon,
   TemplateRegistrationDescription,
+  XiaomiRegistrationDescription,
+  XiaomiTemplateRegistrationDescription,
   WindowsRegistrationDescription,
   WindowsTemplateRegistrationDescription,
 } from "../models/registration.js";
@@ -129,6 +131,20 @@ export interface RegistrationDescriptionParser {
   createMpnsTemplateRegistrationDescription: (
     rawRegistrationDescription: Record<string, any>
   ) => MpnsTemplateRegistrationDescription;
+  /**
+   * @internal
+   * Creates a Xiaomi registration description from the incoming parsed XML.
+   */
+  createXiaomiRegistrationDescription: (
+    rawRegistrationDescription: Record<string, any>
+  ) => XiaomiRegistrationDescription;
+  /**
+   * @internal
+   * Creates a Xiaomi template registration description from the incoming parsed XML.
+   */
+  createXiaomiTemplateRegistrationDescription: (
+    rawRegistrationDescription: Record<string, any>
+  ) => XiaomiTemplateRegistrationDescription;
   /**
    * @internal
    * Creates a Windows Notification Services (WNS) registration description from the incoming parsed XML.
@@ -377,6 +393,37 @@ export const registrationDescriptionParser: RegistrationDescriptionParser = {
 
   /**
    * @internal
+   * Creates a Xiaomi registration description from incoming XML property bag.
+   */
+  createXiaomiRegistrationDescription(
+    rawRegistrationDescription: Record<string, any>
+  ): XiaomiRegistrationDescription {
+    return {
+      xiaomiRegistrationId: getString(
+        rawRegistrationDescription["XiaomiRegistrationId"],
+        "xiaomiRegistrationId"
+      ),
+      ...createRegistrationDescription(rawRegistrationDescription),
+      kind: "Xiaomi",
+    };
+  },
+
+  /**
+   * @internal
+   * Creates a Xiaomi template registration description from incoming XML property bag.
+   */
+  createXiaomiTemplateRegistrationDescription(
+    rawRegistrationDescription: Record<string, any>
+  ): XiaomiTemplateRegistrationDescription {
+    return {
+      ...this.createXiaomiRegistrationDescription(rawRegistrationDescription),
+      ...createTemplateRegistrationDescription(rawRegistrationDescription),
+      kind: "XiaomiTemplate",
+    };
+  },
+
+  /**
+   * @internal
    * Creates a Windows registration description from incoming XML property bag.
    */
   createWindowsRegistrationDescription(
@@ -541,6 +588,20 @@ export interface RegistrationDescriptionSerializer {
    */
   serializeMpnsTemplateRegistrationDescription(
     description: Omit<MpnsTemplateRegistrationDescription, "kind">
+  ): Record<string, any>;
+  /**
+   * @internal
+   * Serializes a Xiaomi registration description into an XML object for serialization.
+   */
+  serializeXiaomiRegistrationDescription(
+    description: Omit<XiaomiRegistrationDescription, "kind">
+  ): Record<string, any>;
+  /**
+   * @internal
+   * Serializes a Xiaomi template registration description into an XML object for serialization.
+   */
+  serializeXiaomiTemplateRegistrationDescription(
+    description: Omit<XiaomiTemplateRegistrationDescription, "kind">
   ): Record<string, any>;
   /**
    * @internal
@@ -770,6 +831,32 @@ export const registrationDescriptionSerializer: RegistrationDescriptionSerialize
       ...this.serializeMpnsRegistrationDescription(description),
       ...serializeTemplateRegistrationDescription(description),
       MpnsHeaders: mpnsHeaders,
+    };
+  },
+
+  /**
+   * @internal
+   * Serializes an existing Xiaomi registration description to an object for serialization.
+   */
+  serializeXiaomiRegistrationDescription(
+    description: Omit<XiaomiRegistrationDescription, "kind">
+  ): Record<string, any> {
+    return {
+      ...serializeRegistrationDescription(description),
+      XiaomiRegistrationId: getString(description.xiaomiRegistrationId, "xiaomiRegistrationId"),
+    };
+  },
+
+  /**
+   * @internal
+   * Serializes an existing Xiaomi template registration description to an object for serialization.
+   */
+  serializeXiaomiTemplateRegistrationDescription(
+    description: Omit<XiaomiTemplateRegistrationDescription, "kind">
+  ): Record<string, any> {
+    return {
+      ...this.serializeXiaomiRegistrationDescription(description),
+      ...serializeTemplateRegistrationDescription(description),
     };
   },
 

--- a/sdk/notificationhubs/notification-hubs/src/utils/constants.ts
+++ b/sdk/notificationhubs/notification-hubs/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0";
+export const SDK_VERSION: string = "1.0.0-beta.9";
 
 export const JSON_CONTENT_TYPE = "application/json;charset=utf-8";
 export const XML_CONTENT_TYPE = "application/xml";

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -217,7 +217,7 @@ const XIAOMI_REGISTRATION = `<?xml version="1.0" encoding="utf-8"?>
 const XIAOMI_TEMPLATE_REGISTRATION = `<?xml version="1.0" encoding="utf-8"?>
 <entry xmlns="http://www.w3.org/2005/Atom">
     <content type="application/xml">
-        <XiaomiemplateRegistrationDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+        <XiaomiTemplateRegistrationDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
             <Tags>myTag,myOtherTag</Tags>
             <XiaomiRegistrationId>{Xiaomi Registration Id}</XiaomiRegistrationId>
             <RegistrationId>{Registration Id}</RegistrationId> 
@@ -413,7 +413,7 @@ describe("parseRegistrationEntry", () => {
       XIAOMI_REGISTRATION
     )) as XiaomiRegistrationDescription;
 
-    assert.equal(registration.kind, "Adm");
+    assert.equal(registration.kind, "Xiaomi");
     assert.equal(registration.registrationId, "{Registration Id}");
     assert.equal(registration.xiaomiRegistrationId, "{Xiaomi Registration Id}");
     assert.deepEqual(registration.tags, ["myTag", "myOtherTag"]);
@@ -424,7 +424,7 @@ describe("parseRegistrationEntry", () => {
       XIAOMI_TEMPLATE_REGISTRATION
     )) as XiaomiTemplateRegistrationDescription;
 
-    assert.equal(registration.kind, "AdmTemplate");
+    assert.equal(registration.kind, "XiaomiTemplate");
     assert.equal(registration.registrationId, "{Registration Id}");
     assert.equal(registration.xiaomiRegistrationId, "{Xiaomi Registration Id}");
     assert.deepEqual(registration.tags, ["myTag", "myOtherTag"]);

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -823,7 +823,7 @@ describe("serializeRegistrationDescription", () => {
     assert.isTrue(
       xml.indexOf("<BodyTemplate><![CDATA[{Template for the body}]]></BodyTemplate>") !== -1
     );
-    assert.isTrue(xml.indexOf("</AdmTemplateRegistrationDescription>") !== -1);
+    assert.isTrue(xml.indexOf("</XiaomiTemplateRegistrationDescription>") !== -1);
   });
 
   it("should serialize an WindowsRegistrationDescription", () => {

--- a/sdk/notificationhubs/notification-hubs/test/public/unit/installation.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/unit/installation.spec.ts
@@ -7,6 +7,7 @@ import {
   createBaiduInstallation,
   createBrowserInstallation,
   createFcmLegacyInstallation,
+  createXiaomiInstallation,
   createWindowsInstallation,
 } from "../../../src/models/installation.js";
 import { assert } from "@azure/test-utils";
@@ -82,6 +83,19 @@ describe("createFcmLegacyInstallation", () => {
     assert.equal(installation.installationId, "abc123");
     assert.equal(installation.pushChannel, "zxy321");
     assert.equal(installation.platform, "gcm");
+  });
+});
+
+describe("createXiaomiInstallation", () => {
+  it("should set the default properties", () => {
+    const installation = createXiaomiInstallation({
+      installationId: "abc123",
+      pushChannel: "zxy321",
+    });
+
+    assert.equal(installation.installationId, "abc123");
+    assert.equal(installation.pushChannel, "zxy321");
+    assert.equal(installation.platform, "xiaomi");
   });
 });
 

--- a/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
@@ -9,6 +9,7 @@ import {
   createBrowserNotification,
   createFcmLegacyNotification,
   createTemplateNotification,
+  createXiaomiNotification,
   createWindowsBadgeNotification,
   createWindowsRawNotification,
   createWindowsTileNotification,
@@ -85,6 +86,18 @@ describe("createTemplateNotification", () => {
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
     assert.equal(notification.platform, "template");
     assert.equal(notification.body, `{"title":"(Hello title)","body":"Hello"}`);
+  });
+});
+
+describe("createXiaomiNotification", () => {
+  it("should create a Xiaomi message with defaults", () => {
+    const notification = createXiaomiNotification({
+      body: `{"data":{"message":"Hello}}`,
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "xiaomi");
+    assert.equal(notification.body, `{"data":{"message":"Hello}}`);
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Adds Xiaomi support for Track 2 SDKs with registration, installation, send and send outcome operations.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

yes

### Provide a list of related PRs _(if any)_

- https://github.com/Azure/azure-notificationhubs-dotnet/pull/261
- https://github.com/Azure/azure-notificationhubs-dotnet/pull/260
- https://github.com/Azure/azure-notificationhubs-dotnet/pull/259

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
