### PR TITLE
[ServiceBus] when batch-receiving add credit when needed

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue of over-adding credits when receiving messages in a batch [PR #25185](https://github.com/Azure/azure-sdk-for-js/pull/25185)
+
 ### Other Changes
 
 - upgrade dependency `rhea-promise` version to `^3.0.0`.

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -517,15 +517,18 @@ export class BatchingReceiverLite {
       reject(err);
     }, args.abortSignal);
 
-    logger.verbose(
-      `${loggingPrefix} Adding credit for receiving ${args.maxMessageCount} messages.`
-    );
-
     // By adding credit here, we let the service know that at max we can handle `maxMessageCount`
     // number of messages concurrently. We will return the user an array of messages that can
     // be of size upto maxMessageCount. Then the user needs to accordingly dispose
     // (complete/abandon/defer/deadletter) the messages from the array.
-    receiver.addCredit(args.maxMessageCount);
+    const creditToAdd = args.maxMessageCount - receiver.credit;
+    logger.verbose(
+      `${loggingPrefix} Ensure enough credit for receiving ${args.maxMessageCount} messages. Current: ${receiver.credit}.  To add: ${creditToAdd}.`
+    );
+
+    if (creditToAdd > 0) {
+      receiver.addCredit(creditToAdd);
+    }
 
     logger.verbose(
       `${loggingPrefix} Setting the wait timer for ${args.maxWaitTimeInMs} milliseconds.`

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -518,7 +518,6 @@ export class BatchingReceiverLite {
         // If a drain is already in process and we cancel, the link state may be out of sync
         // with remote. Reset the link so that we will have fresh start.
         receiver.close();
-        return;
       }
       reject(err);
     }, args.abortSignal);

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -671,7 +671,6 @@ describe("BatchingReceiver unit tests", () => {
         2,
         "No messages received, nothing drained, should still have enough credits."
       );
-
     });
 
     it("batchingReceiverLite.close() (ie, no error) just shuts down the current operation with no error", async () => {


### PR DESCRIPTION
instead of always adding credit of `maxMessageCount`. Otherwise, in the case of user aborting the call then re-receive, we keep adding excessive credits.
