### PR TITLE
[Communication] PhoneNumbers - Simplify status code assertions.

### DIFF
--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -7,6 +7,7 @@ import { assert } from "chai";
 import { Context } from "mocha";
 import { PhoneNumbersClient, SearchAvailablePhoneNumbersRequest } from "../../src";
 import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
+import { isClientErrorStatusCode } from "./utils/statusCodeHelpers";
 
 matrix([[true, false]], async function (useAad) {
   describe(`PhoneNumbersClient - lro - search${useAad ? " [AAD]" : ""}`, function () {
@@ -65,8 +66,7 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginSearchAvailablePhoneNumbers(invalidSearchRequest);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        // TODO: Re-enable when service is fixed to return proper error code
-        assert.equal(error.statusCode, 400);
+        assert.isTrue(isClientErrorStatusCode(error.statusCode));
         return;
       }
 

--- a/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.search.spec.ts
@@ -66,7 +66,10 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginSearchAvailablePhoneNumbers(invalidSearchRequest);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        assert.isTrue(isClientErrorStatusCode(error.statusCode));
+        assert.isTrue(
+          isClientErrorStatusCode(error.statusCode),
+          `Status code ${error.statusCode} does not indicate client error.`
+        );
         return;
       }
 

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -8,6 +8,7 @@ import { Context } from "mocha";
 import { PhoneNumberCapabilitiesRequest, PhoneNumbersClient } from "../../src";
 import { createRecordedClient, createRecordedClientWithToken } from "./utils/recordedClient";
 import { getPhoneNumber } from "./utils/testPhoneNumber";
+import { isClientErrorStatusCode } from "./utils/statusCodeHelpers";
 
 matrix([[true, false]], async function (useAad) {
   describe(`PhoneNumbersClient - lro - update${useAad ? " [AAD]" : ""}`, function () {
@@ -56,7 +57,7 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginUpdatePhoneNumberCapabilities(fakeNumber, update);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        assert.equal(error.statusCode, 404);
+        assert.isTrue(isClientErrorStatusCode(error.statusCode));
         return;
       }
 
@@ -69,7 +70,7 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginUpdatePhoneNumberCapabilities(fakeNumber, update);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        assert.equal(error.statusCode, 404);
+        assert.isTrue(isClientErrorStatusCode(error.statusCode));
         return;
       }
 

--- a/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/lro.update.spec.ts
@@ -57,7 +57,10 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginUpdatePhoneNumberCapabilities(fakeNumber, update);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        assert.isTrue(isClientErrorStatusCode(error.statusCode));
+        assert.isTrue(
+          isClientErrorStatusCode(error.statusCode),
+          `Status code ${error.statusCode} does not indicate client error.`
+        );
         return;
       }
 
@@ -70,7 +73,10 @@ matrix([[true, false]], async function (useAad) {
         const searchPoller = await client.beginUpdatePhoneNumberCapabilities(fakeNumber, update);
         await searchPoller.pollUntilDone();
       } catch (error: any) {
-        assert.isTrue(isClientErrorStatusCode(error.statusCode));
+        assert.isTrue(
+          isClientErrorStatusCode(error.statusCode),
+          `Status code ${error.statusCode} does not indicate client error.`
+        );
         return;
       }
 

--- a/sdk/communication/communication-phone-numbers/test/public/utils/statusCodeHelpers.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/statusCodeHelpers.ts
@@ -2,5 +2,5 @@
 // Licensed under the MIT license.
 
 export function isClientErrorStatusCode(statusCode: number): boolean {
-    return statusCode >= 400 && statusCode < 500;
+  return statusCode >= 400 && statusCode < 500;
 }

--- a/sdk/communication/communication-phone-numbers/test/public/utils/statusCodeHelpers.ts
+++ b/sdk/communication/communication-phone-numbers/test/public/utils/statusCodeHelpers.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export function isClientErrorStatusCode(statusCode: number): boolean {
+    return statusCode >= 400 && statusCode < 500;
+}


### PR DESCRIPTION
Due to a small backend change, tests that validate operations on unauthorized or invalid phone numbers now return status code 403, as opposed to 400 or 404 previously. To simplify the code of the test, the assertion now checks that the request has been rejected due to a client error, which is validated by checking if the status code falls under the 4xx bucket.

While it should be enough to validate that the operation itself fails, the check for client error was added to ensure that the request is indeed being rejected by the server instead of it failing due to another unrelated reason, which would usually be represented by a 5XX error.