### PR TITLE
Fix url appending logic

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.7.3 (Unreleased)
+## 1.7.3 (2023-03-10)
 
 ### Features Added
 

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 1.7.3 (2023-03-10)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
-### Other Changes
+- Fix an appended query param issue when the query key is encoded in returned link.
 
 ## 1.7.2 (2023-02-23)
 

--- a/sdk/core/core-client/src/urlHelpers.ts
+++ b/sdk/core/core-client/src/urlHelpers.ts
@@ -271,7 +271,7 @@ export function appendQueryParams(
   const combinedParams = simpleParseQueryParams(parsedUrl.search);
 
   for (const [name, value] of queryParams) {
-    const existingValue = combinedParams.get(name);
+    const existingValue = combinedParams.get(name) ?? combinedParams.get(encodeURIComponent(name));
     if (Array.isArray(existingValue)) {
       if (Array.isArray(value)) {
         existingValue.push(...value);

--- a/sdk/core/core-client/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client/test/urlHelpers.spec.ts
@@ -253,4 +253,18 @@ describe("getRequestUrl", function () {
       "https://management.azure.com/subscriptions/subscription-id/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01"
     );
   });
+
+  it("should NOT append query param when the query key is the same but one is encoded, the other is not", function () {
+    const url: string =
+      "https://management.azure.com/subscriptions/subscription-id/resources?api-version=2021-04-01&%24filter=ResourceType+eq+%27Microsoft.OperationsManagement%2fsolutions%27&%24top=1";
+
+    const queryParams: Map<string, string | string[]> = new Map<string, string | string[]>();
+    queryParams.set("$filter", "ResourceType+eq+%27Microsoft.OperationsManagement%2fsolutions%27");
+
+    const res: string = appendQueryParams(url, queryParams, new Set<string>(), true);
+    assert.strictEqual(
+      res,
+      "https://management.azure.com/subscriptions/subscription-id/resources?api-version=2021-04-01&%24filter=ResourceType+eq+%27Microsoft.OperationsManagement%2fsolutions%27&%24top=1"
+    );
+  });
 });


### PR DESCRIPTION
Recently we received an [ICM issue](https://portal.microsofticm.com/imp/v3/incidents/details/370060418/home). After investigating we found when we sent the next page request we would append the `$filter` twice. This is because we compare the search param without considering the encoding. And we don't know that the `$filter` and `%24filter` are the same filter.

https://management.azure.com/subscriptions/subscription-id/resources?api-version=2021-04-01&%24filter=ResourceType+eq+%27Microsoft.OperationsManagement%2fsolutions%27&%24top=1&%24skiptoken=Reacted

In this fix we include the both to do comparation.