### PR TITLE
[notification hubs] Updating to README snippets

### DIFF
--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -51,21 +51,7 @@ Once created, the Notification Hub can be configured using the [Azure Portal or 
 
 This SDK for JavaScript offers two ways of interacting with Azure Notification Hubs, either through the class-based approach, or with a modular design approach.  The class-based approach is consistent across all packages to create a client and then interact with the methods on the client.
 
-```typescript
-import { 
-  NotificationHubsClient,
-  createAppleInstallation 
-} from "@azure/notification-hubs";
-
-const client = new NotificationHubsClient("<connection string>", "<hub name>");
-
-const installation = createAppleInstallation({
-  installationId: "<installation-id>",
-  pushChannel: "<push-channel>",
-  tags: ["likes_javascript"],
-});
-
-const result = await client.createOrUpdateInstallation(installation);
+```typescript snippet:ClassicalImportingClient
 ```
 
 The modular approach allows the developer to pick and choose which functions to import as each method is exposed individually.  This approach uses subpath-exports with ES-Modules to expose the methods via direct imports.  With the individual exports, this creates a better tree-shaking experience and smaller bundle sizes that the developer can take advantage of.  
@@ -79,19 +65,7 @@ The following subpaths are exposed:
 
 The above code snippet then becomes the following:
 
-```typescript
-import { createClientContext, createOrUpdateInstallation } from "@azure/notification-hubs/api";
-import { createAppleInstallation } from "@azure/notification-hubs/models";
-
-const context = createClientContext("<connection string>", "<hub name>");
-
-const installation = createAppleInstallation({
-  installationId: "<installation-id>",
-  pushChannel: "<push-channel>",
-  tags: ["likes_javascript"],
-});
-
-const result = await createOrUpdateInstallation(context, installation);
+```typescript snippet:ModularImportingClient
 ```
 
 ### Authenticate the client
@@ -102,18 +76,12 @@ Listen allows for a client to register itself via the Registration and Installat
 
 A new `NotificationHubsClient` client can be created using the constructor with the connection string and Notification Hub name.
 
-```typescript
-import { NotificationHubsClient } from "@azure/notification-hubs";
-
-const client = new NotificationHubsClient("<connection string>", "<hub name>");
+```typescript snippet:ClassicalConstructor
 ```
 
 Using the modular approach, the `createClientContext` can be imported via the `"@azure/notification-hubs/api"` subpath.
 
-```typescript
-import { createClientContext } from "@azure/notification-hubs/api";
-
-const context = createClientContext("<connection string>", "<hub name>");
+```typescript snippet:ModularConstructor
 ```
 
 ## Key concepts

--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -52,6 +52,20 @@ Once created, the Notification Hub can be configured using the [Azure Portal or 
 This SDK for JavaScript offers two ways of interacting with Azure Notification Hubs, either through the class-based approach, or with a modular design approach.  The class-based approach is consistent across all packages to create a client and then interact with the methods on the client.
 
 ```typescript snippet:ClassicalImportingClient
+import { NotificationHubsClient, createAppleInstallation } from "@azure/notification-hubs";
+
+const connectionString = "<connection string>";
+const hubName = "<hub name>";
+
+const client = new NotificationHubsClient(connectionString, hubName);
+
+const installation = createAppleInstallation({
+  installationId: "<installation-id>",
+  pushChannel: "<push-channel>",
+  tags: ["likes_javascript"],
+});
+
+const result = await client.createOrUpdateInstallation(installation);
 ```
 
 The modular approach allows the developer to pick and choose which functions to import as each method is exposed individually.  This approach uses subpath-exports with ES-Modules to expose the methods via direct imports.  With the individual exports, this creates a better tree-shaking experience and smaller bundle sizes that the developer can take advantage of.  
@@ -66,6 +80,20 @@ The following subpaths are exposed:
 The above code snippet then becomes the following:
 
 ```typescript snippet:ModularImportingClient
+import { createClientContext, createOrUpdateInstallation } from "@azure/notification-hubs/api";
+
+const connectionString = "<connection string>";
+const hubName = "<hub name>";
+
+const context = createClientContext(connectionString, hubName);
+
+const installation = createAppleInstallationModular({
+  installationId: "<installation-id>",
+  pushChannel: "<push-channel>",
+  tags: ["likes_javascript"],
+});
+
+const result = await createOrUpdateInstallation(context, installation);
 ```
 
 ### Authenticate the client
@@ -77,11 +105,23 @@ Listen allows for a client to register itself via the Registration and Installat
 A new `NotificationHubsClient` client can be created using the constructor with the connection string and Notification Hub name.
 
 ```typescript snippet:ClassicalConstructor
+import { NotificationHubsClient } from "@azure/notification-hubs";
+
+const connectionString = "<connection string>";
+const hubName = "<hub name>";
+
+const client = new NotificationHubsClient(connectionString, hubName);
 ```
 
 Using the modular approach, the `createClientContext` can be imported via the `"@azure/notification-hubs/api"` subpath.
 
 ```typescript snippet:ModularConstructor
+import { createClientContext } from "@azure/notification-hubs/api";
+
+const connectionString = "<connection string>";
+const hubName = "<hub name>";
+
+const context = createClientContext(connectionString, hubName);
 ```
 
 ## Key concepts

--- a/sdk/notificationhubs/notification-hubs/test/snippets.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/snippets.spec.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { NotificationHubsClient, createAppleInstallation } from "@azure/notification-hubs";
+import { createClientContext, createOrUpdateInstallation } from "@azure/notification-hubs/api";
+import { createAppleInstallation as createAppleInstallationModular } from "@azure/notification-hubs/models";
+
+describe("snippets", () => {
+  it("ClassicalImportingClient", async () => {
+    const connectionString =
+      process.env.NOTIFICATIONHUBS_CONNECTION_STRING ?? "<connection string>";
+    const hubName = process.env.NOTIFICATION_HUB_NAME ?? "<hub name>";
+
+    const client = new NotificationHubsClient(connectionString, hubName);
+
+    const installation = createAppleInstallation({
+      installationId: "<installation-id>",
+      pushChannel: "<push-channel>",
+      tags: ["likes_javascript"],
+    });
+
+    // @ts-ignore
+    const result = await client.createOrUpdateInstallation(installation);
+  });
+
+  it("ModularImportingClient", async () => {
+    const connectionString =
+      process.env.NOTIFICATIONHUBS_CONNECTION_STRING ?? "<connection string>";
+    const hubName = process.env.NOTIFICATION_HUB_NAME ?? "<hub name>";
+
+    const context = createClientContext(connectionString, hubName);
+
+    const installation = createAppleInstallationModular({
+      installationId: "<installation-id>",
+      pushChannel: "<push-channel>",
+      tags: ["likes_javascript"],
+    });
+
+    // @ts-ignore
+    const result = await createOrUpdateInstallation(context, installation);
+  });
+
+  it("ClassicalConstructor", async () => {
+    const connectionString =
+      process.env.NOTIFICATIONHUBS_CONNECTION_STRING ?? "<connection string>";
+    const hubName = process.env.NOTIFICATION_HUB_NAME ?? "<hub name>";
+
+    // @ts-ignore
+    const client = new NotificationHubsClient(connectionString, hubName);
+  });
+
+  it("ModularConstructor", async () => {
+    const connectionString =
+      process.env.NOTIFICATIONHUBS_CONNECTION_STRING ?? "<connection string>";
+    const hubName = process.env.NOTIFICATION_HUB_NAME ?? "<hub name>";
+
+    // @ts-ignore
+    const context = createClientContext(connectionString, hubName);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR


### Describe the problem that is addressed by this PR

This updates Azure Notification Hubs to use README and JSDoc snippets to extract the snippets from the unit tests.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
