### PR TITLE
Update bearerTokenAuthenticationPolicy.ts

### DIFF
--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -170,7 +170,8 @@ export function bearerTokenAuthenticationPolicy(
      * - Retrieve a token with the challenge information, then re-send the request.
      */
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!request.url.toLowerCase().startsWith("https://")) {
+      const lowerCaseUrl = request.url.toLowerCase();
+      if (!lowerCaseUrl.startsWith("https://") && !lowerCaseUrl.startsWith("http://localhost")) {
         throw new Error(
           "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
         );


### PR DESCRIPTION
This adds the ability to send tokens to a URL prefixed with "http://localhost"

### Packages impacted by this PR

`@azure/core-rest-pipeline`

### Issues associated with this PR

This PR fixes #25206

### Describe the problem that is addressed by this PR

Users are unable to issue requests containing a `Bearer` token (in cleartext) to their developer servers running locally.
See the description of the referenced issue for more details.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

- Simply removing the check entirely, since the calling code controls the `url` via the `endpoint` and would know the connection is clear-text if passing a URL prefixed `http://`.
- A boolean option to allow sending tokens over an insecure connection was already attempted but later reverted.
- An option with a callback could be used to provided more granular (per request) control.
- A generated autorest typescript client could avoid calling into this code and bring its own implementation of this policy.

The suggestion seem to be the most pragmatic, given the `allowInsecureConnection` option was reverted and this seemed like the least intrusive fix for my immediate issue.

### Are there test cases added in this PR? _(If not, why?)_

- I would like to get some early feedback on the feasibility of this PR getting merged before investing the time to write tests for this.

### Provide a list of related PRs _(if any)_

- #17517
- #17749

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
