### PR TITLE
Update event hubs to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -345,7 +345,7 @@ testWithServiceTypes((serviceVersion) => {
           await loopUntil({
             maxTimes: 10,
             name: "Wait for subscription1 to read from all partitions",
-            timeBetweenRunsMs: 1000,
+            timeBetweenRunsMs: 5000,
             async until() {
               // wait until we've seen processEvents invoked for each partition.
               return (
@@ -376,7 +376,7 @@ testWithServiceTypes((serviceVersion) => {
           await loopUntil({
             maxTimes: 10,
             name: "Wait for subscription2 to read from all partitions and subscription1 to invoke close handlers",
-            timeBetweenRunsMs: 1000,
+            timeBetweenRunsMs: 5000,
             async until() {
               const sub1CloseHandlersCalled = Boolean(
                 partitionIds.filter((id) => {
@@ -393,7 +393,7 @@ testWithServiceTypes((serviceVersion) => {
           await loopUntil({
             maxTimes: 10,
             name: "Wait for subscription1 to recover",
-            timeBetweenRunsMs: 1000,
+            timeBetweenRunsMs: 5000,
             async until() {
               // wait until we've seen an additional processEvent for each partition.
               return (

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -6,8 +6,19 @@ stages:
       PackageName: "@azure/event-hubs"
       ServiceDirectory: eventhub
       Clouds: 'Public,Canary'
+      TimeoutInMinutes: 90
+      SupportedClouds: 'Public,UsGov,China'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          Location: 'usgovarizona'
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          Location: 'chinaeast'
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_ID: $(EVENTHUB_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(EVENTHUB_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(EVENTHUB_TENANT_ID)
         AZURE_LOG_LEVEL: info


### PR DESCRIPTION
1.These changes enable event hubs to run live tests against `AzureUsGovernment` and `AzureChina` clouds. The sovereign cloud live tests will be green with the changes.

**2.File changed description:**

- eventHubConsumerClient.spec.ts : Increase the waiting time of `loopUntil`. The reason for this is to fix the timeout problem on the `China` cloud.
![image](https://user-images.githubusercontent.com/81678720/225217276-39ff078e-7dcb-44af-808b-4577656a7a09.png)

- test.yml : enable `UsGov` and `China` clouds.
![image](https://user-images.githubusercontent.com/81678720/225217413-806387d2-f877-4260-b5dd-f8b03b14df90.png)

**3.Pipeline results:**
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2630890&view=results

@benbp, @hector-norza, @joheredi, @ronniegeraghty, @jsquire, @deyaaeldeen for notification.