### PR TITLE
[amqp messaging] bump dependency @azure/core-amqp version to ^3.3.0

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^3.1.0",
+    "@azure/core-amqp": "^3.3.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.2.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^3.1.0",
+    "@azure/core-amqp": "^3.3.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",


### PR DESCRIPTION
to ensure v3 rhea and rhea-promise transitive dependencies.
