### PR TITLE
[ACR] Update samples with recent changes

### DIFF
--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -285,7 +285,7 @@ export interface OciImageManifest {
     annotations?: OciAnnotations;
     config: OciDescriptor;
     layers: OciDescriptor[];
-    schemaVersion: number;
+    schemaVersion?: number;
 }
 
 // @public

--- a/sdk/containerregistry/container-registry/samples-dev/uploadCustomManifest.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadCustomManifest.ts
@@ -9,7 +9,6 @@
 import { ContainerRegistryBlobClient } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -25,7 +24,7 @@ async function main() {
 
   const mediaType = "application/vnd.docker.distribution.manifest.list.v2+json";
 
-  const manifest = Readable.from(
+  const manifest = Buffer.from(
     JSON.stringify({
       schemaVersion: 2,
       mediaType,

--- a/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
@@ -26,10 +26,9 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
-    schemaVersion: 2,
     config: {
       digest: configDigest,
       sizeInBytes: configSize,

--- a/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
@@ -23,22 +23,22 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(config);
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(layer);
+  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,
     config: {
-      digest: uploadConfigResult.digest,
-      sizeInBytes: config.byteLength,
+      digest: configDigest,
+      sizeInBytes: configSize,
       mediaType: "application/vnd.oci.image.config.v1+json",
     },
     layers: [
       {
-        digest: uploadLayerResult.digest,
-        sizeInBytes: layer.byteLength,
+        digest: layerDigest,
+        sizeInBytes: layerSize,
         mediaType: "application/vnd.oci.image.layer.v1.tar",
       },
     ],

--- a/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadImage.ts
@@ -9,7 +9,6 @@
 import { ContainerRegistryBlobClient, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -24,10 +23,10 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(Readable.from(config));
+  const uploadConfigResult = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(Readable.from(layer));
+  const uploadLayerResult = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,

--- a/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
@@ -39,7 +39,6 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest: OciImageManifest = {
-    schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,

--- a/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
@@ -9,7 +9,6 @@
 import { ContainerRegistryBlobClient, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -24,7 +23,7 @@ async function main() {
   );
 
   const layer = Buffer.from("Hello, world");
-  const { digest: layerDigest } = await client.uploadBlob(Readable.from(layer));
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const config = Buffer.from(
     JSON.stringify({
@@ -37,20 +36,20 @@ async function main() {
     })
   );
 
-  const { digest: configDigest } = await client.uploadBlob(Readable.from(config));
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,
-      sizeInBytes: config.byteLength,
+      sizeInBytes: configSize,
     },
     layers: [
       {
         mediaType: "application/vnd.oci.image.layer.v1.tar",
         digest: layerDigest,
-        sizeInBytes: layer.byteLength,
+        sizeInBytes: layerSize,
         annotations: {
           title: "artifact.txt",
         },

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadCustomManifest.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadCustomManifest.js
@@ -7,9 +7,7 @@
 
 const { ContainerRegistryBlobClient } = require("@azure/container-registry");
 const { DefaultAzureCredential } = require("@azure/identity");
-const dotenv = require("dotenv");
-const { Readable } = require("stream");
-dotenv.config();
+require("dotenv").config();
 
 async function main() {
   // endpoint should be in the form of "https://myregistryname.azurecr.io"
@@ -24,7 +22,7 @@ async function main() {
 
   const mediaType = "application/vnd.docker.distribution.manifest.list.v2+json";
 
-  const manifest = Readable.from(
+  const manifest = Buffer.from(
     JSON.stringify({
       schemaVersion: 2,
       mediaType,

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
@@ -7,9 +7,7 @@
 
 const { ContainerRegistryBlobClient } = require("@azure/container-registry");
 const { DefaultAzureCredential } = require("@azure/identity");
-const dotenv = require("dotenv");
-const { Readable } = require("stream");
-dotenv.config();
+require("dotenv").config();
 
 async function main() {
   // endpoint should be in the form of "https://myregistryname.azurecr.io"
@@ -23,22 +21,22 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(Readable.from(config));
+  const uploadConfigResult = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(Readable.from(layer));
+  const uploadLayerResult = await client.uploadBlob(layer);
 
   const manifest = {
     schemaVersion: 2,
     config: {
       digest: uploadConfigResult.digest,
-      size: config.byteLength,
+      sizeInBytes: config.byteLength,
       mediaType: "application/vnd.oci.image.config.v1+json",
     },
     layers: [
       {
         digest: uploadLayerResult.digest,
-        size: layer.byteLength,
+        sizeInBytes: layer.byteLength,
         mediaType: "application/vnd.oci.image.layer.v1.tar",
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
@@ -21,22 +21,22 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(config);
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(layer);
+  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest = {
     schemaVersion: 2,
     config: {
-      digest: uploadConfigResult.digest,
-      sizeInBytes: config.byteLength,
+      digest: configDigest,
+      sizeInBytes: configSize,
       mediaType: "application/vnd.oci.image.config.v1+json",
     },
     layers: [
       {
-        digest: uploadLayerResult.digest,
-        sizeInBytes: layer.byteLength,
+        digest: layerDigest,
+        sizeInBytes: layerSize,
         mediaType: "application/vnd.oci.image.layer.v1.tar",
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadImage.js
@@ -24,10 +24,9 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest = {
-    schemaVersion: 2,
     config: {
       digest: configDigest,
       sizeInBytes: configSize,

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadManifest.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadManifest.js
@@ -7,9 +7,7 @@
 
 const { ContainerRegistryBlobClient } = require("@azure/container-registry");
 const { DefaultAzureCredential } = require("@azure/identity");
-const dotenv = require("dotenv");
-const { Readable } = require("stream");
-dotenv.config();
+require("dotenv").config();
 
 async function main() {
   // endpoint should be in the form of "https://myregistryname.azurecr.io"
@@ -23,7 +21,7 @@ async function main() {
   );
 
   const layer = Buffer.from("Hello, world");
-  const { digest: layerDigest } = await client.uploadBlob(Readable.from(layer));
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const config = Buffer.from(
     JSON.stringify({
@@ -36,20 +34,20 @@ async function main() {
     })
   );
 
-  const { digest: configDigest } = await client.uploadBlob(Readable.from(config));
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest = {
     schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,
-      size: config.byteLength,
+      sizeInBytes: configSize,
     },
     layers: [
       {
         mediaType: "application/vnd.oci.image.layer.v1.tar",
         digest: layerDigest,
-        size: layer.byteLength,
+        sizeInBytes: layerSize,
         annotations: {
           title: "artifact.txt",
         },

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadManifest.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/uploadManifest.js
@@ -37,7 +37,6 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest = {
-    schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadCustomManifest.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadCustomManifest.ts
@@ -8,7 +8,6 @@
 import { ContainerRegistryBlobClient } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -24,7 +23,7 @@ async function main() {
 
   const mediaType = "application/vnd.docker.distribution.manifest.list.v2+json";
 
-  const manifest = Readable.from(
+  const manifest = Buffer.from(
     JSON.stringify({
       schemaVersion: 2,
       mediaType,

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
@@ -8,7 +8,6 @@
 import { ContainerRegistryBlobClient, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -23,22 +22,22 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(Readable.from(config));
+  const uploadConfigResult = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(Readable.from(layer));
+  const uploadLayerResult = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,
     config: {
       digest: uploadConfigResult.digest,
-      size: config.byteLength,
+      sizeInBytes: config.byteLength,
       mediaType: "application/vnd.oci.image.config.v1+json",
     },
     layers: [
       {
         digest: uploadLayerResult.digest,
-        size: layer.byteLength,
+        sizeInBytes: layer.byteLength,
         mediaType: "application/vnd.oci.image.layer.v1.tar",
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
@@ -25,10 +25,9 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
-    schemaVersion: 2,
     config: {
       digest: configDigest,
       sizeInBytes: configSize,

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadImage.ts
@@ -22,22 +22,22 @@ async function main() {
   );
 
   const config = Buffer.from("Sample config");
-  const uploadConfigResult = await client.uploadBlob(config);
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const layer = Buffer.from("Sample layer");
-  const uploadLayerResult = await client.uploadBlob(layer);
+  const { digets: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,
     config: {
-      digest: uploadConfigResult.digest,
-      sizeInBytes: config.byteLength,
+      digest: configDigest,
+      sizeInBytes: configSize,
       mediaType: "application/vnd.oci.image.config.v1+json",
     },
     layers: [
       {
-        digest: uploadLayerResult.digest,
-        sizeInBytes: layer.byteLength,
+        digest: layerDigest,
+        sizeInBytes: layerSize,
         mediaType: "application/vnd.oci.image.layer.v1.tar",
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadManifest.ts
@@ -8,7 +8,6 @@
 import { ContainerRegistryBlobClient, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
-import { Readable } from "stream";
 dotenv.config();
 
 async function main() {
@@ -23,7 +22,7 @@ async function main() {
   );
 
   const layer = Buffer.from("Hello, world");
-  const { digest: layerDigest } = await client.uploadBlob(Readable.from(layer));
+  const { digest: layerDigest, sizeInBytes: layerSize } = await client.uploadBlob(layer);
 
   const config = Buffer.from(
     JSON.stringify({
@@ -36,20 +35,20 @@ async function main() {
     })
   );
 
-  const { digest: configDigest } = await client.uploadBlob(Readable.from(config));
+  const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest: OciImageManifest = {
     schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,
-      size: config.byteLength,
+      sizeInBytes: configSize,
     },
     layers: [
       {
         mediaType: "application/vnd.oci.image.layer.v1.tar",
         digest: layerDigest,
-        size: layer.byteLength,
+        sizeInBytes: layerSize,
         annotations: {
           title: "artifact.txt",
         },

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/uploadManifest.ts
@@ -38,7 +38,6 @@ async function main() {
   const { digest: configDigest, sizeInBytes: configSize } = await client.uploadBlob(config);
 
   const manifest: OciImageManifest = {
-    schemaVersion: 2,
     config: {
       mediaType: "application/vnd.oci.image.config.v1+json",
       digest: configDigest,

--- a/sdk/containerregistry/container-registry/src/blob/models.ts
+++ b/sdk/containerregistry/container-registry/src/blob/models.ts
@@ -110,7 +110,7 @@ export interface OciDescriptor {
 /** Type representing an OCI image manifest (manifest of media type "application/vnd.oci.image.manifest.v1+json"). */
 export interface OciImageManifest {
   /** Schema version */
-  schemaVersion: number;
+  schemaVersion?: number;
   /** V2 image config descriptor */
   config: OciDescriptor;
   /** List of V2 image layer information */


### PR DESCRIPTION
- Remove `Readable.from` since we have a `Buffer` overload now
- Use new `sizeInBytes` in upload manifest sample
- Fix custom manifest upload sample
