### PR TITLE
Update auxiliary auth toke policy

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.10.3 (Unreleased)
+## 1.11.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added AuxiliaryAuthenticationPolicy
 
 ## 1.10.2 (2023-03-02)
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -49,6 +49,19 @@ export interface AuthorizeRequestOptions {
 }
 
 // @public
+export function auxiliaryAuthenticationPolicy(options: AuxiliaryAuthenticationPolicyNameOptions): PipelinePolicy;
+
+// @public
+export const auxiliaryAuthenticationPolicyName = "auxiliaryAuthenticationPolicy";
+
+// @public
+export interface AuxiliaryAuthenticationPolicyNameOptions {
+    credentials?: TokenCredential[];
+    logger?: AzureLogger;
+    scopes: string | string[];
+}
+
+// @public
 export function bearerTokenAuthenticationPolicy(options: BearerTokenAuthenticationPolicyOptions): PipelinePolicy;
 
 // @public

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -87,3 +87,8 @@ export {
   AuthorizeRequestOnChallengeOptions,
 } from "./policies/bearerTokenAuthenticationPolicy";
 export { ndJsonPolicy, ndJsonPolicyName } from "./policies/ndJsonPolicy";
+export {
+  auxiliaryAuthenticationPolicy,
+  AuxiliaryAuthenticationPolicyNameOptions,
+  auxiliaryAuthenticationPolicyName
+} from "./policies/auxiliaryAuthenticationPolicy"

--- a/sdk/core/core-rest-pipeline/src/policies/auxiliaryAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/auxiliaryAuthenticationPolicy.ts
@@ -77,7 +77,7 @@ export function auxiliaryAuthenticationPolicy(
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       if (!request.url.toLowerCase().startsWith("https://")) {
         throw new Error(
-          "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
+          "Auxiliary token authentication is not permitted for non-TLS protected (non-https) URLs."
         );
       }
 

--- a/sdk/core/core-rest-pipeline/src/policies/auxiliaryAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/auxiliaryAuthenticationPolicy.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { AzureLogger } from "@azure/logger";
+import { PipelineRequest, PipelineResponse, SendRequest } from "../interfaces";
+import { PipelinePolicy } from "../pipeline";
+import { createTokenCycler } from "../util/tokenCycler";
+import { logger as coreLogger } from "../log";
+import { AuthorizeRequestOptions } from "./bearerTokenAuthenticationPolicy";
+
+/**
+ * The programmatic identifier of the bearerTokenAuthenticationPolicy.
+ */
+export const auxiliaryAuthenticationPolicyName = "auxiliaryAuthenticationPolicy";
+const AUTHORIZATION_AUXILIARY_HEADER = "x-ms-authorization-auxiliary";
+
+/**
+ * Options to configure the auxiliaryAuthenticationPolicy
+ */
+export interface AuxiliaryAuthenticationPolicyNameOptions {
+  /**
+   * The TokenCredential list that can supply the auxiliary authentication token.
+   */
+  credentials?: TokenCredential[];
+  /**
+   * The scopes for which the auxiliary token applies.
+   */
+  scopes: string | string[];
+  /**
+   * A logger can be sent for debugging purposes.
+   */
+  logger?: AzureLogger;
+}
+
+/**
+ * Default authorize request handler
+ */
+async function defaultAuthorizeRequest(options: AuthorizeRequestOptions): Promise<string | null> {
+  const { scopes, getAccessToken, request } = options;
+  const getTokenOptions: GetTokenOptions = {
+    abortSignal: request.abortSignal,
+    tracingOptions: request.tracingOptions,
+  };
+
+  const accessToken = await getAccessToken(scopes, getTokenOptions);
+
+  if (accessToken) {
+    return accessToken.token;
+  }
+  return null;
+}
+
+function buildAccessTokenCycler(credential: TokenCredential) {
+  return credential
+    ? createTokenCycler(credential /* , options */)
+    : () => Promise.resolve(null);
+}
+
+function formatSingleToken(token: string) {
+  return `Bearer ${token}`;
+}
+
+/**
+ * A policy that can request a token from a TokenCredential implementation and
+ * then apply it to the Authorization header of a request as a Bearer token.
+ */
+export function auxiliaryAuthenticationPolicy(
+  options: AuxiliaryAuthenticationPolicyNameOptions
+): PipelinePolicy {
+  const { credentials, scopes } = options;
+  const logger = options.logger || coreLogger;
+  const tokenCyclerMap = new Map();
+
+  return {
+    name: auxiliaryAuthenticationPolicyName,
+    async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      if (!request.url.toLowerCase().startsWith("https://")) {
+        throw new Error(
+          "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs."
+        );
+      }
+
+      const tokenList: string[] = [];
+      for (const credential of (credentials ?? [])) {
+        if (!tokenCyclerMap.has(credential)) {
+          tokenCyclerMap.set(credential, buildAccessTokenCycler(credential))
+        }
+        const getAccessToken = tokenCyclerMap.get(credential);
+        const singalAccessToken = await defaultAuthorizeRequest({
+          scopes: Array.isArray(scopes) ? scopes : [scopes],
+          request,
+          getAccessToken,
+          logger,
+        });
+        if (singalAccessToken) {
+          tokenList.push(singalAccessToken);
+        }
+      }
+
+      request.headers.set(AUTHORIZATION_AUXILIARY_HEADER, tokenList.map(formatSingleToken).join(","));
+
+      let response: PipelineResponse;
+      let error: Error | undefined;
+      try {
+        response = await next(request);
+      } catch (err: any) {
+        error = err;
+        response = err.response;
+      }
+
+      if (error) {
+        throw error;
+      } else {
+        return response;
+      }
+    },
+  };
+}

--- a/sdk/core/core-rest-pipeline/test/auxiliaryAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/auxiliaryAuthenticationPolicy.spec.ts
@@ -1,0 +1,231 @@
+import { assert } from "chai";
+import * as sinon from "sinon";
+import { AccessToken, TokenCredential } from "@azure/core-auth";
+import {
+  PipelinePolicy,
+  PipelineResponse,
+  SendRequest,
+  auxiliaryAuthenticationPolicy,
+  createHttpHeaders,
+  createPipelineRequest,
+} from "../src";
+import { DEFAULT_CYCLER_OPTIONS } from "../src/util/tokenCycler";
+
+const { refreshWindowInMs: defaultRefreshWindow } = DEFAULT_CYCLER_OPTIONS;
+
+describe("AuxiliaryAuthenticationPolicy", function () {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(Date.now());
+  });
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("correctly adds an Authentication header with the access token", async function () {
+    const mockToken = "token";
+    const tokenScopes = ["scope1", "scope2"];
+    const fakeGetToken = sinon.fake.returns(
+      Promise.resolve({ token: mockToken, expiresOn: new Date() })
+    );
+    const mockCredential: TokenCredential = {
+      getToken: fakeGetToken,
+    };
+
+    const request = createPipelineRequest({ url: "https://example.com" });
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(successResponse);
+
+    const auxiTokenAuthPolicy = createAuxiliaryTokenPolicy(tokenScopes, [mockCredential]);
+    await auxiTokenAuthPolicy.sendRequest(request, next);
+
+    assert(
+      fakeGetToken.calledWith(tokenScopes, {
+        abortSignal: undefined,
+        tracingOptions: undefined,
+      }),
+      "fakeGetToken called incorrectly."
+    );
+    assert.strictEqual(request.headers.get("x-ms-authorization-auxiliary"), `Bearer ${mockToken}`);
+  });
+
+  it("correctly adds an Authentication header with two access tokens", async function () {
+    const mockToken1 = "token1", mockToken2 = "token2";
+    const tokenScopes = ["scope1", "scope2"];
+    const fakeGetToken1 = sinon.fake.returns(
+      Promise.resolve({ token: mockToken1, expiresOn: new Date() })
+    );
+    const fakeGetToken2 = sinon.fake.returns(
+      Promise.resolve({ token: mockToken2, expiresOn: new Date() })
+    );
+    const mockCredential1: TokenCredential = {
+      getToken: fakeGetToken1,
+    };
+    const mockCredential2: TokenCredential = {
+      getToken: fakeGetToken2,
+    };
+
+    const request = createPipelineRequest({ url: "https://example.com" });
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(successResponse);
+
+    const auxiTokenAuthPolicy = createAuxiliaryTokenPolicy(tokenScopes, [mockCredential1, mockCredential2]);
+    await auxiTokenAuthPolicy.sendRequest(request, next);
+
+    assert(
+      fakeGetToken1.calledWith(tokenScopes, {
+        abortSignal: undefined,
+        tracingOptions: undefined,
+      }),
+      "fakeGetToken called incorrectly."
+    );
+    assert.strictEqual(request.headers.get("x-ms-authorization-auxiliary"), `Bearer ${mockToken1},Bearer ${mockToken2}`);
+  });
+
+  it("only refreshes invalid token during the refresh window", async () => {
+    const expireDelayMs = defaultRefreshWindow + 5000;
+    let tokenExpiration = Date.now() + expireDelayMs;
+    const shortCredential = new MockRefreshAzureCredential(tokenExpiration);
+    const longCredential = new MockRefreshAzureCredential(Date.now() + expireDelayMs * 3);
+
+    const request = createPipelineRequest({ url: "https://example.com" });
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(successResponse);
+
+    const policy = createAuxiliaryTokenPolicy("test-scope", [shortCredential, longCredential]);
+
+    // The token is cached and remains cached for a bit.
+    await policy.sendRequest(request, next);
+    await policy.sendRequest(request, next);
+    assert.strictEqual(shortCredential.authCount, 1);
+    assert.strictEqual(longCredential.authCount, 1);
+    assert.strictEqual(request.headers.get("x-ms-authorization-auxiliary"), `Bearer mock-token,Bearer mock-token`);
+
+    // The token will remain cached until tokenExpiration - testTokenRefreshBufferMs, so in (5000 - 1000) milliseconds.
+
+    // For safe measure, we test the token is still cached a second earlier than the forced refresh expectation.
+    clock.tick(expireDelayMs - defaultRefreshWindow - 1000);
+    await policy.sendRequest(request, next);
+    assert.strictEqual(shortCredential.authCount, 1);
+    assert.strictEqual(longCredential.authCount, 1);
+
+    // The new token will last for a few minutes again.
+    tokenExpiration = Date.now() + expireDelayMs;
+    shortCredential.expiresOnTimestamp = tokenExpiration;
+
+    // Now we wait until it expires:
+    clock.tick(expireDelayMs + 1000);
+    await policy.sendRequest(request, next);
+    assert.strictEqual(shortCredential.authCount, 2);
+    assert.strictEqual(longCredential.authCount, 1);
+  });
+
+  it("credential errors should bubble up", async () => {
+    const expireDelayMs = 5000;
+    const startTime = Date.now();
+    const tokenExpiration = startTime + expireDelayMs;
+    const getTokenDelay = 100;
+    const credential = new MockRefreshAzureCredential(tokenExpiration, getTokenDelay, clock);
+
+    const request = createPipelineRequest({ url: "https://example.com" });
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+    next.resolves(successResponse);
+
+    const policy = createAuxiliaryTokenPolicy("test-scope", [credential]);
+
+    credential.shouldThrow = true;
+
+    let error: Error | undefined;
+    try {
+      await policy.sendRequest(request, next);
+    } catch (e: any) {
+      error = e;
+    }
+    assert.equal(error?.message, "Failed to retrieve the token");
+
+    assert.strictEqual(
+      credential.authCount,
+      1,
+      "The first authentication attempt should have happened"
+    );
+  });
+
+  it("throws if the target URI doesn't start with 'https'", async () => {
+    const expireDelayMs = defaultRefreshWindow + 5000;
+    const tokenExpiration = Date.now() + expireDelayMs;
+    const credential = new MockRefreshAzureCredential(tokenExpiration);
+
+    const request = createPipelineRequest({ url: "http://example.com" });
+    const policy = createAuxiliaryTokenPolicy("test-scope", [credential]);
+    const next = sinon.stub<Parameters<SendRequest>, ReturnType<SendRequest>>();
+
+    let error: Error | undefined;
+    try {
+      await policy.sendRequest(request, next);
+    } catch (e: any) {
+      error = e;
+    }
+
+    assert.equal(
+      error?.message,
+      "Auxiliary token authentication is not permitted for non-TLS protected (non-https) URLs."
+    );
+  });
+
+  function createAuxiliaryTokenPolicy(
+    scopes: string | string[],
+    credentials: TokenCredential[]
+  ): PipelinePolicy {
+    return auxiliaryAuthenticationPolicy({
+      scopes,
+      credentials,
+    });
+  }
+});
+
+class MockRefreshAzureCredential implements TokenCredential {
+  public authCount = 0;
+  public shouldThrow: boolean = false;
+
+  constructor(
+    public expiresOnTimestamp: number,
+    public getTokenDelay?: number,
+    public clock?: sinon.SinonFakeTimers
+  ) { }
+
+  public async getToken(): Promise<AccessToken> {
+    this.authCount++;
+
+    if (this.shouldThrow) {
+      throw new Error("Failed to retrieve the token");
+    }
+
+    // Allowing getToken to take a while
+    if (this.getTokenDelay && this.clock) {
+      this.clock.tick(this.getTokenDelay);
+    }
+
+    return { token: "mock-token", expiresOnTimestamp: this.expiresOnTimestamp };
+  }
+}


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-js/issues/20147

Like in Python core [pr](https://github.com/Azure/azure-sdk-for-python/pull/24585), we need to add a new policy temp named as `auxiliaryAuthenticationPolicy`.