### PR TITLE
[ServiceBus] Fix a race condition in generating replyTo and initializing link

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -252,7 +252,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     options: SendManagementRequestOptions = {}
   ): Promise<SendManagementRequestOptions> {
     const retryTimeoutInMs = options.timeoutInMs ?? Constants.defaultOperationTimeoutInMs;
-    return await defaultCancellableLock.acquire(
+    return defaultCancellableLock.acquire(
       this._initLock,
       async () => {
         managementClientLogger.verbose(

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -17,6 +17,7 @@ import {
 import {
   ConditionErrorNameMapper,
   Constants,
+  defaultCancellableLock,
   MessagingError,
   RequestResponseLink,
   SendRequestOptions,
@@ -219,7 +220,10 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
    * Provides the sequence number of the last peeked message.
    */
   private _lastPeekedSequenceNumber: Long = Long.ZERO;
-
+  /**
+   * lock token for init operation
+   */
+  private _initLock: string = generate_uuid();
   /**
    * Instantiates the management client.
    * @param context - The connection context
@@ -239,10 +243,57 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     this._context = context;
   }
 
-  private ensureUniqueReplyToForRequest() {
-    if (!this.isOpen()) {
-      this.replyTo = generate_uuid();
+  /**
+   * initialize link with unique this.replyTo address.
+   * @param options -
+   * @returns updated options bag that has adjusted `timeoutInMs` to account for init time
+   */
+  private async initWithUniqueReplyTo(options: SendManagementRequestOptions = {}): Promise<SendManagementRequestOptions> {
+    const retryTimeoutInMs = options.timeoutInMs ?? Constants.defaultOperationTimeoutInMs;
+    return await defaultCancellableLock.acquire(this._initLock, async () => {
+      managementClientLogger.verbose(`{this._logPrefix} lock acquired for initializing replyTo address and link`);
+      if (!this.isOpen()) {
+        this.replyTo = generate_uuid();
+        managementClientLogger.verbose(`{this._logPrefix} new replyTo address: ${this.replyTo} generated`);
+      }
+    const initOperationStartTime = Date.now();
+    const actionAfterTimeout = (reject: (reason?: any) => void): void => {
+      const desc: string = `The management request with timed out. Please try again later.`;
+      const e: Error = {
+        name: "OperationTimeoutError",
+        message: desc,
+      };
+
+      reject(e);
+    };
+
+    let waitTimer: ReturnType<typeof setTimeout>;
+    // eslint-disable-next-line promise/param-names
+    const operationTimeout = new Promise<void>((_, reject) => {
+      waitTimer = setTimeout(() => actionAfterTimeout(reject), retryTimeoutInMs);
+    });
+    managementClientLogger.verbose(`${this.logPrefix} Acquiring lock to get the management req res link.`);
+
+    try {
+      if (!this.isOpen()) {
+        await Promise.race([this._init(options.abortSignal), operationTimeout]);
+      }
+    } finally {
+      clearTimeout(waitTimer!);
     }
+
+    // time taken by the init operation
+    const timeTakenByInit = Date.now() - initOperationStartTime;
+      return {
+        ...options,
+    // Left over time
+        timeoutInMs: retryTimeoutInMs - timeTakenByInit,
+      }
+
+    }, {
+      abortSignal: options.abortSignal,
+      timeoutInMs: retryTimeoutInMs,
+    });
   }
 
   private async _init(abortSignal?: AbortSignalLike): Promise<void> {
@@ -347,41 +398,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     if (request.message_id === undefined) {
       request.message_id = generate_uuid();
     }
-    const retryTimeoutInMs =
-      sendRequestOptions.timeoutInMs ?? Constants.defaultOperationTimeoutInMs;
-    const initOperationStartTime = Date.now();
-    const actionAfterTimeout = (reject: (reason?: any) => void): void => {
-      const desc: string = `The request with message_id "${request.message_id}" timed out. Please try again later.`;
-      const e: Error = {
-        name: "OperationTimeoutError",
-        message: desc,
-      };
-
-      reject(e);
-    };
-
-    let waitTimer: ReturnType<typeof setTimeout>;
-    // eslint-disable-next-line promise/param-names
-    const operationTimeout = new Promise<void>((_, reject) => {
-      waitTimer = setTimeout(() => actionAfterTimeout(reject), retryTimeoutInMs);
-    });
-    internalLogger.verbose(`${this.logPrefix} Acquiring lock to get the management req res link.`);
 
     try {
-      if (!this.isOpen()) {
-        await Promise.race([this._init(sendRequestOptions?.abortSignal), operationTimeout]);
-      }
-    } finally {
-      clearTimeout(waitTimer!);
-    }
-
-    // time taken by the init operation
-    const timeTakenByInit = Date.now() - initOperationStartTime;
-    // Left over time
-    sendRequestOptions.timeoutInMs = retryTimeoutInMs - timeTakenByInit;
-
-    try {
-      if (!request.message_id) request.message_id = generate_uuid();
       return await this.link!.sendRequest(request, sendRequestOptions);
     } catch (err: any) {
       const translatedError = translateServiceBusError(err);
@@ -527,7 +545,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         const omitMessageBodyKey = "omit-message-body"; // TODO: Service Bus specific. Put it somewhere
         messageBody[omitMessageBodyKey] = types.wrap_boolean(omitMessageBody);
       }
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -535,8 +553,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.peekMessage,
         },
       };
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
 
@@ -548,14 +566,14 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         request.body
       );
 
-      const result = await this._makeManagementRequest(request, receiverLogger, options);
+      const result = await this._makeManagementRequest(request, receiverLogger, updatedOptions);
       if (result.application_properties!.statusCode !== 204) {
         const messages = result.body.messages as { message: Buffer }[];
         for (const msg of messages) {
           const decodedMessage = RheaMessageUtil.decode(msg.message);
           const message = fromRheaMessage(decodedMessage as any, {
-            skipParsingBodyAsJson: options?.skipParsingBodyAsJson ?? false,
-            skipConvertingDate: options?.skipConvertingDate ?? false,
+            skipParsingBodyAsJson: updatedOptions?.skipParsingBodyAsJson ?? false,
+            skipConvertingDate: updatedOptions?.skipConvertingDate ?? false,
           });
           messageList.push(message);
           this._lastPeekedSequenceNumber = message.sequenceNumber!;
@@ -603,7 +621,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         0x98,
         undefined
       );
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -612,8 +630,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         },
       };
       request.application_properties![Constants.trackingId] = generate_uuid();
-      if (options.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options.associatedLinkName;
+      if (updatedOptions.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions.associatedLinkName;
       }
       receiverLogger.verbose(
         "[%s] Renew message Lock request: %O.",
@@ -621,7 +639,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         request
       );
       const result = await this._makeManagementRequest(request, receiverLogger, {
-        abortSignal: options?.abortSignal,
+        abortSignal: updatedOptions?.abortSignal,
         requestName: "renewLock",
       });
       const lockedUntilUtc = new Date(result.body.expirations[0]);
@@ -695,7 +713,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         throw error;
       }
     }
-    this.ensureUniqueReplyToForRequest();
+    const updatedOptions = await this.initWithUniqueReplyTo(options);
     try {
       const request: RheaMessage = {
         body: { messages: messageBody },
@@ -704,12 +722,12 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.scheduleMessage,
         },
       };
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       senderLogger.verbose("%s Schedule messages request body: %O.", this.logPrefix, request.body);
-      const result = await this._makeManagementRequest(request, senderLogger, options);
+      const result = await this._makeManagementRequest(request, senderLogger, updatedOptions);
       const sequenceNumbers = result.body[Constants.sequenceNumbers];
       const sequenceNumbersAsLong = [];
       for (let i = 0; i < sequenceNumbers.length; i++) {
@@ -764,7 +782,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         0x81,
         undefined
       );
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -773,8 +791,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         },
       };
 
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       senderLogger.verbose(
@@ -783,7 +801,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         request.body
       );
 
-      await this._makeManagementRequest(request, senderLogger, options);
+      await this._makeManagementRequest(request, senderLogger, updatedOptions);
       return;
     } catch (err: any) {
       const error = translateServiceBusError(err);
@@ -843,7 +861,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       if (sessionId != null) {
         messageBody[Constants.sessionIdMapKey] = sessionId;
       }
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -851,8 +869,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.receiveBySequenceNumber,
         },
       };
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       receiverLogger.verbose(
@@ -861,7 +879,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         request.body
       );
 
-      const result = await this._makeManagementRequest(request, receiverLogger, options);
+      const result = await this._makeManagementRequest(request, receiverLogger, updatedOptions);
       const messages = result.body.messages as {
         message: Buffer;
         "lock-token": Buffer;
@@ -873,7 +891,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           { tag: msg["lock-token"] } as any,
           false,
           receiveMode,
-          options?.skipParsingBodyAsJson ?? false,
+          updatedOptions?.skipParsingBodyAsJson ?? false,
           false
         );
         messageList.push(message);
@@ -930,7 +948,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       if (options.sessionId != null) {
         messageBody[Constants.sessionIdMapKey] = options.sessionId;
       }
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -938,8 +956,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.updateDisposition,
         },
       };
-      if (options.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options.associatedLinkName;
+      if (updatedOptions.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       receiverLogger.verbose(
@@ -947,7 +965,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      await this._makeManagementRequest(request, receiverLogger, options);
+      await this._makeManagementRequest(request, receiverLogger, updatedOptions);
     } catch (err: any) {
       const error = translateServiceBusError(err);
       receiverLogger.logError(
@@ -973,7 +991,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -982,15 +1000,15 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         },
       };
       request.application_properties![Constants.trackingId] = generate_uuid();
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       receiverLogger.verbose(
         "%s Renew Session Lock request body: %O.",
         this.logPrefix,
         request.body
       );
-      const result = await this._makeManagementRequest(request, receiverLogger, options);
+      const result = await this._makeManagementRequest(request, receiverLogger, updatedOptions);
       const lockedUntilUtc = new Date(result.body.expiration);
       receiverLogger.verbose(
         "%s Lock for session '%s' will expire at %s.",
@@ -1026,7 +1044,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
       messageBody["session-state"] = toBuffer(state);
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1034,8 +1052,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.setSessionState,
         },
       };
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       receiverLogger.verbose(
@@ -1043,7 +1061,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      await this._makeManagementRequest(request, receiverLogger, options);
+      await this._makeManagementRequest(request, receiverLogger, updatedOptions);
     } catch (err: any) {
       const error = translateServiceBusError(err);
       receiverLogger.logError(
@@ -1068,7 +1086,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1076,8 +1094,8 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           operation: Constants.operations.getSessionState,
         },
       };
-      if (options?.associatedLinkName) {
-        request.application_properties![Constants.associatedLinkName] = options?.associatedLinkName;
+      if (updatedOptions?.associatedLinkName) {
+        request.application_properties![Constants.associatedLinkName] = updatedOptions?.associatedLinkName;
       }
       request.application_properties![Constants.trackingId] = generate_uuid();
       receiverLogger.verbose(
@@ -1085,7 +1103,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      const result = await this._makeManagementRequest(request, receiverLogger, options);
+      const result = await this._makeManagementRequest(request, receiverLogger, updatedOptions);
       return result.body["session-state"]
         ? tryToJsonDecode(result.body["session-state"])
         : result.body["session-state"];
@@ -1131,7 +1149,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       messageBody["last-updated-time"] = lastUpdatedTime;
       messageBody["skip"] = types.wrap_int(skip);
       messageBody["top"] = types.wrap_int(top);
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: messageBody,
         reply_to: this.replyTo,
@@ -1145,7 +1163,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      const response = await this._makeManagementRequest(request, managementClientLogger, options);
+      const response = await this._makeManagementRequest(request, managementClientLogger, updatedOptions);
 
       return (response && response.body && response.body["sessions-ids"]) || [];
     } catch (err: any) {
@@ -1167,13 +1185,13 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
   ): Promise<RuleProperties[]> {
     throwErrorIfConnectionClosed(this._context);
     try {
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options) as ListRequestOptions & OperationOptionsBase & SendManagementRequestOptions;
       const request: RheaMessage = {
         body: {
-          top: options?.maxCount
-            ? types.wrap_int(options.maxCount)
+          top: updatedOptions?.maxCount
+            ? types.wrap_int(updatedOptions.maxCount)
             : types.wrap_int(max32BitNumber),
-          skip: options?.skip ? types.wrap_int(options.skip) : types.wrap_int(0),
+          skip: updatedOptions?.skip ? types.wrap_int(updatedOptions.skip) : types.wrap_int(0),
         },
         reply_to: this.replyTo,
         application_properties: {
@@ -1187,7 +1205,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      const response = await this._makeManagementRequest(request, managementClientLogger, options);
+      const response = await this._makeManagementRequest(request, managementClientLogger, updatedOptions);
       if (
         response.application_properties!.statusCode === 204 ||
         !response.body ||
@@ -1301,7 +1319,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
     throwTypeErrorIfParameterIsEmptyString(this._context.connectionId, "ruleName", ruleName);
 
     try {
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: {
           "rule-name": types.wrap_string(ruleName),
@@ -1318,7 +1336,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
         this.logPrefix,
         request.body
       );
-      await this._makeManagementRequest(request, managementClientLogger, options);
+      await this._makeManagementRequest(request, managementClientLogger, updatedOptions);
     } catch (err: any) {
       const error = translateServiceBusError(err);
       managementClientLogger.logError(
@@ -1379,7 +1397,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           expression: String(sqlRuleActionExpression),
         };
       }
-      this.ensureUniqueReplyToForRequest();
+      const updatedOptions = await this.initWithUniqueReplyTo(options);
       const request: RheaMessage = {
         body: {
           "rule-name": types.wrap_string(ruleName),
@@ -1393,7 +1411,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       request.application_properties![Constants.trackingId] = generate_uuid();
 
       managementClientLogger.verbose("%s Add Rule request body: %O.", this.logPrefix, request.body);
-      await this._makeManagementRequest(request, managementClientLogger, options);
+      await this._makeManagementRequest(request, managementClientLogger, updatedOptions);
     } catch (err: any) {
       const error = translateServiceBusError(err);
       managementClientLogger.logError(

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -420,7 +420,7 @@ describe("Sender Tests", () => {
     );
   }
 
-  it.only(anyRandomTestClientType + ": scheduleMessages in parallel should not throw error", async function() {
+  it(anyRandomTestClientType + ": scheduleMessages in parallel should not throw error", async function () {
     await beforeEachTest(anyRandomTestClientType);
     const ids = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
     const msgs = await Promise.all(
@@ -429,6 +429,7 @@ describe("Sender Tests", () => {
           body: {
             userId: user.id,
           },
+          sessionId: TestMessage.sessionId,
         }))
         .map((message) =>
           sender
@@ -442,9 +443,9 @@ describe("Sender Tests", () => {
             })
         )
     );
-    should.equal(msgs.length, "Expect total of 5 messages scheduled");
+    should.equal(msgs.length, 5, "Expect total of 5 messages scheduled");
     const received = await receiver.receiveMessages(5);
-    should.equal(received.length, "Expect total of 5 messages received");
+    should.equal(received.length, 5, "Expect total of 5 messages received");
     for (let i = 0; i < 5; i++){
       await receiver.completeMessage(received[i]);
     }

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -420,6 +420,36 @@ describe("Sender Tests", () => {
     );
   }
 
+  it.only(anyRandomTestClientType + ": scheduleMessages in parallel should not throw error", async function() {
+    await beforeEachTest(anyRandomTestClientType);
+    const ids = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
+    const msgs = await Promise.all(
+      ids
+        .map((user) => ({
+          body: {
+            userId: user.id,
+          },
+        }))
+        .map((message) =>
+          sender
+            .scheduleMessages(
+              message,
+              new Date(new Date().getTime() + 1000 * 6)
+            )
+            .then((numbers) => {
+              should.equal(numbers.length, 1, "Expect message scheduled");
+              return numbers[0];
+            })
+        )
+    );
+    should.equal(msgs.length, "Expect total of 5 messages scheduled");
+    const received = await receiver.receiveMessages(5);
+    should.equal(received.length, "Expect total of 5 messages received");
+    for (let i = 0; i < 5; i++){
+      await receiver.completeMessage(received[i]);
+    }
+  });
+
   it(
     anyRandomTestClientType + ": Abort scheduleMessages request on the sender",
     async function (): Promise<void> {

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -420,36 +420,36 @@ describe("Sender Tests", () => {
     );
   }
 
-  it(anyRandomTestClientType + ": scheduleMessages in parallel should not throw error", async function () {
-    await beforeEachTest(anyRandomTestClientType);
-    const ids = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
-    const msgs = await Promise.all(
-      ids
-        .map((user) => ({
-          body: {
-            userId: user.id,
-          },
-          sessionId: TestMessage.sessionId,
-        }))
-        .map((message) =>
-          sender
-            .scheduleMessages(
-              message,
-              new Date(new Date().getTime() + 1000 * 6)
-            )
-            .then((numbers) => {
-              should.equal(numbers.length, 1, "Expect message scheduled");
-              return numbers[0];
-            })
-        )
-    );
-    should.equal(msgs.length, 5, "Expect total of 5 messages scheduled");
-    const received = await receiver.receiveMessages(5);
-    should.equal(received.length, 5, "Expect total of 5 messages received");
-    for (let i = 0; i < 5; i++){
-      await receiver.completeMessage(received[i]);
+  it(
+    anyRandomTestClientType + ": scheduleMessages in parallel should not throw error",
+    async function () {
+      await beforeEachTest(anyRandomTestClientType);
+      const ids = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
+      const msgs = await Promise.all(
+        ids
+          .map((user) => ({
+            body: {
+              userId: user.id,
+            },
+            sessionId: TestMessage.sessionId,
+          }))
+          .map((message) =>
+            sender
+              .scheduleMessages(message, new Date(new Date().getTime() + 1000 * 6))
+              .then((numbers) => {
+                should.equal(numbers.length, 1, "Expect message scheduled");
+                return numbers[0];
+              })
+          )
+      );
+      should.equal(msgs.length, 5, "Expect total of 5 messages scheduled");
+      const received = await receiver.receiveMessages(5);
+      should.equal(received.length, 5, "Expect total of 5 messages received");
+      for (let i = 0; i < 5; i++) {
+        await receiver.completeMessage(received[i]);
+      }
     }
-  });
+  );
 
   it(
     anyRandomTestClientType + ": Abort scheduleMessages request on the sender",


### PR DESCRIPTION
When a link is not ready for sending management request we will initialize it
and a unique `replyTo` address is generated. The problem is the two steps are
separate and only the link initialization is guarded by a lock to ensure the
link is only initialized once. When multiple management requests are made at the
same time, multiple `replyTo` addresses could be generated but only one is
associated with the link, resulting in errors like

```
ServiceBusError: The response link '0f6cd6e7-16d1-034a-b661-5d632917cd50' was not found in the entity management node $management.
```

This PR groups the two parts into one locked operation, thus preventing multiple
`replyTo` addresses from being generated for a new link.

- add a failing test without fix
- Move initialization code out of `_makeManagementRequest()` into a locked block together with code to generate unique `replyTo`