### PR TITLE
[text-analytics] Skip TextElement Test 

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -585,8 +585,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             );
           });
 
-          // Skip the tests until hear back from services about offset
-          it.skip("emoji with skin tone modifier", async function () {
+          it("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻 SSN: 859-98-0987",
@@ -597,7 +596,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             );
           });
 
-          it.skip("family emoji", async function () {
+          it("family emoji", async function () {
             await checkOffsetAndLength(
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
@@ -608,7 +607,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             );
           });
 
-          it.skip("family emoji with skin tone modifier", async function (this: Context) {
+          it("family emoji with skin tone modifier", async function (this: Context) {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",
@@ -776,7 +775,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 8 with UTF16
           });
 
-          it("emoji with skin tone modifier", async function () {
+          it.skip("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻 SSN: 859-98-0987",
@@ -786,7 +785,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 10 with UTF16
           });
 
-          it("family emoji", async function () {
+          it.skip("family emoji", async function () {
             await checkOffsetAndLength(
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
@@ -796,7 +795,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 17 with UTF16
           });
 
-          it("family emoji with skin tone modifier", async function () {
+          it.skip("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -775,6 +775,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 8 with UTF16
           });
 
+          // Skip the tests until hear back from services about offset
           it.skip("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -867,6 +867,7 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
             await checkOffsetAndLength(client, "👩 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 8 with UTF16
           });
 
+          // Skip the tests until hear back from services about offset
           it.skip("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 8, 11); // offset was 10 with UTF16
           });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -867,15 +867,15 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
             await checkOffsetAndLength(client, "👩 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 8 with UTF16
           });
 
-          it("emoji with skin tone modifier", async function () {
+          it.skip("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 8, 11); // offset was 10 with UTF16
           });
 
-          it("family emoji", async function () {
+          it.skip("family emoji", async function () {
             await checkOffsetAndLength(client, "👩‍👩‍👧‍👧 SSN: 859-98-0987", "TextElement_v8", 13, 11); // offset was 17 with UTF16
           });
 
-          it("family emoji with skin tone modifier", async function () {
+          it.skip("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR
#25272

### Describe the problem that is addressed by this PR
"PII Entity Recognition" task returns different offset for documents with emoji. Planning to skip the tests for now.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
