### PR TITLE
[language-text] Fix test for grapheme offset in PII Entity

### DIFF
--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "685ccaf1-fc87-44d0-b576-6e79a62876db",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "b3371b74-1b93-4515-8631-a5855843eef4",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c884905f-c04b-42e9-8f75-b7d6cb91aa53",
+        "apim-request-id": "cd4920a2-e70c-47d2-892d-203e09fa45fd",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:43 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32",
+        "x-envoy-upstream-service-time": "36",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 8,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "86cd3f9b-6578-449d-86e3-f96ae45924a8",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "01d0e1be-d882-456b-b991-8e58346333ff",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "33d23f5d-6213-4319-bf9b-389463c7cbdb",
-        "Content-Length": "308",
+        "apim-request-id": "bd37683e-6e6d-4e03-b29a-cb8fa3d92d50",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:44 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57",
+        "x-envoy-upstream-service-time": "33",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 13,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "fd5a08fa-f080-4562-8c62-cde20d120b51",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "9868cb80-2353-49b9-9a46-669935f3351c",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "29b0840c-728a-4b82-a5fb-414a17edd17d",
-        "Content-Length": "324",
+        "apim-request-id": "b2eb63e6-abba-4353-ad5f-ee17a9f32c36",
+        "Content-Length": "323",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:44 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:44 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32",
+        "x-envoy-upstream-service-time": "31",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 17,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "ae2497a8-c3de-4664-90ea-45ac24509e83",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "81ae9f22-ae57-40ab-bee8-ded0a2ebe807",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8c8c8d70-733d-425a-96c1-b2e6c61b8bcf",
+        "apim-request-id": "bb3d8cf8-eb9b-44fd-804d-160bbdf69622",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:11 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23",
+        "x-envoy-upstream-service-time": "33",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 8,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "08bb1831-ce8f-4088-9458-6e2d039343bc",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "b6c90584-7cb4-4875-a52f-03c8a5fcdff9",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "63a3329c-ac27-47b8-91f6-1368c3bdfc84",
-        "Content-Length": "308",
+        "apim-request-id": "d6b2e7ec-b3b4-48ed-b491-4e8107029256",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:11 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29",
+        "x-envoy-upstream-service-time": "33",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 13,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/browsers/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "aaa21301-de28-4b43-89a1-ef06e0ca80b1",
-        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "ca5dde3d-9416-4b41-8748-89c5863a2eb5",
+        "x-ms-useragent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -39,15 +39,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "42463986-8a08-4110-8906-b766a92456fe",
-        "Content-Length": "324",
+        "apim-request-id": "e83e7032-b8e6-4f02-a4d1-0d5f0732737a",
+        "Content-Length": "323",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:59:11 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:40 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "127",
+        "x-envoy-upstream-service-time": "29",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -61,7 +61,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 17,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "176",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "46cd49ff-606d-4713-a73f-b6052b2be9a3"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "f65a4a2b-1635-4724-969c-590a1f5345fb"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa63111d-d76e-4522-a08b-f398123368bd",
+        "apim-request-id": "5b55426d-0644-46f5-8c24-6d418fe93f03",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:47 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:28 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "117",
+        "x-envoy-upstream-service-time": "32",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 8,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "193",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "57d5cb63-368d-44ce-91e3-d6bbb2ab51ae"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "58d67604-e4cd-4c94-961c-b1dfa881a01c"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b0931e90-3721-4cae-b105-899c86abb970",
-        "Content-Length": "308",
+        "apim-request-id": "80adfa68-6f97-4369-a67f-468fabf7f0af",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:49 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "53",
+        "x-envoy-upstream-service-time": "31",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 13,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/aad_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "6aed73f9-d112-4c54-8ca7-1b6cd83046bf"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "3e748ac5-f505-4999-925f-888ec4ef59cc"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3a50891d-4a09-4beb-adf8-2159f17cacea",
-        "Content-Length": "324",
+        "apim-request-id": "1465ed40-504d-4a8a-863b-41e4e7675f68",
+        "Content-Length": "323",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:49 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:29 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30",
+        "x-envoy-upstream-service-time": "33",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 17,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "176",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4c073498-94e1-4469-af33-43fb1b941ee3"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "71c155c4-6d0a-43c9-b9b3-c6ea67645a16"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "060a7d96-cda6-4fca-99d9-2c71a275a45d",
+        "apim-request-id": "6ed74245-4873-4b8a-b559-1018bd671a2f",
         "Content-Length": "290",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:03 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30",
+        "x-envoy-upstream-service-time": "32",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 8,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "193",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4743ae95-506a-4078-9ede-f473785694c6"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "7aad96f5-9a89-435a-86d4-5c392fb47f5a"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e94babc8-c175-4e97-a272-00c1aee91b3f",
-        "Content-Length": "308",
+        "apim-request-id": "174d63ec-1077-4466-996d-98a26d43fc69",
+        "Content-Length": "307",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:03 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27",
+        "x-envoy-upstream-service-time": "32",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 13,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/cognitivelanguage/ai-language-text/recordings/node/apikey_textanalysisclient_analyze_string_encoding_textelementsv8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "209",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.1 core-rest-pipeline/1.10.0 Node/v18.6.0 OS/(x64-Linux-5.15.68.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "9caf9ca1-0ba6-44b0-8ecf-11a0a5ea7757"
+        "User-Agent": "azsdk-js-ai-language-text/1.1.0-beta.3 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "707f3e85-4889-4a16-b85f-29176643f6db"
       },
       "RequestBody": {
         "kind": "PiiEntityRecognition",
@@ -30,15 +30,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec5f055f-6cea-4d76-822d-7415fd58bb96",
-        "Content-Length": "324",
+        "apim-request-id": "ce30df53-0eba-471c-9a54-42319ec9267d",
+        "Content-Length": "323",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 01 Nov 2022 22:52:03 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:29:27 GMT",
         "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "42",
+        "x-envoy-upstream-service-time": "32",
         "x-ms-region": "East US"
       },
       "ResponseBody": {
@@ -52,7 +52,7 @@
                 {
                   "text": "859-98-0987",
                   "category": "USSocialSecurityNumber",
-                  "offset": 17,
+                  "offset": 7,
                   "length": 11,
                   "confidenceScore": 0.65
                 }

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -774,7 +774,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 8 with UTF16
           });
 
-          it.only("emoji with skin tone modifier", async function () {
+          it("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻 SSN: 859-98-0987",
@@ -784,7 +784,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 10 with UTF16
           });
 
-          it.only("family emoji", async function () {
+          it("family emoji", async function () {
             await checkOffsetAndLength(
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
@@ -794,7 +794,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 17 with UTF16
           });
 
-          it.only("family emoji with skin tone modifier", async function () {
+          it("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -589,7 +589,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩🏻 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              7,
+              10,
               11,
               checkEntityTextOffset
             );
@@ -600,7 +600,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              7,
+              17,
               11,
               checkEntityTextOffset
             );
@@ -611,7 +611,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              7,
+              25,
               11,
               checkEntityTextOffset
             );
@@ -779,7 +779,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩🏻 SSN: 859-98-0987",
               KnownStringIndexType.TextElementsV8,
-              8,
+              7,
               11
             ); // offset was 10 with UTF16
           });
@@ -789,7 +789,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
               KnownStringIndexType.TextElementsV8,
-              13,
+              7,
               11
             ); // offset was 17 with UTF16
           });
@@ -799,7 +799,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",
               KnownStringIndexType.TextElementsV8,
-              17,
+              7,
               11
             ); // offset was 25 with UTF16
           });

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -584,36 +584,34 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
               checkEntityTextOffset
             );
           });
-
-          // Skip the tests until hear back from services about offset
-          it.skip("emoji with skin tone modifier", async function () {
+          it("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              10,
+              7,
               11,
               checkEntityTextOffset
             );
           });
 
-          it.skip("family emoji", async function () {
+          it("family emoji", async function () {
             await checkOffsetAndLength(
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              17,
+              7,
               11,
               checkEntityTextOffset
             );
           });
 
-          it.skip("family emoji with skin tone modifier", async function (this: Context) {
+          it("family emoji with skin tone modifier", async function (this: Context) {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",
               KnownStringIndexType.Utf16CodeUnit,
-              25,
+              7,
               11,
               checkEntityTextOffset
             );

--- a/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
+++ b/sdk/cognitivelanguage/ai-language-text/test/public/analyze.spec.ts
@@ -774,7 +774,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 8 with UTF16
           });
 
-          it("emoji with skin tone modifier", async function () {
+          it.only("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻 SSN: 859-98-0987",
@@ -784,7 +784,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 10 with UTF16
           });
 
-          it("family emoji", async function () {
+          it.only("family emoji", async function () {
             await checkOffsetAndLength(
               client,
               "👩‍👩‍👧‍👧 SSN: 859-98-0987",
@@ -794,7 +794,7 @@ matrix([["APIKey", "AAD"]] as const, async (authMethod: AuthMethod) => {
             ); // offset was 17 with UTF16
           });
 
-          it("family emoji with skin tone modifier", async function () {
+          it.only("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "66cb47e4-5e91-4398-b47d-730285dbe2a0",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "32ae52e7-a7ba-4136-958f-fabc8f40a70d",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84cbb0ec-5689-4d2d-a8f3-56cdef2def16",
+        "apim-request-id": "d50f85d8-1c80-4929-b572-55cf997ffb54",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:41:15 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:41 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "43",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 8,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "06f67b54-0727-42fb-af62-6a8832c2d36a",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "d2d9e4ce-c9c6-4758-84c6-27172bb4a107",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9326a44d-a946-47e7-a286-f93d9920c9e4",
+        "apim-request-id": "02fe0755-b83c-4f67-893b-5cf155c35910",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:41:15 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:41 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 13,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "e54af759-ccc8-4242-a06a-0c089ad6dd50",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "2b2bdd42-8412-4e53-a8b7-1df806079a38",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5fdfb75-5bfe-4fc5-97e2-fd77f1b2949a",
+        "apim-request-id": "27f8f955-4b83-43a4-a4ce-c64746343f84",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:41:16 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:42 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "32",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 17,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "7bbcfed1-437e-4ac9-bcd0-402576874974",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "7599b5db-7200-42e5-a9fc-4269c6f22124",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca8377d5-564d-47ab-b8b2-eb228c86447f",
+        "apim-request-id": "c4e493af-e03e-4bbc-9c08-ddd874a1ce0a",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:45:14 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:42 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 8,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "9a6c8978-2947-4cac-a18a-1f56f614726f",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "52ceb0a7-f4ae-4732-8e7d-add6cc02dc42",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3952ac22-2d64-401d-ac6d-f74bd2f89be5",
+        "apim-request-id": "b4450635-462b-44ca-b134-e4231253c251",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:45:14 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:42 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 13,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
@@ -18,9 +18,9 @@
         "Sec-Fetch-Dest": "empty",
         "Sec-Fetch-Mode": "cors",
         "Sec-Fetch-Site": "same-site",
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/103.0.5058.0 Safari/537.36",
-        "x-ms-client-request-id": "05a8f82a-d678-4461-ae10-72e7d5565299",
-        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 OS/Linuxx86_64"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5555.0 Safari/537.36",
+        "x-ms-client-request-id": "2956c7e6-7ff3-44fb-b82a-3a88bf25dc9b",
+        "x-ms-useragent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 OS"
       },
       "RequestBody": {
         "documents": [
@@ -33,14 +33,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ddafbd8c-7522-4a2c-85d7-a480a0983111",
+        "apim-request-id": "14aff1a2-a7a2-431e-861e-025fce67e2db",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:45:14 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:42 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "31",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -51,7 +53,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 17,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "77",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "dc286870-9ab8-4b42-8f83-82fea6f05a15"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "26af8bf0-f018-4ed5-8b19-69270e961ea8"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47c2f769-f293-4ae1-937d-775ed460ca90",
+        "apim-request-id": "ab45dc18-8010-43ce-8228-d2d92aa16587",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:31:24 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:31 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "34",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 8,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "94",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a41dbe92-54b3-4390-8993-2c501b718370"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "de61714e-f75e-44ff-96e2-6e4a1b064d3b"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ef1d0219-a68e-42f4-b7ee-08140c7be9cd",
+        "apim-request-id": "0f31e554-b680-4804-b212-2fadf43c031f",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:31:24 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:32 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "36",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 13,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Connection": "keep-alive",
         "Content-Length": "110",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "06c67aa9-77f9-42d5-8c68-f307e22c6d27"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "731c62fe-00cc-4c28-86c1-8020636e73de"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7633a806-55ac-4e13-9bb5-e4889979e2d2",
+        "apim-request-id": "f4e0d940-fbdf-4bf2-943d-fa0599c93188",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:31:26 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:32 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 17,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "77",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "cc63cfb7-9ea4-460b-afa5-1e18b0e8a040"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "b59c0080-439b-4cb8-8141-81321e3939cd"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4604503-1b86-411e-b05f-7ee61223ae28",
+        "apim-request-id": "305e9f8c-a81c-4a98-a877-760106b44c91",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:36:05 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:33 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "42",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 8,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji.json
@@ -10,8 +10,8 @@
         "Content-Length": "94",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b24f6a56-60fe-4f86-a449-42c0c00f8331"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "0d204ada-c352-4f6e-a9ee-27218f699fc3"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a094abc-69d8-412d-87fb-bf429f7a2255",
+        "apim-request-id": "a5bbd1b2-2b4c-4b1d-b0f3-35c6075b330f",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:36:05 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:33 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "44",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 13,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/apikey_textanalyticsclient_fast_tests_string_encoding_textelement_v8/recording_family_emoji_with_skin_tone_modifier.json
@@ -10,8 +10,8 @@
         "Content-Length": "110",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "api_key",
-        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.9.1 Node/v18.6.0 OS/(x64-Linux-5.10.102.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "52e3f105-c8aa-4f7e-abf2-016b08354885"
+        "User-Agent": "azsdk-js-ai-textanalytics/5.1.1 azsdk-js-ai-text-analytics/5.1.1 core-rest-pipeline/1.10.3 Node/v16.17.0 OS/(x64-Windows_NT-10.0.22621)",
+        "x-ms-client-request-id": "831afef5-2e09-47c7-bc5d-7dad547e81a3"
       },
       "RequestBody": {
         "documents": [
@@ -24,14 +24,16 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0ee3376d-80ea-4904-9c5d-54c3d8db0d9f",
+        "apim-request-id": "c525c386-c1f3-4e75-b169-c115b957fe24",
         "Content-Type": "application/json; charset=utf-8",
-        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 22 Jul 2022 02:36:05 GMT",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.Language.Text.PII=1,CognitiveServices.TextAnalytics.TextRecords=1",
+        "Date": "Fri, 17 Mar 2023 17:31:33 GMT",
+        "Set-Cookie": ".AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; samesite=lax; httponly",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "48",
+        "x-ms-region": "East US"
       },
       "ResponseBody": {
         "documents": [
@@ -42,7 +44,7 @@
               {
                 "text": "859-98-0987",
                 "category": "USSocialSecurityNumber",
-                "offset": 17,
+                "offset": 7,
                 "length": 11,
                 "confidenceScore": 0.65
               }

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -868,11 +868,11 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
           });
 
           it("emoji with skin tone modifier", async function () {
-            await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 8, 11); // offset was 10 with UTF16
+            await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 10 with UTF16
           });
 
           it("family emoji", async function () {
-            await checkOffsetAndLength(client, "👩‍👩‍👧‍👧 SSN: 859-98-0987", "TextElement_v8", 13, 11); // offset was 17 with UTF16
+            await checkOffsetAndLength(client, "👩‍👩‍👧‍👧 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 17 with UTF16
           });
 
           it("family emoji with skin tone modifier", async function () {
@@ -880,7 +880,7 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",
               "TextElement_v8",
-              17,
+              7,
               11
             ); // offset was 25 with UTF16
           });

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -867,15 +867,15 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
             await checkOffsetAndLength(client, "👩 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 8 with UTF16
           });
 
-          it("emoji with skin tone modifier", async function () {
+          it.only("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 10 with UTF16
           });
 
-          it("family emoji", async function () {
+          it.only("family emoji", async function () {
             await checkOffsetAndLength(client, "👩‍👩‍👧‍👧 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 17 with UTF16
           });
 
-          it("family emoji with skin tone modifier", async function () {
+          it.only("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -867,15 +867,15 @@ matrix([["AAD", "APIKey"]] as const, async (authMethod: AuthMethod) => {
             await checkOffsetAndLength(client, "👩 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 8 with UTF16
           });
 
-          it.only("emoji with skin tone modifier", async function () {
+          it("emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(client, "👩🏻 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 10 with UTF16
           });
 
-          it.only("family emoji", async function () {
+          it("family emoji", async function () {
             await checkOffsetAndLength(client, "👩‍👩‍👧‍👧 SSN: 859-98-0987", "TextElement_v8", 7, 11); // offset was 17 with UTF16
           });
 
-          it.only("family emoji with skin tone modifier", async function () {
+          it("family emoji with skin tone modifier", async function () {
             await checkOffsetAndLength(
               client,
               "👩🏻‍👩🏽‍👧🏾‍👦🏿 SSN: 859-98-0987",


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR
#25272 

### Describe the problem that is addressed by this PR
All compound emojis are correctly counted as a single TextElement or grapheme after the service bug fixed

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
