### PR TITLE
[Search] Remove service version checks

### DIFF
--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -180,21 +180,9 @@ export class SearchClient<Model extends object> implements IndexDocumentsClient<
       },
     };
 
-    if (options.apiVersion) {
-      if (!utils.serviceVersions.includes(options.apiVersion)) {
-        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
-      }
-      this.serviceVersion = options.apiVersion;
-      this.apiVersion = options.apiVersion;
-    }
-
-    if (options.serviceVersion) {
-      if (!utils.serviceVersions.includes(options.serviceVersion)) {
-        throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
-      }
-      this.serviceVersion = options.serviceVersion;
-      this.apiVersion = options.serviceVersion;
-    }
+    this.serviceVersion =
+      options.serviceVersion ?? options.apiVersion ?? utils.defaultServiceVersion;
+    this.apiVersion = this.serviceVersion;
 
     this.client = new GeneratedClient(
       this.endpoint,

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -160,21 +160,9 @@ export class SearchIndexClient {
       },
     };
 
-    if (options.apiVersion) {
-      if (!utils.serviceVersions.includes(options.apiVersion)) {
-        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
-      }
-      this.serviceVersion = options.apiVersion;
-      this.apiVersion = options.apiVersion;
-    }
-
-    if (options.serviceVersion) {
-      if (!utils.serviceVersions.includes(options.serviceVersion)) {
-        throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
-      }
-      this.serviceVersion = options.serviceVersion;
-      this.apiVersion = options.serviceVersion;
-    }
+    this.serviceVersion =
+      options.serviceVersion ?? options.apiVersion ?? utils.defaultServiceVersion;
+    this.apiVersion = this.serviceVersion;
 
     this.client = new GeneratedClient(
       this.endpoint,

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -142,21 +142,9 @@ export class SearchIndexerClient {
       },
     };
 
-    if (options.apiVersion) {
-      if (!utils.serviceVersions.includes(options.apiVersion)) {
-        throw new Error(`Invalid Api Version: ${options.apiVersion}`);
-      }
-      this.serviceVersion = options.apiVersion;
-      this.apiVersion = options.apiVersion;
-    }
-
-    if (options.serviceVersion) {
-      if (!utils.serviceVersions.includes(options.serviceVersion)) {
-        throw new Error(`Invalid Service Version: ${options.serviceVersion}`);
-      }
-      this.serviceVersion = options.serviceVersion;
-      this.apiVersion = options.serviceVersion;
-    }
+    this.serviceVersion =
+      options.serviceVersion ?? options.apiVersion ?? utils.defaultServiceVersion;
+    this.apiVersion = this.serviceVersion;
 
     this.client = new GeneratedClient(
       this.endpoint,

--- a/sdk/search/search-documents/test/public/node/searchClient.spec.ts
+++ b/sdk/search/search-documents/test/public/node/searchClient.spec.ts
@@ -405,32 +405,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions) => {
         assert.equal(serviceVersion, client.apiVersion);
       });
 
-      it("passing invalid apiVersion type and valid serviceVersion", () => {
-        let errorThrown = false;
-        try {
-          new SearchClient<Hotel>("", "", credential, {
-            serviceVersion,
-            apiVersion: "foo",
-          });
-        } catch (ex: any) {
-          errorThrown = true;
-        }
-        assert.isTrue(errorThrown, "Invalid apiVersion");
-      });
-
-      it("passing invalid serviceVersion type and valid apiVersion", () => {
-        let errorThrown = false;
-        try {
-          new SearchClient<Hotel>("", "", credential, {
-            apiVersion: serviceVersion,
-            serviceVersion: "foo",
-          });
-        } catch (ex: any) {
-          errorThrown = true;
-        }
-        assert.isTrue(errorThrown, "Invalid serviceVersion");
-      });
-
       it("supports passing the deprecated apiVersion", () => {
         const client = new SearchClient<Hotel>("", "", credential, {
           apiVersion: serviceVersion,


### PR DESCRIPTION
This change allows for the service to be the source of truth in validating the service version. The client is tested against the latest stable and preview APIs, and older API versions are not guaranteed by the SDK to be backward compatible. 

Fixes #24145 