### PR TITLE
[notification hubs] Fixing tag expression send

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2023-03-21)
 
 ### Features Added
 
-### Breaking Changes
+- Added section for React Native support in troubleshooting.
 
 ### Bugs Fixed
+
+- [#25316](https://github.com/Azure/azure-sdk-for-js/issues/25316) - Fix `isSendNotificationOptions` to check for `tagExpression` instead of `tags`.
 
 ### Other Changes
 

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added section for React Native support in troubleshooting.
+- [#25230](ttps://github.com/Azure/azure-sdk-for-js/issues/25230) - Added section for React Native support in troubleshooting.
 
 ### Bugs Fixed
 

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 - [#25316](https://github.com/Azure/azure-sdk-for-js/issues/25316) - Fix `isSendNotificationOptions` to check for `tagExpression` instead of `tags`.
 
-### Other Changes
-
 ## 1.0.0 (2023-03-15)
 
 ### Features Added

--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -663,12 +663,6 @@ React Native currently does not have support for [`URLSearchParams`] which is us
 import 'url-search-params-polyfill';
 ```
 
-This project requires the Web Crypto API to be available in the global scope.  If you are using React Native, you will need to install the [`isomorphic-webcrypto`](https://www.npmjs.com/package/isomorphic-webcrypto) package and import it before using the SDK.
-
-```typescript
-import crypto from 'isomorphic-webcrypto';
-```
-
 ### Diagnose Dropped Notifications
 
 Azure Notification Hubs has a complete guide to troubleshooting problems with dropped notifications in the [Diagnose dropped notifications in Azure Notification Hubs Guide](https://docs.microsoft.com/azure/notification-hubs/notification-hubs-push-notification-fixer).  

--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -655,6 +655,20 @@ console.log(`Notification ID: ${result.notificationId}`);
 
 ## Troubleshooting
 
+## React Native Support
+
+React Native currently does not have support for [`URLSearchParams`] which is used by the Azure Notification Hubs SDK.  In order to use the SDK in React Native, you will need to install the [`url-search-params-polyfill`](https://www.npmjs.com/package/url-search-params-polyfill) package and import it before using the SDK.
+
+```typescript
+import 'url-search-params-polyfill';
+```
+
+This project requires the Web Crypto API to be available in the global scope.  If you are using React Native, you will need to install the [`isomorphic-webcrypto`](https://www.npmjs.com/package/isomorphic-webcrypto) package and import it before using the SDK.
+
+```typescript
+import crypto from 'isomorphic-webcrypto';
+```
+
 ### Diagnose Dropped Notifications
 
 Azure Notification Hubs has a complete guide to troubleshooting problems with dropped notifications in the [Diagnose dropped notifications in Azure Notification Hubs Guide](https://docs.microsoft.com/azure/notification-hubs/notification-hubs-push-notification-fixer).  

--- a/sdk/notificationhubs/notification-hubs/src/auth/hmacSha256.browser.ts
+++ b/sdk/notificationhubs/notification-hubs/src/auth/hmacSha256.browser.ts
@@ -7,14 +7,18 @@ export async function signString(key: string, toSign: string): Promise<string> {
   const enc = new TextEncoder();
   const algorithm: HmacImportParams = { name: "HMAC", hash: { name: "SHA-256" } };
 
-  const extractedKey = await self.crypto.subtle.importKey(
+  const extractedKey = await globalThis.crypto.subtle.importKey(
     "raw",
     enc.encode(key),
     algorithm,
     false,
     ["sign", "verify"]
   );
-  const signature = await self.crypto.subtle.sign(algorithm, extractedKey, enc.encode(toSign));
+  const signature = await globalThis.crypto.subtle.sign(
+    algorithm,
+    extractedKey,
+    enc.encode(toSign)
+  );
   const digest = btoa(String.fromCharCode(...new Uint8Array(signature)));
 
   return encodeURIComponent(digest);

--- a/sdk/notificationhubs/notification-hubs/src/utils/optionUtils.ts
+++ b/sdk/notificationhubs/notification-hubs/src/utils/optionUtils.ts
@@ -10,7 +10,9 @@ import { objectHasProperty } from "@azure/core-util";
  * @returns true if SendNotificationOptions otherwise false.
  */
 export function isSendNotificationOptions(options: unknown): options is SendNotificationOptions {
-  return objectHasProperty(options, "tags") || objectHasProperty(options, "enableTestSend");
+  return (
+    objectHasProperty(options, "tagExpression") || objectHasProperty(options, "enableTestSend")
+  );
 }
 
 /**

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/optionUtils.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/optionUtils.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "@azure/test-utils";
+import {
+  isDirectSendNotificationOptions,
+  isSendNotificationOptions,
+} from "../../../src/utils/optionUtils.js";
+
+describe("optionUtils", () => {
+  describe("isSendNotificationOptions", () => {
+    it("should return true if options has tagExpression", () => {
+      const options = { tagExpression: "tag" };
+      assert.isTrue(isSendNotificationOptions(options));
+    });
+
+    it("should return true if options has enableTestSend", () => {
+      const options = { enableTestSend: true };
+      assert.isTrue(isSendNotificationOptions(options));
+    });
+
+    it("should return false if options is bad", () => {
+      const options1 = undefined;
+      assert.isFalse(isSendNotificationOptions(options1));
+
+      const options2 = null;
+      assert.isFalse(isSendNotificationOptions(options2));
+
+      const options3 = "";
+      assert.isFalse(isSendNotificationOptions(options3));
+
+      const options4 = {};
+      assert.isFalse(isSendNotificationOptions(options4));
+    });
+  });
+
+  describe("isDirectSendNotificationOptions", () => {
+    it("should return true if options has deviceHandle", () => {
+      const options = { deviceHandle: "handle" };
+      assert.isTrue(isDirectSendNotificationOptions(options));
+    });
+
+    it("should return false if options is bad", () => {
+      const options1 = undefined;
+      assert.isFalse(isDirectSendNotificationOptions(options1));
+
+      const options2 = null;
+      assert.isFalse(isDirectSendNotificationOptions(options2));
+
+      const options3 = "";
+      assert.isFalse(isDirectSendNotificationOptions(options3));
+
+      const options4 = {};
+      assert.isFalse(isDirectSendNotificationOptions(options4));
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR

- #25316
- #25230

### Describe the problem that is addressed by this PR

The `optionUtils` function `isSendNotificationOptions` used the old version of the `SendNotificationOptions` which had the `tags` and not the `tagExpression`.  This PR fixes that.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
