### PR TITLE
[ACR] Validate digest on downloadManifest

### DIFF
--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -160,7 +160,7 @@ export interface DownloadManifestOptions extends OperationOptions {
 
 // @public
 export interface DownloadManifestResult {
-    content: NodeJS.ReadableStream;
+    content: Buffer;
     digest: string;
     mediaType: string;
 }

--- a/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
@@ -40,9 +40,8 @@ async function main() {
   }
 
   const manifest = result.manifest;
-  // Manifests of all media types can be written to a file using the `content` stream.
-  const manifestFile = fs.createWriteStream("manifest.json");
-  result.content.pipe(manifestFile);
+  // Manifests of all media types have a buffer containing their content; this can be written to a file.
+  fs.writeFileSync("manifest.json", result.content);
 
   const configResult = await client.downloadBlob(manifest.config.digest);
   const configFile = fs.createWriteStream("config.json");

--- a/sdk/containerregistry/container-registry/samples/v1-beta/javascript/downloadImage.js
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/javascript/downloadImage.js
@@ -39,9 +39,8 @@ async function main() {
   }
 
   const manifest = result.manifest;
-  // Manifests of all media types can be written to a file using the `content` stream.
-  const manifestFile = fs.createWriteStream("manifest.json");
-  result.content.pipe(manifestFile);
+  // Manifests of all media types have a buffer containing their content; this can be written to a file.
+  fs.writeFileSync("manifest.json", result.content);
 
   const configResult = await client.downloadBlob(manifest.config.digest);
   const configFile = fs.createWriteStream("config.json");

--- a/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/downloadImage.ts
+++ b/sdk/containerregistry/container-registry/samples/v1-beta/typescript/src/downloadImage.ts
@@ -39,9 +39,8 @@ async function main() {
   }
 
   const manifest = result.manifest;
-  // Manifests of all media types can be written to a file using the `content` stream.
-  const manifestFile = fs.createWriteStream("manifest.json");
-  result.content.pipe(manifestFile);
+  // Manifests of all media types have a buffer containing their content; this can be written to a file.
+  fs.writeFileSync("manifest.json", result.content);
 
   const configResult = await client.downloadBlob(manifest.config.digest);
   const configFile = fs.createWriteStream("config.json");

--- a/sdk/containerregistry/container-registry/src/blob/models.ts
+++ b/sdk/containerregistry/container-registry/src/blob/models.ts
@@ -48,9 +48,9 @@ export interface DownloadManifestResult {
   mediaType: string;
 
   /**
-   * The manifest stream that was downloaded.
+   * The raw content of the manifest that was downloaded.
    */
-  content: NodeJS.ReadableStream;
+  content: Buffer;
 }
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Fixes #24628

### Describe the problem that is addressed by this PR

See the underlying issue for details, but, basically, we should be verifying the downloaded manifest using the digest provided by the user, if one is provided.
