### PR TITLE
[Communication][Email] Adding parameter for only running the PPE stage

### DIFF
--- a/sdk/communication/communication-email/tests.yml
+++ b/sdk/communication/communication-email/tests.yml
@@ -1,5 +1,11 @@
 trigger: none
 
+parameters:
+  - name: runOnlyPPE
+    displayName: "Run only the PPE stage"
+    type: boolean
+    default: false
+
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
@@ -22,5 +28,9 @@ stages:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-js)
       Clouds: Public,PPE,Int
+      ${{ if eq(parameters.runOnlyPPE, true) }}:
+        Clouds: PPE
+      ${{ if eq(parameters.runOnlyPPE, false) }}:
+        Clouds: Public,PPE,Int
       TestResourceDirectories:
         - communication/communication-email/


### PR DESCRIPTION
I've added a parameter to the email live test pipelines that allows only the PPE stage to be run. This allows us to start a build on this pipeline from our service deployment pipeline.