### PR TITLE
[ServiceBus] Fix issue sending message body of `Uint8Array`

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix an issue of over-adding credits when receiving messages in a batch [PR #25185](https://github.com/Azure/azure-sdk-for-js/pull/25185)
 - Fix a race condition in initializing management links [PR #25279](https://github.com/Azure/azure-sdk-for-js/pull/25279)
+- `Uint8Array` payload is converted into JSON before being sent. This PR fixes it so that `Uint8Array` is being treated the same as a Buffer.
 
 ### Other Changes
 

--- a/sdk/servicebus/service-bus/src/dataTransformer.ts
+++ b/sdk/servicebus/service-bus/src/dataTransformer.ts
@@ -50,7 +50,7 @@ export const defaultDataTransformer = {
       result.typecode = valueSectionTypeCode;
     } else if (bodyType === "sequence") {
       result = message.sequence_section(body);
-    } else if (isBuffer(body)) {
+    } else if (isBuffer(body) || body instanceof Uint8Array) {
       result = message.data_section(body);
     } else {
       // string, undefined, null, boolean, array, object, number should end up here

--- a/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
@@ -38,6 +38,7 @@ describe("DataTransformer", function () {
   const emptyStringBody: string = "";
   const bufferBody: Buffer = Buffer.from("zzz", "utf8");
   const hexBufferBody: Buffer = Buffer.from("7468697320697320612074c3a97374", "hex");
+  const uint8ArrayBody = new Uint8Array([0x1, 0x2, 0x3, 0x4]);
   const transformer = defaultDataTransformer;
 
   it("should correctly encode/decode a string message body", function (done) {
@@ -127,6 +128,17 @@ describe("DataTransformer", function () {
     isBuffer(encoded.content).should.equal(true);
     const decoded: any = transformer.decode(encoded, false);
     assert.deepEqual(decoded, bufferBody);
+    done();
+  });
+
+  it("should correctly encode/decode a Uint8Array message body", function (done) {
+    const encoded: any = transformer.encode(uint8ArrayBody, "data");
+    encoded.typecode.should.equal(117);
+    console.dir({ encoded });
+    (encoded.content instanceof Uint8Array).should.equal(true);
+    (encoded.content as Uint8Array).length.should.equal(4);
+    const decoded: any = transformer.decode(encoded, false);
+    assert.deepEqual(decoded, uint8ArrayBody);
     done();
   });
 


### PR DESCRIPTION
We should treat `Uint8Array` message body similar to what we do with `Buffer`.

Fixes #25336

Related Event Hubs PR: #21185
