### PR TITLE
[ServiceBus] add drainCredit timeout when suspending receiver

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix an issue of over-adding credits when receiving messages in a batch [PR #25185](https://github.com/Azure/azure-sdk-for-js/pull/25185)
 - Fix a race condition in initializing management links [PR #25279](https://github.com/Azure/azure-sdk-for-js/pull/25279)
 - `Uint8Array` payload is converted into JSON before being sent. This PR fixes it so that `Uint8Array` is being treated the same as a Buffer.
+- Fix an issue where closing receiver could be blocked indefinitely when we don't receive a drain credit response.
 
 ### Other Changes
 

--- a/sdk/servicebus/service-bus/src/core/receiverHelper.ts
+++ b/sdk/servicebus/service-bus/src/core/receiverHelper.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortError } from "@azure/abort-controller";
+import { AbortController, AbortError } from "@azure/abort-controller";
+import { delay } from "@azure/core-util";
 import { Receiver, ReceiverEvents } from "rhea-promise";
 import { receiverLogger as logger } from "../log";
 import { ServiceBusError } from "../serviceBusError";
@@ -135,10 +136,52 @@ export class ReceiverHelper {
       receiver.drainCredit();
     });
 
-    return drainPromise;
+    return timeboxedPromise(drainPromise, 1000, async () => {
+      logger.warning(`${logPrefix} Time out when draining credits in suspend().`);
+      // Close the receiver link since we have not received the receiver_drained event
+      // to prevent out-of-sync link state between local and remote
+      await receiver?.close();
+    });
   }
 
   private _isValidReceiver(receiver: Receiver | undefined): receiver is Receiver {
     return receiver != null && receiver.isOpen();
+  }
+}
+
+const sym = Symbol();
+class TimeoutError extends Error {
+  constructor(public symbol: symbol, ...args: any[]) {
+    super(...args);
+  }
+}
+
+/**
+ * Takes a Promise and create a new Promise that resolves either the original promise
+ * resolves, or a timeout limit is reached. Optionally it can take callbacks for the case
+ * where the time expires.
+ * @param promise - the Promise instance to be time boxed.
+ * @param timeoutInMs - the time out limit in milliseconds.
+ * @param timeoutCallback - optional callback when time out happens.
+ * @internal
+ */
+async function timeboxedPromise(
+  promise: Promise<void>,
+  timeoutInMs: number,
+  timeoutCallback?: () => Promise<void>
+): Promise<void> {
+  const aborter = new AbortController();
+  const timeoutPromise = delay(timeoutInMs, { abortSignal: aborter.signal }).then(() => {
+    throw new TimeoutError(sym, "Timeout limited reached for time boxed promise");
+  });
+
+  try {
+    await Promise.race([promise, timeoutPromise]).finally(() => {
+      aborter.abort();
+    });
+  } catch (e) {
+    if (timeoutCallback && (e as TimeoutError).symbol === sym) {
+      await timeoutCallback();
+    }
   }
 }

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -17,7 +17,6 @@ export const messageDispositionTimeout = 20000;
 /**
  * The amount of time in milliseconds that a receiver
  * will wait while draining credits before returning
- * the received messages.
  * @internal
  */
 export const receiveDrainTimeoutInMs = 200;

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -15,6 +15,14 @@ export const packageJsonInfo = {
 export const messageDispositionTimeout = 20000;
 
 /**
+ * The amount of time in milliseconds that a receiver
+ * will wait while draining credits before returning
+ * the received messages.
+ * @internal
+ */
+export const receiveDrainTimeoutInMs = 200;
+
+/**
  * @internal
  */
 export const max32BitNumber = Math.pow(2, 31) - 1;


### PR DESCRIPTION
There are cases where the service doesn't respond to our drain-credit request, or the response comes back after a long and unexpected time. Since we are blocking on the `receiver_drained` event before resolving, application code could be blocked indefinitely when suspending/closing.

This PR adds a timeout around credit draining, and if the timeout limit expires we close the receiver then returns.
