### PR TITLE
[ACR] Remove securityDefinitions property from Swagger

### DIFF
--- a/sdk/containerregistry/container-registry/swagger/README.md
+++ b/sdk/containerregistry/container-registry/swagger/README.md
@@ -214,3 +214,14 @@ directive:
   transform: >
     $.properties.size["x-ms-client-name"] = "sizeInBytes";
 ```
+
+# Remove security definitions
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.
+    transform: >
+      delete $["securityDefinitions"];
+      delete $["security"];
+```


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Fixes #25029

### Describe the problem that is addressed by this PR

Removes incorrect section from the Swagger.