### PR TITLE
[Event Hubs] Convert EventHubReceiver class to a function

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingPartitionChannel.ts
+++ b/sdk/eventhub/event-hubs/src/batchingPartitionChannel.ts
@@ -13,7 +13,7 @@ import { isDefined, isObjectWithProperties } from "@azure/core-util";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { AwaitableQueue } from "./impl/awaitableQueue";
 import { getPromiseParts } from "./util/getPromiseParts";
-import { logger } from "./log";
+import { logger } from "./logger";
 
 export interface BatchingPartitionChannelProps {
   loopAbortSignal: AbortSignalLike;

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -25,10 +25,10 @@ import {
   isNamedKeyCredential,
   isSASCredential,
 } from "@azure/core-auth";
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import { EventHubClientOptions } from "./models/public";
 import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
-import { PartitionReceiver } from "./eventHubReceiver";
+import { PartitionReceiver } from "./partitionReceiver";
 import { EventHubSender } from "./eventHubSender";
 import { getRuntimeInfo } from "./util/runtimeInfo";
 import { isCredential } from "./util/typeGuards";

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -28,7 +28,7 @@ import {
 import { logErrorStackTrace, logger } from "./log";
 import { EventHubClientOptions } from "./models/public";
 import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
-import { EventHubReceiver } from "./eventHubReceiver";
+import { PartitionReceiver } from "./eventHubReceiver";
 import { EventHubSender } from "./eventHubSender";
 import { getRuntimeInfo } from "./util/runtimeInfo";
 import { isCredential } from "./util/typeGuards";
@@ -60,7 +60,7 @@ export interface ConnectionContext extends ConnectionContextBase {
   /**
    * A dictionary of the EventHub Receivers associated with this client.
    */
-  receivers: Dictionary<EventHubReceiver>;
+  receivers: Dictionary<PartitionReceiver>;
   /**
    * A dictionary of the EventHub Senders associated with this client.
    */

--- a/sdk/eventhub/event-hubs/src/dataTransformer.ts
+++ b/sdk/eventhub/event-hubs/src/dataTransformer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import { Buffer } from "buffer";
 import isBuffer from "is-buffer";
 import { message } from "rhea-promise";

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -19,7 +19,7 @@ import { AbortController } from "@azure/abort-controller";
 import { AmqpAnnotatedMessage, delay } from "@azure/core-amqp";
 import { BatchingPartitionChannel } from "./batchingPartitionChannel";
 import { PartitionAssigner } from "./impl/partitionAssigner";
-import { logger } from "./log";
+import { logger } from "./logger";
 
 /**
  * Contains the events that were successfully sent to the Event Hub,

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -25,7 +25,7 @@ import { LoadBalancingStrategy } from "./loadBalancerStrategies/loadBalancingStr
 import { PartitionGate } from "./impl/partitionGate";
 import { UnbalancedLoadBalancingStrategy } from "./loadBalancerStrategies/unbalancedStrategy";
 import { isCredential } from "./util/typeGuards";
-import { logger } from "./log";
+import { logger } from "./logger";
 import { v4 as uuid } from "uuid";
 import { validateEventPositions } from "./eventPosition";
 

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -3,7 +3,7 @@
 
 import { CloseReason } from "./models/public";
 import { EventPosition } from "./eventPosition";
-import { LastEnqueuedEventProperties } from "./eventHubReceiver";
+import { LastEnqueuedEventProperties } from "./partitionReceiver";
 import { MessagingError } from "@azure/core-amqp";
 import { OperationTracingOptions } from "@azure/core-tracing";
 import { ReceivedEventData } from "./eventData";

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -17,7 +17,7 @@ import { TracingContext, TracingSpanLink } from "@azure/core-tracing";
 import { NamedKeyCredential, SASCredential, TokenCredential } from "@azure/core-auth";
 import { isDefined } from "@azure/core-util";
 import { isCredential } from "./util/typeGuards";
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import {
   idempotentAlreadyPublished,
   idempotentSomeAlreadyPublished,

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -34,7 +34,7 @@ import {
   createSimpleLogger,
   logger,
   SimpleLogger,
-} from "./log";
+} from "./logger";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { ConnectionContext } from "./connectionContext";
 import { EventHubProducerOptions, IdempotentLinkProperties } from "./models/private";

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -5,7 +5,7 @@ import { AbortController, AbortError, AbortSignalLike } from "@azure/abort-contr
 import { Checkpoint, PartitionProcessor } from "./partitionProcessor";
 import { EventPosition, isEventPosition, latestEventPosition } from "./eventPosition";
 import { PumpManager, PumpManagerImpl } from "./pumpManager";
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import { CloseReason } from "./models/public";
 import { CommonEventProcessorOptions } from "./models/private";
 import { ConnectionContext } from "./connectionContext";

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -5,7 +5,7 @@
 
 export { EventData, ReceivedEventData } from "./eventData";
 export { WebSocketImpl } from "rhea-promise";
-export { LastEnqueuedEventProperties } from "./eventHubReceiver";
+export { LastEnqueuedEventProperties } from "./partitionReceiver";
 export { OperationOptions } from "./util/operationOptions";
 export {
   EventHubClientOptions,
@@ -46,7 +46,7 @@ export { CheckpointStore, PartitionOwnership } from "./eventProcessor";
 export { CloseReason } from "./models/public";
 export { MessagingError, RetryOptions, RetryMode, WebSocketOptions } from "@azure/core-amqp";
 export { TokenCredential } from "@azure/core-auth";
-export { logger } from "./log";
+export { logger } from "./logger";
 export {
   parseEventHubConnectionString,
   EventHubConnectionStringProperties,

--- a/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
+++ b/sdk/eventhub/event-hubs/src/loadBalancerStrategies/loadBalancingStrategy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { PartitionOwnership } from "../eventProcessor";
-import { logger } from "../log";
+import { logger } from "../logger";
 
 /**
  * Determines which partitions to claim as part of load balancing.

--- a/sdk/eventhub/event-hubs/src/logger.ts
+++ b/sdk/eventhub/event-hubs/src/logger.ts
@@ -58,7 +58,7 @@ function createLogFunction(
 ): (arg: any, ...args: any[]) => void {
   return (arg: any, ...args: any[]) =>
     azureLogger[level](
-      ...(typeof arg === "string" ? [`${prefix}  ${arg}`] : [prefix, arg]),
+      ...(typeof arg === "string" ? [`${prefix}: ${arg}`] : [prefix, arg]),
       ...args
     );
 }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -28,7 +28,7 @@ import {
   createSimpleLogger,
   logger,
   SimpleLogger,
-} from "./log";
+} from "./logger";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { AccessToken } from "@azure/core-auth";

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -8,9 +8,9 @@ import {
 } from "./eventHubConsumerClientModels";
 import { CheckpointStore } from "./eventProcessor";
 import { CloseReason } from "./models/public";
-import { LastEnqueuedEventProperties } from "./eventHubReceiver";
+import { LastEnqueuedEventProperties } from "./partitionReceiver";
 import { ReceivedEventData } from "./eventData";
-import { logger } from "./log";
+import { logger } from "./logger";
 
 /**
  * A checkpoint is meant to represent the last successfully processed event by the user from a particular

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -8,7 +8,7 @@ import { CloseReason } from "./models/public";
 import { CommonEventProcessorOptions } from "./models/private";
 import { ConnectionContext } from "./connectionContext";
 import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
-import { EventHubReceiver } from "./eventHubReceiver";
+import { createReceiver, PartitionReceiver } from "./eventHubReceiver";
 import { EventPosition } from "./eventPosition";
 import { MessagingError } from "@azure/core-amqp";
 import { PartitionProcessor } from "./partitionProcessor";
@@ -22,7 +22,7 @@ import { extractSpanContextFromEventData } from "./diagnostics/instrumentEventDa
 export class PartitionPump {
   private _partitionProcessor: PartitionProcessor;
   private _processorOptions: CommonEventProcessorOptions;
-  private _receiver: EventHubReceiver | undefined;
+  private _receiver: PartitionReceiver | undefined;
   private _isReceiving: boolean = false;
   private _isStopped: boolean = false;
   private _abortController: AbortController;
@@ -59,7 +59,7 @@ export class PartitionPump {
   }
 
   /**
-   * Creates a new `EventHubReceiver` and replaces any existing receiver.
+   * Creates a new `PartitionReceiver` and replaces any existing receiver.
    * @param partitionId - The partition the receiver should read messages from.
    * @param lastSeenSequenceNumber - The sequence number to begin receiving messages from (exclusive).
    * If `-1`, then the PartitionPump's startPosition will be used instead.
@@ -67,7 +67,7 @@ export class PartitionPump {
   private _setOrReplaceReceiver(
     partitionId: string,
     lastSeenSequenceNumber: number
-  ): EventHubReceiver {
+  ): PartitionReceiver {
     // Determine what the new EventPosition should be.
     // If this PartitionPump has received events, we'll start from the last
     // seen sequenceNumber (exclusive).
@@ -81,7 +81,7 @@ export class PartitionPump {
         : this._startPosition;
 
     // Set or replace the PartitionPump's receiver.
-    this._receiver = new EventHubReceiver(
+    this._receiver = createReceiver(
       this._context,
       this._partitionProcessor.consumerGroup,
       partitionId,

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 import { TracingSpanOptions, TracingSpanLink } from "@azure/core-tracing";
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import { AbortController } from "@azure/abort-controller";
 import { CloseReason } from "./models/public";
 import { CommonEventProcessorOptions } from "./models/private";
 import { ConnectionContext } from "./connectionContext";
 import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
-import { createReceiver, PartitionReceiver } from "./eventHubReceiver";
+import { createReceiver, PartitionReceiver } from "./partitionReceiver";
 import { EventPosition } from "./eventPosition";
 import { MessagingError } from "@azure/core-amqp";
 import { PartitionProcessor } from "./partitionProcessor";

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -27,7 +27,7 @@ import {
   logObj,
   logger as azureLogger,
   SimpleLogger,
-} from "./log";
+} from "./logger";
 import { ConnectionContext } from "./connectionContext";
 import { EventHubConsumerOptions } from "./models/private";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logErrorStackTrace, logger } from "./log";
+import { logErrorStackTrace, logger } from "./logger";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { CloseReason } from "./models/public";
 import { CommonEventProcessorOptions } from "./models/private";

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logErrorStackTrace, logger } from "../log";
+import { logErrorStackTrace, logger } from "../logger";
 import { ConnectionContext } from "../connectionContext";
 import { isDefined } from "@azure/core-util";
 import { AmqpError, isAmqpError } from "rhea-promise";

--- a/sdk/eventhub/event-hubs/src/withAuth.ts
+++ b/sdk/eventhub/event-hubs/src/withAuth.ts
@@ -14,7 +14,7 @@ import { AbortSignalLike } from "@azure/abort-controller";
 import { AccessToken, TokenCredential } from "@azure/core-auth";
 import { ConnectionContext } from "./connectionContext";
 import { createTimerLoop, TimerLoop } from "./util/timerLoop";
-import { SimpleLogger, logObj } from "./log";
+import { SimpleLogger, logObj } from "./logger";
 
 /**
  *

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -3,7 +3,7 @@
 
 import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
-import { createReceiver, PartitionReceiver } from "../../src/eventHubReceiver";
+import { createReceiver, PartitionReceiver } from "../../src/partitionReceiver";
 import { EventHubSender } from "../../src/eventHubSender";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -3,7 +3,7 @@
 
 import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
-import { EventHubReceiver } from "../../src/eventHubReceiver";
+import { createReceiver, PartitionReceiver } from "../../src/eventHubReceiver";
 import { EventHubSender } from "../../src/eventHubSender";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -77,9 +77,9 @@ testWithServiceTypes((serviceVersion) => {
     ];
 
     describe("EventHubReceiver", () => {
-      let client: EventHubReceiver;
+      let client: PartitionReceiver;
       beforeEach("instantiate EventHubReceiver", () => {
-        client = new EventHubReceiver(
+        client = createReceiver(
           context,
           "$default", // consumer group
           "0", // partition id
@@ -97,7 +97,7 @@ testWithServiceTypes((serviceVersion) => {
         it(`initialize supports cancellation (${caseType})`, async () => {
           const abortSignal = getSignal();
           try {
-            await client.initialize({ abortSignal, timeoutInMs: 60000 });
+            await client.connect({ abortSignal, timeoutInMs: 60000 });
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
@@ -118,7 +118,7 @@ testWithServiceTypes((serviceVersion) => {
 
         it(`receiveBatch supports cancellation when connection already exists (${caseType})`, async () => {
           // Open the connection.
-          await client.initialize({ abortSignal: undefined, timeoutInMs: 60000 });
+          await client.connect({ abortSignal: undefined, timeoutInMs: 60000 });
           try {
             const abortSignal = getSignal();
             await client.receiveBatch(10, undefined, abortSignal);

--- a/sdk/eventhub/event-hubs/test/internal/checkOnInterval.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/checkOnInterval.spec.ts
@@ -4,7 +4,7 @@
 import * as sinon from "sinon";
 import { AbortController } from "@azure/abort-controller";
 import { assert } from "chai";
-import { checkOnInterval } from "../../src/eventHubReceiver";
+import { checkOnInterval } from "../../src/partitionReceiver";
 
 describe("checkOnInterval", function () {
   it("should resolve when the check function returns true", async function () {

--- a/sdk/eventhub/event-hubs/test/internal/checkOnInterval.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/checkOnInterval.spec.ts
@@ -3,7 +3,7 @@
 
 import * as sinon from "sinon";
 import { AbortController } from "@azure/abort-controller";
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 import { checkOnInterval } from "../../src/partitionReceiver";
 
 describe("checkOnInterval", function () {
@@ -12,11 +12,12 @@ describe("checkOnInterval", function () {
     const delayTime = 2500;
     const callCount = 3;
     let curCallCount = 0;
-    const delayPromise = checkOnInterval(delayTime, () => ++curCallCount === callCount);
-    const time = await clock.runAllAsync();
-    clock.restore();
+    const [_, time] = await Promise.all([
+      checkOnInterval(delayTime, () => ++curCallCount === callCount),
+      clock.runAllAsync(),
+    ]);
     assert.strictEqual(time, delayTime * callCount);
-    await delayPromise;
+    clock.restore();
   });
 
   it("should return when the abort signal is called", async function () {

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -3,7 +3,7 @@
 
 import { EnvVarKeys, getEnvVars } from "../../public/utils/testUtils";
 import { EventHubConsumerClient, latestEventPosition } from "../../../src";
-import { createReceiver, WritableReceiver } from "../../../src/eventHubReceiver";
+import { createReceiver, WritableReceiver } from "../../../src/partitionReceiver";
 import { EventHubSender } from "../../../src/eventHubSender";
 import { MessagingError } from "@azure/core-amqp";
 import chai from "chai";

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -3,7 +3,7 @@
 
 import { EnvVarKeys, getEnvVars } from "../../public/utils/testUtils";
 import { EventHubConsumerClient, latestEventPosition } from "../../../src";
-import { EventHubReceiver } from "../../../src/eventHubReceiver";
+import { createReceiver, WritableReceiver } from "../../../src/eventHubReceiver";
 import { EventHubSender } from "../../../src/eventHubSender";
 import { MessagingError } from "@azure/core-amqp";
 import chai from "chai";
@@ -98,13 +98,13 @@ testWithServiceTypes((serviceVersion) => {
           const context = createConnectionContext(service.connectionString, service.path);
 
           // Add 2 receivers.
-          const receiver1 = new EventHubReceiver(
+          const receiver1 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
             partitionIds[0],
             latestEventPosition
           );
-          const receiver2 = new EventHubReceiver(
+          const receiver2 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
             partitionIds[1],
@@ -120,11 +120,11 @@ testWithServiceTypes((serviceVersion) => {
           await sender2["_getLink"]();
 
           // Initialize receiver links
-          await receiver1.initialize({
+          await receiver1.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
           });
-          await receiver2.initialize({
+          await receiver2.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
           });
@@ -140,7 +140,7 @@ testWithServiceTypes((serviceVersion) => {
 
           // We are going to override receiver1's close method so that it also invokes receiver2's close method.
           const receiver1Close = receiver1.close.bind(receiver1);
-          receiver1.close = async function () {
+          (receiver1 as WritableReceiver).close = async function () {
             receiver2.close().catch(() => {
               /* no-op */
             });
@@ -158,13 +158,13 @@ testWithServiceTypes((serviceVersion) => {
           const context = createConnectionContext(service.connectionString, service.path);
 
           // Add 2 receivers.
-          const receiver1 = new EventHubReceiver(
+          const receiver1 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
             partitionIds[0],
             latestEventPosition
           );
-          const receiver2 = new EventHubReceiver(
+          const receiver2 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
             partitionIds[1],
@@ -180,11 +180,11 @@ testWithServiceTypes((serviceVersion) => {
           await sender2["_getLink"]();
 
           // Initialize receiver links
-          await receiver1.initialize({
+          await receiver1.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
           });
-          await receiver2.initialize({
+          await receiver2.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
           });
@@ -200,7 +200,7 @@ testWithServiceTypes((serviceVersion) => {
 
           // We are going to override receiver1's close method so that it also invokes receiver2's close method.
           const originalClose = receiver1.close.bind(receiver1);
-          receiver1.close = async function () {
+          (receiver1 as WritableReceiver).close = async function () {
             receiver2.close().catch(() => {
               /* no-op */
             });

--- a/sdk/eventhub/event-hubs/test/internal/node/waitForEvents.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/waitForEvents.spec.ts
@@ -4,7 +4,7 @@
 import { assert } from "@azure/test-utils";
 import * as sinon from "sinon";
 import EventEmitter from "events";
-import { waitForEvents } from "../../../src/eventHubReceiver";
+import { waitForEvents } from "../../../src/partitionReceiver";
 import { AbortSignalLike, AbortController } from "@azure/abort-controller";
 
 function assertWaitForEvents(inputs: {

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -9,7 +9,7 @@ import {
   EventPosition,
   MessagingError,
 } from "../../src";
-import { createReceiver } from "../../src/eventHubReceiver";
+import { createReceiver } from "../../src/partitionReceiver";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -9,7 +9,7 @@ import {
   EventPosition,
   MessagingError,
 } from "../../src";
-import { EventHubReceiver } from "../../src/eventHubReceiver";
+import { createReceiver } from "../../src/eventHubReceiver";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "../public/utils/mockService";
@@ -85,7 +85,7 @@ testWithServiceTypes((serviceVersion) => {
         await producerClient.sendBatch([message], { partitionId });
 
         // Disable retries to make it easier to test scenario.
-        const receiver = new EventHubReceiver(
+        const receiver = createReceiver(
           consumerClient["_context"],
           EventHubConsumerClient.defaultConsumerGroupName,
           partitionId,
@@ -140,7 +140,7 @@ testWithServiceTypes((serviceVersion) => {
         await producerClient.sendBatch([message], { partitionId });
 
         // Disable retries to make it easier to test scenario.
-        const receiver = new EventHubReceiver(
+        const receiver = createReceiver(
           consumerClient["_context"],
           EventHubConsumerClient.defaultConsumerGroupName,
           partitionId,


### PR DESCRIPTION
As the title says. This makes the code more safe as more things become const and thus unmutable. It also decreases the surface of the receiver. Also decomposes the receiver into many smaller functions that can be easily unit-tested.

[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2660101) for 299ae54e3e379c05e6fe07226c536f7bcbb8e1d0
[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2661988&view=results) for  https://github.com/Azure/azure-sdk-for-js/pull/25390/commits/e3fb251e264db1b396edeafb28331d17d0835fb8
[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2665541&view=results) for https://github.com/Azure/azure-sdk-for-js/pull/25390/commits/47afb57856b44028cc73dee770945056e6b724f1
[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2666005&view=results) for https://github.com/Azure/azure-sdk-for-js/pull/25390/commits/9d752fc3d87ebed01b7ef811f22bfe861c49e1d9
[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2667474&view=results) for https://github.com/Azure/azure-sdk-for-js/pull/25390/commits/9e4f7588ef6ad246f484715df0b89a9413e9fddc