### PR TITLE
[Event Hubs] Remove uuid dep

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -117,8 +117,7 @@
     "jssha": "^3.1.0",
     "process": "^0.11.10",
     "rhea-promise": "^3.0.0",
-    "tslib": "^2.2.0",
-    "uuid": "^8.3.0"
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
@@ -141,7 +140,6 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.0",
     "@types/sinon": "^9.0.4",
-    "@types/uuid": "^8.0.0",
     "@types/ws": "^7.2.4",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -3,8 +3,8 @@
 
 import { CheckpointStore, PartitionOwnership } from "./eventProcessor";
 import { Checkpoint } from "./partitionProcessor";
-import { generate_uuid } from "rhea-promise";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
+import { getRandomName } from "./util/utils";
 
 /**
  * The `EventProcessor` relies on a `CheckpointStore` to store checkpoints and handle partition
@@ -64,7 +64,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
 
         const newOwnership = {
           ...ownership,
-          etag: generate_uuid(),
+          etag: getRandomName(),
           lastModifiedTimeInMs: date.getTime(),
         };
 
@@ -93,7 +93,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
 
     const partitionOwnership = this._partitionOwnershipMap.get(checkpoint.partitionId);
     if (partitionOwnership) {
-      partitionOwnership.etag = generate_uuid();
+      partitionOwnership.etag = getRandomName();
 
       const key = `${checkpoint.fullyQualifiedNamespace}:${checkpoint.eventHubName}:${checkpoint.consumerGroup}`;
       let partitionMap = this._committedCheckpoints.get(key);

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -20,7 +20,6 @@ import {
   ReceiverOptions,
   SenderEvents,
   SenderOptions,
-  generate_uuid,
 } from "rhea-promise";
 import {
   createLogPrefix,
@@ -450,10 +449,10 @@ export class ManagementClient {
         count++;
         if (count !== 1) {
           // Generate a new message_id every time after the first attempt
-          request.message_id = generate_uuid();
+          request.message_id = getRandomName();
         } else if (!request.message_id) {
           // Set the message_id in the first attempt only if it is not set
-          request.message_id = generate_uuid();
+          request.message_id = getRandomName();
         }
 
         return this._mgmtReqResLink!.sendRequest(request, sendRequestOptions);

--- a/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventProcessor.spec.ts
@@ -14,7 +14,7 @@ import {
   earliestEventPosition,
   latestEventPosition,
 } from "../../src";
-import { Dictionary, generate_uuid } from "rhea-promise";
+import { Dictionary } from "rhea-promise";
 import { EnvVarKeys, getEnvVars, loopUntil } from "../public/utils/testUtils";
 import { EventProcessor, FullEventProcessorOptions } from "../../src/eventProcessor";
 import {
@@ -38,6 +38,7 @@ import { isLatestPosition } from "../../src/eventPosition";
 import { loggerForTest } from "../public/utils/logHelpers";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
 import { getRandomName } from "../../src/util/utils";
+import { randomUUID } from "@azure/core-util";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -854,14 +855,14 @@ testWithServiceTypes((serviceVersion) => {
           fullyQualifiedNamespace: "myNamespace.servicebus.windows.net",
           eventHubName: "myEventHub",
           consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
-          ownerId: generate_uuid(),
+          ownerId: randomUUID(),
           partitionId: "0",
         };
         const partitionOwnership2: PartitionOwnership = {
           fullyQualifiedNamespace: "myNamespace.servicebus.windows.net",
           eventHubName: "myEventHub",
           consumerGroup: EventHubConsumerClient.defaultConsumerGroupName,
-          ownerId: generate_uuid(),
+          ownerId: randomUUID(),
           partitionId: "1",
         };
         const partitionOwnership = await inMemoryCheckpointStore.claimOwnership([

--- a/sdk/eventhub/event-hubs/test/public/amqpAnnotatedMessage.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/amqpAnnotatedMessage.spec.ts
@@ -17,7 +17,7 @@ import chaiAsPromised from "chai-as-promised";
 import chaiExclude from "chai-exclude";
 import { createMockServer } from "./utils/mockService";
 import { testWithServiceTypes } from "./utils/testWithServiceTypes";
-import { v4 } from "uuid";
+import { randomUUID } from "@azure/core-util";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -89,7 +89,7 @@ testWithServiceTypes((serviceVersion) => {
         properties: {
           contentEncoding: "application/json; charset=utf-8",
           correlationId: randomTag,
-          messageId: v4(),
+          messageId: randomUUID(),
         },
       } as AmqpAnnotatedMessage;
     }

--- a/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
@@ -15,7 +15,7 @@ import chaiAsPromised from "chai-as-promised";
 import chaiExclude from "chai-exclude";
 import { createMockServer } from "./utils/mockService";
 import { testWithServiceTypes } from "./utils/testWithServiceTypes";
-import { v4 } from "uuid";
+import { randomUUID } from "@azure/core-util";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -75,7 +75,7 @@ testWithServiceTypes((serviceVersion) => {
         body: `message body ${randomTag}`,
         contentEncoding: "application/json; charset=utf-8",
         correlationId: randomTag,
-        messageId: v4(),
+        messageId: randomUUID(),
       } as EventData;
     }
 
@@ -114,7 +114,7 @@ testWithServiceTypes((serviceVersion) => {
         "work around initial state issue by filling partitions with at least one message",
         async () => {
           for (let i = 1; i < 100; i++) {
-            const filer = { body: "b", messageId: v4() };
+            const filer = { body: "b", messageId: randomUUID() };
             await producerClient.sendBatch([filer]);
           }
         }

--- a/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/test/public/utils/testInMemoryCheckpointStore.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { randomUUID } from "@azure/core-util";
 import { Checkpoint, CheckpointStore, PartitionOwnership } from "../../../src";
-import { generate_uuid } from "rhea-promise";
 
 /**
  * The `EventProcessor` relies on a `CheckpointStore` to store checkpoints and handle partition
@@ -62,7 +62,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
 
         const newOwnership = {
           ...ownership,
-          etag: generate_uuid(),
+          etag: randomUUID(),
           lastModifiedTimeInMs: date.getTime(),
         };
 
@@ -83,7 +83,7 @@ export class TestInMemoryCheckpointStore implements CheckpointStore {
 
     const partitionOwnership = this._partitionOwnershipMap.get(checkpoint.partitionId);
     if (partitionOwnership) {
-      partitionOwnership.etag = generate_uuid();
+      partitionOwnership.etag = randomUUID();
 
       const key = `${checkpoint.fullyQualifiedNamespace}:${checkpoint.eventHubName}:${checkpoint.consumerGroup}`;
       let partitionMap = this._committedCheckpoints.get(key);


### PR DESCRIPTION
- Replaces calls to `generate_uuid` from rhea-promise with calls to `getRandomName`
- Replaces calls to `uuid` in public tests with `randomUUID`
- Removes the dependency on `uuid`

[Successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2668672&view=results)