### PR TITLE
Fix the query property inconsistency with the protocol

### DIFF
--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Fix bug https://github.com/Azure/azure-sdk-for-js/issues/24515
+- Address issue with `query` property from CloudEvent https://github.com/Azure/azure-sdk-for-js/issues/24515
 
 ## 1.0.3 (2022-06-15)
 

--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -1,18 +1,15 @@
 # Release History
 
-## 1.0.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.4 (2023-04-03)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix bug https://github.com/Azure/azure-sdk-for-js/issues/24515
 
 ## 1.0.3 (2022-06-15)
 
 ### Bugs Fixed
+
 - Fix issue https://github.com/Azure/azure-sdk-for-js/issues/22134 that hub name should be case insensitive
 
 ## 1.0.2 (2022-01-30)
@@ -56,7 +53,7 @@ No changes.
       res.setState("calledTime", calledTime);
       res.success();
     },
-    allowedEndpoints: ["https://xxx.webpubsub.azure.com"]
+    allowedEndpoints: ["https://xxx.webpubsub.azure.com"],
   });
   ```
 
@@ -78,7 +75,7 @@ No changes.
       // You can also set the state here
       res.setState("calledTime", calledTime);
       res.success();
-    }
+    },
   });
   ```
 

--- a/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
+++ b/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
@@ -34,6 +34,8 @@ export interface ConnectRequest {
     context: ConnectionContext;
     headers?: Record<string, string[]>;
     queries?: Record<string, string[]>;
+    // @deprecated
+    query?: Record<string, string[]>;
     subprotocols?: string[];
 }
 

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -279,6 +279,8 @@ export class CloudEventsDispatcher {
     switch (eventType) {
       case EventType.Connect: {
         const connectRequest = await readSystemEventRequest<ConnectRequest>(request, origin);
+        // service passes out query property, assign it to queries
+        connectRequest.queries = connectRequest.query;
         logger.verbose(connectRequest);
 
         this.eventHandler.handleConnect!(

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -70,7 +70,7 @@ export interface ConnectRequest {
    */
   claims?: Record<string, string[]>;
   /**
-   * The query that the client WebSocket connection has when it connects. 
+   * The query that the client WebSocket connection has when it connects.
    * @deprecated Please use queries instead.
    */
   query?: Record<string, string[]>;

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsProtocols.ts
@@ -70,6 +70,11 @@ export interface ConnectRequest {
    */
   claims?: Record<string, string[]>;
   /**
+   * The query that the client WebSocket connection has when it connects. 
+   * @deprecated Please use queries instead.
+   */
+  query?: Record<string, string[]>;
+  /**
    * The queries that the client WebSocket connection has when it connects.
    */
   queries?: Record<string, string[]>;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-express

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/24515

### Describe the problem that is addressed by this PR
The Azure Web PubSub service defines it's protocol sending CloudEvents out as `query`, however in TS we defined it as `queries` in the interface. To resolve the inconsistency between them, add a `query` property to the interface but mark it as obsolete and mean why set the value of `queries` as the value of `query` to make the property work.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
