### PR TITLE
[Communication][communication-alpha-ids] enable code coverage report in alpha sender ids tests

### DIFF
--- a/sdk/communication/communication-alpha-ids/.nycrc
+++ b/sdk/communication/communication-alpha-ids/.nycrc
@@ -1,0 +1,18 @@
+{
+  "include": [
+    "dist-esm/src/**/*.js"
+  ],
+  "exclude": [
+    "**/*.d.ts"
+  ],
+  "reporter": [
+    "text-summary",
+    "html",
+    "cobertura"
+  ],
+  "exclude-after-remap": false,
+  "sourceMap": true,
+  "produce-source-map": true,
+  "instrument": true,
+  "all": true
+}


### PR DESCRIPTION
Enable the Code Coverage tab report by adding the missing .nycrc file to Alpha Sender Ids
