### PR TITLE
Issue-21383:Fix Upsert

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -328,14 +328,13 @@ export class Items {
     body: T,
     options: RequestOptions = {}
   ): Promise<ItemResponse<T>> {
-    const { resource: partitionKeyDefinition } = await this.container.readPartitionKeyDefinition();
-    const partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
-
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
     if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
       body.id = uuid();
     }
+    const { resource: partitionKeyDefinition } = await this.container.readPartitionKeyDefinition();
+    const partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
 
     const err = {};
     if (!isItemResourceValid(body, err)) {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#21383 

### Describe the problem that is addressed by this PR
Upsert operation was failing when partition key of container is `/id` and `id` is missing in the object body. This fix generates the uuid before extracting partition key from the body, similar to create operation. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
