### PR TITLE
[core-http] Expose max sockets options in ServiceClient

### DIFF
--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -422,6 +422,15 @@ export const MapperType: {
 };
 
 // @public
+export interface MaxSocketsOptions {
+    perHost?: number;
+    total?: number;
+}
+
+// @public
+export function maxSocketsPolicy(maxSocketsOptions?: MaxSocketsOptions): RequestPolicyFactory;
+
+// @public
 export interface OperationArguments {
     [parameterName: string]: any;
     options?: RequestOptionsBase;
@@ -510,6 +519,7 @@ export function parseXML(str: string, opts?: SerializerOptions): Promise<any>;
 export interface PipelineOptions {
     httpClient?: HttpClient;
     keepAliveOptions?: KeepAliveOptions;
+    maxSocketsOptions?: MaxSocketsOptions;
     proxyOptions?: ProxyOptions;
     redirectOptions?: RedirectOptions;
     retryOptions?: RetryOptions;
@@ -858,6 +868,8 @@ export class WebResource implements WebResourceLike {
     formData?: any;
     headers: HttpHeadersLike;
     keepAlive?: boolean;
+    maxSockets?: number;
+    maxTotalSockets?: number;
     method: HttpMethods;
     onDownloadProgress?: (progress: TransferProgressEvent) => void;
     onUploadProgress?: (progress: TransferProgressEvent) => void;
@@ -890,6 +902,8 @@ export interface WebResourceLike {
     formData?: any;
     headers: HttpHeadersLike;
     keepAlive?: boolean;
+    maxSockets?: number;
+    maxTotalSockets?: number;
     method: HttpMethods;
     onDownloadProgress?: (progress: TransferProgressEvent) => void;
     onUploadProgress?: (progress: TransferProgressEvent) => void;

--- a/sdk/core/core-http/src/index.ts
+++ b/sdk/core/core-http/src/index.ts
@@ -63,6 +63,7 @@ export { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 export { getDefaultProxySettings, proxyPolicy } from "./policies/proxyPolicy";
 export { redirectPolicy, RedirectOptions } from "./policies/redirectPolicy";
 export { keepAlivePolicy, KeepAliveOptions } from "./policies/keepAlivePolicy";
+export { maxSocketsPolicy, MaxSocketsOptions } from "./policies/maxSocketsPolicy";
 export { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 export { signingPolicy } from "./policies/signingPolicy";
 export {

--- a/sdk/core/core-http/src/nodeFetchHttpClient.ts
+++ b/sdk/core/core-http/src/nodeFetchHttpClient.ts
@@ -324,6 +324,12 @@ export class NodeFetchHttpClient implements HttpClient {
       );
 
       agent = tunnel.agent;
+      if (httpRequest.maxSockets !== undefined) {
+        agent.maxSockets = httpRequest.maxSockets;
+      }
+      if (httpRequest.maxTotalSockets !== undefined) {
+        agent.maxTotalSockets = httpRequest.maxTotalSockets;
+      }
       if (tunnel.isHttps) {
         proxyAgents.httpsAgent = tunnel.agent as https.Agent;
       } else {
@@ -340,6 +346,8 @@ export class NodeFetchHttpClient implements HttpClient {
 
       const agentOptions: http.AgentOptions | https.AgentOptions = {
         keepAlive: httpRequest.keepAlive,
+        maxSockets: httpRequest.maxSockets,
+        maxTotalSockets: httpRequest.maxTotalSockets,
       };
 
       if (isHttps) {

--- a/sdk/core/core-http/src/pipelineOptions.ts
+++ b/sdk/core/core-http/src/pipelineOptions.ts
@@ -4,6 +4,7 @@
 import { DeserializationOptions } from "./policies/deserializationPolicy";
 import { HttpClient } from "./httpClient";
 import { KeepAliveOptions } from "./policies/keepAlivePolicy";
+import { MaxSocketsOptions } from "./policies/maxSocketsPolicy";
 import { LogPolicyOptions } from "./policies/logPolicy";
 import { ProxyOptions } from "./serviceClient";
 import { RedirectOptions } from "./policies/redirectPolicy";
@@ -36,6 +37,12 @@ export interface PipelineOptions {
    * requests.
    */
   keepAliveOptions?: KeepAliveOptions;
+
+  /**
+   * Options for how HTTP connections should be maintained for future
+   * requests.
+   */
+  maxSocketsOptions?: MaxSocketsOptions;
 
   /**
    * Options for how redirect responses are handled.

--- a/sdk/core/core-http/src/pipelineOptions.ts
+++ b/sdk/core/core-http/src/pipelineOptions.ts
@@ -39,8 +39,7 @@ export interface PipelineOptions {
   keepAliveOptions?: KeepAliveOptions;
 
   /**
-   * Options for how HTTP connections should be maintained for future
-   * requests.
+   * Options for how many concurrent sockets an HTTP agent can have open.
    */
   maxSocketsOptions?: MaxSocketsOptions;
 

--- a/sdk/core/core-http/src/policies/maxSocketsPolicy.ts
+++ b/sdk/core/core-http/src/policies/maxSocketsPolicy.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  BaseRequestPolicy,
+  RequestPolicy,
+  RequestPolicyFactory,
+  RequestPolicyOptions,
+} from "./requestPolicy";
+import { HttpOperationResponse } from "../httpOperationResponse";
+import { WebResourceLike } from "../webResource";
+
+/**
+ * Options for how many concurrent sockets the HTTP agent can have open.
+ */
+export interface MaxSocketsOptions {
+  /**
+   * The number of concurrent sockets the agent can have open per host.
+   * Unset by default, corresponding to Infinity. Node.js only.
+   */
+  perHost?: number;
+
+  /**
+   * The total number of concurrent sockets the agent can have open.
+   * Unset by default, corresponding to Infinity. Node.js only.
+   */
+  total?: number;
+}
+
+/**
+ * By default, no limit is set on the maximum number of sockets.
+ */
+export const DefaultMaxSocketsOptions: MaxSocketsOptions = {};
+
+/**
+ * Creates a policy that controls the maximum number of concurrent sockets the
+ * HTTP agent can have open per host and in total.
+ * @param maxSocketsOptions - Max sockets options. By default, these options
+ * are unset, corresponding to "no limit". Node.js.
+ * @returns An instance of {@link MaxSocketsOptions}
+ */
+export function maxSocketsPolicy(maxSocketsOptions?: MaxSocketsOptions): RequestPolicyFactory {
+  return {
+    create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
+      return new MaxSocketsPolicy(
+        nextPolicy,
+        options,
+        maxSocketsOptions || DefaultMaxSocketsOptions
+      );
+    },
+  };
+}
+
+/**
+ * MaxSocketsPolicy is a policy used to configure the maximum number of
+ * concurrent sockets for HTTP agents.
+ */
+export class MaxSocketsPolicy extends BaseRequestPolicy {
+  constructor(
+    nextPolicy: RequestPolicy,
+    options: RequestPolicyOptions,
+    private readonly maxSocketsOptions: MaxSocketsOptions
+  ) {
+    super(nextPolicy, options);
+  }
+
+  /**
+   * Sends out request
+   */
+  public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
+    request.maxSockets = this.maxSocketsOptions.perHost;
+    request.maxTotalSockets = this.maxSocketsOptions.total;
+    return this._nextPolicy.sendRequest(request);
+  }
+}

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -9,6 +9,7 @@ import {
   deserializationPolicy,
 } from "./policies/deserializationPolicy";
 import { DefaultKeepAliveOptions, keepAlivePolicy } from "./policies/keepAlivePolicy";
+import { DefaultMaxSocketsOptions, maxSocketsPolicy } from "./policies/maxSocketsPolicy";
 import { DefaultRedirectOptions, redirectPolicy } from "./policies/redirectPolicy";
 import { DefaultRetryOptions, exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
 import { HttpOperationResponse, RestResponse } from "./httpOperationResponse";
@@ -781,6 +782,11 @@ export function createPipelineFromOptions(
     ...pipelineOptions.keepAliveOptions,
   };
 
+  const maxSocketsOptions = {
+    ...DefaultMaxSocketsOptions,
+    ...pipelineOptions.maxSocketsOptions,
+  };
+
   const retryOptions = {
     ...DefaultRetryOptions,
     ...pipelineOptions.retryOptions,
@@ -807,6 +813,7 @@ export function createPipelineFromOptions(
   requestPolicyFactories.push(
     tracingPolicy({ userAgent: userAgentValue }),
     keepAlivePolicy(keepAliveOptions),
+    maxSocketsPolicy(maxSocketsOptions),
     userAgentPolicy({ value: userAgentValue }),
     generateClientRequestIdPolicy(),
     deserializationPolicy(deserializationOptions.expectedContentTypes),

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -118,6 +118,14 @@ export interface WebResourceLike {
    */
   keepAlive?: boolean;
   /**
+   * The number of concurrent sockets the HTTP agent can have open per host. Node.js only.
+   */
+  maxSockets?: number;
+  /**
+   * The total number of concurrent sockets the HTTP agent can have open. Node.js only.
+   */
+  maxTotalSockets?: number;
+  /**
    * Whether or not to decompress response according to Accept-Encoding header (node-fetch only)
    */
   decompressResponse?: boolean;
@@ -260,6 +268,14 @@ export class WebResource implements WebResourceLike {
    * Whether to keep the HTTP connections alive throughout requests.
    */
   keepAlive?: boolean;
+  /**
+   * The number of concurrent sockets the HTTP agent can have open per host. Node.js only.
+   */
+  maxSockets?: number;
+  /**
+   * The total number of concurrent sockets the HTTP agent can have open. Node.js only.
+   */
+  maxTotalSockets?: number;
   /**
    * Whether or not to decompress response according to Accept-Encoding header (node-fetch only)
    */


### PR DESCRIPTION
- Support configuring Node.js http.Agent maxSockets and maxTotalSockets when creating service clients.

# THIS IS A DRAFT PR

The below information will be populated after soliciting feedback on whether this is an appropriate approach.

### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
