### PR TITLE
[ACR] Deprecate support for Azure Germany

### DIFF
--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -223,6 +223,7 @@ export enum KnownArtifactOperatingSystem {
 // @public
 export enum KnownContainerRegistryAudience {
     AzureResourceManagerChina = "https://management.chinacloudapi.cn",
+    // @deprecated
     AzureResourceManagerGermany = "https://management.microsoftazure.de",
     AzureResourceManagerGovernment = "https://management.usgovcloudapi.net",
     AzureResourceManagerPublicCloud = "https://management.azure.com"

--- a/sdk/containerregistry/container-registry/src/models.ts
+++ b/sdk/containerregistry/container-registry/src/models.ts
@@ -11,7 +11,10 @@ import { ArtifactTagProperties } from "./generated";
 export enum KnownContainerRegistryAudience {
   /** Azure China */
   AzureResourceManagerChina = "https://management.chinacloudapi.cn",
-  /** Azure Gemany */
+  /**
+   * Azure Germany
+   * @deprecated Azure Germany is being deprecated in favor of standard nonsovereign Azure regions in Germany.
+   */
   AzureResourceManagerGermany = "https://management.microsoftazure.de",
   /** Azure Government */
   AzureResourceManagerGovernment = "https://management.usgovcloudapi.net",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Fix #24128

### Describe the problem that is addressed by this PR

Azure Germany is deprecated. This PR marks the corresponding audience in `KnownContainerRegistryAudience` as deprecated.