### PR TITLE
[ACR] Lower @azure/abort-controller dependency to latest published version

### DIFF
--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -73,7 +73,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/abort-controller": "^1.1.1",
+    "@azure/abort-controller": "^1.1.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.8.0",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Describe the problem that is addressed by this PR

In preparation for beta release, lower the new `@azure/abort-controller` dependency to the latest released version (1.1.0).