### PR TITLE
[eventhubs-checkpointstore-table] upgrade dependency `@azure/data-tables` to `^13.2.2`

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-table/CHANGELOG.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 - This is the first preview of the `@azure/eventhubs-checkpointstore-table` library.
 
+### Other Changes
+
+- Upgrade dependency `@azure/data-tables` version to `^13.2.2`

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/event-hubs": "^5.6.0",
-    "@azure/data-tables": "^12.1.2",
+    "@azure/data-tables": "^13.2.2",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/eventhubs-checkpointstore-table`

