### PR TITLE
[engsys] exclude `.github/CODEOWNERS` from spell checking

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,6 +23,7 @@
     "*.crt",
     "*.key",
     ".vscode/cspell.json",
+    ".github/CODEOWNERS",
     "sdk/**/arm-*/**",
     "sdk/test-utils/**",
     "sdk/agrifood/agrifood-farming-rest/review/*.md",


### PR DESCRIPTION
as the file mostly contains aliases and paths, with a handful comments. There's little value spell-checking it.  Also aliases will cause a lot of noises.  This PR excludes it from being checked.
