### PR TITLE
[perf-tests][metrics-advisor] upgrade to depend on `ai-metrics-advisor` GA version

### DIFF
--- a/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/ai-metrics-advisor": "1.0.0-beta.3",
+    "@azure/ai-metrics-advisor": "^1.0.0",
     "@azure/test-utils-perf": "^1.0.0",
     "dotenv": "^16.0.0"
   },

--- a/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/test/listAnomalies.spec.ts
+++ b/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/test/listAnomalies.spec.ts
@@ -15,7 +15,7 @@ export class AnomaliesListTest extends MetricsAdvisorTest<MetricsAdvisorTestOpti
   }
 
   async run(): Promise<void> {
-    const listIterator = this.client.listAnomalies({
+    const listIterator = this.client.listAnomaliesForAlert({
       alertConfigId: this.alertConfigId,
       id: this.alertId,
     });

--- a/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/test/listIncidents.spec.ts
+++ b/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/test/listIncidents.spec.ts
@@ -15,7 +15,7 @@ export class IncidentsListTest extends MetricsAdvisorTest<MetricsAdvisorTestOpti
   }
 
   async run(): Promise<void> {
-    const listIterator = this.client.listIncidents({
+    const listIterator = this.client.listIncidentsForAlert({
       alertConfigId: this.alertConfigId,
       id: this.alertId,
     });


### PR DESCRIPTION
This allows us to remove transitive dependency on core-http v1
