### PR TITLE
Engsys/prepare for types node v16

### DIFF
--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_multivariate_detection.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_multivariate_detection.ts
@@ -25,7 +25,7 @@ const apiKey = process.env["ANOMALY_DETECTOR_API_KEY"] || "";
 const endpoint = process.env["ANOMALY_DETECTOR_ENDPOINT"] || "";
 const dataSource = "<your data source>";
 
-function sleep(time: number): Promise<NodeJS.Timer> {
+function sleep(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
 

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -122,8 +122,6 @@ export const defaultCancellableLock: CancellableAsyncLock = new CancellableAsync
  * the promise with the given value.
  */
 export class Timeout {
-  // Node and browsers return different types from setTimeout
-  // Any is the easiest way to avoid type errors in either platform
   private _timer?: ReturnType<typeof setTimeout>;
 
   set<T>(t: number, value?: T): Promise<T> {

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -124,12 +124,12 @@ export const defaultCancellableLock: CancellableAsyncLock = new CancellableAsync
 export class Timeout {
   // Node and browsers return different types from setTimeout
   // Any is the easiest way to avoid type errors in either platform
-  private _timer?: any;
+  private _timer?: ReturnType<typeof setTimeout>;
 
   set<T>(t: number, value?: T): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       this.clear();
-      const callback = value ? () => reject(new Error(`${value}`)) : resolve;
+      const callback: (args: any) => void = value ? () => reject(new Error(`${value}`)) : resolve;
       this._timer = setTimeout(callback, t);
     });
   }

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -23,17 +23,6 @@ import { assert } from "chai";
 import { createConnectionStub } from "./utils/createConnectionStub";
 import { isError } from "@azure/core-util";
 
-interface Window {}
-declare let self: Window & typeof globalThis;
-
-function getGlobal(): NodeJS.Global | (Window & typeof globalThis) {
-  if (typeof global !== "undefined") {
-    return global;
-  } else {
-    return self;
-  }
-}
-
 const assertItemsLengthInResponsesMap = (
   _responsesMap: Map<string, DeferredPromiseWithCallback>,
   expectedNumberOfItems: number
@@ -622,20 +611,19 @@ describe("RequestResponseLink", function () {
   });
 
   describe("sendRequest clears timeout", () => {
-    const _global = getGlobal();
     const originalClearTimeout = clearTimeout;
     let clearTimeoutCalledCount = 0;
 
     beforeEach(() => {
       clearTimeoutCalledCount = 0;
-      _global.clearTimeout = (tid: any) => {
+      globalThis.clearTimeout = (tid: any) => {
         clearTimeoutCalledCount++;
         return originalClearTimeout(tid);
       };
     });
 
     afterEach(() => {
-      _global.clearTimeout = originalClearTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
     });
 
     it("sendRequest clears timeout after error message", async function () {


### PR DESCRIPTION
- with `globalThis`, old logic to get global object is no longer needed.
- After upgrading TypeScript compiler couldn't resolve to proper `setTimeout` overload because we use `lib: []` compiler option. Working around by casting callback to `(args: any) => void` or just returning `Promise<void>`

