### PR TITLE
[Test Proxy] Init fix - "test-proxy init" command unrecognized error

### DIFF
--- a/common/tools/dev-tool/src/commands/test-proxy/index.ts
+++ b/common/tools/dev-tool/src/commands/test-proxy/index.ts
@@ -10,6 +10,7 @@ export const commandInfo = makeCommandInfo(
 
 export default subCommand(commandInfo, {
   "wait-for-proxy-endpoint": () => import("./waitForProxyEndpoint"),
+  init: () => import("./init"),
   push: () => import("./push"),
   restore: () => import("./restore"),
   reset: () => import("./reset"),


### PR DESCRIPTION
Fixes the following error
<img width="614" alt="image" src="https://user-images.githubusercontent.com/10452642/233515545-7d69e5d8-154f-4ec3-872a-153ad6fdb41e.png">

Updates the index file by adding the "init" command, unsure how we missed the first time.

Fixes #25610 