### PR TITLE
[samples][web-worker] use SAS url in browsers

### DIFF
--- a/samples/web-workers/js/worker.js
+++ b/samples/web-workers/js/worker.js
@@ -6,7 +6,9 @@ import "./polyfill.worker";
 import { ContainerClient } from "@azure/storage-blob";
 
 async function uploadToStorageBlob() {
-  const containerSasUrl = "<your container SAS url>";
+  // For example, in Azure public cloud, a container SAS URL has the form of
+  // `https://${account}.blob.core.windows.net/${containerName}?${sasToken}`
+  const containerSasUrl = "<container SAS url>";
 
   const data = "Hello, Web Workers!";
 

--- a/samples/web-workers/js/worker.js
+++ b/samples/web-workers/js/worker.js
@@ -6,26 +6,11 @@ import "./polyfill.worker";
 import { ContainerClient } from "@azure/storage-blob";
 
 async function uploadToStorageBlob() {
-  const azureStorageBlobConnectionString = process.env.AZURE_STORAGE_BLOB_CONNECTION_STRING;
-  if (!azureStorageBlobConnectionString) {
-    throw new Error(
-      "Required environment variable AZURE_STORAGE_BLOB_CONNECTION_STRING is either missing or empty."
-    );
-  }
-
-  const azureStorageBlobContainerName = process.env.AZURE_STORAGE_BLOB_CONTAINER_NAME;
-  if (!azureStorageBlobContainerName) {
-    throw new Error(
-      "Required environment variable AZURE_STORAGE_BLOB_CONTAINER_NAME is either missing or empty."
-    );
-  }
+  const containerSasUrl = "<your container SAS url>";
 
   const data = "Hello, Web Workers!";
 
-  const containerClient = new ContainerClient(
-    azureStorageBlobConnectionString,
-    azureStorageBlobContainerName
-  );
+  const containerClient = new ContainerClient(containerSasUrl);
   const blockBlobClient = containerClient.getBlockBlobClient("sample.txt");
 
   await blockBlobClient.upload(data, data.length);

--- a/samples/web-workers/ts/worker.ts
+++ b/samples/web-workers/ts/worker.ts
@@ -7,26 +7,11 @@ import "./polyfill.worker";
 import { ContainerClient } from "@azure/storage-blob";
 
 async function uploadToStorageBlob() {
-  const azureStorageBlobConnectionString = process.env.AZURE_STORAGE_BLOB_CONNECTION_STRING;
-  if (!azureStorageBlobConnectionString) {
-    throw new Error(
-      "Required environment variable AZURE_STORAGE_BLOB_CONNECTION_STRING is either missing or empty."
-    );
-  }
-
-  const azureStorageBlobContainerName = process.env.AZURE_STORAGE_BLOB_CONTAINER_NAME;
-  if (!azureStorageBlobContainerName) {
-    throw new Error(
-      "Required environment variable AZURE_STORAGE_BLOB_CONTAINER_NAME is either missing or empty."
-    );
-  }
+  const containerSasUrl = "<your container SAS url>";
 
   const data = "Hello, Web Workers!";
 
-  const containerClient = new ContainerClient(
-    azureStorageBlobConnectionString,
-    azureStorageBlobContainerName
-  );
+  const containerClient = new ContainerClient(containerSasUrl);
   const blockBlobClient = containerClient.getBlockBlobClient("sample.txt");
 
   await blockBlobClient.upload(data, data.length);

--- a/samples/web-workers/ts/worker.ts
+++ b/samples/web-workers/ts/worker.ts
@@ -7,7 +7,9 @@ import "./polyfill.worker";
 import { ContainerClient } from "@azure/storage-blob";
 
 async function uploadToStorageBlob() {
-  const containerSasUrl = "<your container SAS url>";
+  // For example, in Azure public cloud, a container SAS URL has the form of
+  // `https://${account}.blob.core.windows.net/${containerName}?${sasToken}`
+  const containerSasUrl = "<container SAS url>";
 
   const data = "Hello, Web Workers!";
 


### PR DESCRIPTION
Due to security reason we don't want to have secrets in the browsers. This PR updates the web-worker sample to use container SAS url to construct storage blob clients.
