### PR TITLE
azure board review comments

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -10,7 +10,6 @@ import { CommonClientOptions } from '@azure/core-client';
 import { CommunicationIdentifier } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import * as coreClient from '@azure/core-client';
-import { InternalPipelineOptions } from '@azure/core-rest-pipeline';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PhoneNumberIdentifier } from '@azure/communication-common';
@@ -91,7 +90,8 @@ export interface CallConnectedEventData extends Omit<RestCallConnected, "callCon
 
 // @public
 export class CallConnection {
-    constructor(callConnectionId: string, endpoint: string, credential: KeyCredential | TokenCredential, options?: InternalPipelineOptions);
+    // Warning: (ae-forgotten-export) The symbol "CallAutomationApiClientOptionalParams" needs to be exported by the entry point index.d.ts
+    constructor(callConnectionId: string, endpoint: string, credential: KeyCredential | TokenCredential, options?: CallAutomationApiClientOptionalParams);
     addParticipant(targetParticipant: CallInvite, options?: AddParticipantOptions): Promise<AddParticipantResult>;
     getCallConnectionProperties(options?: GetCallConnectionPropertiesOptions): Promise<CallConnectionProperties>;
     getCallMedia(): CallMedia;
@@ -153,7 +153,6 @@ export type CallLocatorType = "serverCallLocator" | "groupCallLocator";
 
 // @public
 export class CallMedia {
-    // Warning: (ae-forgotten-export) The symbol "CallAutomationApiClientOptionalParams" needs to be exported by the entry point index.d.ts
     constructor(callConnectionId: string, endpoint: string, credential: KeyCredential | TokenCredential, options?: CallAutomationApiClientOptionalParams);
     cancelAllOperations(): Promise<void>;
     play(playSource: FileSource, playTo: CommunicationIdentifier[], playOptions?: PlayOptions): Promise<void>;

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -10,10 +10,10 @@ import { CommonClientOptions } from '@azure/core-client';
 import { CommunicationIdentifier } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import * as coreClient from '@azure/core-client';
+import { InternalPipelineOptions } from '@azure/core-rest-pipeline';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PhoneNumberIdentifier } from '@azure/communication-common';
-import { PipelineResponse } from '@azure/core-rest-pipeline';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
@@ -91,16 +91,14 @@ export interface CallConnectedEventData extends Omit<RestCallConnected, "callCon
 
 // @public
 export class CallConnection {
-    // Warning: (ae-forgotten-export) The symbol "CallConnectionImpl" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "CallMediaImpl" needs to be exported by the entry point index.d.ts
-    constructor(callConnectionId: string, callConnection: CallConnectionImpl, callMedia: CallMediaImpl);
+    constructor(callConnectionId: string, endpoint: string, credential: KeyCredential | TokenCredential, options?: InternalPipelineOptions);
     addParticipant(targetParticipant: CallInvite, options?: AddParticipantOptions): Promise<AddParticipantResult>;
     getCallConnectionProperties(options?: GetCallConnectionPropertiesOptions): Promise<CallConnectionProperties>;
     getCallMedia(): CallMedia;
     getParticipant(targetParticipant: CommunicationIdentifier, options?: GetParticipantOptions): Promise<CallParticipant>;
     hangUp(isForEveryone: boolean, options?: HangUpOptions): Promise<void>;
     listParticipants(options?: GetParticipantOptions): Promise<ListParticipantsResult>;
-    removeParticipant(participant: CommunicationIdentifier, options?: RemoveParticipantsOptions): Promise<RemoveParticipantsResult>;
+    removeParticipant(participant: CommunicationIdentifier, options?: RemoveParticipantsOption): Promise<RemoveParticipantResult>;
     transferCallToParticipant(targetParticipant: CallInvite, options?: TransferCallToParticipantOptions): Promise<TransferCallResult>;
 }
 
@@ -155,7 +153,8 @@ export type CallLocatorType = "serverCallLocator" | "groupCallLocator";
 
 // @public
 export class CallMedia {
-    constructor(callConnectionId: string, callMediaImpl: CallMediaImpl);
+    // Warning: (ae-forgotten-export) The symbol "CallAutomationApiClientOptionalParams" needs to be exported by the entry point index.d.ts
+    constructor(callConnectionId: string, endpoint: string, credential: KeyCredential | TokenCredential, options?: CallAutomationApiClientOptionalParams);
     cancelAllOperations(): Promise<void>;
     play(playSource: FileSource, playTo: CommunicationIdentifier[], playOptions?: PlayOptions): Promise<void>;
     playToAll(playSource: FileSource, playOptions?: PlayOptions): Promise<void>;
@@ -167,7 +166,7 @@ export interface CallMediaRecognizeDtmfOptions extends CallMediaRecognizeOptions
     // (undocumented)
     interToneTimeoutInSeconds?: number;
     // (undocumented)
-    readonly kind?: "callMediaRecognizeDtmfOptions";
+    readonly kind: "callMediaRecognizeDtmfOptions";
     // (undocumented)
     stopDtmfTones?: DtmfTone[];
 }
@@ -196,9 +195,7 @@ export interface CallParticipant {
 
 // @public
 export class CallRecording {
-    // Warning: (ae-forgotten-export) The symbol "CallRecordingImpl" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ContentDownloaderImpl" needs to be exported by the entry point index.d.ts
-    constructor(callRecordingImpl: CallRecordingImpl, contentDownloader: ContentDownloaderImpl);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: CallAutomationApiClientOptionalParams);
     delete(recordingLocationUrl: string, options?: DeleteRecordingOptions): Promise<void>;
     downloadStreaming(sourceLocationUrl: string, options?: DownloadRecordingOptions): Promise<NodeJS.ReadableStream>;
     downloadToPath(sourceLocationUrl: string, destinationPath: string, options?: DownloadRecordingOptions): Promise<void>;
@@ -285,7 +282,7 @@ export enum DtmfTone {
 // @public
 export interface FileSource extends PlaySource {
     // (undocumented)
-    readonly kind?: "fileSource";
+    readonly kind: "fileSource";
     // (undocumented)
     url: string;
 }
@@ -493,12 +490,12 @@ export interface RemoveParticipantFailedEventData extends Omit<RemoveParticipant
 }
 
 // @public
-export interface RemoveParticipantsOptions extends OperationOptions {
+export interface RemoveParticipantResult {
     operationContext?: string;
 }
 
 // @public
-export interface RemoveParticipantsResult {
+export interface RemoveParticipantsOption extends OperationOptions {
     operationContext?: string;
 }
 

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -62,8 +62,7 @@ export type AnswerCallResult = CallResult;
 // @public
 export class CallAutomationClient {
     constructor(connectionString: string, options?: CallAutomationClientOptions);
-    constructor(endpoint: string, credential: KeyCredential, options?: CallAutomationClientOptions);
-    constructor(endpoint: string, credential: TokenCredential, options?: CallAutomationClientOptions);
+    constructor(endpoint: string, credential: TokenCredential | KeyCredential, options?: CallAutomationClientOptions);
     answerCall(incomingCallContext: string, callbackUrl: string, options?: AnswerCallOptions): Promise<AnswerCallResult>;
     createCall(targetParticipant: CallInvite, callbackUrl: string, options?: CreateCallOptions): Promise<CreateCallResult>;
     createGroupCall(targetParticipants: CommunicationIdentifier[], callbackUrl: string, options?: CreateCallOptions): Promise<CreateCallResult>;

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -62,7 +62,8 @@ export type AnswerCallResult = CallResult;
 // @public
 export class CallAutomationClient {
     constructor(connectionString: string, options?: CallAutomationClientOptions);
-    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: CallAutomationClientOptions);
+    constructor(endpoint: string, credential: KeyCredential, options?: CallAutomationClientOptions);
+    constructor(endpoint: string, credential: TokenCredential, options?: CallAutomationClientOptions);
     answerCall(incomingCallContext: string, callbackUrl: string, options?: AnswerCallOptions): Promise<AnswerCallResult>;
     createCall(targetParticipant: CallInvite, callbackUrl: string, options?: CreateCallOptions): Promise<CreateCallResult>;
     createGroupCall(targetParticipants: CommunicationIdentifier[], callbackUrl: string, options?: CreateCallOptions): Promise<CreateCallResult>;
@@ -156,10 +157,10 @@ export type CallLocatorType = "serverCallLocator" | "groupCallLocator";
 // @public
 export class CallMedia {
     constructor(callConnectionId: string, callMediaImpl: CallMediaImpl);
-    cancelAllMediaOperations(): Promise<void>;
-    playMedia(playSource: FileSource, playTo: CommunicationIdentifier[], playOptions?: PlayOptions): Promise<void>;
-    playMediaToAll(playSource: FileSource, playOptions?: PlayOptions): Promise<void>;
-    startRecognizing(recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void>;
+    cancelAllOperations(): Promise<void>;
+    play(playSource: FileSource, playTo: CommunicationIdentifier[], playOptions?: PlayOptions): Promise<void>;
+    playToAll(playSource: FileSource, playOptions?: PlayOptions): Promise<void>;
+    startRecognizing(targetParticipant: CommunicationIdentifier, maxTonesToCollect: number, recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void>;
 }
 
 // @public
@@ -168,8 +169,6 @@ export interface CallMediaRecognizeDtmfOptions extends CallMediaRecognizeOptions
     interToneTimeoutInSeconds?: number;
     // (undocumented)
     readonly kind?: "callMediaRecognizeDtmfOptions";
-    // (undocumented)
-    maxTonesToCollect: number;
     // (undocumented)
     stopDtmfTones?: DtmfTone[];
 }
@@ -187,11 +186,7 @@ export interface CallMediaRecognizeOptions extends OperationOptions {
     // (undocumented)
     playPrompt?: FileSource;
     // (undocumented)
-    recognizeInputType: RecognizeInputType;
-    // (undocumented)
     stopCurrentOperations?: boolean;
-    // (undocumented)
-    targetParticipant: CommunicationIdentifier;
 }
 
 // @public
@@ -205,15 +200,15 @@ export class CallRecording {
     // Warning: (ae-forgotten-export) The symbol "CallRecordingImpl" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ContentDownloaderImpl" needs to be exported by the entry point index.d.ts
     constructor(callRecordingImpl: CallRecordingImpl, contentDownloader: ContentDownloaderImpl);
-    deleteRecording(recordingLocationUrl: string, options?: DeleteRecordingOptions): Promise<void>;
+    delete(recordingLocationUrl: string, options?: DeleteRecordingOptions): Promise<void>;
     downloadStreaming(sourceLocationUrl: string, options?: DownloadRecordingOptions): Promise<NodeJS.ReadableStream>;
     downloadToPath(sourceLocationUrl: string, destinationPath: string, options?: DownloadRecordingOptions): Promise<void>;
     downloadToStream(sourceLocationUrl: string, destinationStream: NodeJS.WritableStream, options?: DownloadRecordingOptions): Promise<void>;
-    getRecordingState(recordingId: string, options?: GetRecordingPropertiesOptions): Promise<RecordingStateResult>;
-    pauseRecording(recordingId: string, options?: PauseRecordingOptions): Promise<void>;
-    resumeRecording(recordingId: string, options?: ResumeRecordingOptions): Promise<void>;
-    startRecording(options: StartRecordingOptions): Promise<RecordingStateResult>;
-    stopRecording(recordingId: string, options?: StopRecordingOptions): Promise<void>;
+    getState(recordingId: string, options?: GetRecordingPropertiesOptions): Promise<RecordingStateResult>;
+    pause(recordingId: string, options?: PauseRecordingOptions): Promise<void>;
+    resume(recordingId: string, options?: ResumeRecordingOptions): Promise<void>;
+    start(options: StartRecordingOptions): Promise<RecordingStateResult>;
+    stop(recordingId: string, options?: StopRecordingOptions): Promise<void>;
 }
 
 // @public

--- a/sdk/communication/communication-call-automation/samples-dev/createCallOperations.ts
+++ b/sdk/communication/communication-call-automation/samples-dev/createCallOperations.ts
@@ -25,7 +25,7 @@ export async function main() {
   const callAutomationClient = new CallAutomationClient(connectionString);
 
   // create invitation
-  const callInvite = new CallInvite(user);
+  const callInvite: CallInvite = { targetParticipant: user };
 
   // Create Call
   console.log("Creating call...");

--- a/sdk/communication/communication-call-automation/src/callAutomationClient.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationClient.ts
@@ -177,7 +177,7 @@ export class CallAutomationClient {
         sourceIdentity: result.sourceIdentity
           ? communicationIdentifierConverter(result.sourceIdentity)
           : undefined,
-        targets: result.targets?.map((returnedTarget) =>
+        targetParticipants: result.targets?.map((returnedTarget) =>
           communicationIdentifierConverter(returnedTarget)
         ),
         sourceCallerIdNumber: result.sourceCallerIdNumber
@@ -200,28 +200,28 @@ export class CallAutomationClient {
 
   /**
    * Create an outgoing call from source to a target identity.
-   * @param target - A single target.
+   * @param targetParticipant - A single target.
    * @param callbackUrl - The callback url.
    * @param options - Additional request options contains createCallConnection api options.
    */
   public async createCall(
-    target: CallInvite,
+    targetParticipant: CallInvite,
     callbackUrl: string,
     options: CreateCallOptions = {}
   ): Promise<CreateCallResult> {
     const request: CreateCallRequest = {
       sourceIdentity: this.sourceIdentity,
-      targets: [communicationIdentifierModelConverter(target.target)],
+      targets: [communicationIdentifierModelConverter(targetParticipant.targetParticipant)],
       callbackUri: callbackUrl,
       operationContext: options.operationContext,
       azureCognitiveServicesEndpointUrl: options.azureCognitiveServicesEndpointUrl,
       mediaStreamingConfiguration: options.mediaStreamingConfiguration,
       customContext: {
-        sipHeaders: target.sipHeaders,
-        voipHeaders: target.voipHeaders,
+        sipHeaders: targetParticipant.sipHeaders,
+        voipHeaders: targetParticipant.voipHeaders,
       },
-      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(target.sourceCallIdNumber),
-      sourceDisplayName: target.sourceDisplayName,
+      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(targetParticipant.sourceCallIdNumber),
+      sourceDisplayName: targetParticipant.sourceDisplayName,
     };
 
     return this.createCallInternal(request, options);
@@ -229,18 +229,18 @@ export class CallAutomationClient {
 
   /**
    * Create an outgoing call from source to a group of targets identities.
-   * @param targets - A group of targets identities.
+   * @param targetParticipants - A group of targets identities.
    * @param callbackUrl - The callback url.
    * @param options - Additional request options contains createCallConnection api options.
    */
   public async createGroupCall(
-    targets: CommunicationIdentifier[],
+    targetParticipants: CommunicationIdentifier[],
     callbackUrl: string,
     options: CreateCallOptions = {}
   ): Promise<CreateCallResult> {
     const request: CreateCallRequest = {
       sourceIdentity: this.sourceIdentity,
-      targets: targets.map((target) => communicationIdentifierModelConverter(target)),
+      targets: targetParticipants.map((target) => communicationIdentifierModelConverter(target)),
       callbackUri: callbackUrl,
       operationContext: options.operationContext,
       azureCognitiveServicesEndpointUrl: options.azureCognitiveServicesEndpointUrl,
@@ -286,7 +286,7 @@ export class CallAutomationClient {
         sourceIdentity: result.sourceIdentity
           ? communicationIdentifierConverter(result.sourceIdentity)
           : undefined,
-        targets: result.targets?.map((target) => communicationIdentifierConverter(target)),
+        targetParticipants: result.targets?.map((target) => communicationIdentifierConverter(target)),
         sourceCallerIdNumber: result.sourceCallerIdNumber
           ? phoneNumberIdentifierConverter(result.sourceCallerIdNumber)
           : undefined,
@@ -309,22 +309,22 @@ export class CallAutomationClient {
    * Redirect the call.
    *
    * @param incomingCallContext - The context associated with the call.
-   * @param target - The target identity to redirect the call to.
+   * @param targetParticipant - The target identity to redirect the call to.
    * @param options - Additional request options contains redirectCall api options.
    */
   public async redirectCall(
     incomingCallContext: string,
-    target: CallInvite,
+    targetParticipant: CallInvite,
     options: RedirectCallOptions = {}
   ): Promise<void> {
     const request: RedirectCallRequest = {
       incomingCallContext: incomingCallContext,
-      target: communicationIdentifierModelConverter(target.target),
+      target: communicationIdentifierModelConverter(targetParticipant.targetParticipant),
       customContext: {
         sipHeaders:
-          target instanceof CallInvite ? target.sipHeaders : options.sipHeaders ?? undefined,
+          targetParticipant.sipHeaders ?? options.sipHeaders ?? undefined,
         voipHeaders:
-          target instanceof CallInvite ? target.voipHeaders : options.voipHeaders ?? undefined,
+          targetParticipant.voipHeaders ?? options.voipHeaders ?? undefined
       },
     };
     const optionsInternal = {

--- a/sdk/communication/communication-call-automation/src/callAutomationClient.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationClient.ts
@@ -220,7 +220,9 @@ export class CallAutomationClient {
         sipHeaders: targetParticipant.sipHeaders,
         voipHeaders: targetParticipant.voipHeaders,
       },
-      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(targetParticipant.sourceCallIdNumber),
+      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(
+        targetParticipant.sourceCallIdNumber
+      ),
       sourceDisplayName: targetParticipant.sourceDisplayName,
     };
 
@@ -286,7 +288,9 @@ export class CallAutomationClient {
         sourceIdentity: result.sourceIdentity
           ? communicationIdentifierConverter(result.sourceIdentity)
           : undefined,
-        targetParticipants: result.targets?.map((target) => communicationIdentifierConverter(target)),
+        targetParticipants: result.targets?.map((target) =>
+          communicationIdentifierConverter(target)
+        ),
         sourceCallerIdNumber: result.sourceCallerIdNumber
           ? phoneNumberIdentifierConverter(result.sourceCallerIdNumber)
           : undefined,
@@ -321,10 +325,8 @@ export class CallAutomationClient {
       incomingCallContext: incomingCallContext,
       target: communicationIdentifierModelConverter(targetParticipant.targetParticipant),
       customContext: {
-        sipHeaders:
-          targetParticipant.sipHeaders ?? options.sipHeaders ?? undefined,
-        voipHeaders:
-          targetParticipant.voipHeaders ?? options.voipHeaders ?? undefined
+        sipHeaders: targetParticipant.sipHeaders ?? options.sipHeaders ?? undefined,
+        voipHeaders: targetParticipant.voipHeaders ?? options.voipHeaders ?? undefined,
       },
     };
     const optionsInternal = {

--- a/sdk/communication/communication-call-automation/src/callAutomationClient.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationClient.ts
@@ -78,20 +78,16 @@ export class CallAutomationClient {
   constructor(connectionString: string, options?: CallAutomationClientOptions);
 
   /**
-   * Initializes a new instance of the CallAutomationClient class using an Azure KeyCredential.
+   * Initializes a new instance of the CallAutomationClient class using a TokenCredential or KeyCredential.
    * @param endpoint - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential - An object that is used to authenticate requests to the service. Use the Azure KeyCredential or `@azure/identity` to create a credential.
+   * @param credential - TokenCredential or KeyCredential that is used to authenticate requests to the service.
    * @param options - Optional. Options to configure the HTTP pipeline.
    */
-  constructor(endpoint: string, credential: KeyCredential, options?: CallAutomationClientOptions);
-
-  /**
-   * Initializes a new instance of the CallAutomationClient class using a TokenCredential.
-   * @param endpoint - The endpoint of the service (ex: https://contoso.eastus.communications.azure.net).
-   * @param credential - TokenCredential that is used to authenticate requests to the service.
-   * @param options - Optional. Options to configure the HTTP pipeline.
-   */
-  constructor(endpoint: string, credential: TokenCredential, options?: CallAutomationClientOptions);
+  constructor(
+    endpoint: string,
+    credential: TokenCredential | KeyCredential,
+    options?: CallAutomationClientOptions
+  );
 
   constructor(
     connectionStringOrUrl: string,

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -7,22 +7,22 @@ import { communicationIdentifierConverter, callParticipantConverter } from "./ut
 
 import {
   CallAutomationEvent,
-  AddParticipantSucceeded,
-  AddParticipantFailed,
-  CallConnected,
-  CallDisconnected,
-  CallTransferAccepted,
-  CallTransferFailed,
-  ParticipantsUpdated,
-  RecordingStateChanged,
-  PlayCompleted,
-  PlayFailed,
-  PlayCanceled,
-  RecognizeCompleted,
-  RecognizeCanceled,
-  RecognizeFailed,
-  RemoveParticipantSucceeded,
-  RemoveParticipantFailed,
+  AddParticipantSucceededEventData,
+  AddParticipantFailedEventData,
+  CallConnectedEventData,
+  CallDisconnectedEventData,
+  CallTransferAcceptedEventData,
+  CallTransferFailedEventData,
+  ParticipantsUpdatedEventData,
+  RecordingStateChangedEventData,
+  PlayCompletedEventData,
+  PlayFailedEventData,
+  PlayCanceledEventData,
+  RecognizeCompletedEventData,
+  RecognizeCanceledEventData,
+  RecognizeFailedEventData,
+  RemoveParticipantSucceededEventData,
+  RemoveParticipantFailedEventData,
 } from "./models/events";
 
 import { CloudEventMapper } from "./models/mapper";
@@ -31,86 +31,80 @@ import { CallParticipantInternal } from "./generated/src";
 const serializer = createSerializer();
 
 /**
- * Helper class for parsing Acs callback events.
+ * Helper function for parsing Acs callback events.
  */
-export class CallAutomationEventParser {
-  public async parse(encodedEvent: string): Promise<CallAutomationEvent>;
+export function parseCallAutomationEvent(
+  encodedEvents: string | Record<string, unknown>
+): CallAutomationEvent {
+  const decodedInput = parseAndWrap(encodedEvents);
 
-  public async parse(encodedEvents: Record<string, unknown>): Promise<CallAutomationEvent>;
+  // parse cloudevent
+  const deserialized = serializer.deserialize(CloudEventMapper, decodedInput, "");
+  const data = deserialized.data;
+  const eventType = deserialized.type;
 
-  public async parse(
-    encodedEvents: string | Record<string, unknown>
-  ): Promise<CallAutomationEvent> {
-    const decodedInput = parseAndWrap(encodedEvents);
-
-    // parse cloudevent
-    const deserialized = serializer.deserialize(CloudEventMapper, decodedInput, "");
-    const data = deserialized.data;
-    const eventType = deserialized.type;
-
-    // get proper callbackevent and its parser
-    let callbackEvent: CallAutomationEvent;
-    let parsed: any = data;
-    switch (eventType) {
-      case "Microsoft.Communication.AddParticipantSucceeded":
-        callbackEvent = { kind: "AddParticipantSucceeded" } as AddParticipantSucceeded;
-        parsed.participant = communicationIdentifierConverter(data.participant);
-        break;
-      case "Microsoft.Communication.AddParticipantFailed":
-        callbackEvent = { kind: "AddParticipantFailed" } as AddParticipantFailed;
-        parsed.participant = communicationIdentifierConverter(data.participant);
-        break;
-      case "Microsoft.Communication.RemoveParticipantSucceeded":
-        callbackEvent = { kind: "RemoveParticipantSucceeded" } as RemoveParticipantSucceeded;
-        parsed.participant = communicationIdentifierConverter(data.participant);
-        break;
-      case "Microsoft.Communication.RemoveParticipantFailed":
-        callbackEvent = { kind: "RemoveParticipantFailed" } as RemoveParticipantFailed;
-        parsed.participant = communicationIdentifierConverter(data.participant);
-        break;
-      case "Microsoft.Communication.CallConnected":
-        callbackEvent = { kind: "CallConnected" } as CallConnected;
-        break;
-      case "Microsoft.Communication.CallDisconnected":
-        callbackEvent = { kind: "CallDisconnected" } as CallDisconnected;
-        break;
-      case "Microsoft.Communication.CallTransferAccepted":
-        callbackEvent = { kind: "CallTransferAccepted" } as CallTransferAccepted;
-        break;
-      case "Microsoft.Communication.CallTransferFailed":
-        callbackEvent = { kind: "CallTransferFailed" } as CallTransferFailed;
-        break;
-      case "Microsoft.Communication.ParticipantsUpdated":
-        callbackEvent = { kind: "ParticipantsUpdated" } as ParticipantsUpdated;
-        parsed = participantsParserForEvent(data);
-        break;
-      case "Microsoft.Communication.RecordingStateChanged":
-        callbackEvent = { kind: "RecordingStateChanged" } as RecordingStateChanged;
-        break;
-      case "Microsoft.Communication.PlayCompleted":
-        callbackEvent = { kind: "PlayCompleted" } as PlayCompleted;
-        break;
-      case "Microsoft.Communication.PlayFailed":
-        callbackEvent = { kind: "PlayFailed" } as PlayFailed;
-        break;
-      case "Microsoft.Communication.PlayCanceled":
-        callbackEvent = { kind: "PlayCanceled" } as PlayCanceled;
-        break;
-      case "Microsoft.Communication.RecognizeCompleted":
-        callbackEvent = { kind: "RecognizeCompleted" } as RecognizeCompleted;
-        break;
-      case "Microsoft.Communication.RecognizeCanceled":
-        callbackEvent = { kind: "RecognizeCanceled" } as RecognizeCanceled;
-        break;
-      case "Microsoft.Communication.RecognizeFailed":
-        callbackEvent = { kind: "RecognizeFailed" } as RecognizeFailed;
-        break;
-      default:
-        throw new TypeError(`Unknown Call Automation Event type: ${eventType}`);
-    }
-
-    return { ...parsed, ...callbackEvent } as CallAutomationEvent;
+  // get proper callbackevent and its parser
+  let callbackEvent: CallAutomationEvent;
+  let parsed: any = data;
+  switch (eventType) {
+    case "Microsoft.Communication.AddParticipantSucceeded":
+      callbackEvent = { kind: "AddParticipantSucceeded" } as AddParticipantSucceededEventData;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.AddParticipantFailed":
+      callbackEvent = { kind: "AddParticipantFailed" } as AddParticipantFailedEventData;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.RemoveParticipantSucceeded":
+      callbackEvent = { kind: "RemoveParticipantSucceeded" } as RemoveParticipantSucceededEventData;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.RemoveParticipantFailed":
+      callbackEvent = { kind: "RemoveParticipantFailed" } as RemoveParticipantFailedEventData;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.CallConnected":
+      callbackEvent = { kind: "CallConnected" } as CallConnectedEventData;
+      break;
+    case "Microsoft.Communication.CallDisconnected":
+      callbackEvent = { kind: "CallDisconnected" } as CallDisconnectedEventData;
+      break;
+    case "Microsoft.Communication.CallTransferAccepted":
+      callbackEvent = { kind: "CallTransferAccepted" } as CallTransferAcceptedEventData;
+      break;
+    case "Microsoft.Communication.CallTransferFailed":
+      callbackEvent = { kind: "CallTransferFailed" } as CallTransferFailedEventData;
+      break;
+    case "Microsoft.Communication.ParticipantsUpdated":
+      callbackEvent = { kind: "ParticipantsUpdated" } as ParticipantsUpdatedEventData;
+      parsed = participantsParserForEvent(data);
+      break;
+    case "Microsoft.Communication.RecordingStateChanged":
+      callbackEvent = { kind: "RecordingStateChanged" } as RecordingStateChangedEventData;
+      break;
+    case "Microsoft.Communication.PlayCompleted":
+      callbackEvent = { kind: "PlayCompleted" } as PlayCompletedEventData;
+      break;
+    case "Microsoft.Communication.PlayFailed":
+      callbackEvent = { kind: "PlayFailed" } as PlayFailedEventData;
+      break;
+    case "Microsoft.Communication.PlayCanceled":
+      callbackEvent = { kind: "PlayCanceled" } as PlayCanceledEventData;
+      break;
+    case "Microsoft.Communication.RecognizeCompleted":
+      callbackEvent = { kind: "RecognizeCompleted" } as RecognizeCompletedEventData;
+      break;
+    case "Microsoft.Communication.RecognizeCanceled":
+      callbackEvent = { kind: "RecognizeCanceled" } as RecognizeCanceledEventData;
+      break;
+    case "Microsoft.Communication.RecognizeFailed":
+      callbackEvent = { kind: "RecognizeFailed" } as RecognizeFailedEventData;
+      break;
+    default:
+      throw new TypeError(`Unknown Call Automation Event type: ${eventType}`);
   }
+
+  return { ...parsed, ...callbackEvent } as CallAutomationEvent;
 }
 
 function parseAndWrap(jsonStringOrObject: string | Record<string, unknown>): any {

--- a/sdk/communication/communication-call-automation/src/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/callConnection.ts
@@ -106,16 +106,10 @@ export class CallConnection {
     targetParticipant: CommunicationIdentifier,
     options: GetParticipantOptions = {}
   ): Promise<CallParticipant> {
+    const rawId: string = communicationIdentifierModelConverter(targetParticipant).rawId || "";
+    if (!rawId) throw Error("Invalid targetParticipant");
 
-    const rawId: string = communicationIdentifierModelConverter(targetParticipant).rawId || '';
-    if (!rawId)
-      throw Error("Invalid targetParticipant");
-
-    const result = await this.callConnection.getParticipant(
-      this.callConnectionId,
-      rawId,
-      options
-    );
+    const result = await this.callConnection.getParticipant(this.callConnectionId, rawId, options);
     const callParticipant: CallParticipant = {
       identifier: result.identifier
         ? communicationIdentifierConverter(result.identifier)
@@ -152,7 +146,9 @@ export class CallConnection {
   ): Promise<AddParticipantResult> {
     const addParticipantRequest: AddParticipantRequest = {
       participantToAdd: communicationIdentifierModelConverter(targetParticipant.targetParticipant),
-      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(targetParticipant.sourceCallIdNumber),
+      sourceCallerIdNumber: PhoneNumberIdentifierModelConverter(
+        targetParticipant.sourceCallIdNumber
+      ),
       sourceDisplayName: targetParticipant.sourceDisplayName,
       invitationTimeoutInSeconds: options.invitationTimeoutInSeconds,
       operationContext: options.operationContext,

--- a/sdk/communication/communication-call-automation/src/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/callConnection.ts
@@ -15,14 +15,14 @@ import {
   GetCallConnectionPropertiesOptions,
   GetParticipantOptions,
   HangUpOptions,
-  RemoveParticipantsOptions,
+  RemoveParticipantsOption,
   TransferCallToParticipantOptions,
 } from "./models/options";
 import {
   ListParticipantsResult,
   TransferCallResult,
   AddParticipantResult,
-  RemoveParticipantsResult,
+  RemoveParticipantResult,
 } from "./models/responses";
 import {
   callParticipantConverter,
@@ -217,8 +217,8 @@ export class CallConnection {
    */
   public async removeParticipant(
     participant: CommunicationIdentifier,
-    options: RemoveParticipantsOptions = {}
-  ): Promise<RemoveParticipantsResult> {
+    options: RemoveParticipantsOption = {}
+  ): Promise<RemoveParticipantResult> {
     const removeParticipantRequest: RemoveParticipantRequest = {
       participantToRemove: communicationIdentifierModelConverter(participant),
       operationContext: options.operationContext,
@@ -233,7 +233,7 @@ export class CallConnection {
       removeParticipantRequest,
       optionsInternal
     );
-    const removeParticipantsResult: RemoveParticipantsResult = {
+    const removeParticipantsResult: RemoveParticipantResult = {
       ...result,
     };
     return removeParticipantsResult;

--- a/sdk/communication/communication-call-automation/src/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/callConnection.ts
@@ -9,6 +9,7 @@ import { CallMedia } from "./callMedia";
 import {
   AddParticipantRequest,
   CallAutomationApiClient,
+  CallAutomationApiClientOptionalParams,
   RemoveParticipantRequest,
   TransferToParticipantRequest,
 } from "./generated/src";
@@ -37,7 +38,6 @@ import {
 } from "./utli/converters";
 import { v4 as uuidv4 } from "uuid";
 import { KeyCredential, TokenCredential } from "@azure/core-auth";
-import { InternalPipelineOptions } from "@azure/core-rest-pipeline";
 
 /**
  * CallConnection class represents call connection based APIs.
@@ -48,12 +48,12 @@ export class CallConnection {
   private readonly callAutomationApiClient: CallAutomationApiClient;
   private readonly endpoint: string;
   private readonly credential: TokenCredential | KeyCredential;
-  private readonly internalPipelineOptions?: InternalPipelineOptions;
+  private readonly callAutomationApiClientOptions?: CallAutomationApiClientOptionalParams;
   constructor(
     callConnectionId: string,
     endpoint: string,
     credential: KeyCredential | TokenCredential,
-    options?: InternalPipelineOptions
+    options?: CallAutomationApiClientOptionalParams
   ) {
     this.callAutomationApiClient = new CallAutomationApiClient(endpoint, options);
     const authPolicy = createCommunicationAuthPolicy(credential);
@@ -62,7 +62,7 @@ export class CallConnection {
     this.callConnection = new CallConnectionImpl(this.callAutomationApiClient);
     this.endpoint = endpoint;
     this.credential = credential;
-    this.internalPipelineOptions = options;
+    this.callAutomationApiClientOptions = options;
   }
 
   /**
@@ -73,7 +73,7 @@ export class CallConnection {
       this.callConnectionId,
       this.endpoint,
       this.credential,
-      this.internalPipelineOptions
+      this.callAutomationApiClientOptions
     );
   }
 

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -80,7 +80,7 @@ export class CallMedia {
   ): Promise<void> {
     const playRequest: PlayRequest = {
       playSourceInfo: this.createPlaySourceInternal(playSource),
-      playTo: []
+      playTo: [],
     };
     return this.callMediaImpl.play(this.callConnectionId, playRequest, playOptions);
   }
@@ -127,7 +127,11 @@ export class CallMedia {
    *  Recognize participant input.
    *  @param recognizeOptions - Different attributes for recognize.
    * */
-  public async startRecognizing(targetParticipant: CommunicationIdentifier, maxTonesToCollect: number, recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void> {
+  public async startRecognizing(
+    targetParticipant: CommunicationIdentifier,
+    maxTonesToCollect: number,
+    recognizeOptions: CallMediaRecognizeDtmfOptions
+  ): Promise<void> {
     return this.callMediaImpl.recognize(
       this.callConnectionId,
       this.createRecognizeRequest(targetParticipant, maxTonesToCollect, recognizeOptions),

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -38,7 +38,7 @@ export class CallMedia {
   private createPlaySourceInternal(playSource: FileSource): PlaySourceInternal {
     if (playSource.kind === "fileSource" || playSource.kind === undefined) {
       const fileSource: FileSourceInternal = {
-        uri: playSource.uri,
+        uri: playSource.url,
       };
       return {
         sourceType: KnownPlaySourceType.File,
@@ -80,12 +80,14 @@ export class CallMedia {
   ): Promise<void> {
     const playRequest: PlayRequest = {
       playSourceInfo: this.createPlaySourceInternal(playSource),
-      playTo: [],
+      playTo: []
     };
     return this.callMediaImpl.play(this.callConnectionId, playRequest, playOptions);
   }
 
   private createRecognizeRequest(
+    targetParticipant: CommunicationIdentifier,
+    maxTonesToCollect: number,
     recognizeOptions: CallMediaRecognizeDtmfOptions
   ): RecognizeRequest {
     if (
@@ -96,7 +98,7 @@ export class CallMedia {
         interToneTimeoutInSeconds: recognizeOptions.interToneTimeoutInSeconds
           ? recognizeOptions.interToneTimeoutInSeconds
           : 2,
-        maxTonesToCollect: recognizeOptions.maxTonesToCollect,
+        maxTonesToCollect: maxTonesToCollect,
         stopTones: recognizeOptions.stopDtmfTones,
       };
       const recognizeOptionsInternal: RecognizeOptions = {
@@ -104,7 +106,7 @@ export class CallMedia {
         initialSilenceTimeoutInSeconds: recognizeOptions.initialSilenceTimeoutInSeconds
           ? recognizeOptions.initialSilenceTimeoutInSeconds
           : 5,
-        targetParticipant: serializeCommunicationIdentifier(recognizeOptions.targetParticipant),
+        targetParticipant: serializeCommunicationIdentifier(targetParticipant),
         dtmfOptions: dtmfOptionsInternal,
       };
       return {
@@ -125,10 +127,10 @@ export class CallMedia {
    *  Recognize participant input.
    *  @param recognizeOptions - Different attributes for recognize.
    * */
-  public async startRecognizing(recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void> {
+  public async startRecognizing(targetParticipant: CommunicationIdentifier, maxTonesToCollect: number, recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void> {
     return this.callMediaImpl.recognize(
       this.callConnectionId,
-      this.createRecognizeRequest(recognizeOptions),
+      this.createRecognizeRequest(targetParticipant, maxTonesToCollect, recognizeOptions),
       {}
     );
   }
@@ -136,7 +138,7 @@ export class CallMedia {
   /**
    * Cancels all the queued media operations.
    */
-  public async cancelAllMediaOperations(): Promise<void> {
+  public async cancelAllOperations(): Promise<void> {
     return this.callMediaImpl.cancelAllMediaOperations(this.callConnectionId, {});
   }
 }

--- a/sdk/communication/communication-call-automation/src/callRecording.ts
+++ b/sdk/communication/communication-call-automation/src/callRecording.ts
@@ -34,19 +34,15 @@ export class CallRecording {
    * @param startCallRecordingRequest - options to start the call recording
    * @param options - Operation options.
    */
-  public async startRecording(options: StartRecordingOptions): Promise<RecordingStateResult> {
+  public async start(options: StartRecordingOptions): Promise<RecordingStateResult> {
     const startCallRecordingRequest: StartCallRecordingRequest = {
       callLocator: options.callLocator,
     };
 
-    if (options.recordingStorageType === "blobStorage" && !options.externalStorageLocation) {
-      throw new Error("externalStorageLocation required for recordingStorageType blobStorage");
-    }
-
     startCallRecordingRequest.recordingChannelType = options.recordingChannel;
     startCallRecordingRequest.recordingContentType = options.recordingContent;
     startCallRecordingRequest.recordingFormatType = options.recordingFormat;
-    startCallRecordingRequest.recordingStateCallbackUri = options.recordingStateCallbackEndpoint;
+    startCallRecordingRequest.recordingStateCallbackUri = options.recordingStateCallbackEndpointUrl;
 
     if (options.audioChannelParticipantOrdering) {
       startCallRecordingRequest.audioChannelParticipantOrdering = [];
@@ -88,7 +84,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains getRecordingProperties api options.
    */
-  public async getRecordingState(
+  public async getState(
     recordingId: string,
     options: GetRecordingPropertiesOptions = {}
   ): Promise<RecordingStateResult> {
@@ -107,7 +103,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains stopRecording api options.
    */
-  public async stopRecording(
+  public async stop(
     recordingId: string,
     options: StopRecordingOptions = {}
   ): Promise<void> {
@@ -119,7 +115,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains pauseRecording api options.
    */
-  public async pauseRecording(
+  public async pause(
     recordingId: string,
     options: PauseRecordingOptions = {}
   ): Promise<void> {
@@ -131,7 +127,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains resumeRecording api options.
    */
-  public async resumeRecording(
+  public async resume(
     recordingId: string,
     options: ResumeRecordingOptions = {}
   ): Promise<void> {
@@ -140,26 +136,26 @@ export class CallRecording {
 
   /**
    * Deletes a recording.
-   * @param recordingLocation - The recording location uri. Required.
+   * @param recordingLocationUrl - The recording location url. Required.
    * @param options - Additional request options contains deleteRecording api options.
    */
-  public async deleteRecording(
-    recordingLocation: string,
+  public async delete(
+    recordingLocationUrl: string,
     options: DeleteRecordingOptions = {}
   ): Promise<void> {
-    await this.contentDownloader.deleteRecording(recordingLocation, options);
+    await this.contentDownloader.deleteRecording(recordingLocationUrl, options);
   }
 
   /**
    * Returns a stream with a call recording.
-   * @param sourceLocation - The source location uri. Required.
+   * @param sourceLocationUrl - The source location url. Required.
    * @param options - Additional request options contains downloadRecording api options.
    */
   public async downloadStreaming(
-    sourceLocation: string,
+    sourceLocationUrl: string,
     options: DownloadRecordingOptions = {}
   ): Promise<NodeJS.ReadableStream> {
-    const result = this.contentDownloader.download(sourceLocation, options);
+    const result = this.contentDownloader.download(sourceLocationUrl, options);
     const recordingStream = (await result).readableStreamBody;
     if (recordingStream) {
       return recordingStream;
@@ -170,16 +166,16 @@ export class CallRecording {
 
   /**
    * Downloads a call recording file to the specified stream.
-   * @param sourceLocation - The source location uri. Required.
+   * @param sourceLocationUrl - The source location url. Required.
    * @param destinationStream - The destination stream. Required.
    * @param options - Additional request options contains downloadRecording api options.
    */
   public async downloadToStream(
-    sourceLocation: string,
+    sourceLocationUrl: string,
     destinationStream: NodeJS.WritableStream,
     options: DownloadRecordingOptions = {}
   ): Promise<void> {
-    const result = this.contentDownloader.download(sourceLocation, options);
+    const result = this.contentDownloader.download(sourceLocationUrl, options);
     const recordingStream = (await result).readableStreamBody;
     if (recordingStream) {
       recordingStream.pipe(destinationStream);
@@ -190,16 +186,16 @@ export class CallRecording {
 
   /**
    * Downloads a call recording file to the specified path.
-   * @param sourceLocation - The source location uri. Required.
+   * @param sourceLocationUrl - The source location url. Required.
    * @param destinationPath - The destination path. Required.
    * @param options - Additional request options contains downloadRecording api options.
    */
   public async downloadToPath(
-    sourceLocation: string,
+    sourceLocationUrl: string,
     destinationPath: string,
     options: DownloadRecordingOptions = {}
   ): Promise<void> {
-    const result = this.contentDownloader.download(sourceLocation, options);
+    const result = this.contentDownloader.download(sourceLocationUrl, options);
     const recordingStream = (await result).readableStreamBody;
     if (recordingStream) {
       recordingStream.pipe(fs.createWriteStream(destinationPath));

--- a/sdk/communication/communication-call-automation/src/callRecording.ts
+++ b/sdk/communication/communication-call-automation/src/callRecording.ts
@@ -103,10 +103,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains stopRecording api options.
    */
-  public async stop(
-    recordingId: string,
-    options: StopRecordingOptions = {}
-  ): Promise<void> {
+  public async stop(recordingId: string, options: StopRecordingOptions = {}): Promise<void> {
     return this.callRecordingImpl.stopRecording(recordingId, options);
   }
 
@@ -115,10 +112,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains pauseRecording api options.
    */
-  public async pause(
-    recordingId: string,
-    options: PauseRecordingOptions = {}
-  ): Promise<void> {
+  public async pause(recordingId: string, options: PauseRecordingOptions = {}): Promise<void> {
     return this.callRecordingImpl.pauseRecording(recordingId, options);
   }
 
@@ -127,10 +121,7 @@ export class CallRecording {
    * @param recordingId - The recordingId associated with the recording.
    * @param options - Additional request options contains resumeRecording api options.
    */
-  public async resume(
-    recordingId: string,
-    options: ResumeRecordingOptions = {}
-  ): Promise<void> {
+  public async resume(recordingId: string, options: ResumeRecordingOptions = {}): Promise<void> {
     return this.callRecordingImpl.resumeRecording(recordingId, options);
   }
 

--- a/sdk/communication/communication-call-automation/src/contentDownloader.ts
+++ b/sdk/communication/communication-call-automation/src/contentDownloader.ts
@@ -46,10 +46,10 @@ export class ContentDownloaderImpl {
 
   /**
    * Deletes a recording.
-   * @param recordingLocation - The recording location uri. Required.
+   * @param deleteLocationUrl - The recording location url. Required.
    */
-  async deleteRecording(recordingLocation: string, options: DeleteRecordingOptions): Promise<void> {
-    const fileLocation = new URL(recordingLocation);
+  async deleteRecording(deleteLocationUrl: string, options: DeleteRecordingOptions): Promise<void> {
+    const fileLocation = new URL(deleteLocationUrl);
     const endpoint = new URL(this.client.endpoint);
     const modifiedUrlForSigning = endpoint.origin + fileLocation.pathname;
 
@@ -62,7 +62,7 @@ export class ContentDownloaderImpl {
       tracingOptions: options?.tracingOptions,
     };
 
-    opt.headers?.set("OriginalUrl", recordingLocation);
+    opt.headers?.set("OriginalUrl", deleteLocationUrl);
     opt.headers?.set("x-ms-host", endpoint.host);
     opt.headers?.set("accept", "application/json");
 
@@ -81,14 +81,14 @@ export class ContentDownloaderImpl {
 
   /**
    * Returns a stream with a call recording.
-   * @param sourceLocation - The source location uri. Required.
+   * @param sourceLocationUrl - The source location url. Required.
    * @param options - Additional request options contains downloadRecording options.
    */
   async download(
-    sourceLocation: string,
+    sourceLocationUrl: string,
     options: DownloadRecordingOptions
   ): Promise<PipelineResponse> {
-    const fileLocation = new URL(sourceLocation);
+    const fileLocation = new URL(sourceLocationUrl);
     const endpoint = new URL(this.client.endpoint);
     const modifiedUrlForSigning = endpoint.origin + fileLocation.pathname;
 
@@ -111,7 +111,7 @@ export class ContentDownloaderImpl {
     let rangeHeader = "bytes=" + options.offset;
     if (options.length) rangeHeader += "-" + options.length;
 
-    opt.headers?.set("OriginalUrl", sourceLocation);
+    opt.headers?.set("OriginalUrl", sourceLocationUrl);
     opt.headers?.set("x-ms-host", endpoint.host);
     opt.headers?.set("accept", "application/json");
     opt.headers?.set("Range", rangeHeader);

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -27,22 +27,22 @@ import { CallParticipant } from "./models";
 
 /** Callback events for Call Automation */
 export type CallAutomationEvent =
-  | AddParticipantSucceeded
-  | AddParticipantFailed
-  | RemoveParticipantSucceeded
-  | RemoveParticipantFailed
-  | CallConnected
-  | CallDisconnected
-  | CallTransferAccepted
-  | CallTransferFailed
-  | ParticipantsUpdated
-  | RecordingStateChanged
-  | PlayCompleted
-  | PlayFailed
-  | PlayCanceled
-  | RecognizeCompleted
-  | RecognizeCanceled
-  | RecognizeFailed;
+  | AddParticipantSucceededEventData
+  | AddParticipantFailedEventData
+  | RemoveParticipantSucceededEventData
+  | RemoveParticipantFailedEventData
+  | CallConnectedEventData
+  | CallDisconnectedEventData
+  | CallTransferAcceptedEventData
+  | CallTransferFailedEventData
+  | ParticipantsUpdatedEventData
+  | RecordingStateChangedEventData
+  | PlayCompletedEventData
+  | PlayFailedEventData
+  | PlayCanceledEventData
+  | RecognizeCompletedEventData
+  | RecognizeCanceledEventData
+  | RecognizeFailedEventData;
 
 export {
   RestAddParticipantSucceeded,
@@ -73,7 +73,7 @@ export interface ResultInformation
 }
 
 /** The participant successfully added event. */
-export interface AddParticipantSucceeded
+export interface AddParticipantSucceededEventData
   extends Omit<
     RestAddParticipantSucceeded,
     "callConnectionId" | "serverCallId" | "correlationId" | "participant" | "resultInformation"
@@ -93,7 +93,7 @@ export interface AddParticipantSucceeded
 }
 
 /** The failed to add participant event. */
-export interface AddParticipantFailed
+export interface AddParticipantFailedEventData
   extends Omit<
     RestAddParticipantFailed,
     "callConnectionId" | "serverCallId" | "correlationId" | "participant" | "resultInformation"
@@ -113,7 +113,7 @@ export interface AddParticipantFailed
 }
 
 /** The participant successfully removed event. */
-export interface RemoveParticipantSucceeded
+export interface RemoveParticipantSucceededEventData
   extends Omit<
     RestRemoveParticipantSucceeded,
     "callConnectionId" | "serverCallId" | "correlationId" | "participant" | "resultInformation"
@@ -133,7 +133,7 @@ export interface RemoveParticipantSucceeded
 }
 
 /** The failed to remove participant event. */
-export interface RemoveParticipantFailed
+export interface RemoveParticipantFailedEventData
   extends Omit<
     RestRemoveParticipantFailed,
     "callConnectionId" | "serverCallId" | "correlationId" | "participant" | "resultInformation"
@@ -153,7 +153,7 @@ export interface RemoveParticipantFailed
 }
 
 /** Event when call was established. */
-export interface CallConnected
+export interface CallConnectedEventData
   extends Omit<RestCallConnected, "callConnectionId" | "serverCallId" | "correlationId"> {
   /** Call connection ID. */
   callConnectionId: string;
@@ -166,7 +166,7 @@ export interface CallConnected
 }
 
 /** Event when all participants left and call was terminated. */
-export interface CallDisconnected
+export interface CallDisconnectedEventData
   extends Omit<RestCallDisconnected, "callConnectionId" | "serverCallId" | "correlationId"> {
   /** Call connection ID. */
   callConnectionId: string;
@@ -179,7 +179,7 @@ export interface CallDisconnected
 }
 
 /** Event when transfer request was successful. */
-export interface CallTransferAccepted
+export interface CallTransferAcceptedEventData
   extends Omit<
     RestCallTransferAccepted,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -197,7 +197,7 @@ export interface CallTransferAccepted
 }
 
 /** Event when transfer request was failed. */
-export interface CallTransferFailed
+export interface CallTransferFailedEventData
   extends Omit<
     RestCallTransferFailed,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -215,7 +215,7 @@ export interface CallTransferFailed
 }
 
 /** Event when there was an update to participant(s). */
-export interface ParticipantsUpdated
+export interface ParticipantsUpdatedEventData
   extends Omit<
     RestParticipantsUpdated,
     "callConnectionId" | "serverCallId" | "correlationId" | "participants"
@@ -233,7 +233,7 @@ export interface ParticipantsUpdated
 }
 
 /** Event when Recording state has been changed. */
-export interface RecordingStateChanged
+export interface RecordingStateChangedEventData
   extends Omit<RestRecordingStateChanged, "callConnectionId" | "serverCallId" | "correlationId"> {
   /** Call connection ID. */
   callConnectionId: string;
@@ -246,7 +246,7 @@ export interface RecordingStateChanged
 }
 
 /** Event when Media play was successfully completed. */
-export interface PlayCompleted
+export interface PlayCompletedEventData
   extends Omit<
     RestPlayCompleted,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -264,7 +264,7 @@ export interface PlayCompleted
 }
 
 /** Event when Media play was failed. */
-export interface PlayFailed
+export interface PlayFailedEventData
   extends Omit<
     RestPlayFailed,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -282,7 +282,7 @@ export interface PlayFailed
 }
 
 /** Event when Media play was canceled by Cancel operation. */
-export interface PlayCanceled
+export interface PlayCanceledEventData
   extends Omit<RestPlayCanceled, "callConnectionId" | "serverCallId" | "correlationId"> {
   /** Call connection ID. */
   callConnectionId: string;
@@ -295,7 +295,7 @@ export interface PlayCanceled
 }
 
 /** Event when Media recognize was successfully completed. */
-export interface RecognizeCompleted
+export interface RecognizeCompletedEventData
   extends Omit<
     RestRecognizeCompleted,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -313,7 +313,7 @@ export interface RecognizeCompleted
 }
 
 /** Event when Media recognize was failed. */
-export interface RecognizeFailed
+export interface RecognizeFailedEventData
   extends Omit<
     RestRecognizeFailed,
     "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
@@ -331,7 +331,7 @@ export interface RecognizeFailed
 }
 
 /** Event when Media recognize was canceled by Cancel operation. */
-export interface RecognizeCanceled
+export interface RecognizeCanceledEventData
   extends Omit<RestRecognizeCanceled, "callConnectionId" | "serverCallId" | "correlationId"> {
   /** Call connection ID. */
   callConnectionId: string;

--- a/sdk/communication/communication-call-automation/src/models/models.ts
+++ b/sdk/communication/communication-call-automation/src/models/models.ts
@@ -68,7 +68,7 @@ export interface PlaySource {
 /** The FileSource model. */
 export interface FileSource extends PlaySource {
   url: string;
-  readonly kind?: "fileSource";
+  readonly kind: "fileSource";
 }
 
 /** A Dtmf Tone. */

--- a/sdk/communication/communication-call-automation/src/models/models.ts
+++ b/sdk/communication/communication-call-automation/src/models/models.ts
@@ -37,11 +37,11 @@ export interface CallConnectionProperties {
   /** Source identity. */
   sourceIdentity?: CommunicationIdentifier;
   /** The targets of the call. */
-  targets?: CommunicationIdentifier[];
+  targetParticipants?: CommunicationIdentifier[];
   /** The state of the call connection. */
   callConnectionState?: CallConnectionStateModel;
-  /** The callback URI. */
-  callbackUri?: string;
+  /** The callback URL. */
+  callbackUrl?: string;
   /** SubscriptionId for media streaming */
   mediaSubscriptionId?: string;
 }
@@ -67,7 +67,7 @@ export interface PlaySource {
 
 /** The FileSource model. */
 export interface FileSource extends PlaySource {
-  uri: string;
+  url: string;
   readonly kind?: "fileSource";
 }
 
@@ -115,73 +115,17 @@ export enum RecognizeInputType {
   Choices = "choices",
 }
 
-function instanceOfPhoneNumberIdentity(object: any): object is PhoneNumberIdentifier {
-  return "phoneNumber" in object;
-}
-
 /** Call invitee details. */
-export class CallInvite {
-  public readonly target: CommunicationIdentifier;
-  public readonly sourceCallIdNumber?: PhoneNumberIdentifier;
-  public sourceDisplayName?: string;
-  public readonly sipHeaders?: { [propertyName: string]: string };
-  public readonly voipHeaders?: { [propertyName: string]: string };
-
-  /**
-   * Create a CallInvite object with PhoneNumberIdentifierr
-   * @param targetPhoneNumberIdentity - Target's PhoneNumberIdentifier
-   * @param callerIdNumber - Caller's phone number identifier
-   */
-  constructor(
-    targetPhoneNumberIdentity: PhoneNumberIdentifier,
-    callerIdNumber: PhoneNumberIdentifier
-  );
-
-  /**
-   * Create a CallInvite object with PhoneNumberIdentifier
-   * @param targetPhoneNumberIdentity - Target's PhoneNumberIdentifier
-   * @param callerIdNumber - Caller's phone number identifier
-   * @param sipHeaders - Custom context for PSTN
-   */
-  constructor(
-    targetPhoneNumberIdentity: PhoneNumberIdentifier,
-    callerIdNumber: PhoneNumberIdentifier,
-    sipHeader: { [propertyName: string]: string }
-  );
-
-  /**
-   * Create a CallInvite object with CommunicationUserIdentifier
-   * @param targetIdentity - Target's CommunicationUserIdentifier
-   */
-  constructor(targetIdentity: CommunicationUserIdentifier);
-
-  /**
-   * Create a CallInvite object with CommunicationUserIdentifier
-   * @param targetIdentity - Target's CommunicationUserIdentifier
-   * @param voipHeaders - Custom context for voip
-   */
-  constructor(
-    targetIdentity: CommunicationUserIdentifier,
-    voipHeaders: { [propertyName: string]: string }
-  );
-
-  constructor(
-    targetIdentity: PhoneNumberIdentifier | CommunicationUserIdentifier,
-    callerIdNumberOrHeaders?: PhoneNumberIdentifier | { [propertyName: string]: string },
-    maybeHeaders?: { [propertyName: string]: string }
-  ) {
-    this.target = targetIdentity;
-    if (callerIdNumberOrHeaders) {
-      if (instanceOfPhoneNumberIdentity(callerIdNumberOrHeaders)) {
-        this.sourceCallIdNumber = callerIdNumberOrHeaders;
-        if (maybeHeaders) {
-          this.sipHeaders = maybeHeaders;
-        }
-      } else {
-        this.voipHeaders = callerIdNumberOrHeaders;
-      }
-    }
-  }
+export interface CallInvite {
+  /** The Target's PhoneNumberIdentifier or CommunicationUserIdentifier. */
+  readonly targetParticipant: PhoneNumberIdentifier | CommunicationUserIdentifier;
+  /** Caller's phone number identifier. */
+  readonly sourceCallIdNumber?: PhoneNumberIdentifier;
+  sourceDisplayName?: string;
+  /** Custom context for PSTN. */
+  readonly sipHeaders?: { [propertyName: string]: string };
+  /** Custom context for voipr. */
+  readonly voipHeaders?: { [propertyName: string]: string };
 }
 
 /** The locator type of a call. */

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -6,32 +6,27 @@ import { OperationOptions } from "@azure/core-client";
 import {
   MediaStreamingConfiguration,
   CallRejectReason,
-  RecognizeInputType,
   FileSource,
   DtmfTone,
   RecordingContent,
   RecordingChannel,
   RecordingFormat,
-  RecordingStorage,
   CallLocator,
 } from "./models";
 
 /** Options to configure the recognize operation. */
 export interface CallMediaRecognizeOptions extends OperationOptions {
-  recognizeInputType: RecognizeInputType;
   playPrompt?: FileSource;
   interruptCallMediaOperation?: boolean;
   stopCurrentOperations?: boolean;
   operationContext?: string;
   interruptPrompt?: boolean;
   initialSilenceTimeoutInSeconds?: number;
-  targetParticipant: CommunicationIdentifier;
 }
 
 /** The recognize configuration specific to Dtmf. */
 export interface CallMediaRecognizeDtmfOptions extends CallMediaRecognizeOptions {
   interToneTimeoutInSeconds?: number;
-  maxTonesToCollect: number;
   stopDtmfTones?: DtmfTone[];
   readonly kind?: "callMediaRecognizeDtmfOptions";
 }
@@ -143,8 +138,8 @@ export type GetParticipantOptions = OperationOptions;
 export interface StartRecordingOptions extends OperationOptions {
   /** The call locator. */
   callLocator: CallLocator;
-  /** The uri to send notifications to. */
-  recordingStateCallbackEndpoint?: string;
+  /** The url to send notifications to. */
+  recordingStateCallbackEndpointUrl?: string;
   /** The content type of call recording. */
   recordingContent?: RecordingContent;
   /** The channel type of call recording. */
@@ -158,10 +153,6 @@ export interface StartRecordingOptions extends OperationOptions {
    * first audio was detected.  Channel to participant mapping details can be found in the metadata of the recording.
    */
   audioChannelParticipantOrdering?: CommunicationIdentifier[];
-  /** Recording storage mode. `External` enables bring your own storage. */
-  recordingStorageType?: RecordingStorage;
-  /** The location where recording is stored, when RecordingStorageType is set to 'BlobStorage'. */
-  externalStorageLocation?: string;
 }
 
 /**

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -104,7 +104,7 @@ export interface AddParticipantOptions extends OperationOptions {
 /**
  * Options to remove participants.
  */
-export interface RemoveParticipantsOptions extends OperationOptions {
+export interface RemoveParticipantsOption extends OperationOptions {
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
 }

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -28,7 +28,7 @@ export interface CallMediaRecognizeOptions extends OperationOptions {
 export interface CallMediaRecognizeDtmfOptions extends CallMediaRecognizeOptions {
   interToneTimeoutInSeconds?: number;
   stopDtmfTones?: DtmfTone[];
-  readonly kind?: "callMediaRecognizeDtmfOptions";
+  readonly kind: "callMediaRecognizeDtmfOptions";
 }
 
 /**

--- a/sdk/communication/communication-call-automation/src/models/responses.ts
+++ b/sdk/communication/communication-call-automation/src/models/responses.ts
@@ -52,7 +52,7 @@ export interface TransferCallResult {
 }
 
 /** The response payload for removing participants from the call. */
-export interface RemoveParticipantsResult {
+export interface RemoveParticipantResult {
   /** The operation context provided by client. */
   operationContext?: string;
 }

--- a/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
@@ -126,7 +126,7 @@ describe("Call Automation Main Client Live Tests", function () {
       : "create_call_and_hang_up";
     await loadPersistedEvents(testName);
 
-    const callInvite = new CallInvite(testUser2);
+    const callInvite: CallInvite = { targetParticipant: testUser2 };
     const uniqueId = await serviceBusWithNewCall(testUser, testUser2);
     const callBackUrl: string = dispatcherCallback + `?q=${uniqueId}`;
 
@@ -153,7 +153,7 @@ describe("Call Automation Main Client Live Tests", function () {
     testName = this.test?.fullTitle() ? this.test?.fullTitle().replace(/ /g, "_") : "reject_call";
     await loadPersistedEvents(testName);
 
-    const callInvite = new CallInvite(testUser2);
+    const callInvite: CallInvite = { targetParticipant: testUser2 };
     const uniqueId = await serviceBusWithNewCall(testUser, testUser2);
     const callBackUrl: string = dispatcherCallback + `?q=${uniqueId}`;
 

--- a/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
@@ -4,8 +4,13 @@
 import { Recorder } from "@azure-tools/test-recorder";
 import Sinon, { SinonStubbedInstance } from "sinon";
 import { CallConnectionProperties } from "../src/models/models";
-import { CreateCallResult } from "../src/models/responses";
-import { CALL_CALLBACK_URL, CALL_TARGET_ID, CALL_TARGET_ID_2 } from "./utils/connectionUtils";
+import { AnswerCallResult, CreateCallResult } from "../src/models/responses";
+import {
+  CALL_CALLBACK_URL,
+  CALL_INCOMING_CALL_CONTEXT,
+  CALL_TARGET_ID,
+  CALL_TARGET_ID_2,
+} from "./utils/connectionUtils";
 import { CommunicationIdentifier, CommunicationUserIdentifier } from "@azure/communication-common";
 import { assert } from "chai";
 import { Context } from "mocha";
@@ -28,6 +33,7 @@ import { v4 as uuidv4 } from "uuid";
 
 describe("Call Automation Client Unit Tests", () => {
   let targets: CommunicationIdentifier[];
+  let target: CallInvite;
   let client: SinonStubbedInstance<CallAutomationClient> & CallAutomationClient;
 
   beforeEach(() => {
@@ -40,6 +46,9 @@ describe("Call Automation Client Unit Tests", () => {
         communicationUserId: CALL_TARGET_ID_2,
       },
     ];
+    target = {
+      targetParticipant: { communicationUserId: CALL_TARGET_ID },
+    };
     // stub CallAutomationClient
     client = Sinon.createStubInstance(
       CallAutomationClient
@@ -56,6 +65,31 @@ describe("Call Automation Client Unit Tests", () => {
     assert.isNotNull(repeatabilityRequestID);
     assert.typeOf(repeatabilityFirstSent, "string");
     assert.typeOf(repeatabilityRequestID, "string");
+  });
+
+  it("CreateCall", async () => {
+    // mocks
+    const createCallResultMock: CreateCallResult = {
+      callConnectionProperties: {} as CallConnectionProperties,
+      callConnection: {} as CallConnection,
+    };
+    client.createCall.returns(
+      new Promise((resolve) => {
+        resolve(createCallResultMock);
+      })
+    );
+
+    const promiseResult = client.createCall(target, CALL_CALLBACK_URL);
+
+    // asserts
+    promiseResult
+      .then((result: CreateCallResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(client.createCall.calledWith(target, CALL_CALLBACK_URL));
+        assert.equal(result, createCallResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
   });
 
   it("CreateGroupCall", async () => {
@@ -78,6 +112,69 @@ describe("Call Automation Client Unit Tests", () => {
         assert.isNotNull(result);
         assert.isTrue(client.createGroupCall.calledWith(targets, CALL_CALLBACK_URL));
         assert.equal(result, createGroupCallResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("AnswerCall", async () => {
+    // mocks
+    const answerCallResultMock: AnswerCallResult = {
+      callConnectionProperties: {} as CallConnectionProperties,
+      callConnection: {} as CallConnection,
+    };
+    client.answerCall.returns(
+      new Promise((resolve) => {
+        resolve(answerCallResultMock);
+      })
+    );
+
+    const promiseResult = client.answerCall(CALL_INCOMING_CALL_CONTEXT, CALL_CALLBACK_URL);
+
+    // asserts
+    promiseResult
+      .then((result: AnswerCallResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(client.answerCall.calledWith(CALL_INCOMING_CALL_CONTEXT, CALL_CALLBACK_URL));
+        assert.equal(result, answerCallResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("RedirectCall", async () => {
+    // mocks
+    client.redirectCall.returns(
+      new Promise((resolve) => {
+        resolve(undefined);
+      })
+    );
+
+    const promiseResult = client.redirectCall(CALL_INCOMING_CALL_CONTEXT, target);
+
+    // asserts
+    promiseResult
+      .then(() => {
+        assert.isTrue(client.redirectCall.calledWith(CALL_INCOMING_CALL_CONTEXT, target));
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("RejectCall", async () => {
+    // mocks
+    client.rejectCall.returns(
+      new Promise((resolve) => {
+        resolve(undefined);
+      })
+    );
+
+    const promiseResult = client.rejectCall(CALL_INCOMING_CALL_CONTEXT);
+
+    // asserts
+    promiseResult
+      .then(() => {
+        assert.isTrue(client.rejectCall.calledWith(CALL_INCOMING_CALL_CONTEXT));
         return;
       })
       .catch((error) => console.error(error));

--- a/sdk/communication/communication-call-automation/test/callConnection.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callConnection.spec.ts
@@ -5,7 +5,19 @@ import { Recorder } from "@azure-tools/test-recorder";
 import { CommunicationUserIdentifier } from "@azure/communication-common";
 import { assert } from "chai";
 import { Context } from "mocha";
-import { CallAutomationClient, CallInvite, CallConnection } from "../src";
+import {
+  CallAutomationClient,
+  CallInvite,
+  CallConnection,
+  CallConnectionProperties,
+  CallParticipant,
+  ListParticipantsResult,
+  AddParticipantResult,
+  TransferCallResult,
+  RemoveParticipantResult,
+} from "../src";
+import Sinon, { SinonStubbedInstance } from "sinon";
+import { CALL_TARGET_ID } from "./utils/connectionUtils";
 import {
   createRecorder,
   createTestUser,
@@ -20,6 +32,193 @@ import {
   persistEvents,
   loadPersistedEvents,
 } from "./utils/recordedClient";
+
+describe("CallConnection Unit Tests", () => {
+  let target: CallInvite;
+  let callConnection: SinonStubbedInstance<CallConnection> & CallConnection;
+
+  beforeEach(() => {
+    // set up
+    target = {
+      targetParticipant: { communicationUserId: CALL_TARGET_ID },
+    };
+
+    // stub CallConnection
+    callConnection = Sinon.createStubInstance(
+      CallConnection
+    ) as SinonStubbedInstance<CallConnection> & CallConnection;
+  });
+
+  it("GetCallConnectionProperties", async () => {
+    // mocks
+    const callConnectionPropertiesMock: CallConnectionProperties = {};
+    callConnection.getCallConnectionProperties.returns(
+      new Promise((resolve) => {
+        resolve(callConnectionPropertiesMock);
+      })
+    );
+
+    const promiseResult = callConnection.getCallConnectionProperties();
+
+    // asserts
+    promiseResult
+      .then((result: CallConnectionProperties) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.getCallConnectionProperties.calledWith());
+        assert.equal(result, callConnectionPropertiesMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("HangUp", async () => {
+    // mocks
+    callConnection.hangUp.returns(
+      new Promise((resolve) => {
+        resolve(undefined);
+      })
+    );
+
+    const promiseResult = callConnection.hangUp(false);
+
+    // asserts
+    promiseResult
+      .then(() => {
+        assert.isTrue(callConnection.hangUp.calledWith(false));
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("Terminate", async () => {
+    // mocks
+    callConnection.hangUp.returns(
+      new Promise((resolve) => {
+        resolve(undefined);
+      })
+    );
+
+    const promiseResult = callConnection.hangUp(true);
+
+    // asserts
+    promiseResult
+      .then(() => {
+        assert.isTrue(callConnection.hangUp.calledWith(true));
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("GetParticipant", async () => {
+    // mocks
+    const callParticipantMock: CallParticipant = {};
+    callConnection.getParticipant.returns(
+      new Promise((resolve) => {
+        resolve(callParticipantMock);
+      })
+    );
+
+    const promiseResult = callConnection.getParticipant(target.targetParticipant);
+
+    // asserts
+    promiseResult
+      .then((result: CallParticipant) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.getParticipant.calledWith(target.targetParticipant));
+        assert.equal(result, callParticipantMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("ListParticipants", async () => {
+    // mocks
+    const listParticipantsResultMock: ListParticipantsResult = {};
+    callConnection.listParticipants.returns(
+      new Promise((resolve) => {
+        resolve(listParticipantsResultMock);
+      })
+    );
+
+    const promiseResult = callConnection.listParticipants();
+
+    // asserts
+    promiseResult
+      .then((result: ListParticipantsResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.listParticipants.calledWith());
+        assert.equal(result, listParticipantsResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("AddParticipant", async () => {
+    // mocks
+    const addParticipantResultMock: AddParticipantResult = {};
+    callConnection.addParticipant.returns(
+      new Promise((resolve) => {
+        resolve(addParticipantResultMock);
+      })
+    );
+
+    const promiseResult = callConnection.addParticipant(target);
+
+    // asserts
+    promiseResult
+      .then((result: AddParticipantResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.addParticipant.calledWith(target));
+        assert.equal(result, addParticipantResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("TransferCallToParticipant", async () => {
+    // mocks
+    const transferCallResultMock: TransferCallResult = {};
+    callConnection.transferCallToParticipant.returns(
+      new Promise((resolve) => {
+        resolve(transferCallResultMock);
+      })
+    );
+
+    const promiseResult = callConnection.transferCallToParticipant(target);
+
+    // asserts
+    promiseResult
+      .then((result: TransferCallResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.transferCallToParticipant.calledWith(target));
+        assert.equal(result, transferCallResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+
+  it("RemoveParticipant", async () => {
+    // mocks
+    const removeParticipantResultMock: RemoveParticipantResult = {};
+    callConnection.removeParticipant.returns(
+      new Promise((resolve) => {
+        resolve(removeParticipantResultMock);
+      })
+    );
+
+    const promiseResult = callConnection.removeParticipant(target.targetParticipant);
+
+    // asserts
+    promiseResult
+      .then((result: TransferCallResult) => {
+        assert.isNotNull(result);
+        assert.isTrue(callConnection.removeParticipant.calledWith(target.targetParticipant));
+        assert.equal(result, removeParticipantResultMock);
+        return;
+      })
+      .catch((error) => console.error(error));
+  });
+});
 
 describe("CallConnection Live Tests", function () {
   let recorder: Recorder;

--- a/sdk/communication/communication-call-automation/test/callConnection.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callConnection.spec.ts
@@ -64,7 +64,7 @@ describe("CallConnection Live Tests", function () {
       : "list_all_participants";
     await loadPersistedEvents(testName);
 
-    const callInvite = new CallInvite(testUser2);
+    const callInvite: CallInvite = { targetParticipant: testUser2 };
     const uniqueId = await serviceBusWithNewCall(testUser, testUser2);
     const callBackUrl: string = dispatcherCallback + `?q=${uniqueId}`;
     const result = await callAutomationClient.createCall(callInvite, callBackUrl);
@@ -90,7 +90,7 @@ describe("CallConnection Live Tests", function () {
       : "add_participant_and_get_call_props";
     await loadPersistedEvents(testName);
 
-    const callInvite = new CallInvite(testUser2);
+    const callInvite: CallInvite = { targetParticipant: testUser2 };
     const uniqueId = await serviceBusWithNewCall(testUser, testUser2);
     const callBackUrl: string = dispatcherCallback + `?q=${uniqueId}`;
     const result = await callAutomationClient.createCall(callInvite, callBackUrl);
@@ -106,7 +106,7 @@ describe("CallConnection Live Tests", function () {
     assert.isDefined(callConnectedEvent);
     callConnection = result.callConnection;
     const testUser3: CommunicationUserIdentifier = await createTestUser(recorder);
-    const participantInvite = new CallInvite(testUser3);
+    const participantInvite: CallInvite = { targetParticipant: testUser3 };
     const uniqueId2 = await serviceBusWithNewCall(testUser, testUser3);
     const callBackUrl2: string = dispatcherCallback + `?q=${uniqueId2}`;
 
@@ -134,7 +134,7 @@ describe("CallConnection Live Tests", function () {
       : "remove_a_participant";
     await loadPersistedEvents(testName);
 
-    const callInvite = new CallInvite(testUser2);
+    const callInvite: CallInvite = { targetParticipant: testUser2 };
     const uniqueId = await serviceBusWithNewCall(testUser, testUser2);
     const callBackUrl: string = dispatcherCallback + `?q=${uniqueId}`;
     const result = await callAutomationClient.createCall(callInvite, callBackUrl);

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -1,108 +1,107 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  CommunicationIdentifier,
-  serializeCommunicationIdentifier,
-} from "@azure/communication-common";
-import Sinon, { SinonStubbedInstance } from "sinon";
-import { CallMedia } from "../src/callMedia";
-import { FileSource } from "../src/models/models";
+import sinon from "sinon";
 import { assert } from "chai";
-import { CallMediaImpl } from "../src/generated/src/operations";
-import { CallMediaRecognizeDtmfOptions } from "../src";
+import { CallMedia } from "../src/callMedia";
+import { createMediaClient, generateHttpClient } from "./utils/mockClient";
+import {
+  CALL_CONNECTION_ID,
+  CALL_TARGET_ID,
+  MEDIA_UR_MP3,
+  MEDIA_URL_WAV,
+  baseUri,
+  generateToken,
+} from "./utils/connectionUtils";
+import { CommunicationIdentifier } from "@azure/communication-common";
+import { FileSource } from "../src/models/models";
+import { CallMediaRecognizeDtmfOptions } from "../src/models/options";
 
-describe("CallMedia Unit Tests", () => {
-  let callConnectionId: string;
-  let callMediaImpl: SinonStubbedInstance<CallMediaImpl>;
+describe("CallMedia Unit Tests", async function () {
   let callMedia: CallMedia;
 
-  beforeEach(() => {
-    callConnectionId = "test-connection-id";
-    callMediaImpl = Sinon.createStubInstance(CallMediaImpl);
-    callMedia = new CallMedia(callConnectionId, callMediaImpl as any);
+  afterEach(function () {
+    sinon.restore();
   });
 
-  it("Play", async () => {
+  it("can instantiate", async function () {
+    new CallMedia(CALL_CONNECTION_ID, baseUri, { key: generateToken() });
+  });
+
+  it("makes successful Play request", async function () {
+    const mockHttpClient = generateHttpClient(202);
+
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
     const playSource: FileSource = {
-      url: "https://example.com/audio.mp3",
+      url: MEDIA_UR_MP3,
+      kind: "fileSource",
     };
-    const playTo: CommunicationIdentifier[] = [{ communicationUserId: "user1" }];
-    // Call the play function
+
+    const playTo: CommunicationIdentifier[] = [{ communicationUserId: CALL_TARGET_ID }];
+
     await callMedia.play(playSource, playTo);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
 
-    // Check if the callMediaImpl.play was called with the correct arguments
-    assert.isTrue(
-      callMediaImpl.play.calledWith(callConnectionId, {
-        playSourceInfo: {
-          sourceType: "file",
-          fileSource: { uri: playSource.url },
-          playSourceId: playSource.playSourceId,
-        },
-        playTo: playTo.map((identifier) => serializeCommunicationIdentifier(identifier)),
-      })
-    );
+    assert.equal(data.playTo[0].rawId, CALL_TARGET_ID);
+    assert.equal(data.playSourceInfo.sourceType, "file");
+    assert.equal(data.playSourceInfo.fileSource.uri, playSource.url);
+    assert.equal(request.method, "POST");
   });
 
-  it("PlayToAll", async () => {
+  it("makes successful PlayToAll request", async function () {
+    const mockHttpClient = generateHttpClient(202);
+
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
     const playSource: FileSource = {
-      url: "https://example.com/audio/test.wav",
+      url: MEDIA_URL_WAV,
+      kind: "fileSource",
     };
+
     const playTo: CommunicationIdentifier[] = [];
 
-    // Call the play function
-    await callMedia.playToAll(playSource);
+    await callMedia.play(playSource, playTo);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
 
-    // Check if the callMediaImpl.play was called with the correct arguments
-    assert.isTrue(
-      callMediaImpl.play.calledWith(callConnectionId, {
-        playSourceInfo: {
-          sourceType: "file",
-          fileSource: { uri: playSource.url },
-          playSourceId: playSource.playSourceId,
-        },
-        playTo: playTo.map((identifier) => serializeCommunicationIdentifier(identifier)),
-      })
-    );
+    assert.equal(data.playSourceInfo.sourceType, "file");
+    assert.equal(data.playSourceInfo.fileSource.uri, playSource.url);
+    assert.equal(request.method, "POST");
   });
 
-  it("StartRecognizing", async () => {
-    const recognizeOptions: CallMediaRecognizeDtmfOptions = {};
+  it("makes successful StartRecognizing request", async function () {
+    const mockHttpClient = generateHttpClient(202);
 
-    const targetParticipant: CommunicationIdentifier = { communicationUserId: "user1" };
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+    const targetParticipant: CommunicationIdentifier = { communicationUserId: CALL_TARGET_ID };
+    const recognizeOptions: CallMediaRecognizeDtmfOptions = {
+      kind: "callMediaRecognizeDtmfOptions",
+    };
     const maxTonesToCollect = 5;
 
-    // Call the startRecognizing function
     await callMedia.startRecognizing(targetParticipant, maxTonesToCollect, recognizeOptions);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
 
-    // Check if the callMediaImpl.recognize was called with the correct arguments
-    assert.isTrue(
-      callMediaImpl.recognize.calledWith(
-        callConnectionId,
-        {
-          recognizeInputType: "dtmf",
-          playPrompt: undefined,
-          interruptCallMediaOperation: undefined,
-          recognizeOptions: {
-            interruptPrompt: undefined,
-            initialSilenceTimeoutInSeconds: 5, // Set default value here
-            targetParticipant: serializeCommunicationIdentifier(targetParticipant),
-            dtmfOptions: {
-              interToneTimeoutInSeconds: 2, // Set default value here
-              maxTonesToCollect: 5,
-              stopTones: undefined,
-            },
-          },
-          operationContext: undefined,
-        },
-        {}
-      )
-    );
+    assert.equal(data.recognizeInputType, "dtmf");
+    assert.equal(data.recognizeOptions.dtmfOptions.maxTonesToCollect, 5);
+    assert.equal(request.method, "POST");
   });
 
-  it("CancelAllMediaOperations", async () => {
+  it("makes successful CancelAllMediaOperations request", async function () {
+    const mockHttpClient = generateHttpClient(202);
+
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
     await callMedia.cancelAllOperations();
 
-    assert.isTrue(callMediaImpl.cancelAllMediaOperations.calledOnceWith(callConnectionId, {}));
+    const request = spy.getCall(0).args[0];
+
+    assert.equal(request.method, "POST");
   });
 });

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@azure/communication-common";
 import Sinon, { SinonStubbedInstance } from "sinon";
 import { CallMedia } from "../src/callMedia";
-import { FileSource, RecognizeInputType } from "../src/models/models";
+import { FileSource } from "../src/models/models";
 import { assert } from "chai";
 import { CallMediaImpl } from "../src/generated/src/operations";
 import { CallMediaRecognizeDtmfOptions } from "../src";
@@ -25,7 +25,7 @@ describe("CallMedia Unit Tests", () => {
 
   it("Play", async () => {
     const playSource: FileSource = {
-      uri: "https://example.com/audio.mp3",
+      url: "https://example.com/audio.mp3",
     };
     const playTo: CommunicationIdentifier[] = [{ communicationUserId: "user1" }];
     // Call the play function
@@ -36,7 +36,7 @@ describe("CallMedia Unit Tests", () => {
       callMediaImpl.play.calledWith(callConnectionId, {
         playSourceInfo: {
           sourceType: "file",
-          fileSource: { uri: playSource.uri },
+          fileSource: { uri: playSource.url },
           playSourceId: playSource.playSourceId,
         },
         playTo: playTo.map((identifier) => serializeCommunicationIdentifier(identifier)),
@@ -46,7 +46,7 @@ describe("CallMedia Unit Tests", () => {
 
   it("PlayToAll", async () => {
     const playSource: FileSource = {
-      uri: "https://example.com/audio/test.wav",
+      url: "https://example.com/audio/test.wav",
     };
     const playTo: CommunicationIdentifier[] = [];
 
@@ -58,7 +58,7 @@ describe("CallMedia Unit Tests", () => {
       callMediaImpl.play.calledWith(callConnectionId, {
         playSourceInfo: {
           sourceType: "file",
-          fileSource: { uri: playSource.uri },
+          fileSource: { uri: playSource.url },
           playSourceId: playSource.playSourceId,
         },
         playTo: playTo.map((identifier) => serializeCommunicationIdentifier(identifier)),
@@ -68,13 +68,13 @@ describe("CallMedia Unit Tests", () => {
 
   it("StartRecognizing", async () => {
     const recognizeOptions: CallMediaRecognizeDtmfOptions = {
-      maxTonesToCollect: 5,
-      targetParticipant: { communicationUserId: "user1" },
-      recognizeInputType: RecognizeInputType.Dtmf,
     };
 
+    const targetParticipant: CommunicationIdentifier = { communicationUserId: "user1" }
+    const maxTonesToCollect = 5
+
     // Call the startRecognizing function
-    await callMedia.startRecognizing(recognizeOptions);
+    await callMedia.startRecognizing(targetParticipant, maxTonesToCollect, recognizeOptions);
 
     // Check if the callMediaImpl.recognize was called with the correct arguments
     assert.isTrue(
@@ -87,7 +87,7 @@ describe("CallMedia Unit Tests", () => {
           recognizeOptions: {
             interruptPrompt: undefined,
             initialSilenceTimeoutInSeconds: 5, // Set default value here
-            targetParticipant: serializeCommunicationIdentifier(recognizeOptions.targetParticipant),
+            targetParticipant: serializeCommunicationIdentifier(targetParticipant),
             dtmfOptions: {
               interToneTimeoutInSeconds: 2, // Set default value here
               maxTonesToCollect: 5,
@@ -102,7 +102,7 @@ describe("CallMedia Unit Tests", () => {
   });
 
   it("CancelAllMediaOperations", async () => {
-    await callMedia.cancelAllMediaOperations();
+    await callMedia.cancelAllOperations();
 
     assert.isTrue(callMediaImpl.cancelAllMediaOperations.calledOnceWith(callConnectionId, {}));
   });

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -67,11 +67,10 @@ describe("CallMedia Unit Tests", () => {
   });
 
   it("StartRecognizing", async () => {
-    const recognizeOptions: CallMediaRecognizeDtmfOptions = {
-    };
+    const recognizeOptions: CallMediaRecognizeDtmfOptions = {};
 
-    const targetParticipant: CommunicationIdentifier = { communicationUserId: "user1" }
-    const maxTonesToCollect = 5
+    const targetParticipant: CommunicationIdentifier = { communicationUserId: "user1" };
+    const maxTonesToCollect = 5;
 
     // Call the startRecognizing function
     await callMedia.startRecognizing(targetParticipant, maxTonesToCollect, recognizeOptions);

--- a/sdk/communication/communication-call-automation/test/callRecordingClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callRecordingClient.spec.ts
@@ -32,14 +32,14 @@ describe("CallRecording Unit Tests", () => {
     );
 
     const recOptions: StartRecordingOptions = {
-      recordingStateCallbackEndpoint: "https://contoso.com/download",
+      recordingStateCallbackEndpointUrl: "https://contoso.com/download",
       callLocator: { id: "testCallId", kind: "serverCallLocator" },
       recordingChannel: "unmixed",
       recordingFormat: "wav",
       recordingContent: "audio",
     };
 
-    await callRecording.startRecording(recOptions);
+    await callRecording.start(recOptions);
 
     // Check if the callRecordingImpl.startRecording was called with the correct arguments
     assert.isTrue(
@@ -59,7 +59,7 @@ describe("CallRecording Unit Tests", () => {
   it("Sends correct args to stop a recording", async () => {
     const testRecordingID = "testRecordingId";
 
-    await callRecording.stopRecording(testRecordingID);
+    await callRecording.stop(testRecordingID);
 
     // Check if the callRecordingImpl.stopRecording was called with the correct arguments
     assert.isTrue(callRecordingImpl.stopRecording.calledWith(testRecordingID));
@@ -68,7 +68,7 @@ describe("CallRecording Unit Tests", () => {
   it("Sends correct args to pause a recording", async () => {
     const testRecordingID = "testRecordingId";
 
-    await callRecording.pauseRecording(testRecordingID);
+    await callRecording.pause(testRecordingID);
 
     // Check if the callRecordingImpl.pauseRecording was called with the correct arguments
     assert.isTrue(callRecordingImpl.pauseRecording.calledWith(testRecordingID));
@@ -77,7 +77,7 @@ describe("CallRecording Unit Tests", () => {
   it("Sends correct args to resume a recording", async () => {
     const testRecordingID = "testRecordingId";
 
-    await callRecording.resumeRecording(testRecordingID);
+    await callRecording.resume(testRecordingID);
 
     // Check if the callRecordingImpl.resumeRecording was called with the correct arguments
     assert.isTrue(callRecordingImpl.resumeRecording.calledWith(testRecordingID));
@@ -98,7 +98,7 @@ describe("CallRecording Unit Tests", () => {
 
     const testRecordingID = "testRecordingId";
 
-    await callRecording.getRecordingState(testRecordingID);
+    await callRecording.getState(testRecordingID);
 
     // Check if the callRecordingImpl.getRecordingProperties was called with the correct arguments
     assert.isTrue(callRecordingImpl.getRecordingProperties.calledWith(testRecordingID));

--- a/sdk/communication/communication-call-automation/test/callRecordingClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callRecordingClient.spec.ts
@@ -1,106 +1,123 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import Sinon, { SinonStubbedInstance } from "sinon";
+import sinon from "sinon";
 import { assert } from "chai";
-import { CallRecordingImpl } from "../src/generated/src/operations";
-import { CallRecording, StartRecordingOptions } from "../src";
-import { ContentDownloaderImpl } from "../src/contentDownloader";
-import { RecordingStateResponse } from "../src/generated/src";
+import * as RestModel from "../src/generated/src/models";
+import { createRecordingClient, generateHttpClient } from "./utils/mockClient";
+import {
+  baseUri,
+  CALL_CALLBACK_URL,
+  CALL_SERVER_CALL_ID,
+  generateToken,
+  RECORDING_ID,
+  RECORDING_STATE,
+} from "./utils/connectionUtils";
+import { CallRecording } from "../src/callRecording";
+import { StartRecordingOptions } from "../src/models/options";
+import { apiVersion } from "../src/generated/src/models/parameters";
 
-describe("CallRecording Unit Tests", () => {
-  let callRecordingImpl: SinonStubbedInstance<CallRecordingImpl>;
-  let contentDownloaderImpl: SinonStubbedInstance<ContentDownloaderImpl>;
+describe("CallRecording Unit Tests", async function () {
   let callRecording: CallRecording;
 
-  beforeEach(() => {
-    callRecordingImpl = Sinon.createStubInstance(CallRecordingImpl);
-    callRecording = new CallRecording(callRecordingImpl as any, contentDownloaderImpl as any);
+  afterEach(function () {
+    sinon.restore();
   });
 
-  it("Sends correct args to start a recording", async () => {
-    // mocks
-    const startRecordingResultMock: RecordingStateResponse = {
-      recordingId: "testId",
-      recordingState: "testState",
+  it("can instantiate", async function () {
+    new CallRecording(baseUri, { key: generateToken() });
+  });
+
+  it("makes successful startRecording request", async function () {
+    const mockResponse: RestModel.RecordingStateResponse = {
+      recordingId: RECORDING_ID,
+      recordingState: RECORDING_STATE,
     };
 
-    callRecordingImpl.startRecording.returns(
-      new Promise((resolve) => {
-        resolve(startRecordingResultMock);
-      })
-    );
+    const mockHttpClient = generateHttpClient(200, mockResponse);
+    callRecording = createRecordingClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
 
     const recOptions: StartRecordingOptions = {
-      recordingStateCallbackEndpointUrl: "https://contoso.com/download",
-      callLocator: { id: "testCallId", kind: "serverCallLocator" },
+      recordingStateCallbackEndpointUrl: CALL_CALLBACK_URL,
+      callLocator: { id: CALL_SERVER_CALL_ID, kind: "serverCallLocator" },
       recordingChannel: "unmixed",
       recordingFormat: "wav",
       recordingContent: "audio",
     };
 
     await callRecording.start(recOptions);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
 
-    // Check if the callRecordingImpl.startRecording was called with the correct arguments
-    assert.isTrue(
-      callRecordingImpl.startRecording.calledWithMatch({
-        callLocator: {
-          kind: "serverCallLocator",
-          serverCallId: "testCallId",
-        },
-        recordingChannelType: "unmixed",
-        recordingStateCallbackUri: "https://contoso.com/download",
-        recordingContentType: "audio",
-        recordingFormatType: "wav",
-      })
+    assert.equal(data.callLocator.kind, "serverCallLocator");
+    assert.equal(data.recordingStateCallbackUri, CALL_CALLBACK_URL);
+    assert.equal(request.method, "POST");
+    assert.equal(
+      request.url,
+      `${baseUri}/calling/recordings?api-version=${apiVersion.mapper.defaultValue}`
+    );
+  });
+
+  it("makes successful getRecordingProperties request", async function () {
+    const mockResponse: RestModel.RecordingStateResponse = {
+      recordingId: RECORDING_ID,
+      recordingState: RECORDING_STATE,
+    };
+
+    const mockHttpClient = generateHttpClient(200, mockResponse);
+    callRecording = createRecordingClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
+    await callRecording.getState(RECORDING_ID);
+    const request = spy.getCall(0).args[0];
+
+    assert.equal(request.method, "GET");
+    assert.equal(
+      request.url,
+      `${baseUri}/calling/recordings/${RECORDING_ID}?api-version=${apiVersion.mapper.defaultValue}`
     );
   });
 
   it("Sends correct args to stop a recording", async () => {
-    const testRecordingID = "testRecordingId";
+    const mockHttpClient = generateHttpClient(204);
+    callRecording = createRecordingClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+    await callRecording.stop(RECORDING_ID);
+    const request = spy.getCall(0).args[0];
 
-    await callRecording.stop(testRecordingID);
-
-    // Check if the callRecordingImpl.stopRecording was called with the correct arguments
-    assert.isTrue(callRecordingImpl.stopRecording.calledWith(testRecordingID));
+    assert.equal(
+      request.url,
+      `${baseUri}/calling/recordings/${RECORDING_ID}?api-version=${apiVersion.mapper.defaultValue}`
+    );
+    assert.equal(request.method, "DELETE");
   });
 
   it("Sends correct args to pause a recording", async () => {
-    const testRecordingID = "testRecordingId";
+    const mockHttpClient = generateHttpClient(202);
+    callRecording = createRecordingClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+    await callRecording.pause(RECORDING_ID);
+    const request = spy.getCall(0).args[0];
 
-    await callRecording.pause(testRecordingID);
-
-    // Check if the callRecordingImpl.pauseRecording was called with the correct arguments
-    assert.isTrue(callRecordingImpl.pauseRecording.calledWith(testRecordingID));
+    assert.equal(
+      request.url,
+      `${baseUri}/calling/recordings/${RECORDING_ID}:pause?api-version=${apiVersion.mapper.defaultValue}`
+    );
+    assert.equal(request.method, "POST");
   });
 
   it("Sends correct args to resume a recording", async () => {
-    const testRecordingID = "testRecordingId";
+    const mockHttpClient = generateHttpClient(202);
+    callRecording = createRecordingClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+    await callRecording.resume(RECORDING_ID);
+    const request = spy.getCall(0).args[0];
 
-    await callRecording.resume(testRecordingID);
-
-    // Check if the callRecordingImpl.resumeRecording was called with the correct arguments
-    assert.isTrue(callRecordingImpl.resumeRecording.calledWith(testRecordingID));
-  });
-
-  it("Sends correct args to get a get recording state", async () => {
-    // mocks
-    const getRecordingPropertiesMock: RecordingStateResponse = {
-      recordingId: "testID",
-      recordingState: "testState",
-    };
-
-    callRecordingImpl.getRecordingProperties.returns(
-      new Promise((resolve) => {
-        resolve(getRecordingPropertiesMock);
-      })
+    assert.equal(
+      request.url,
+      `${baseUri}/calling/recordings/${RECORDING_ID}:resume?api-version=${apiVersion.mapper.defaultValue}`
     );
-
-    const testRecordingID = "testRecordingId";
-
-    await callRecording.getState(testRecordingID);
-
-    // Check if the callRecordingImpl.getRecordingProperties was called with the correct arguments
-    assert.isTrue(callRecordingImpl.getRecordingProperties.calledWith(testRecordingID));
+    assert.equal(request.method, "POST");
   });
 });

--- a/sdk/communication/communication-call-automation/test/utils/connectionUtils.ts
+++ b/sdk/communication/communication-call-automation/test/utils/connectionUtils.ts
@@ -18,7 +18,11 @@ export const CALL_SUBJECT = "subject";
 export const CALL_CALLBACK_URL = "https://REDACTED.com/events";
 export const CALL_INCOMING_CALL_CONTEXT = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.REDACTED";
 export const CALL_OPERATION_CONTEXT = "operationContext";
+export const RECORDING_ID = "recordingId";
+export const RECORDING_STATE = "active";
 export const MEDIA_SUBSCRIPTION_ID = "mediaSubscriptionId";
+export const MEDIA_UR_MP3 = "https://example.com/audio.mp3";
+export const MEDIA_URL_WAV = "https://example.com/audio/test.wav";
 
 declare function btoa(stringToEncode: string): string;
 

--- a/sdk/communication/communication-call-automation/test/utils/mockClient.ts
+++ b/sdk/communication/communication-call-automation/test/utils/mockClient.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  HttpClient,
+  PipelineRequest,
+  PipelineResponse,
+  createHttpHeaders,
+} from "@azure/core-rest-pipeline";
+import { baseUri, CALL_CONNECTION_ID, generateToken } from "../utils/connectionUtils";
+import { CallMedia } from "../../src/callMedia";
+import { CallRecording } from "../../src/callRecording";
+
+export const generateHttpClient = (status: number, parsedBody?: unknown): HttpClient => {
+  const mockHttpClient: HttpClient = {
+    async sendRequest(httpRequest: PipelineRequest): Promise<PipelineResponse> {
+      return {
+        status: status,
+        headers: createHttpHeaders(),
+        request: httpRequest,
+        bodyAsText: JSON.stringify(parsedBody),
+      };
+    },
+  };
+  return mockHttpClient;
+};
+
+export const createMediaClient = (mockHttpClient: HttpClient): CallMedia => {
+  return new CallMedia(
+    CALL_CONNECTION_ID,
+    baseUri,
+    { key: generateToken() },
+    {
+      httpClient: mockHttpClient,
+    }
+  );
+};
+
+export const createRecordingClient = (mockHttpClient: HttpClient): CallRecording => {
+  return new CallRecording(
+    baseUri,
+    { key: generateToken() },
+    {
+      httpClient: mockHttpClient,
+    }
+  );
+};

--- a/sdk/communication/communication-call-automation/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-call-automation/test/utils/recordedClient.ts
@@ -28,7 +28,7 @@ import {
   CallAutomationClient,
   CallAutomationClientOptions,
   CallAutomationEvent,
-  CallAutomationEventParser,
+  parseCallAutomationEvent,
 } from "../../src";
 import { CommunicationIdentifierModel } from "../../src/generated/src";
 import { assert } from "chai";
@@ -141,8 +141,7 @@ async function eventBodyHandler(body: any): Promise<void> {
     const key: string = removeAllNonChar(callerRawId + calleeRawId);
     incomingCallContexts.set(key, incomingCallContext);
   } else {
-    const eventParser: CallAutomationEventParser = new CallAutomationEventParser();
-    const event: CallAutomationEvent = await eventParser.parse(body);
+    const event: CallAutomationEvent = await parseCallAutomationEvent(body);
     if (event.callConnectionId) {
       if (events.has(event.callConnectionId)) {
         events.get(event.callConnectionId)?.set(event.kind, event);

--- a/sdk/communication/communication-call-automation/test/utils/recordedClient.ts
+++ b/sdk/communication/communication-call-automation/test/utils/recordedClient.ts
@@ -11,7 +11,6 @@ import {
   assertEnvironmentVariable,
   isRecordMode,
   isPlaybackMode,
-  relativeRecordingsPath,
 } from "@azure-tools/test-recorder";
 import { Test } from "mocha";
 import { generateToken } from "./connectionUtils";
@@ -261,7 +260,7 @@ export function persistEvents(testName: string): void {
 export async function loadPersistedEvents(testName: string): Promise<void> {
   if (isPlaybackMode()) {
     let data: string = "";
-    console.log("path is: " + relativeRecordingsPath());
+    // Different OS has differnt file system path format.
     try {
       data = fs.readFileSync(`recordings\\${testName}.txt`, "utf-8");
     } catch (e) {


### PR DESCRIPTION
### Packages impacted by this PR
Communication-call-automation

### Describe the problem that is addressed by this PR
feedback from azure board review

General
- callInvite is now an interface instead of a class
- rename target/s to targetParticipant/s
- append EventData to events
- event parser parse is now a function instead of a class
- update uri to url 

CallMediaUpdates
- move all required params in options to method signature 


CallConnectionUpdates
- rename callConnectionImpl to callConnection
- getParticipant takes a CommunicationIdentifier instead of a participantMri string. 



CallRecordingUpdates
- remove "recording from method names" ex startRecording is now start. 