### PR TITLE
[EventHubs] workaround known memory leak in azure/AbortController

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix a memory leak issue of linked child abort signals not being released.
+
 ### Other Changes
 
 - upgrade dependency `rhea-promise` version to `^3.0.0`.

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -357,16 +357,10 @@ export function waitForEvents(
   }
 
   const aborter = new AbortController();
-  let abortListener: (() => void) | undefined;
-  if (clientAbortSignal) {
-    if (clientAbortSignal.aborted) {
-      throw new AbortError("The operation was aborted.");
-    }
-    abortListener = () => {
-      aborter.abort();
-    };
-    clientAbortSignal.addEventListener("abort", abortListener);
-  }
+  const abortListener = () => {
+    aborter.abort();
+  };
+  clientAbortSignal?.addEventListener("abort", abortListener);
 
   const updatedOptions = {
     abortSignal: aborter.signal,
@@ -384,9 +378,7 @@ export function waitForEvents(
     delay(maxWaitTimeInMs, updatedOptions).then(receivedNone),
   ]).finally(() => {
     aborter.abort();
-    if (abortListener) {
-      clientAbortSignal?.removeEventListener("abort", abortListener);
-    }
+    clientAbortSignal?.removeEventListener("abort", abortListener);
   });
 }
 


### PR DESCRIPTION
when long-lived parent signal is holding onto all it's child signal

https://github.com/Azure/azure-sdk-for-js/issues/12030

This PR adds a listener to the abort event directly.

