### PR TITLE
[engsys] Enable linting for PR descriptions

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,22 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+# This removes all unnecessary permissions, the ones needed will be set below.
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+permissions: {}
+
+jobs:
+  lint-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: xirzec/pr-lint@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          required-sections: |
+            Packages impacted by this PR
+            Describe the problem that is addressed by this PR


### PR DESCRIPTION
I created a simple GitHub action to check PRs for correctness in a few configurable ways.

This workflow won't block unless we mark it as `required` in the GitHub repo configuration, so we will have ample opportunity to test it out for false positives.

Currently supported checks:

- PR body is not empty
- Any markdown sections (denoted by headers) in the PR body are not empty
- A customized list of markdown sections are present (currently it's what packages are impacted and what is solved by the PR)
- The title starts with a token surrounded by square brackets that is either a package name, service group, or area

action repo: https://github.com/xirzec/pr-lint