### PR TITLE
[dev-tool] Fix TypeError when `//metadata` field not present in package.json

### DIFF
--- a/common/tools/dev-tool/src/util/samples/configuration.ts
+++ b/common/tools/dev-tool/src/util/samples/configuration.ts
@@ -131,7 +131,7 @@ declare global {
  */
 export function getSampleConfiguration(packageJson: PackageJson): SampleConfiguration {
   return (
-    packageJson[METADATA_KEY].sampleConfiguration ?? packageJson["//sampleConfiguration"] ?? {}
+    packageJson[METADATA_KEY]?.sampleConfiguration ?? packageJson["//sampleConfiguration"] ?? {}
   );
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/dev-tool`

### Describe the problem that is addressed by this PR

Fixes an issue with publishing samples where the `//metadata` field is not present in the `package.json`. This was the error:

```
[publish] Cannot read properties of undefined (reading 'sampleConfiguration')
```