### PR TITLE
[dev-tool][recorder] Use full argument name for `storage-location` when starting test proxy

### DIFF
--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -195,8 +195,9 @@ export interface TestProxy {
 export async function startTestProxy(): Promise<TestProxy> {
   const testProxy = await runCommand(await getTestProxyExecutable(), [
     "start",
-    "-l",
+    "--storage-location",
     await resolveRoot(),
+    "--",
     `http://0.0.0.0:${process.env.TEST_PROXY_HTTP_PORT ?? 5000}/`,
     `https://0.0.0.0:${process.env.TEST_PROXY_HTTPS_PORT ?? 5001}/`,
   ]);


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/dev-tool`

### Describe the problem that is addressed by this PR

Fix for test proxy issue with argument parsing where `-l` was not being recognized correctly.
