### PR TITLE
[Monitor Query] Merge Hotfix/monitor query 1.0.4 to main and update version for next release 1.1.0

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.0 (2023-05-09)
+
+### Features Added
+
+### Bugs Fixed
+
+### Breaking Changes
+
+### Other Changes
+
 ## 1.0.4 (2023-05-05)
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Features Added
 
-### Bugs Fixed
-
-### Breaking Changes
-
-### Other Changes
+- Added Resource centric query logs api for `LogsIngestionClient` from (`1.1.0-beta.1` release).
 
 ## 1.0.4 (2023-05-05)
 

--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 1.0.4 (2023-05-05)
+
+### Bugs Fixed
+
+- Fixed the ISO8601 value for `twentyFourHours`to reflect `P24H`, instead of `P1D` under `Durations` object.
+
+### Other Changes
+
+- Added alias `fortyEightHours` for ISO8601 value `P48H` under `Durations` object.
+- Deprecated alias name `fourtyEightHours` and fixed the ISO8601 value  to be `P48H` instead of `P2D` under `Durations` object.
+
 ## 1.1.0-beta.1 (2023-05-02)
 
 ### Features Added
@@ -7,7 +18,6 @@
 - Added Resource centric query logs api for `LogsIngestionClient`.
 
 ## 1.0.3 (2022-10-05)
-
 ### Bugs Fixed
 
 - #23349 Fixed endpoint resolution to allow endpoints from sovereign clouds

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-query",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0",
   "description": "An isomorphic client library for querying Azure Monitor's Logs and Metrics data sources.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests/recording_includequerystatistics.json
+++ b/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests/recording_includequerystatistics.json
@@ -25,7 +25,7 @@
       },
       "RequestBody": {
         "query": "AppEvents | limit 1",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 200,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests/recording_includerenderincludevisualization.json
+++ b/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests/recording_includerenderincludevisualization.json
@@ -25,7 +25,7 @@
       },
       "RequestBody": {
         "query": "datatable (s: string, i: long) [ \u0022a\u0022, 1, \u0022b\u0022, 2, \u0022c\u0022, 3 ] | render columnchart with (title=\u0022the chart title\u0022, xtitle=\u0022the x axis title\u0022)",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 200,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests__server_timeout/recording_servertimeoutinseconds.json
+++ b/sdk/monitor/monitor-query/recordings/browsers/logsqueryclient_live_tests__server_timeout/recording_servertimeoutinseconds.json
@@ -25,7 +25,7 @@
       },
       "RequestBody": {
         "query": "range x from 1 to 10000000000 step 1 | count",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 504,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests/recording_includequerystatistics.json
+++ b/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests/recording_includequerystatistics.json
@@ -16,7 +16,7 @@
       },
       "RequestBody": {
         "query": "AppEvents | limit 1",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 200,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests/recording_includerenderincludevisualization.json
+++ b/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests/recording_includerenderincludevisualization.json
@@ -16,7 +16,7 @@
       },
       "RequestBody": {
         "query": "datatable (s: string, i: long) [ \u0022a\u0022, 1, \u0022b\u0022, 2, \u0022c\u0022, 3 ] | render columnchart with (title=\u0022the chart title\u0022, xtitle=\u0022the x axis title\u0022)",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 200,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests__server_timeout/recording_servertimeoutinseconds.json
+++ b/sdk/monitor/monitor-query/recordings/node/logsqueryclient_live_tests__server_timeout/recording_servertimeoutinseconds.json
@@ -16,7 +16,7 @@
       },
       "RequestBody": {
         "query": "range x from 1 to 10000000000 step 1 | count",
-        "timespan": "P1D"
+        "timespan": "P24H"
       },
       "StatusCode": 504,
       "ResponseHeaders": {

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -20,8 +20,9 @@ export const Durations: {
     readonly oneDay: "P1D";
     readonly oneHour: "PT1H";
     readonly fourHours: "PT4H";
-    readonly twentyFourHours: "P1D";
-    readonly fourtyEightHours: "P2D";
+    readonly twentyFourHours: "P24H";
+    readonly fortyEightHours: "P48H";
+    readonly fourtyEightHours: "P48H";
     readonly thirtyMinutes: "PT30M";
     readonly fiveMinutes: "PT5M";
 };

--- a/sdk/monitor/monitor-query/src/constants.ts
+++ b/sdk/monitor/monitor-query/src/constants.ts
@@ -4,4 +4,4 @@
 /**
  * @internal
  */
-export const SDK_VERSION: string = "1.1.0-beta.1";
+export const SDK_VERSION: string = "1.1.0";

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
@@ -26,7 +26,7 @@ export class AzureLogAnalyticsContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-log-query/1.1.0-beta.1`;
+    const packageDetails = `azsdk-js-monitor-log-query/1.1.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics/1.1.0-beta.1`;
+    const packageDetails = `azsdk-js-monitor-metrics/1.1.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics-definitions/1.1.0-beta.1`;
+    const packageDetails = `azsdk-js-monitor-metrics-definitions/1.1.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics-namespaces/1.1.0-beta.1`;
+    const packageDetails = `azsdk-js-monitor-metrics-namespaces/1.1.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/models/constants.ts
+++ b/sdk/monitor/monitor-query/src/models/constants.ts
@@ -17,10 +17,14 @@ export const Durations = {
   oneHour: "PT1H",
   /** Alias for ISO8601 value 'PT4H' */
   fourHours: "PT4H",
-  /** Alias for ISO8601 value 'P1D' */
-  twentyFourHours: "P1D",
-  /** Alias for ISO8601 value 'P2D' */
-  fourtyEightHours: "P2D",
+  /** Alias for ISO8601 value 'P24H' */
+  twentyFourHours: "P24H",
+  /** Alias for ISO8601 value 'P48H' */
+  fortyEightHours: "P48H",
+  /**
+   * @deprecated Alias name `fourtyEightHours` for ISO8601 value 'P48H' is deprecated
+   */
+  fourtyEightHours: "P48H",
   /** Alias for ISO8601 value 'PT30M' */
   thirtyMinutes: "PT30M",
   /** Alias for ISO8601 value 'PT5M' */

--- a/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/metricsQueryClient.spec.ts
@@ -69,7 +69,7 @@ describe("MetricsClient live tests", function () {
       if (i % 20 === 0 || i === metricDefinitionsLength) {
         const newResults = await metricsQueryClient.queryResource(resourceId, definitionNames, {
           timespan: {
-            duration: Durations.twentyFourHours,
+            duration: Durations.oneDay,
           },
         });
         assert.ok(newResults);
@@ -87,7 +87,7 @@ describe("MetricsClient live tests", function () {
       resourceId,
       [firstResult.name!],
       {
-        timespan: { duration: Durations.twentyFourHours },
+        timespan: { duration: Durations.oneDay },
         metricNamespace: firstResult.namespace,
       }
     );


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-query

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The hotfix resolves these 2 issues:
- Fixed the aliases spelling error for a `Durations` constant for `fortyEightHours`.
- Fixed the ISO8601 values for `twentyFourHours` and `fortyEightHours` to reflect `P24H` and `P48H` respectively, instead of `P1D` and `P2D`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
