### PR TITLE
[core][util] export `randomUUID` for react-native

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.3.2 (2023-05-05)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix an issue where `randomUUID()` is not exported for react-native [issue #25754](https://github.com/Azure/azure-sdk-for-js/issues/25754)
 
 ## 1.3.1 (2023-04-13)
 

--- a/sdk/core/core-util/src/uuidUtils.native.ts
+++ b/sdk/core/core-util/src/uuidUtils.native.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * NOTE: When moving this file, please update "react-native" section in package.json.
+ */
+
 /**
  * Generated Universally Unique Identifier
  *
@@ -27,4 +31,13 @@ export function generateUUID(): string {
     }
   }
   return uuid;
+}
+
+/**
+ * Generated Universally Unique Identifier
+ *
+ * @returns RFC4122 v4 UUID.
+ */
+export function randomUUID(): string {
+  return generateUUID();
 }


### PR DESCRIPTION
We have the functionality implemented but didn't export it. This PR adds the export.

Related issue https://github.com/Azure/azure-sdk-for-js/issues/25754

### Packages impacted by this PR
`@azure/core-util`
