### PR TITLE
[ACR] Harden downloadBlob and getManifest validation

### DIFF
--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -35,6 +35,7 @@ import { RetriableReadableStream } from "../utils/retriableReadableStream";
 const LATEST_API_VERSION = "2021-07-01";
 
 const CHUNK_SIZE = 4 * 1024 * 1024; // 4 MB
+const MAX_MANIFEST_SIZE_BYTES = 4 * 1024 * 1024; // 4 MB
 
 const ACCEPTED_MANIFEST_MEDIA_TYPES = [
   KnownManifestMediaType.OciImageManifest,
@@ -256,7 +257,7 @@ export class ContainerRegistryContentClient {
         assertHasProperty(response, "mediaType");
 
         const content = response.readableStreamBody
-          ? await readStreamToEnd(response.readableStreamBody)
+          ? await readStreamToEnd(response.readableStreamBody, MAX_MANIFEST_SIZE_BYTES)
           : Buffer.alloc(0);
 
         const expectedDigest = await calculateDigest(content);

--- a/sdk/containerregistry/container-registry/src/utils/retriableReadableStream.ts
+++ b/sdk/containerregistry/container-registry/src/utils/retriableReadableStream.ts
@@ -121,6 +121,16 @@ export class RetriableReadableStream extends Readable {
 
     this.offset += data.length;
 
+    if (this.offset > this.end + 1) {
+      this.destroy(
+        new Error(
+          `Data corruption failure: Received more data than original request, data needed offset is ${
+            this.end
+          }, received offset: ${this.offset - 1}`
+        )
+      );
+    }
+
     this.onData?.(data);
     this.onProgress?.({ loadedBytes: this.offset - this.start });
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Fix #25645

### Describe the problem that is addressed by this PR

Add extra validation to `downloadBlob` and `getManifest`:
- Restrict manifest size to 4 MB
- Throw early if bytes read during `downloadBlob` exceed the value in the
  `Content-Length` header

Based somewhat on the [Java PR for the same thing](https://github.com/Azure/azure-sdk-for-java/pull/34737), but without validation of the `Content-Range` header since we are using optimistic download.
