### PR TITLE
[ACR] Model updates and improvements to `isOciImageManifest`

### DIFF
--- a/sdk/containerregistry/container-registry/README.md
+++ b/sdk/containerregistry/container-registry/README.md
@@ -302,13 +302,13 @@ main().catch((err) => {
 #### Download images
 
 ```javascript
-const { ContainerRegistryContentClient, isOciImageManifest } = require("@azure/container-registry");
-const { DefaultAzureCredential } = require("@azure/identity");
-const dotenv = require("dotenv");
-const fs = require("fs");
+import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest, isOciImageManifest } from "@azure/container-registry";
+import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
+import fs from "fs";
 dotenv.config();
 
-function trimSha(digest) {
+function trimSha(digest: string) {
   const index = digest.indexOf(":");
   return index === -1 ? digest : digest.substring(index);
 }
@@ -327,10 +327,11 @@ async function main() {
   // Download the manifest to obtain the list of files in the image based on the tag
   const result = await client.getManifest("demo");
 
-  const manifest = result.manifest;
-  if (!isOciImageManifest(manifest)) {
+  if (result.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
+
+  const manifest = result.manifest as OciImageManifest;
 
   // Manifests of all media types have a buffer containing their content; this can be written to a file.
   fs.writeFileSync("manifest.json", result.content);
@@ -384,9 +385,10 @@ main().catch((err) => {
 #### Delete blob
 
 ```javascript
-const { ContainerRegistryContentClient, isOciImageManifest } = require("@azure/container-registry");
-const { DefaultAzureCredential } = require("@azure/identity");
-require("dotenv").config();
+import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
+import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 async function main() {
   // Get the service endpoint from the environment
@@ -401,11 +403,11 @@ async function main() {
 
   const downloadResult = await client.getManifest("latest");
 
-  if (!isOciImageManifest(downloadResult.manifest)) {
+  if (downloadResult.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
 
-  for (const layer of downloadResult.manifest.layers) {
+  for (const layer of (downloadResult.manifest as OciImageManifest).layers) {
     await client.deleteBlob(layer.digest);
   }
 }

--- a/sdk/containerregistry/container-registry/README.md
+++ b/sdk/containerregistry/container-registry/README.md
@@ -302,13 +302,16 @@ main().catch((err) => {
 #### Download images
 
 ```javascript
-import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest, isOciImageManifest } from "@azure/container-registry";
-import { DefaultAzureCredential } from "@azure/identity";
-import * as dotenv from "dotenv";
-import fs from "fs";
+const {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+} = require("@azure/container-registry");
+const { DefaultAzureCredential } = require("@azure/identity");
+const dotenv = require("dotenv");
+const fs = require("fs");
 dotenv.config();
 
-function trimSha(digest: string) {
+function trimSha(digest) {
   const index = digest.indexOf(":");
   return index === -1 ? digest : digest.substring(index);
 }
@@ -331,7 +334,7 @@ async function main() {
     throw new Error("Expected an OCI image manifest");
   }
 
-  const manifest = result.manifest as OciImageManifest;
+  const manifest = result.manifest;
 
   // Manifests of all media types have a buffer containing their content; this can be written to a file.
   fs.writeFileSync("manifest.json", result.content);
@@ -352,7 +355,6 @@ async function main() {
 main().catch((err) => {
   console.error("The sample encountered an error:", err);
 });
-
 ```
 
 #### Delete manifest
@@ -385,10 +387,12 @@ main().catch((err) => {
 #### Delete blob
 
 ```javascript
-import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
-import { DefaultAzureCredential } from "@azure/identity";
-import * as dotenv from "dotenv";
-dotenv.config();
+const {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+} = require("@azure/container-registry");
+const { DefaultAzureCredential } = require("@azure/identity");
+require("dotenv").config();
 
 async function main() {
   // Get the service endpoint from the environment
@@ -407,15 +411,10 @@ async function main() {
     throw new Error("Expected an OCI image manifest");
   }
 
-  for (const layer of (downloadResult.manifest as OciImageManifest).layers) {
+  for (const layer of downloadResult.manifest.layers) {
     await client.deleteBlob(layer.digest);
   }
 }
-
-main().catch((err) => {
-  console.error("The sample encountered an error:", err);
-});
-
 ```
 
 ## Troubleshooting

--- a/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_can_upload_oci_manifest.json
+++ b/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_can_upload_oci_manifest.json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "299e9c44-4ee0-4f12-a375-73f23bfed9b6"
+        "x-ms-client-request-id": "332fca86-8e5d-4052-a3a1-dafa3368232f"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -23,16 +23,16 @@
         "Connection": "keep-alive",
         "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:50 GMT",
+        "Date": "Mon, 08 May 2023 07:38:45 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
-        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022t3f3dad0153774741.azurecr.io\u0022,scope=\u0022repository:oci-artifact:pull,push\u0022",
+        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022timovcontainerregistry2.azurecr.io\u0022,scope=\u0022repository:oci-artifact:pull,push\u0022",
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Correlation-Request-Id": "e74a2610-fae7-4cc9-90e3-e2121367b461"
+        "X-Ms-Correlation-Request-Id": "266334e3-2cbb-4884-8965-2e09a026ce6f"
       },
       "ResponseBody": {
         "errors": [
@@ -62,21 +62,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "91",
+        "Content-Length": "97",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "930f66e8-1f3f-4e2a-9bc6-15fd4f6656ac"
+        "x-ms-client-request-id": "64166d01-a628-4228-ad42-50f5bfb3553c"
       },
-      "RequestBody": "grant_type=access_token\u0026service=t3f3dad0153774741.azurecr.io\u0026access_token=SecretPlaceholder",
+      "RequestBody": "grant_type=access_token\u0026service=timovcontainerregistry2.azurecr.io\u0026access_token=SecretPlaceholder",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:51 GMT",
+        "Date": "Mon, 08 May 2023 07:38:46 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "2fe6eb19-a8b2-4fe3-a386-a1686e6af5ba",
+        "X-Ms-Correlation-Request-Id": "ca2cdf66-8af7-4e20-81ae-099670d2d12f",
         "x-ms-ratelimit-remaining-calls-per-second": "166.65"
       },
       "ResponseBody": {
@@ -90,21 +90,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "170",
+        "Content-Length": "176",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "df855176-52a8-49f8-8903-75bc88381867"
+        "x-ms-client-request-id": "b4430ba3-5b93-4350-9822-42df24241da2"
       },
-      "RequestBody": "service=t3f3dad0153774741.azurecr.io\u0026scope=repository%3Aoci-artifact%3Apull%2Cpush\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
+      "RequestBody": "service=timovcontainerregistry2.azurecr.io\u0026scope=repository%3Aoci-artifact%3Apull%2Cpush\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:51 GMT",
+        "Date": "Mon, 08 May 2023 07:38:46 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "52d39d78-bfff-4ae5-ac43-64ee152bd601",
+        "X-Ms-Correlation-Request-Id": "c85f3923-5675-4704-a997-ac0026053785",
         "x-ms-ratelimit-remaining-calls-per-second": "166.633333"
       },
       "ResponseBody": {
@@ -121,7 +121,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "299e9c44-4ee0-4f12-a375-73f23bfed9b6"
+        "x-ms-client-request-id": "332fca86-8e5d-4052-a3a1-dafa3368232f"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -134,10 +134,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:46 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6",
-        "Location": "/v2/oci-artifact/blobs/uploads/4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6?_nouploadcache=false\u0026_state=HDVVN6vvn5moiQjgKhYQ5Ty6P5fGJwKqB7M7TGwMgvF7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNGQzOTIzYTktNWVhNC00MWIyLWFiOWYtOTkxZjFkNmRmYmU2IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjUyLjAwODgxNjcwOFoifQ%3D%3D",
+        "Docker-Upload-Uuid": "7817dc61-d1db-4787-9c7d-32db67bfb83d",
+        "Location": "/v2/oci-artifact/blobs/uploads/7817dc61-d1db-4787-9c7d-32db67bfb83d?_nouploadcache=false\u0026_state=vfvcPVHfm_rl6ESJbHSjGXdwH5g8CJ0DZbo1yBlzv6R7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNzgxN2RjNjEtZDFkYi00Nzg3LTljN2QtMzJkYjY3YmZiODNkIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjQ2Ljc4MDM2ODY2NloifQ%3D%3D",
         "Range": "0-0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -145,14 +145,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "299e9c44-4ee0-4f12-a375-73f23bfed9b6",
-        "X-Ms-Correlation-Request-Id": "01516a41-054c-4434-a290-ac83f05dbcde",
-        "X-Ms-Request-Id": "46231433-d74c-419d-bda7-e461a167c5ff"
+        "X-Ms-Client-Request-Id": "332fca86-8e5d-4052-a3a1-dafa3368232f",
+        "X-Ms-Correlation-Request-Id": "8d31e83c-aad0-4110-80bf-23fa08df00c6",
+        "X-Ms-Request-Id": "33658e4d-4c77-4b65-8fad-73e07e4bdd86"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6?_nouploadcache=false\u0026_state=HDVVN6vvn5moiQjgKhYQ5Ty6P5fGJwKqB7M7TGwMgvF7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNGQzOTIzYTktNWVhNC00MWIyLWFiOWYtOTkxZjFkNmRmYmU2IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjUyLjAwODgxNjcwOFoifQ%3D%3D",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/7817dc61-d1db-4787-9c7d-32db67bfb83d?_nouploadcache=false\u0026_state=vfvcPVHfm_rl6ESJbHSjGXdwH5g8CJ0DZbo1yBlzv6R7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNzgxN2RjNjEtZDFkYi00Nzg3LTljN2QtMzJkYjY3YmZiODNkIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjQ2Ljc4MDM2ODY2NloifQ%3D%3D",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -162,7 +162,7 @@
         "Content-Length": "28",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bcbff975-f2ea-4b50-b370-d4cd91392ed2"
+        "x-ms-client-request-id": "9cd3fbe9-c1e3-4a21-bc4e-4f1817257718"
       },
       "RequestBody": "//5oAGUAbABsAG8AIAB3AG8AcgBsAGQADQAKAA==",
       "StatusCode": 202,
@@ -175,10 +175,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:47 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6",
-        "Location": "/v2/oci-artifact/blobs/uploads/4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6?_nouploadcache=false\u0026_state=ybF5h72M0C5WsUUPVzc8DvdFsvICaysWtKzLOc87Dc17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNGQzOTIzYTktNWVhNC00MWIyLWFiOWYtOTkxZjFkNmRmYmU2IiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNC0xOVQyMToyNzo1MloifQ%3D%3D",
+        "Docker-Upload-Uuid": "7817dc61-d1db-4787-9c7d-32db67bfb83d",
+        "Location": "/v2/oci-artifact/blobs/uploads/7817dc61-d1db-4787-9c7d-32db67bfb83d?_nouploadcache=false\u0026_state=c3oercwbqQ29GBn53ZYxv3Utd-664TCiuv4AVihHdwp7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNzgxN2RjNjEtZDFkYi00Nzg3LTljN2QtMzJkYjY3YmZiODNkIiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNS0wOFQwNzozODo0NloifQ%3D%3D",
         "Range": "0-27",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -186,14 +186,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "bcbff975-f2ea-4b50-b370-d4cd91392ed2",
-        "X-Ms-Correlation-Request-Id": "297d08f7-8496-4e95-9f1a-3defc4c45d32",
-        "X-Ms-Request-Id": "edc55872-04ee-4423-b5bb-e82b3384bb6e"
+        "X-Ms-Client-Request-Id": "9cd3fbe9-c1e3-4a21-bc4e-4f1817257718",
+        "X-Ms-Correlation-Request-Id": "ac0a840c-2620-4cdc-8d05-5961952e2a0c",
+        "X-Ms-Request-Id": "6ef26b44-2eac-429e-b539-290f2db2979e"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/4d3923a9-5ea4-41b2-ab9f-991f1d6dfbe6?_nouploadcache=false\u0026_state=ybF5h72M0C5WsUUPVzc8DvdFsvICaysWtKzLOc87Dc17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNGQzOTIzYTktNWVhNC00MWIyLWFiOWYtOTkxZjFkNmRmYmU2IiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNC0xOVQyMToyNzo1MloifQ%3D%3D\u0026digest=sha256%3A654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/7817dc61-d1db-4787-9c7d-32db67bfb83d?_nouploadcache=false\u0026_state=c3oercwbqQ29GBn53ZYxv3Utd-664TCiuv4AVihHdwp7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNzgxN2RjNjEtZDFkYi00Nzg3LTljN2QtMzJkYjY3YmZiODNkIiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNS0wOFQwNzozODo0NloifQ%3D%3D\u0026digest=sha256%3A654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -203,7 +203,7 @@
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2eef9dca-c374-44b3-86a6-0262d436651f"
+        "x-ms-client-request-id": "200f12c7-a6f8-4646-8246-b375b6dd2dea"
       },
       "RequestBody": null,
       "StatusCode": 201,
@@ -216,7 +216,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:47 GMT",
         "Docker-Content-Digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Location": "/v2/oci-artifact/blobs/sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
@@ -226,9 +226,9 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "2eef9dca-c374-44b3-86a6-0262d436651f",
-        "X-Ms-Correlation-Request-Id": "0935a087-939b-43af-86aa-bf7cb0bc1309",
-        "X-Ms-Request-Id": "7be12b45-5fe7-45c1-8673-613a4c620f8b"
+        "X-Ms-Client-Request-Id": "200f12c7-a6f8-4646-8246-b375b6dd2dea",
+        "X-Ms-Correlation-Request-Id": "9f103d8d-c85b-4210-a0e9-cd4d3db060ad",
+        "X-Ms-Request-Id": "abe3f13b-7175-40e6-ba76-1aa125c917ae"
       },
       "ResponseBody": null
     },
@@ -242,7 +242,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "24d49c82-2dee-4c10-941c-e693e25198e8"
+        "x-ms-client-request-id": "c43ff54d-38b8-49b4-b869-105e8d610d1b"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -255,10 +255,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:47 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "2584c25f-500f-4b5d-ac1e-b30f3ef79d21",
-        "Location": "/v2/oci-artifact/blobs/uploads/2584c25f-500f-4b5d-ac1e-b30f3ef79d21?_nouploadcache=false\u0026_state=8CQ0Tk2dwoSp-nEsWg74HeKzznzsGxCTslo4wZox41h7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMjU4NGMyNWYtNTAwZi00YjVkLWFjMWUtYjMwZjNlZjc5ZDIxIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjUyLjMxMzU5MzYxNloifQ%3D%3D",
+        "Docker-Upload-Uuid": "d778b044-c6b7-42da-9061-1fcdc0367c64",
+        "Location": "/v2/oci-artifact/blobs/uploads/d778b044-c6b7-42da-9061-1fcdc0367c64?_nouploadcache=false\u0026_state=TYVLZWlSsGQ0a8JRYR24TxEOMVzpTJyjnQXzMGFEdB97Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZDc3OGIwNDQtYzZiNy00MmRhLTkwNjEtMWZjZGMwMzY3YzY0IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjQ3LjUwNDM4NjIwNFoifQ%3D%3D",
         "Range": "0-0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -266,14 +266,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "24d49c82-2dee-4c10-941c-e693e25198e8",
-        "X-Ms-Correlation-Request-Id": "e71dcad6-2837-4ddf-acfb-d992d3757cec",
-        "X-Ms-Request-Id": "75528e7b-7ce9-4915-a66c-f0a88a8ba4ef"
+        "X-Ms-Client-Request-Id": "c43ff54d-38b8-49b4-b869-105e8d610d1b",
+        "X-Ms-Correlation-Request-Id": "ba5302ed-4c6a-4cfa-be1e-7623b1a137d2",
+        "X-Ms-Request-Id": "8f01bc55-5105-44ce-85f3-61b3b83843a2"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/2584c25f-500f-4b5d-ac1e-b30f3ef79d21?_nouploadcache=false\u0026_state=8CQ0Tk2dwoSp-nEsWg74HeKzznzsGxCTslo4wZox41h7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMjU4NGMyNWYtNTAwZi00YjVkLWFjMWUtYjMwZjNlZjc5ZDIxIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjUyLjMxMzU5MzYxNloifQ%3D%3D",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/d778b044-c6b7-42da-9061-1fcdc0367c64?_nouploadcache=false\u0026_state=TYVLZWlSsGQ0a8JRYR24TxEOMVzpTJyjnQXzMGFEdB97Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZDc3OGIwNDQtYzZiNy00MmRhLTkwNjEtMWZjZGMwMzY3YzY0IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjQ3LjUwNDM4NjIwNFoifQ%3D%3D",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -283,7 +283,7 @@
         "Content-Length": "171",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "a06fae85-3400-4f3a-9c90-6536adf1df9c"
+        "x-ms-client-request-id": "fbf2c007-0979-43e8-b910-9a1d873ee8e2"
       },
       "RequestBody": "H4sIAAAAAAAA/\u002BzRwcrCMBAE4Dn/8L9DD551tulmn6dUq4VioUb06VUsORU8aRQx32VzSjYzi2bYt90WKZGkmU2T5HxOZ6lo6lTNPCjUUlFo0q2i4yHUI8hn75l/7kvE/lf1GLq2bsIynMOr37jn4b1/3L\u002BrYv9lWYkDxYkoireE\u002BOP9Xy87bNCjx4ACJwwY0WONf/x9erUsy7IsoVsAAAD//yO/fykACgAA",
       "StatusCode": 202,
@@ -296,10 +296,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:47 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "2584c25f-500f-4b5d-ac1e-b30f3ef79d21",
-        "Location": "/v2/oci-artifact/blobs/uploads/2584c25f-500f-4b5d-ac1e-b30f3ef79d21?_nouploadcache=false\u0026_state=BSK1VRItnNwpwSoE_P9tgrY4PLx9ZcxAjPhWhfCTKtt7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMjU4NGMyNWYtNTAwZi00YjVkLWFjMWUtYjMwZjNlZjc5ZDIxIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDQtMTlUMjE6Mjc6NTJaIn0%3D",
+        "Docker-Upload-Uuid": "d778b044-c6b7-42da-9061-1fcdc0367c64",
+        "Location": "/v2/oci-artifact/blobs/uploads/d778b044-c6b7-42da-9061-1fcdc0367c64?_nouploadcache=false\u0026_state=DNfe7bCUf5sR17Xq2wrUJAQLKC6IhD1ySPGYWl8onY17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZDc3OGIwNDQtYzZiNy00MmRhLTkwNjEtMWZjZGMwMzY3YzY0IiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDUtMDhUMDc6Mzg6NDdaIn0%3D",
         "Range": "0-170",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -307,14 +307,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "a06fae85-3400-4f3a-9c90-6536adf1df9c",
-        "X-Ms-Correlation-Request-Id": "8ea1de48-f428-4490-9859-ba5704c067bb",
-        "X-Ms-Request-Id": "7c0a1b7c-b8c2-41ca-bca2-6013197cc905"
+        "X-Ms-Client-Request-Id": "fbf2c007-0979-43e8-b910-9a1d873ee8e2",
+        "X-Ms-Correlation-Request-Id": "8b9cc2cb-420e-4a0d-8218-4ecff3d5a7d1",
+        "X-Ms-Request-Id": "a5b3d6ef-c783-447a-9272-9e1d589c9b4c"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/2584c25f-500f-4b5d-ac1e-b30f3ef79d21?_nouploadcache=false\u0026_state=BSK1VRItnNwpwSoE_P9tgrY4PLx9ZcxAjPhWhfCTKtt7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMjU4NGMyNWYtNTAwZi00YjVkLWFjMWUtYjMwZjNlZjc5ZDIxIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDQtMTlUMjE6Mjc6NTJaIn0%3D\u0026digest=sha256%3Ad25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/d778b044-c6b7-42da-9061-1fcdc0367c64?_nouploadcache=false\u0026_state=DNfe7bCUf5sR17Xq2wrUJAQLKC6IhD1ySPGYWl8onY17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZDc3OGIwNDQtYzZiNy00MmRhLTkwNjEtMWZjZGMwMzY3YzY0IiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDUtMDhUMDc6Mzg6NDdaIn0%3D\u0026digest=sha256%3Ad25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -324,7 +324,7 @@
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "3f6f5cc7-b4d1-4875-b91d-ca97fb066f26"
+        "x-ms-client-request-id": "8e15a347-bfd3-4cce-b796-d8c488d5fbcf"
       },
       "RequestBody": null,
       "StatusCode": 201,
@@ -337,7 +337,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:47 GMT",
         "Docker-Content-Digest": "sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Location": "/v2/oci-artifact/blobs/sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
@@ -347,24 +347,24 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "3f6f5cc7-b4d1-4875-b91d-ca97fb066f26",
-        "X-Ms-Correlation-Request-Id": "dd718956-be9d-4f26-b746-05c3eb6d3b80",
-        "X-Ms-Request-Id": "7e7553fa-6cdf-4e4b-a1ae-e459ed402fd6"
+        "X-Ms-Client-Request-Id": "8e15a347-bfd3-4cce-b796-d8c488d5fbcf",
+        "X-Ms-Correlation-Request-Id": "63ff5bd5-4e3c-4ba2-8e3a-1cf396c7b799",
+        "X-Ms-Request-Id": "86b130f3-3de6-4033-a900-dc9a4062f0ba"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "377",
+        "Content-Length": "402",
         "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "4c1fec8a-914a-46d7-a720-3bcdf534132b"
+        "x-ms-client-request-id": "af47b8d8-55e5-419e-95eb-6b83aa0cf6a2"
       },
       "RequestBody": {
         "schemaVersion": 2,
@@ -379,7 +379,7 @@
             "digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
             "size": 28,
             "annotations": {
-              "title": "artifact.txt"
+              "org.opencontainers.image.title": "artifact.txt"
             }
           }
         ]
@@ -394,24 +394,24 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
-        "Docker-Content-Digest": "sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Date": "Mon, 08 May 2023 07:38:48 GMT",
+        "Docker-Content-Digest": "sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Location": "/v2/oci-artifact/manifests/sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Location": "/v2/oci-artifact/manifests/sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "4c1fec8a-914a-46d7-a720-3bcdf534132b",
-        "X-Ms-Correlation-Request-Id": "21b23697-a39e-4ee0-8cc0-5ef1ed4b09c8",
-        "X-Ms-Request-Id": "ecc1b03b-9f44-435e-be3a-b2cc9cae96de"
+        "X-Ms-Client-Request-Id": "af47b8d8-55e5-419e-95eb-6b83aa0cf6a2",
+        "X-Ms-Correlation-Request-Id": "8641ecac-206c-4cca-94de-782075fbbfd8",
+        "X-Ms-Request-Id": "ba5f5db6-3e01-4825-9d98-ffc1333444af"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.oci.image.manifest.v1\u002Bjson, application/vnd.docker.distribution.manifest.v2\u002Bjson, application/vnd.oci.image.index.v1\u002Bjson, application/vnd.docker.distribution.manifest.list.v2\u002Bjson, application/vnd.docker.container.image.v1\u002Bjson",
@@ -419,7 +419,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "330a5f3f-9296-4493-a21c-160fb56f6c99"
+        "x-ms-client-request-id": "05549096-5aa6-453c-b8e6-870352e8bc8d"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -431,21 +431,21 @@
           "X-Ms-Correlation-Request-Id"
         ],
         "Connection": "keep-alive",
-        "Content-Length": "377",
+        "Content-Length": "402",
         "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
-        "Docker-Content-Digest": "sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Date": "Mon, 08 May 2023 07:38:48 GMT",
+        "Docker-Content-Digest": "sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "ETag": "\u0022sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b\u0022",
+        "ETag": "\u0022sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed\u0022",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "330a5f3f-9296-4493-a21c-160fb56f6c99",
-        "X-Ms-Correlation-Request-Id": "e33951be-f7f1-414f-bef1-a96fc67b35cf",
-        "X-Ms-Request-Id": "9fe98b9c-b0b7-415b-ae3e-83df9f599627"
+        "X-Ms-Client-Request-Id": "05549096-5aa6-453c-b8e6-870352e8bc8d",
+        "X-Ms-Correlation-Request-Id": "e486e73d-08e1-4deb-a711-f2342ea78283",
+        "X-Ms-Request-Id": "9ce17b89-dd00-4c5f-a7fe-7c0b7c0118ad"
       },
       "ResponseBody": {
         "schemaVersion": 2,
@@ -460,14 +460,14 @@
             "digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
             "size": 28,
             "annotations": {
-              "title": "artifact.txt"
+              "org.opencontainers.image.title": "artifact.txt"
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -475,7 +475,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "51e37f40-829d-4608-9aec-19a3a4f8f718"
+        "x-ms-client-request-id": "0b3acaac-3817-49d7-a633-384261c27b54"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -489,16 +489,16 @@
         "Connection": "keep-alive",
         "Content-Length": "208",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:48 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
-        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022t3f3dad0153774741.azurecr.io\u0022,scope=\u0022repository:oci-artifact:delete\u0022,error=\u0022insufficient_scope\u0022",
+        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022timovcontainerregistry2.azurecr.io\u0022,scope=\u0022repository:oci-artifact:delete\u0022,error=\u0022insufficient_scope\u0022",
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Correlation-Request-Id": "4681923c-6713-4179-86d2-3fe822df0280"
+        "X-Ms-Correlation-Request-Id": "0af3a6df-3f51-4e24-8a47-14a9b35139fe"
       },
       "ResponseBody": {
         "errors": [
@@ -523,21 +523,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "165",
+        "Content-Length": "171",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "c6b23491-e8c8-4d12-8d6e-4a7214f81265"
+        "x-ms-client-request-id": "b6c84547-ab15-4704-b3ed-7cd91490e18b"
       },
-      "RequestBody": "service=t3f3dad0153774741.azurecr.io\u0026scope=repository%3Aoci-artifact%3Adelete\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
+      "RequestBody": "service=timovcontainerregistry2.azurecr.io\u0026scope=repository%3Aoci-artifact%3Adelete\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:52 GMT",
+        "Date": "Mon, 08 May 2023 07:38:48 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "36f2717f-cb97-40b3-b21c-ba6d403f794e",
+        "X-Ms-Correlation-Request-Id": "5adaddc6-0368-46f1-b2bc-a399c0280300",
         "x-ms-ratelimit-remaining-calls-per-second": "166.616667"
       },
       "ResponseBody": {
@@ -545,7 +545,7 @@
       }
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -553,7 +553,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "51e37f40-829d-4608-9aec-19a3a4f8f718"
+        "x-ms-client-request-id": "0b3acaac-3817-49d7-a633-384261c27b54"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -566,7 +566,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:53 GMT",
+        "Date": "Mon, 08 May 2023 07:38:49 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -574,10 +574,10 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "51e37f40-829d-4608-9aec-19a3a4f8f718",
-        "X-Ms-Correlation-Request-Id": "0c1b21ba-4bdb-4202-ab93-5f8444e2e7fb",
+        "X-Ms-Client-Request-Id": "0b3acaac-3817-49d7-a633-384261c27b54",
+        "X-Ms-Correlation-Request-Id": "cd5ff6f9-4fa6-4778-8535-21e45a6ddb8a",
         "X-Ms-Ratelimit-Remaining-Calls-Per-Second": "8.000000",
-        "X-Ms-Request-Id": "3d9b1bf7-15e0-4d4e-a606-e332874dfde4"
+        "X-Ms-Request-Id": "8460fe38-40f2-40a0-8b96-5aae78325f6a"
       },
       "ResponseBody": null
     }

--- a/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_can_upload_oci_manifest_with_tag.json
+++ b/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_can_upload_oci_manifest_with_tag.json
@@ -9,7 +9,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "89cd9357-a825-4774-9f69-73870d78ead5"
+        "x-ms-client-request-id": "20adee0a-362b-4ec4-bb98-411ac43de4ca"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -23,16 +23,16 @@
         "Connection": "keep-alive",
         "Content-Length": "266",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:53 GMT",
+        "Date": "Mon, 08 May 2023 07:38:49 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
-        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022t3f3dad0153774741.azurecr.io\u0022,scope=\u0022repository:oci-artifact:pull,push\u0022",
+        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022timovcontainerregistry2.azurecr.io\u0022,scope=\u0022repository:oci-artifact:pull,push\u0022",
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Correlation-Request-Id": "1c6eb74c-b238-4225-8788-adb0497be04b"
+        "X-Ms-Correlation-Request-Id": "414e00f0-6db6-4929-b4e7-2dd5f26988f7"
       },
       "ResponseBody": {
         "errors": [
@@ -62,21 +62,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "91",
+        "Content-Length": "97",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "233539fb-206c-4f3a-bde8-73bf8ee55cb1"
+        "x-ms-client-request-id": "c6e51b1b-f3cc-492d-b7d0-eaafa796ff35"
       },
-      "RequestBody": "grant_type=access_token\u0026service=t3f3dad0153774741.azurecr.io\u0026access_token=SecretPlaceholder",
+      "RequestBody": "grant_type=access_token\u0026service=timovcontainerregistry2.azurecr.io\u0026access_token=SecretPlaceholder",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:50 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "f602ef19-7bbb-44de-aed7-ac6252c3d063",
+        "X-Ms-Correlation-Request-Id": "7b3e522a-7c20-474d-bdf2-1b2603af2905",
         "x-ms-ratelimit-remaining-calls-per-second": "166.6"
       },
       "ResponseBody": {
@@ -90,21 +90,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "170",
+        "Content-Length": "176",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "f6a3100d-9f39-43f5-a6e6-900f634b3ae2"
+        "x-ms-client-request-id": "60698e44-7cd9-4acc-8057-e9639fc7dcf3"
       },
-      "RequestBody": "service=t3f3dad0153774741.azurecr.io\u0026scope=repository%3Aoci-artifact%3Apull%2Cpush\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
+      "RequestBody": "service=timovcontainerregistry2.azurecr.io\u0026scope=repository%3Aoci-artifact%3Apull%2Cpush\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:50 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "ad20dad5-b8e7-45ad-b963-3509857a077d",
+        "X-Ms-Correlation-Request-Id": "ceacd66b-a9c7-4fff-84ce-d748f414e24b",
         "x-ms-ratelimit-remaining-calls-per-second": "166.583333"
       },
       "ResponseBody": {
@@ -121,7 +121,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "89cd9357-a825-4774-9f69-73870d78ead5"
+        "x-ms-client-request-id": "20adee0a-362b-4ec4-bb98-411ac43de4ca"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -134,10 +134,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:50 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "631fa0b2-cd86-4792-a0dc-aa0c65ba397a",
-        "Location": "/v2/oci-artifact/blobs/uploads/631fa0b2-cd86-4792-a0dc-aa0c65ba397a?_nouploadcache=false\u0026_state=Fiw1_5ZsB4NjSZ90UpwUx3flIpph2aLmB2GAMd0a5gx7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNjMxZmEwYjItY2Q4Ni00NzkyLWEwZGMtYWEwYzY1YmEzOTdhIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjU0LjEyODQwMDExNFoifQ%3D%3D",
+        "Docker-Upload-Uuid": "31ac7e66-b590-48f6-acc0-4e3fd898b757",
+        "Location": "/v2/oci-artifact/blobs/uploads/31ac7e66-b590-48f6-acc0-4e3fd898b757?_nouploadcache=false\u0026_state=4PQdxwBUIrITixDvOu-MST9Rz8RH300UOZ7BfGohgBB7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMzFhYzdlNjYtYjU5MC00OGY2LWFjYzAtNGUzZmQ4OThiNzU3IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjUwLjY4OTA0OTU0M1oifQ%3D%3D",
         "Range": "0-0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -145,14 +145,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "89cd9357-a825-4774-9f69-73870d78ead5",
-        "X-Ms-Correlation-Request-Id": "bc1a11e0-3967-4d2d-a571-a72c540b9e91",
-        "X-Ms-Request-Id": "9160f5b2-a9d0-4207-9af6-b3c87f3cea5d"
+        "X-Ms-Client-Request-Id": "20adee0a-362b-4ec4-bb98-411ac43de4ca",
+        "X-Ms-Correlation-Request-Id": "ed55398f-5048-4044-b4af-46b6545249b8",
+        "X-Ms-Request-Id": "12447f83-c187-434b-ba23-8423b1995555"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/631fa0b2-cd86-4792-a0dc-aa0c65ba397a?_nouploadcache=false\u0026_state=Fiw1_5ZsB4NjSZ90UpwUx3flIpph2aLmB2GAMd0a5gx7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNjMxZmEwYjItY2Q4Ni00NzkyLWEwZGMtYWEwYzY1YmEzOTdhIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjU0LjEyODQwMDExNFoifQ%3D%3D",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/31ac7e66-b590-48f6-acc0-4e3fd898b757?_nouploadcache=false\u0026_state=4PQdxwBUIrITixDvOu-MST9Rz8RH300UOZ7BfGohgBB7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMzFhYzdlNjYtYjU5MC00OGY2LWFjYzAtNGUzZmQ4OThiNzU3IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjUwLjY4OTA0OTU0M1oifQ%3D%3D",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -162,7 +162,7 @@
         "Content-Length": "28",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "b6fec5ae-5e90-445e-8cd3-962e5c0040a2"
+        "x-ms-client-request-id": "2727166c-0bb8-48b7-bcae-7d98fa6450de"
       },
       "RequestBody": "//5oAGUAbABsAG8AIAB3AG8AcgBsAGQADQAKAA==",
       "StatusCode": 202,
@@ -175,10 +175,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:50 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "631fa0b2-cd86-4792-a0dc-aa0c65ba397a",
-        "Location": "/v2/oci-artifact/blobs/uploads/631fa0b2-cd86-4792-a0dc-aa0c65ba397a?_nouploadcache=false\u0026_state=v1R94gv2YitV58y3nY_yQZaB4ZYY5YzQXdzyX8izxe17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNjMxZmEwYjItY2Q4Ni00NzkyLWEwZGMtYWEwYzY1YmEzOTdhIiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNC0xOVQyMToyNzo1NFoifQ%3D%3D",
+        "Docker-Upload-Uuid": "31ac7e66-b590-48f6-acc0-4e3fd898b757",
+        "Location": "/v2/oci-artifact/blobs/uploads/31ac7e66-b590-48f6-acc0-4e3fd898b757?_nouploadcache=false\u0026_state=cba02xflIbwYVhGHoYVge3ShFWwyifPToTmR9IreC3V7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMzFhYzdlNjYtYjU5MC00OGY2LWFjYzAtNGUzZmQ4OThiNzU3IiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNS0wOFQwNzozODo1MFoifQ%3D%3D",
         "Range": "0-27",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -186,14 +186,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "b6fec5ae-5e90-445e-8cd3-962e5c0040a2",
-        "X-Ms-Correlation-Request-Id": "32653a0f-9b11-48c3-aeca-97c5122ef738",
-        "X-Ms-Request-Id": "579d7d0a-1348-435b-8db9-4752d514feab"
+        "X-Ms-Client-Request-Id": "2727166c-0bb8-48b7-bcae-7d98fa6450de",
+        "X-Ms-Correlation-Request-Id": "3448816c-cdb1-461a-842d-b15e98931a01",
+        "X-Ms-Request-Id": "4758179b-b2d5-43ed-b531-4b8bc0e216c8"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/631fa0b2-cd86-4792-a0dc-aa0c65ba397a?_nouploadcache=false\u0026_state=v1R94gv2YitV58y3nY_yQZaB4ZYY5YzQXdzyX8izxe17Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNjMxZmEwYjItY2Q4Ni00NzkyLWEwZGMtYWEwYzY1YmEzOTdhIiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNC0xOVQyMToyNzo1NFoifQ%3D%3D\u0026digest=sha256%3A654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/31ac7e66-b590-48f6-acc0-4e3fd898b757?_nouploadcache=false\u0026_state=cba02xflIbwYVhGHoYVge3ShFWwyifPToTmR9IreC3V7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiMzFhYzdlNjYtYjU5MC00OGY2LWFjYzAtNGUzZmQ4OThiNzU3IiwiT2Zmc2V0IjoyOCwiU3RhcnRlZEF0IjoiMjAyMy0wNS0wOFQwNzozODo1MFoifQ%3D%3D\u0026digest=sha256%3A654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -203,7 +203,7 @@
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "bf389952-d0b3-4083-8b0c-a6730736712c"
+        "x-ms-client-request-id": "adb10d57-40b3-46c9-be34-41d02168d594"
       },
       "RequestBody": null,
       "StatusCode": 201,
@@ -216,7 +216,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:51 GMT",
         "Docker-Content-Digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Location": "/v2/oci-artifact/blobs/sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
@@ -226,9 +226,9 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "bf389952-d0b3-4083-8b0c-a6730736712c",
-        "X-Ms-Correlation-Request-Id": "5bc3ac81-a012-441a-95e4-acdbcf5e3eb9",
-        "X-Ms-Request-Id": "9cef3490-ce47-44f7-bfa2-a3669a264552"
+        "X-Ms-Client-Request-Id": "adb10d57-40b3-46c9-be34-41d02168d594",
+        "X-Ms-Correlation-Request-Id": "0c91708c-ef7b-45c7-9f54-a9f10a3d0252",
+        "X-Ms-Request-Id": "c4213beb-61d1-4e9f-ac8c-35890e1f909f"
       },
       "ResponseBody": null
     },
@@ -242,7 +242,7 @@
         "Connection": "keep-alive",
         "Content-Length": "0",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "5a7b633c-ec3b-4fa7-bca7-e11cd4d4487f"
+        "x-ms-client-request-id": "2ad4d9c5-d093-47df-87f5-9571351d5ac4"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -255,10 +255,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:51 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "e3143435-0027-4c66-a4d0-99e89905cd33",
-        "Location": "/v2/oci-artifact/blobs/uploads/e3143435-0027-4c66-a4d0-99e89905cd33?_nouploadcache=false\u0026_state=fLcGnslrjGZFRyKQAWin74zv4WMKTOdtZB9t_i6pO0F7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZTMxNDM0MzUtMDAyNy00YzY2LWE0ZDAtOTllODk5MDVjZDMzIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjU0LjM5MjQ4MDI1OVoifQ%3D%3D",
+        "Docker-Upload-Uuid": "48f66723-17e1-4b69-ab7e-2e32d3454e9f",
+        "Location": "/v2/oci-artifact/blobs/uploads/48f66723-17e1-4b69-ab7e-2e32d3454e9f?_nouploadcache=false\u0026_state=lITfxrUzJliyTz6oKxpirtl9Pd04f-DnccaJa5Z2XYB7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNDhmNjY3MjMtMTdlMS00YjY5LWFiN2UtMmUzMmQzNDU0ZTlmIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjUxLjMxMjc5ODM3NVoifQ%3D%3D",
         "Range": "0-0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -266,14 +266,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "5a7b633c-ec3b-4fa7-bca7-e11cd4d4487f",
-        "X-Ms-Correlation-Request-Id": "3d7c8193-f214-4647-bf31-5c79f97d209a",
-        "X-Ms-Request-Id": "e3233d85-d7a5-49c1-a3a7-fb397fafa007"
+        "X-Ms-Client-Request-Id": "2ad4d9c5-d093-47df-87f5-9571351d5ac4",
+        "X-Ms-Correlation-Request-Id": "44310c37-bdec-4b70-bce8-66aec0e63c80",
+        "X-Ms-Request-Id": "52890f62-dc7b-4b38-8be8-6c37a8ed68a1"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/e3143435-0027-4c66-a4d0-99e89905cd33?_nouploadcache=false\u0026_state=fLcGnslrjGZFRyKQAWin74zv4WMKTOdtZB9t_i6pO0F7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZTMxNDM0MzUtMDAyNy00YzY2LWE0ZDAtOTllODk5MDVjZDMzIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA0LTE5VDIxOjI3OjU0LjM5MjQ4MDI1OVoifQ%3D%3D",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/48f66723-17e1-4b69-ab7e-2e32d3454e9f?_nouploadcache=false\u0026_state=lITfxrUzJliyTz6oKxpirtl9Pd04f-DnccaJa5Z2XYB7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNDhmNjY3MjMtMTdlMS00YjY5LWFiN2UtMmUzMmQzNDU0ZTlmIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDIzLTA1LTA4VDA3OjM4OjUxLjMxMjc5ODM3NVoifQ%3D%3D",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -283,7 +283,7 @@
         "Content-Length": "171",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "1cb812d9-0b79-4e8a-920a-887b4bd9c801"
+        "x-ms-client-request-id": "6579f386-f8ff-448c-985d-79e9bac10024"
       },
       "RequestBody": "H4sIAAAAAAAA/\u002BzRwcrCMBAE4Dn/8L9DD551tulmn6dUq4VioUb06VUsORU8aRQx32VzSjYzi2bYt90WKZGkmU2T5HxOZ6lo6lTNPCjUUlFo0q2i4yHUI8hn75l/7kvE/lf1GLq2bsIynMOr37jn4b1/3L\u002BrYv9lWYkDxYkoireE\u002BOP9Xy87bNCjx4ACJwwY0WONf/x9erUsy7IsoVsAAAD//yO/fykACgAA",
       "StatusCode": 202,
@@ -296,10 +296,10 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:51 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Docker-Upload-Uuid": "e3143435-0027-4c66-a4d0-99e89905cd33",
-        "Location": "/v2/oci-artifact/blobs/uploads/e3143435-0027-4c66-a4d0-99e89905cd33?_nouploadcache=false\u0026_state=CDfw8O87c4_OzD9w5-QCzARDcoLnE0Xmsuvv6VtqvBp7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZTMxNDM0MzUtMDAyNy00YzY2LWE0ZDAtOTllODk5MDVjZDMzIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDQtMTlUMjE6Mjc6NTRaIn0%3D",
+        "Docker-Upload-Uuid": "48f66723-17e1-4b69-ab7e-2e32d3454e9f",
+        "Location": "/v2/oci-artifact/blobs/uploads/48f66723-17e1-4b69-ab7e-2e32d3454e9f?_nouploadcache=false\u0026_state=QTMuySaI22gmrUy2B5KtwMsNc4ZEWfAFn7EcBiZd7Uh7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNDhmNjY3MjMtMTdlMS00YjY5LWFiN2UtMmUzMmQzNDU0ZTlmIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDUtMDhUMDc6Mzg6NTFaIn0%3D",
         "Range": "0-170",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -307,14 +307,14 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "1cb812d9-0b79-4e8a-920a-887b4bd9c801",
-        "X-Ms-Correlation-Request-Id": "514e7d10-c884-486e-86db-00719fe1f461",
-        "X-Ms-Request-Id": "672712fb-1054-44ef-8c5c-968770b86f0c"
+        "X-Ms-Client-Request-Id": "6579f386-f8ff-448c-985d-79e9bac10024",
+        "X-Ms-Correlation-Request-Id": "7acd21c1-ddd5-4b87-869d-1020ecbfcfb1",
+        "X-Ms-Request-Id": "30195c77-89ae-4c55-8a2f-a69ee77136e5"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/e3143435-0027-4c66-a4d0-99e89905cd33?_nouploadcache=false\u0026_state=CDfw8O87c4_OzD9w5-QCzARDcoLnE0Xmsuvv6VtqvBp7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiZTMxNDM0MzUtMDAyNy00YzY2LWE0ZDAtOTllODk5MDVjZDMzIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDQtMTlUMjE6Mjc6NTRaIn0%3D\u0026digest=sha256%3Ad25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/blobs/uploads/48f66723-17e1-4b69-ab7e-2e32d3454e9f?_nouploadcache=false\u0026_state=QTMuySaI22gmrUy2B5KtwMsNc4ZEWfAFn7EcBiZd7Uh7Ik5hbWUiOiJvY2ktYXJ0aWZhY3QiLCJVVUlEIjoiNDhmNjY3MjMtMTdlMS00YjY5LWFiN2UtMmUzMmQzNDU0ZTlmIiwiT2Zmc2V0IjoxNzEsIlN0YXJ0ZWRBdCI6IjIwMjMtMDUtMDhUMDc6Mzg6NTFaIn0%3D\u0026digest=sha256%3Ad25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -324,7 +324,7 @@
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "aba613ae-f233-46bb-9224-304dd6347fd8"
+        "x-ms-client-request-id": "b908ccf4-4583-4fc6-9a42-d259236ce88e"
       },
       "RequestBody": null,
       "StatusCode": 201,
@@ -337,7 +337,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
+        "Date": "Mon, 08 May 2023 07:38:51 GMT",
         "Docker-Content-Digest": "sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Location": "/v2/oci-artifact/blobs/sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
@@ -347,9 +347,9 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "aba613ae-f233-46bb-9224-304dd6347fd8",
-        "X-Ms-Correlation-Request-Id": "ef9dc416-83f1-4582-8f89-53e16ef67b98",
-        "X-Ms-Request-Id": "7711941f-389f-4304-a521-20397187301d"
+        "X-Ms-Client-Request-Id": "b908ccf4-4583-4fc6-9a42-d259236ce88e",
+        "X-Ms-Correlation-Request-Id": "8e922f2c-038a-4ab9-af75-9061550c4548",
+        "X-Ms-Request-Id": "66a8e875-5f69-4565-876a-8dc34d4aedff"
       },
       "ResponseBody": null
     },
@@ -361,10 +361,10 @@
         "Accept-Encoding": "gzip,deflate",
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
-        "Content-Length": "377",
+        "Content-Length": "402",
         "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "61262cf2-09f7-40cd-8fe3-35b63293f057"
+        "x-ms-client-request-id": "0ca6f15a-018b-4633-89bb-dd1842fa3aef"
       },
       "RequestBody": {
         "schemaVersion": 2,
@@ -379,7 +379,7 @@
             "digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
             "size": 28,
             "annotations": {
-              "title": "artifact.txt"
+              "org.opencontainers.image.title": "artifact.txt"
             }
           }
         ]
@@ -394,19 +394,19 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
-        "Docker-Content-Digest": "sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Date": "Mon, 08 May 2023 07:38:52 GMT",
+        "Docker-Content-Digest": "sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "Location": "/v2/oci-artifact/manifests/sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Location": "/v2/oci-artifact/manifests/sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "61262cf2-09f7-40cd-8fe3-35b63293f057",
-        "X-Ms-Correlation-Request-Id": "3541dcd3-baa7-4092-aff3-f8aa33ee4691",
-        "X-Ms-Request-Id": "66a604ec-0e1c-4c9e-ac69-961cfd201143"
+        "X-Ms-Client-Request-Id": "0ca6f15a-018b-4633-89bb-dd1842fa3aef",
+        "X-Ms-Correlation-Request-Id": "07b8869c-f370-47ea-bfcd-c49a541f3dc4",
+        "X-Ms-Request-Id": "d1b7ef70-e293-42ac-ac82-d9b87290494d"
       },
       "ResponseBody": null
     },
@@ -419,7 +419,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "ae9d208c-a177-4b8c-bfda-2be6a8a44ac9"
+        "x-ms-client-request-id": "4004cdd4-a682-479f-a176-356258317e3f"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -431,21 +431,21 @@
           "X-Ms-Correlation-Request-Id"
         ],
         "Connection": "keep-alive",
-        "Content-Length": "377",
+        "Content-Length": "402",
         "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
-        "Date": "Wed, 19 Apr 2023 21:27:54 GMT",
-        "Docker-Content-Digest": "sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+        "Date": "Mon, 08 May 2023 07:38:52 GMT",
+        "Docker-Content-Digest": "sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
         "Docker-Distribution-Api-Version": "registry/2.0",
-        "ETag": "\u0022sha256:f5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b\u0022",
+        "ETag": "\u0022sha256:70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed\u0022",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "ae9d208c-a177-4b8c-bfda-2be6a8a44ac9",
-        "X-Ms-Correlation-Request-Id": "78e5c847-125b-437c-81a9-d4bb8ac9ac08",
-        "X-Ms-Request-Id": "2cf9523e-28c7-42df-8292-9b568c6544fc"
+        "X-Ms-Client-Request-Id": "4004cdd4-a682-479f-a176-356258317e3f",
+        "X-Ms-Correlation-Request-Id": "f34174bb-4782-460e-82e0-a954fa4fbe9a",
+        "X-Ms-Request-Id": "45d034b2-a459-46f9-a6ff-9a13dcd1176b"
       },
       "ResponseBody": {
         "schemaVersion": 2,
@@ -460,14 +460,14 @@
             "digest": "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
             "size": 28,
             "annotations": {
-              "title": "artifact.txt"
+              "org.opencontainers.image.title": "artifact.txt"
             }
           }
         ]
       }
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -475,7 +475,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "167101ea-572c-411a-bcbf-7576f1142a5f"
+        "x-ms-client-request-id": "ff2e9e68-7780-4679-b441-529d27751166"
       },
       "RequestBody": null,
       "StatusCode": 401,
@@ -489,16 +489,16 @@
         "Connection": "keep-alive",
         "Content-Length": "208",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:55 GMT",
+        "Date": "Mon, 08 May 2023 07:38:52 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains",
           "max-age=31536000; includeSubDomains"
         ],
-        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022t3f3dad0153774741.azurecr.io\u0022,scope=\u0022repository:oci-artifact:delete\u0022,error=\u0022insufficient_scope\u0022",
+        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022timovcontainerregistry2.azurecr.io\u0022,scope=\u0022repository:oci-artifact:delete\u0022,error=\u0022insufficient_scope\u0022",
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Correlation-Request-Id": "ef06201f-2c44-4bb7-bb7c-96ed53cb0a17"
+        "X-Ms-Correlation-Request-Id": "ec131534-9a10-489d-9856-794cabf73439"
       },
       "ResponseBody": {
         "errors": [
@@ -523,21 +523,21 @@
         "Accept": "application/json",
         "Accept-Encoding": "gzip,deflate",
         "Connection": "keep-alive",
-        "Content-Length": "165",
+        "Content-Length": "171",
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "2f136316-236e-4d5c-a533-adef7c6d1bc3"
+        "x-ms-client-request-id": "c40f202a-25cf-4f98-87f2-fe67601e9f12"
       },
-      "RequestBody": "service=t3f3dad0153774741.azurecr.io\u0026scope=repository%3Aoci-artifact%3Adelete\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
+      "RequestBody": "service=timovcontainerregistry2.azurecr.io\u0026scope=repository%3Aoci-artifact%3Adelete\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 19 Apr 2023 21:27:55 GMT",
+        "Date": "Mon, 08 May 2023 07:38:52 GMT",
         "Server": "openresty",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "Transfer-Encoding": "chunked",
-        "X-Ms-Correlation-Request-Id": "34f425a6-bf46-4bf4-a253-ecb975be9b4a",
+        "X-Ms-Correlation-Request-Id": "d1f95b7c-5c83-426f-90f7-c662370bc287",
         "x-ms-ratelimit-remaining-calls-per-second": "166.566667"
       },
       "ResponseBody": {
@@ -545,7 +545,7 @@
       }
     },
     {
-      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3Af5d8107e2ee41308df6d9aa2b0c6b51c18043daa8351b3f97ff0b64f9dc5a28b",
+      "RequestUri": "https://myregistry.azurecr.io/v2/oci-artifact/manifests/sha256%3A70e2ffca8e79adc4bd34b67363a972522d75933e435084826d39a19f958579ed",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -553,7 +553,7 @@
         "Authorization": "Sanitized",
         "Connection": "keep-alive",
         "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
-        "x-ms-client-request-id": "167101ea-572c-411a-bcbf-7576f1142a5f"
+        "x-ms-client-request-id": "ff2e9e68-7780-4679-b441-529d27751166"
       },
       "RequestBody": null,
       "StatusCode": 202,
@@ -566,7 +566,7 @@
         ],
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "Date": "Wed, 19 Apr 2023 21:27:55 GMT",
+        "Date": "Mon, 08 May 2023 07:38:53 GMT",
         "Docker-Distribution-Api-Version": "registry/2.0",
         "Server": "openresty",
         "Strict-Transport-Security": [
@@ -574,10 +574,10 @@
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": "nosniff",
-        "X-Ms-Client-Request-Id": "167101ea-572c-411a-bcbf-7576f1142a5f",
-        "X-Ms-Correlation-Request-Id": "986892f0-a2ab-4038-a427-a5b5d5de3482",
+        "X-Ms-Client-Request-Id": "ff2e9e68-7780-4679-b441-529d27751166",
+        "X-Ms-Correlation-Request-Id": "5f67fb96-b289-40b3-a620-115eec7a82ac",
         "X-Ms-Ratelimit-Remaining-Calls-Per-Second": "8.000000",
-        "X-Ms-Request-Id": "14cdc7c0-6d50-4c31-8062-346953f43191"
+        "X-Ms-Request-Id": "5a96c2fd-2ba1-49ae-a878-14dc67d923f7"
       },
       "ResponseBody": null
     }

--- a/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_must_specify_media_type_when_uploading_docker_manifest.json
+++ b/sdk/containerregistry/container-registry/recordings/node/containerregistrycontentclient/recording_must_specify_media_type_when_uploading_docker_manifest.json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://myregistry.azurecr.io/v2/library%2Fhello-world/manifests/sha256%3Ae6c1c9dcc9c45a3dbfa654f8c8fad5c91529c137c1e2f6eb0995931c0aa74d99",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "435",
+        "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
+        "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b9539932-b6c8-4fb4-800c-08af15047f5c"
+      },
+      "RequestBody": {
+        "config": {
+          "mediaType": "application/vnd.docker.container.image.v1\u002Bjson",
+          "size": 1469,
+          "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"
+        },
+        "layers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 2479,
+            "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"
+          }
+        ],
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2\u002Bjson"
+      },
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Connection": "keep-alive",
+        "Content-Length": "280",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sat, 06 May 2023 04:05:58 GMT",
+        "Docker-Distribution-Api-Version": "registry/2.0",
+        "Server": "openresty",
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "WWW-Authenticate": "Bearer realm=\u0022https://myregistry.azurecr.io/oauth2/token\u0022,service=\u0022timovcontainerregistry2.azurecr.io\u0022,scope=\u0022repository:library/hello-world:pull,push\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Ms-Correlation-Request-Id": "06f4eaee-b540-4db3-82ad-bc15f5907403"
+      },
+      "ResponseBody": {
+        "errors": [
+          {
+            "code": "UNAUTHORIZED",
+            "message": "authentication required, visit https://aka.ms/acr/authorization for more information.",
+            "detail": [
+              {
+                "Type": "repository",
+                "Name": "library/hello-world",
+                "Action": "pull"
+              },
+              {
+                "Type": "repository",
+                "Name": "library/hello-world",
+                "Action": "push"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://myregistry.azurecr.io/oauth2/exchange?api-version=2021-07-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "97",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "45cf9247-2854-4b45-919b-97abb29ac687"
+      },
+      "RequestBody": "grant_type=access_token\u0026service=timovcontainerregistry2.azurecr.io\u0026access_token=SecretPlaceholder",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sat, 06 May 2023 04:05:59 GMT",
+        "Server": "openresty",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Ms-Correlation-Request-Id": "348c34a0-beac-491c-8604-a502b5bad5e9",
+        "x-ms-ratelimit-remaining-calls-per-second": "166.233333"
+      },
+      "ResponseBody": {
+        "refresh_token": "sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized"
+      }
+    },
+    {
+      "RequestUri": "https://myregistry.azurecr.io/oauth2/token?api-version=2021-07-01",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "185",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "a2a75027-35e7-4a79-a039-eb72b810c05f"
+      },
+      "RequestBody": "service=timovcontainerregistry2.azurecr.io\u0026scope=repository%3Alibrary%2Fhello-world%3Apull%2Cpush\u0026refresh_token=sanitized.eyJleHAiOjg2NDAwMDAwMDAwMDB9.sanitized\u0026grant_type=refresh_token",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sat, 06 May 2023 04:05:59 GMT",
+        "Server": "openresty",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "X-Ms-Correlation-Request-Id": "86e35dad-fd8a-4a64-b438-db64c6cfc1ff",
+        "x-ms-ratelimit-remaining-calls-per-second": "166.216667"
+      },
+      "ResponseBody": {
+        "access_token": "Sanitized"
+      }
+    },
+    {
+      "RequestUri": "https://myregistry.azurecr.io/v2/library%2Fhello-world/manifests/sha256%3Ae6c1c9dcc9c45a3dbfa654f8c8fad5c91529c137c1e2f6eb0995931c0aa74d99",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip,deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "435",
+        "Content-Type": "application/vnd.oci.image.manifest.v1\u002Bjson",
+        "User-Agent": "azsdk-js-container-registry/1.1.0-beta.4 core-rest-pipeline/1.10.4 Node/v18.16.0 OS/(x64-Linux-5.15.90.1-microsoft-standard-WSL2)",
+        "x-ms-client-request-id": "b9539932-b6c8-4fb4-800c-08af15047f5c"
+      },
+      "RequestBody": {
+        "config": {
+          "mediaType": "application/vnd.docker.container.image.v1\u002Bjson",
+          "size": 1469,
+          "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"
+        },
+        "layers": [
+          {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 2479,
+            "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"
+          }
+        ],
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2\u002Bjson"
+      },
+      "StatusCode": 400,
+      "ResponseHeaders": {
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Connection": "keep-alive",
+        "Content-Length": "93",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sat, 06 May 2023 04:05:59 GMT",
+        "Docker-Distribution-Api-Version": "registry/2.0",
+        "Server": "openresty",
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "X-Ms-Client-Request-Id": "b9539932-b6c8-4fb4-800c-08af15047f5c",
+        "X-Ms-Correlation-Request-Id": "da64dfd3-e5d2-476b-9d5e-7b825de845f9",
+        "X-Ms-Request-Id": "8287fbb0-4011-4b99-9b6a-0bceb2e35b7a"
+      },
+      "ResponseBody": {
+        "errors": [
+          {
+            "code": "MANIFEST_INVALID",
+            "message": "manifest invalid",
+            "detail": {
+              "Reason": {}
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -250,19 +250,19 @@ export interface ManifestPageResponse extends Array<ArtifactManifestProperties> 
 }
 
 // @public
-export interface OciAnnotations extends Record<string, unknown> {
-    authors?: string;
-    created?: string;
-    description?: string;
-    documentation?: string;
-    licenses?: string;
-    name?: string;
-    revision?: string;
-    source?: string;
-    title?: string;
-    url?: string;
-    vendor?: string;
-    version?: string;
+export interface OciAnnotations extends Record<string, string | undefined> {
+    "org.opencontainers.image.authors"?: string;
+    "org.opencontainers.image.created"?: string;
+    "org.opencontainers.image.description"?: string;
+    "org.opencontainers.image.documentation"?: string;
+    "org.opencontainers.image.licenses"?: string;
+    "org.opencontainers.image.ref.name"?: string;
+    "org.opencontainers.image.revision"?: string;
+    "org.opencontainers.image.source"?: string;
+    "org.opencontainers.image.title"?: string;
+    "org.opencontainers.image.url"?: string;
+    "org.opencontainers.image.vendor"?: string;
+    "org.opencontainers.image.version"?: string;
 }
 
 // @public

--- a/sdk/containerregistry/container-registry/review/container-registry.api.md
+++ b/sdk/containerregistry/container-registry/review/container-registry.api.md
@@ -83,7 +83,7 @@ export class ContainerRegistryContentClient {
     readonly endpoint: string;
     getManifest(tagOrDigest: string, options?: GetManifestOptions): Promise<GetManifestResult>;
     readonly repositoryName: string;
-    setManifest(manifest: Buffer | NodeJS.ReadableStream | Record<string, unknown>, options?: SetManifestOptions): Promise<SetManifestResult>;
+    setManifest(manifest: Buffer | NodeJS.ReadableStream | OciImageManifest | Record<string, unknown>, options?: SetManifestOptions): Promise<SetManifestResult>;
     uploadBlob(blob: NodeJS.ReadableStream | Buffer, options?: UploadBlobOptions): Promise<UploadBlobResult>;
 }
 
@@ -178,9 +178,6 @@ export interface GetTagPropertiesOptions extends OperationOptions {
 }
 
 // @public
-export function isOciImageManifest(manifest: Record<string, unknown>): manifest is OciImageManifest;
-
-// @public
 export enum KnownArtifactArchitecture {
     Amd64 = "amd64",
     Arm = "arm",
@@ -250,7 +247,7 @@ export interface ManifestPageResponse extends Array<ArtifactManifestProperties> 
 }
 
 // @public
-export interface OciAnnotations extends Record<string, string | undefined> {
+export interface OciAnnotations extends Record<string, unknown> {
     "org.opencontainers.image.authors"?: string;
     "org.opencontainers.image.created"?: string;
     "org.opencontainers.image.description"?: string;
@@ -275,14 +272,14 @@ export interface OciDescriptor {
 }
 
 // @public
-export interface OciImageManifest extends Record<string, unknown> {
-    annotations?: OciAnnotations;
+export type OciImageManifest = {
+    schemaVersion: 2;
+    mediaType?: `${KnownManifestMediaType.OciImageManifest}`;
     artifactType?: string;
     config: OciDescriptor;
     layers: OciDescriptor[];
-    mediaType?: `${KnownManifestMediaType.OciImageManifest}`;
-    schemaVersion: 2;
-}
+    annotations?: OciAnnotations;
+};
 
 // @public
 export interface RegistryArtifact {

--- a/sdk/containerregistry/container-registry/samples-dev/deleteBlob.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/deleteBlob.ts
@@ -6,7 +6,11 @@
  * @azsdk-weight 3
  */
 
-import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
+import {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+  OciImageManifest,
+} from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 dotenv.config();

--- a/sdk/containerregistry/container-registry/samples-dev/deleteBlob.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/deleteBlob.ts
@@ -6,7 +6,7 @@
  * @azsdk-weight 3
  */
 
-import { ContainerRegistryContentClient, isOciImageManifest } from "@azure/container-registry";
+import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 dotenv.config();
@@ -24,11 +24,11 @@ async function main() {
 
   const downloadResult = await client.getManifest("latest");
 
-  if (!isOciImageManifest(downloadResult.manifest)) {
+  if (downloadResult.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
 
-  for (const layer of downloadResult.manifest.layers) {
+  for (const layer of (downloadResult.manifest as OciImageManifest).layers) {
     await client.deleteBlob(layer.digest);
   }
 }

--- a/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
@@ -6,7 +6,7 @@
  * @azsdk-weight 3
  */
 
-import { ContainerRegistryContentClient, isOciImageManifest } from "@azure/container-registry";
+import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 import fs from "fs";
@@ -31,10 +31,11 @@ async function main() {
   // Download the manifest to obtain the list of files in the image based on the tag
   const result = await client.getManifest("demo");
 
-  const manifest = result.manifest;
-  if (!isOciImageManifest(manifest)) {
+  if (result.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
+
+  const manifest = result.manifest as OciImageManifest;
 
   // Manifests of all media types have a buffer containing their content; this can be written to a file.
   fs.writeFileSync("manifest.json", result.content);

--- a/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/downloadImage.ts
@@ -6,7 +6,11 @@
  * @azsdk-weight 3
  */
 
-import { ContainerRegistryContentClient, KnownManifestMediaType, OciImageManifest } from "@azure/container-registry";
+import {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+  OciImageManifest,
+} from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 import fs from "fs";

--- a/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples-dev/uploadManifest.ts
@@ -51,7 +51,7 @@ async function main() {
         digest: layerDigest,
         size: layerSize,
         annotations: {
-          title: "artifact.txt",
+          "org.opencontainers.image.title": "artifact.txt",
         },
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/deleteBlob.js
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/deleteBlob.js
@@ -5,7 +5,10 @@
  * @summary Deletes the blobs associated with a given manifest from the repository.
  */
 
-const { ContainerRegistryContentClient, isOciImageManifest } = require("@azure/container-registry");
+const {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+} = require("@azure/container-registry");
 const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
@@ -22,7 +25,7 @@ async function main() {
 
   const downloadResult = await client.getManifest("latest");
 
-  if (!isOciImageManifest(downloadResult.manifest)) {
+  if (downloadResult.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
 

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/downloadImage.js
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/downloadImage.js
@@ -5,7 +5,10 @@
  * @summary Downloads an image from the repository.
  */
 
-const { ContainerRegistryContentClient, isOciImageManifest } = require("@azure/container-registry");
+const {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+} = require("@azure/container-registry");
 const { DefaultAzureCredential } = require("@azure/identity");
 const dotenv = require("dotenv");
 const fs = require("fs");
@@ -30,10 +33,11 @@ async function main() {
   // Download the manifest to obtain the list of files in the image based on the tag
   const result = await client.getManifest("demo");
 
-  const manifest = result.manifest;
-  if (!isOciImageManifest(manifest)) {
+  if (result.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
+
+  const manifest = result.manifest;
 
   // Manifests of all media types have a buffer containing their content; this can be written to a file.
   fs.writeFileSync("manifest.json", result.content);

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/uploadManifest.js
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/uploadManifest.js
@@ -49,7 +49,7 @@ async function main() {
         digest: layerDigest,
         size: layerSize,
         annotations: {
-          title: "artifact.txt",
+          "org.opencontainers.image.title": "artifact.txt",
         },
       },
     ],

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/src/deleteBlob.ts
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/src/deleteBlob.ts
@@ -5,7 +5,11 @@
  * @summary Deletes the blobs associated with a given manifest from the repository.
  */
 
-import { ContainerRegistryContentClient, isOciImageManifest } from "@azure/container-registry";
+import {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+  OciImageManifest,
+} from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 dotenv.config();
@@ -23,11 +27,11 @@ async function main() {
 
   const downloadResult = await client.getManifest("latest");
 
-  if (!isOciImageManifest(downloadResult.manifest)) {
+  if (downloadResult.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
 
-  for (const layer of downloadResult.manifest.layers) {
+  for (const layer of (downloadResult.manifest as OciImageManifest).layers) {
     await client.deleteBlob(layer.digest);
   }
 }

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/src/downloadImage.ts
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/src/downloadImage.ts
@@ -5,7 +5,11 @@
  * @summary Downloads an image from the repository.
  */
 
-import { ContainerRegistryContentClient, isOciImageManifest } from "@azure/container-registry";
+import {
+  ContainerRegistryContentClient,
+  KnownManifestMediaType,
+  OciImageManifest,
+} from "@azure/container-registry";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 import fs from "fs";
@@ -30,10 +34,11 @@ async function main() {
   // Download the manifest to obtain the list of files in the image based on the tag
   const result = await client.getManifest("demo");
 
-  const manifest = result.manifest;
-  if (!isOciImageManifest(manifest)) {
+  if (result.mediaType !== KnownManifestMediaType.OciImageManifest) {
     throw new Error("Expected an OCI image manifest");
   }
+
+  const manifest = result.manifest as OciImageManifest;
 
   // Manifests of all media types have a buffer containing their content; this can be written to a file.
   fs.writeFileSync("manifest.json", result.content);

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/src/uploadManifest.ts
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/src/uploadManifest.ts
@@ -50,7 +50,7 @@ async function main() {
         digest: layerDigest,
         size: layerSize,
         annotations: {
-          title: "artifact.txt",
+          "org.opencontainers.image.title": "artifact.txt",
         },
       },
     ],

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -24,6 +24,7 @@ import {
   UploadBlobResult,
   SetManifestOptions,
   SetManifestResult,
+  OciImageManifest,
 } from "./models";
 import { CommonClientOptions } from "@azure/core-client";
 import { isDigest, readChunksFromStream, readStreamToEnd } from "../utils/helpers";
@@ -189,7 +190,7 @@ export class ContainerRegistryContentClient {
    * @param manifest - the manifest to upload.
    */
   public async setManifest(
-    manifest: Buffer | NodeJS.ReadableStream | Record<string, unknown>,
+    manifest: Buffer | NodeJS.ReadableStream | OciImageManifest | Record<string, unknown>,
     options: SetManifestOptions = {}
   ): Promise<SetManifestResult> {
     return tracingClient.withSpan(
@@ -231,8 +232,7 @@ export class ContainerRegistryContentClient {
    * Downloads the manifest for an OCI artifact.
    *
    * @param tagOrDigest - a tag or digest that identifies the artifact
-   * @returns - the downloaded manifest. To test if the downloaded manifest is an OCI manifest, use `isOciManifest` on the `manifest`
-   *            property of the result, in addition to checking the mediaType property on the result.
+   * @returns - the downloaded manifest.
    */
   public async getManifest(
     tagOrDigest: string,

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -230,11 +230,9 @@ export class ContainerRegistryContentClient {
   /**
    * Downloads the manifest for an OCI artifact.
    *
-   * If the manifest downloaded was of type {@link KnownManifestMediaType.OciImageManifest}, the downloaded manifest will be of type {@link GetOciImageManifestResult}.
-   * You can use {@link isGetOciImageManifestResult} to determine whether this is the case. If so, the strongly typed deserialized manifest will be available through the `manifest` property.
-   *
    * @param tagOrDigest - a tag or digest that identifies the artifact
-   * @returns - the downloaded manifest
+   * @returns - the downloaded manifest. To test if the downloaded manifest is an OCI manifest, use `isOciManifest` on the `manifest`
+   *            property of the result, in addition to checking the mediaType property on the result.
    */
   public async getManifest(
     tagOrDigest: string,

--- a/sdk/containerregistry/container-registry/src/content/models.ts
+++ b/sdk/containerregistry/container-registry/src/content/models.ts
@@ -114,7 +114,7 @@ export type OciImageManifest = {
   layers: OciDescriptor[];
   /** Additional information provided through arbitrary metadata. */
   annotations?: OciAnnotations;
-}
+};
 
 /** Additional information provided through arbitrary metadata.
  * See the specification at https://github.com/opencontainers/image-spec/blob/main/annotations.md for more information.

--- a/sdk/containerregistry/container-registry/src/content/models.ts
+++ b/sdk/containerregistry/container-registry/src/content/models.ts
@@ -105,6 +105,7 @@ export function isOciImageManifest(
 ): manifest is OciImageManifest {
   return (
     manifest.schemaVersion === 2 &&
+    manifest.mediaType === KnownManifestMediaType.OciImageManifest &&
     typeof manifest.config === "object" &&
     Array.isArray(manifest.layers)
   );
@@ -129,32 +130,34 @@ export interface OciImageManifest extends Record<string, unknown> {
   annotations?: OciAnnotations;
 }
 
-/** Additional information provided through arbitrary metadata */
-export interface OciAnnotations extends Record<string, unknown> {
+/** Additional information provided through arbitrary metadata.
+ * See the specification at https://github.com/opencontainers/image-spec/blob/main/annotations.md for more information.
+ */
+export interface OciAnnotations extends Record<string, string | undefined> {
   /** Date and time on which the image was built (string, date-time as defined by https://tools.ietf.org/html/rfc3339#section-5.6) */
-  created?: string;
+  "org.opencontainers.image.created"?: string;
   /** Contact details of the people or organization responsible for the image. */
-  authors?: string;
+  "org.opencontainers.image.authors"?: string;
   /** URL to find more information on the image. */
-  url?: string;
+  "org.opencontainers.image.url"?: string;
   /** URL to get documentation on the image. */
-  documentation?: string;
+  "org.opencontainers.image.documentation"?: string;
   /** URL to get source code for building the image. */
-  source?: string;
+  "org.opencontainers.image.source"?: string;
   /** Version of the packaged software. The version MAY match a label or tag in the source code repository, may also be Semantic versioning-compatible */
-  version?: string;
+  "org.opencontainers.image.version"?: string;
   /** Source control revision identifier for the packaged software. */
-  revision?: string;
+  "org.opencontainers.image.revision"?: string;
   /** Name of the distributing entity, organization or individual. */
-  vendor?: string;
+  "org.opencontainers.image.vendor"?: string;
   /** License(s) under which contained software is distributed as an SPDX License Expression. */
-  licenses?: string;
+  "org.opencontainers.image.licenses"?: string;
   /** Name of the reference for a target. */
-  name?: string;
+  "org.opencontainers.image.ref.name"?: string;
   /** Human-readable title of the image */
-  title?: string;
+  "org.opencontainers.image.title"?: string;
   /** Human-readable description of the software packaged in the image */
-  description?: string;
+  "org.opencontainers.image.description"?: string;
 }
 
 /**

--- a/sdk/containerregistry/container-registry/src/content/models.ts
+++ b/sdk/containerregistry/container-registry/src/content/models.ts
@@ -98,17 +98,30 @@ export interface OciDescriptor {
 }
 
 /**
- * Helper used to determine whether a given manifest downloaded using ContainerRegistryBlobClient.getManifest() is an OCI image manifest.
+ * Helper used to determine whether a given manifest downloaded using ContainerRegistryBlobClient.getManifest() satisfies the OCI image manifest schema.
  */
 export function isOciImageManifest(
   manifest: Record<string, unknown>
 ): manifest is OciImageManifest {
-  return (
-    manifest.schemaVersion === 2 &&
-    manifest.mediaType === KnownManifestMediaType.OciImageManifest &&
-    typeof manifest.config === "object" &&
-    Array.isArray(manifest.layers)
-  );
+  // schemaVersion must be 2
+  if (manifest.schemaVersion !== 2) {
+    return false;
+  }
+
+  // Media type can be unset, but if it is set it must match the OCI image manifest media type
+  if (manifest.mediaType && manifest.mediaType !== KnownManifestMediaType.OciImageManifest) {
+    return false;
+  }
+
+  if (typeof manifest.config !== "object" || manifest.config === null) {
+    return false;
+  }
+
+  if (!Array.isArray(manifest.layers)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/sdk/containerregistry/container-registry/src/content/models.ts
+++ b/sdk/containerregistry/container-registry/src/content/models.ts
@@ -98,37 +98,10 @@ export interface OciDescriptor {
 }
 
 /**
- * Helper used to determine whether a given manifest downloaded using ContainerRegistryBlobClient.getManifest() satisfies the OCI image manifest schema.
- */
-export function isOciImageManifest(
-  manifest: Record<string, unknown>
-): manifest is OciImageManifest {
-  // schemaVersion must be 2
-  if (manifest.schemaVersion !== 2) {
-    return false;
-  }
-
-  // Media type can be unset, but if it is set it must match the OCI image manifest media type
-  if (manifest.mediaType && manifest.mediaType !== KnownManifestMediaType.OciImageManifest) {
-    return false;
-  }
-
-  if (typeof manifest.config !== "object" || manifest.config === null) {
-    return false;
-  }
-
-  if (!Array.isArray(manifest.layers)) {
-    return false;
-  }
-
-  return true;
-}
-
-/**
  * Type representing an OCI image manifest (manifest of media type "application/vnd.oci.image.manifest.v1+json").
  * See the specification at https://github.com/opencontainers/image-spec/blob/main/manifest.md for more information.
  */
-export interface OciImageManifest extends Record<string, unknown> {
+export type OciImageManifest = {
   /** Schema version */
   schemaVersion: 2;
   /** The media type, when used, must be application/vnd.oci.image.manifest.v1+json. */
@@ -146,7 +119,7 @@ export interface OciImageManifest extends Record<string, unknown> {
 /** Additional information provided through arbitrary metadata.
  * See the specification at https://github.com/opencontainers/image-spec/blob/main/annotations.md for more information.
  */
-export interface OciAnnotations extends Record<string, string | undefined> {
+export interface OciAnnotations extends Record<string, unknown> {
   /** Date and time on which the image was built (string, date-time as defined by https://tools.ietf.org/html/rfc3339#section-5.6) */
   "org.opencontainers.image.created"?: string;
   /** Contact details of the people or organization responsible for the image. */

--- a/sdk/containerregistry/container-registry/test/internal/basic.spec.ts
+++ b/sdk/containerregistry/container-registry/test/internal/basic.spec.ts
@@ -6,7 +6,6 @@
 import {
   ContainerRegistryClient,
   KnownContainerRegistryAudience,
-  isOciImageManifest,
 } from "../../src";
 import { assert } from "chai";
 import { calculateDigest } from "../../src/utils/digest";
@@ -151,84 +150,5 @@ describe("WWW-Authenticate parser", () => {
       service: "dummy.azurecr.io",
       scope: "repository:dummyrepo:pull,push",
     });
-  });
-});
-
-describe("isOciImageManifest", function () {
-  it("should return true for OCI image manifest", function () {
-    const ociManifest = {
-      schemaVersion: 2,
-      mediaType: "application/vnd.oci.image.manifest.v1+json",
-      config: {
-        mediaType: "application/vnd.oci.image.config.v1+json",
-        digest: "sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
-        size: 171,
-      },
-      layers: [
-        {
-          mediaType: "application/vnd.oci.image.layer.v1.tar",
-          digest: "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
-          size: 28,
-          annotations: {
-            "org.opencontainers.image.title": "artifact.txt",
-          },
-        },
-      ],
-    };
-
-    assert.isTrue(isOciImageManifest(ociManifest));
-  });
-
-  it("should return true for OCI image manifest without mediaType", function () {
-    const ociManifest = {
-      schemaVersion: 2,
-      config: {
-        mediaType: "application/vnd.oci.image.config.v1+json",
-        digest: "sha256:d25b42d3dbad5361ed2d909624d899e7254a822c9a632b582ebd3a44f9b0dbc8",
-        size: 171,
-      },
-      layers: [
-        {
-          mediaType: "application/vnd.oci.image.layer.v1.tar",
-          digest: "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
-          size: 28,
-          annotations: {
-            "org.opencontainers.image.title": "artifact.txt",
-          },
-        },
-      ],
-    };
-
-    assert.isTrue(isOciImageManifest(ociManifest));
-  });
-
-  it("should return false for Docker image manifest v2 schema 2", function () {
-    const dockerManifest = {
-      schemaVersion: 2,
-      mediaType: "application/vnd.docker.distribution.manifest.v2+json",
-      manifests: [
-        {
-          mediaType: "application/vnd.docker.distribution.manifest.v2+json",
-          digest: "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
-          size: 7143,
-          platform: {
-            architecture: "ppc64le",
-            os: "linux",
-          },
-        },
-        {
-          mediaType: "application/vnd.docker.distribution.manifest.v2+json",
-          digest: "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
-          size: 7682,
-          platform: {
-            architecture: "amd64",
-            os: "linux",
-            features: ["sse4"],
-          },
-        },
-      ],
-    };
-
-    assert.isFalse(isOciImageManifest(dockerManifest));
   });
 });

--- a/sdk/containerregistry/container-registry/test/internal/basic.spec.ts
+++ b/sdk/containerregistry/container-registry/test/internal/basic.spec.ts
@@ -3,10 +3,7 @@
 
 // Chai is the Azure SDK Team's preferred assertion library, and it is included
 // as part of our template project.
-import {
-  ContainerRegistryClient,
-  KnownContainerRegistryAudience,
-} from "../../src";
+import { ContainerRegistryClient, KnownContainerRegistryAudience } from "../../src";
 import { assert } from "chai";
 import { calculateDigest } from "../../src/utils/digest";
 import { Readable } from "stream";

--- a/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
@@ -11,7 +11,6 @@ import {
   ContainerRegistryContentClient,
   KnownManifestMediaType,
   OciImageManifest,
-  isOciImageManifest,
 } from "../../src";
 import { assert, versionsToTest } from "@azure/test-utils";
 import { Context } from "mocha";
@@ -88,7 +87,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const uploadResult = await client.setManifest(manifest);
       const downloadResult = await client.getManifest(uploadResult.digest);
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -108,7 +106,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const downloadResult = await client.getManifest(uploadResult.digest);
 
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -130,7 +127,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const downloadResult = await client.getManifest(uploadResult.digest);
 
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -144,7 +140,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const downloadResult = await client.getManifest("my_artifact");
 
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -202,7 +197,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const result = await helloWorldClient.getManifest(digest);
 
       assert.equal(result.digest, digest);
-      assert.isFalse(isOciImageManifest(result.manifest));
     });
 
     it("can upload blob", async () => {

--- a/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
@@ -11,6 +11,7 @@ import {
   ContainerRegistryContentClient,
   KnownManifestMediaType,
   OciImageManifest,
+  isOciImageManifest,
 } from "../../src";
 import { assert, versionsToTest } from "@azure/test-utils";
 import { Context } from "mocha";
@@ -66,7 +67,7 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
           digest: "sha256:654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed",
           size: 28,
           annotations: {
-            title: "artifact.txt",
+            "org.opencontainers.image.title": "artifact.txt",
           },
         },
       ],
@@ -189,9 +190,7 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const result = await helloWorldClient.getManifest(digest);
 
       assert.equal(result.digest, digest);
-
-      // Since this is not an OCI manifest we expect `manifest` to be undefined.
-      assert.doesNotHaveAnyKeys(result, ["manifest"]);
+      assert.isFalse(isOciImageManifest(result.manifest));
     });
 
     it.skip("can upload OCI manifest stream with tag", async function (this: Mocha.Context) {

--- a/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
@@ -157,15 +157,26 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
         recorder
       );
 
-      const manifestStream = () =>
-        fs.createReadStream("test/data/docker/hello-world/manifest.json");
-      await helloWorldClient.setManifest(manifestStream(), {
+      const manifestStream = fs.createReadStream("test/data/docker/hello-world/manifest.json");
+      await helloWorldClient.setManifest(manifestStream, {
         mediaType: KnownManifestMediaType.DockerManifest,
       });
+    });
 
+    it("must specify media type when uploading Docker manifest", async () => {
+      const helloWorldClient = createBlobClient(
+        assertEnvironmentVariable("CONTAINER_REGISTRY_ENDPOINT"),
+        "library/hello-world",
+        serviceVersion,
+        recorder
+      );
+
+      const manifestStream =
+        fs.createReadStream("test/data/docker/hello-world/manifest.json");
+      
       try {
         // Need to provide the correct media type.
-        await helloWorldClient.setManifest(manifestStream());
+        await helloWorldClient.setManifest(manifestStream);
         assert.fail("Expected exception to be thrown");
       } catch {
         // ignore expected exception
@@ -246,11 +257,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
     });
 
     it("can upload a big blob with size a multiple of 4MB", async function (this: Mocha.Context) {
-      // Skip in record and playback due to large recording size
-      if (!isLiveMode()) {
-        this.skip();
-      }
-
       // Skip in record and playback due to large recording size
       if (!isLiveMode()) {
         this.skip();

--- a/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
+++ b/sdk/containerregistry/container-registry/test/public/containerRegistryContentClient.spec.ts
@@ -88,7 +88,7 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const uploadResult = await client.setManifest(manifest);
       const downloadResult = await client.getManifest(uploadResult.digest);
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-
+      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -108,7 +108,7 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       const downloadResult = await client.getManifest(uploadResult.digest);
 
       assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-
+      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -128,8 +128,9 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
       );
       const uploadResult = await client.setManifest(manifestBuffer);
       const downloadResult = await client.getManifest(uploadResult.digest);
-      assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
 
+      assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
+      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -141,8 +142,9 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
 
       const uploadResult = await client.setManifest(manifest, { tag: "my_artifact" });
       const downloadResult = await client.getManifest("my_artifact");
-      assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
 
+      assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
+      assert.isTrue(isOciImageManifest(downloadResult.manifest));
       assert.equal(downloadResult.digest, uploadResult.digest);
       assert.deepStrictEqual(downloadResult.manifest, manifest);
 
@@ -171,9 +173,8 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
         recorder
       );
 
-      const manifestStream =
-        fs.createReadStream("test/data/docker/hello-world/manifest.json");
-      
+      const manifestStream = fs.createReadStream("test/data/docker/hello-world/manifest.json");
+
       try {
         // Need to provide the correct media type.
         await helloWorldClient.setManifest(manifestStream);
@@ -202,25 +203,6 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions): void => {
 
       assert.equal(result.digest, digest);
       assert.isFalse(isOciImageManifest(result.manifest));
-    });
-
-    it.skip("can upload OCI manifest stream with tag", async function (this: Mocha.Context) {
-      if (isPlaybackMode()) {
-        // Temporarily skip during playback while dealing with recorder issue
-        this.skip();
-      }
-
-      await uploadManifestPrerequisites();
-
-      const manifestStream = fs.createReadStream("test/data/oci-artifact/manifest.json");
-      const uploadResult = await client.setManifest(manifestStream, { tag: "my_artifact" });
-      const downloadResult = await client.getManifest("my_artifact");
-      assert.equal(downloadResult.mediaType, KnownManifestMediaType.OciImageManifest);
-
-      assert.equal(downloadResult.digest, uploadResult.digest);
-      assert.deepStrictEqual(downloadResult.manifest, manifest);
-
-      await client.deleteManifest(uploadResult.digest);
     });
 
     it("can upload blob", async () => {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Should fix #25757

### Describe the problem that is addressed by this PR

- As a result of changes introduced in #25592, the properties in `OciAnnotations` are not being remapped. This PR updates `OciAnnotations` so that the property names correspond to the specification.
- `isOciImageManifest` was returning `false` for OCI image manifests that did not have a media type specified, even though this is an optional property. This PR makes `isOciImageManifest` more robust plus adds tests for different kinds of manifests to make sure it's doing what it should.
