### PR TITLE
[Search] Fix ISO8601 deserialization

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -29,6 +29,7 @@
     - `SearchRequestOptions`
     - `SuggestRequest`
 - Fix discarded user-defined `onResponse` callback [#24479](https://github.com/Azure/azure-sdk-for-js/pull/24479)
+- Fix ISO8601 deserialization [#25801](https://github.com/Azure/azure-sdk-for-js/pull/25801)
 
 ### Other Changes
 

--- a/sdk/search/search-documents/src/serialization.ts
+++ b/sdk/search/search-documents/src/serialization.ts
@@ -3,7 +3,7 @@
 
 import GeographyPoint from "./geographyPoint";
 
-const ISO8601DateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/i;
+const ISO8601DateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/i;
 const GeoJSONPointTypeName = "Point";
 const WorldGeodeticSystem1984 = "EPSG:4326"; // See https://epsg.io/4326
 

--- a/sdk/search/search-documents/test/internal/serialization.spec.ts
+++ b/sdk/search/search-documents/test/internal/serialization.spec.ts
@@ -116,6 +116,11 @@ describe("serialization.deserialize", function () {
     assert.deepEqual(result, { a: new Date(Date.UTC(1975, 3, 4)) });
   });
 
+  it("Date with truncated ms field", function () {
+    const result = deserialize({ a: "1975-04-04T00:00:00.0Z" });
+    assert.deepEqual(result, { a: new Date(Date.UTC(1975, 3, 4)) });
+  });
+
   it("doesn't deserialize as Date if text before", function () {
     const value = "before 1975-04-04T00:00:00.000Z";
     const result = deserialize({ a: value });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Issues associated with this PR

#25777 

### Describe the problem that is addressed by this PR

Some valid ISO8601 date strings were not being deserialized into `Date` objects. This fixes the deserialization behavior for ISO8601 date strings with millisecond values specified with under 3 digits of precision.
