### PR TITLE
[core] add proper parameter type for TrustedTypePolicy `createHTML` callback

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,7 +16,6 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@types/trusted-types": "2.0.2" // #24872
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -42,7 +42,7 @@ function getSerializer(): XMLSerializer {
 let ttPolicy: Pick<TrustedTypePolicy, "createHTML"> | undefined;
 if (typeof self.trustedTypes !== "undefined") {
   ttPolicy = self.trustedTypes.createPolicy("@azure/core-http#xml.browser", {
-    createHTML: (s) => s,
+    createHTML: (s: string) => s,
   });
 }
 

--- a/sdk/core/core-xml/src/xml.browser.ts
+++ b/sdk/core/core-xml/src/xml.browser.ts
@@ -20,7 +20,7 @@ let ttPolicy: Pick<TrustedTypePolicy, "createHTML"> | undefined;
 try {
   if (typeof self.trustedTypes !== "undefined") {
     ttPolicy = self.trustedTypes.createPolicy("@azure/core-xml#xml.browser", {
-      createHTML: (s: any) => s,
+      createHTML: (s: string) => s,
     });
   }
 } catch (e: any) {


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/core-xml`, `@azure/core-http`

### Issues associated with this PR
Fixes issue #24872.

### Describe the problem that is addressed by this PR

Upgrading to @trusted-types v2.0.3 caused compilation error. While it is breaking, it surfaces an issue that we can address by adding propert parameter type.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Pinning to v2.0.2 which isn't desirable as we want to stay on latest dependency versions.
