### PR TITLE
[Identity] Fix undefined dereference

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 3.2.1 (2023-05-11)
-
+## 3.2.1 (2023-05-10)
 
 ### Bug Fixes
  - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
    Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).
-
 
 ## 3.2.0 (2023-05-09)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.2.1
+
+ - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
+   Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).
+
+
 ## 3.2.0 (2023-05-09)
 
 ### Breaking Changes

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.2.1 (2023-05-11)
 
+
+### Bug Fixes
  - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
    Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.2.1
+## 3.2.1 (2023-05-11)
 
  - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
    Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -394,7 +394,7 @@ export interface VisualStudioCodeCredentialOptions extends MultiTenantTokenCrede
 
 // @public
 export class WorkloadIdentityCredential implements TokenCredential {
-    constructor(options: WorkloadIdentityCredentialOptions);
+    constructor(options?: WorkloadIdentityCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
 }
 

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -5,7 +5,7 @@
  * Current version of the `@azure/identity` package.
  */
 
-export const SDK_VERSION = `3.2.0`;
+export const SDK_VERSION = `3.2.1`;
 
 /**
  * The default client ID for authentication

--- a/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
@@ -48,12 +48,12 @@ export class WorkloadIdentityCredential implements TokenCredential {
    *
    * @param options - The identity client options to use for authentication.
    */
-  constructor(options: WorkloadIdentityCredentialOptions) {
+  constructor(options?: WorkloadIdentityCredentialOptions) {
     // Logging environment variables for error details
     const assignedEnv = processEnvVars(SupportedWorkloadEnvironmentVariables).assigned.join(", ");
     logger.info(`Found the following environment variables: ${assignedEnv}`);
 
-    const workloadIdentityCredentialOptions = options as WorkloadIdentityCredentialOptions;
+    const workloadIdentityCredentialOptions = options || {};
     const tenantId = workloadIdentityCredentialOptions.tenantId || process.env.AZURE_TENANT_ID;
     const clientId = workloadIdentityCredentialOptions.clientId || process.env.AZURE_CLIENT_ID;
     this.federatedTokenFilePath =

--- a/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
@@ -53,7 +53,7 @@ export class WorkloadIdentityCredential implements TokenCredential {
     const assignedEnv = processEnvVars(SupportedWorkloadEnvironmentVariables).assigned.join(", ");
     logger.info(`Found the following environment variables: ${assignedEnv}`);
 
-    const workloadIdentityCredentialOptions = options || {};
+    const workloadIdentityCredentialOptions = options ?? {};
     const tenantId = workloadIdentityCredentialOptions.tenantId || process.env.AZURE_TENANT_ID;
     const clientId = workloadIdentityCredentialOptions.clientId || process.env.AZURE_CLIENT_ID;
     this.federatedTokenFilePath =


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'tenantId')
    at new WorkloadIdentityCredential (.../@azure/identity/dist/index.js:1999:60)
    at new DefaultWorkloadIdentityCredential (...@azure/identity/dist/index.js:3589:13)



### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
- #25827


### Provide a list of related PRs _(if any)_
- #25402

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
