### PR TITLE
[keyvault] Run Managed HSM tests only weekly

### DIFF
--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -1,22 +1,22 @@
 trigger: none
 
 stages:
-  ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
-    - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
-      parameters:
-        PackageName: "@azure/keyvault-admin"
-        ServiceDirectory: keyvault
-        # KV HSM limitation prevents us from running live tests
-        # against multiple platforms in parallel (we're limited to five
-        # instances per region per subscription) so we're only running
-        # live tests against a single instance.
-        Location: eastus2
-        MatrixConfigs:
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    parameters:
+      PackageName: "@azure/keyvault-admin"
+      ServiceDirectory: keyvault
+      # KV HSM limitation prevents us from running live tests
+      # against multiple platforms in parallel (we're limited to five
+      # instances per region per subscription) so we're only running
+      # live tests against a single instance.
+      Location: eastus2
+      MatrixConfigs:
+        - ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
           - Name: Keyvault_live_test_base
             Path: sdk/keyvault/keyvault-admin/platform-matrix.json
             Selection: sparse
             GenerateVMJobs: true
-        EnvVars:
-          AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-          AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-          AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      EnvVars:
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -1,22 +1,22 @@
 trigger: none
 
 stages:
-  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
-    parameters:
-      PackageName: "@azure/keyvault-admin"
-      ServiceDirectory: keyvault
-      # KV HSM limitation prevents us from running live tests
-      # against multiple platforms in parallel (we're limited to five
-      # instances per region per subscription) so we're only running
-      # live tests against a single instance.
-      Location: eastus2
-      ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+  ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+    - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+      parameters:
+        PackageName: "@azure/keyvault-admin"
+        ServiceDirectory: keyvault
+        # KV HSM limitation prevents us from running live tests
+        # against multiple platforms in parallel (we're limited to five
+        # instances per region per subscription) so we're only running
+        # live tests against a single instance.
+        Location: eastus2
         MatrixConfigs:
           - Name: Keyvault_live_test_base
             Path: sdk/keyvault/keyvault-admin/platform-matrix.json
             Selection: sparse
             GenerateVMJobs: true
-      EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        EnvVars:
+          AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+          AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+          AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -10,11 +10,12 @@ stages:
       # instances per region per subscription) so we're only running
       # live tests against a single instance.
       Location: eastus2
-      MatrixConfigs:
-        - Name: Keyvault_live_test_base
-          Path: sdk/keyvault/keyvault-admin/platform-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
+      ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+        MatrixConfigs:
+          - Name: Keyvault_live_test_base
+            Path: sdk/keyvault/keyvault-admin/platform-matrix.json
+            Selection: sparse
+            GenerateVMJobs: true
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -23,11 +23,13 @@ stages:
       # against multiple platforms in parallel (we're limited to a single
       # instance per region per subscription) so we're only running
       # live tests against a single instance.
-      AdditionalMatrixConfigs:
-        - Name: Keyvault_live_test_base
-          Path: sdk/keyvault/keyvault-keys/platform-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
+      ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+        AdditionalMatrixConfigs:
+          - Name: Keyvault_live_test_base
+            Path: sdk/keyvault/keyvault-keys/platform-matrix.json
+            Selection: sparse
+            GenerateVMJobs: true
+
       EnvVars:
         AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
         AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-keys`
- `@azure/keyvault-admin`

### Issues associated with this PR

- Fix #25734

### Describe the problem that is addressed by this PR

Make the Managed HSM tests run only weekly to save Managed HSM resource.
