### PR TITLE
[Search] Fix constant paths for version bumping

### DIFF
--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -46,12 +46,20 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/generated/data/searchClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "swagger/Service.md",
+        "prefix": "package-version"
       },
       {
-        "path": "src/generated/service/searchServiceClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "swagger/Data.md",
+        "prefix": "package-version"
+      },
+      {
+        "path": "src/generated/data/searchClient.ts",
+        "prefix": "packageDetails"
+      },
+      {
+        "path": "src/generated/service/searchServiceClient.ts",
+        "prefix": "packageDetails"
       },
       {
         "path": "src/constants.ts",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Describe the problem that is addressed by this PR

The release pipeline failed to bump the version of this package. This change updates the package's metadata so it'll have the correct behavior next time.