### PR TITLE
Auto gererated code with latest swagger changes

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -246,7 +246,7 @@ export interface ContinuousDtmfRecognitionOptions extends OperationOptions {
 }
 
 // @public
-export interface ContinuousDtmfRecognitionStopped extends Omit<RestContinuousDtmfRecognitionStopped, "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"> {
+export interface ContinuousDtmfRecognitionStopped extends Omit<RestContinuousDtmfRecognitionStopped, "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"> {
     callConnectionId: string;
     correlationId: string;
     kind: "ContinuousDtmfRecognitionStopped";
@@ -256,19 +256,21 @@ export interface ContinuousDtmfRecognitionStopped extends Omit<RestContinuousDtm
 }
 
 // @public
-export interface ContinuousDtmfRecognitionToneFailed extends Omit<RestContinuousDtmfRecognitionToneFailed, "callConnectionId" | "serverCallId" | "correlationId | resultInformation"> {
+export interface ContinuousDtmfRecognitionToneFailed extends Omit<RestContinuousDtmfRecognitionToneFailed, "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"> {
     callConnectionId: string;
     correlationId: string;
     kind: "ContinuousDtmfRecognitionToneFailed";
+    operationContext?: string;
     resultInformation?: ResultInformation;
     serverCallId: string;
 }
 
 // @public
-export interface ContinuousDtmfRecognitionToneReceived extends Omit<RestContinuousDtmfRecognitionToneReceived, "toneInfo | callConnectionId" | "serverCallId" | "correlationId | resultInformation"> {
+export interface ContinuousDtmfRecognitionToneReceived extends Omit<RestContinuousDtmfRecognitionToneReceived, "toneInfo" | "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"> {
     callConnectionId: string;
     correlationId: string;
     kind: "ContinuousDtmfRecognitionToneReceived";
+    operationContext?: string;
     resultInformation?: ResultInformation;
     serverCallId: string;
     toneInfo: ToneInfo;
@@ -785,7 +787,7 @@ export interface ResultInformation extends Omit<RestResultInformation, "code" | 
 export type ResumeRecordingOptions = OperationOptions;
 
 // @public
-export interface SendDtmfCompleted extends Omit<RestSendDtmfCompleted, "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"> {
+export interface SendDtmfCompleted extends Omit<RestSendDtmfCompleted, "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"> {
     callConnectionId: string;
     correlationId: string;
     kind: "SendDtmfCompleted";
@@ -795,7 +797,7 @@ export interface SendDtmfCompleted extends Omit<RestSendDtmfCompleted, "callConn
 }
 
 // @public
-export interface SendDtmfFailed extends Omit<RestSendDtmfFailed, "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"> {
+export interface SendDtmfFailed extends Omit<RestSendDtmfFailed, "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"> {
     callConnectionId: string;
     correlationId: string;
     kind: "SendDtmfFailed";

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -161,7 +161,7 @@ export class CallMedia {
     play(playSource: FileSource, playTo: CommunicationIdentifier[], playOptions?: PlayOptions): Promise<void>;
     playToAll(playSource: FileSource, playOptions?: PlayOptions): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "Tone" needs to be exported by the entry point index.d.ts
-    sendDtmf(targetParticipant: CommunicationIdentifier, tones: Tone[], sendDtmfOptions?: SendDtmfOptions): Promise<void>;
+    sendDtmf(tones: Tone[], targetParticipant: CommunicationIdentifier, sendDtmfOptions?: SendDtmfOptions): Promise<void>;
     startContinuousDtmfRecognition(targetParticipant: CommunicationIdentifier, continuousDtmfRecognitionOptions?: ContinuousDtmfRecognitionOptions): Promise<void>;
     startRecognizing(targetParticipant: CommunicationIdentifier, maxTonesToCollect: number, recognizeOptions: CallMediaRecognizeDtmfOptions): Promise<void>;
     stopContinuousDtmfRecognition(targetParticipant: CommunicationIdentifier, continuousDtmfRecognitionOptions?: ContinuousDtmfRecognitionOptions): Promise<void>;
@@ -621,6 +621,7 @@ export interface RestContinuousDtmfRecognitionStopped {
 export interface RestContinuousDtmfRecognitionToneFailed {
     callConnectionId?: string;
     correlationId?: string;
+    operationContext?: string;
     resultInformation?: RestResultInformation;
     serverCallId?: string;
 }
@@ -629,6 +630,7 @@ export interface RestContinuousDtmfRecognitionToneFailed {
 export interface RestContinuousDtmfRecognitionToneReceived {
     callConnectionId?: string;
     correlationId?: string;
+    operationContext?: string;
     resultInformation?: RestResultInformation;
     serverCallId?: string;
     toneInfo?: RestToneInfo;
@@ -767,7 +769,6 @@ export interface RestSendDtmfFailed {
 
 // @public
 export interface RestToneInfo {
-    participantId?: string;
     sequenceId: number;
     // (undocumented)
     tone: Tone;
@@ -823,8 +824,7 @@ export interface StartRecordingOptions extends OperationOptions {
 export type StopRecordingOptions = OperationOptions;
 
 // @public
-export interface ToneInfo extends Omit<RestToneInfo, "sequenceId" | "tone" | "participantId"> {
-    participantId?: string;
+export interface ToneInfo extends Omit<RestToneInfo, "sequenceId" | "tone"> {
     sequenceId: number;
     tone: Tone;
 }

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -185,7 +185,7 @@ export class CallMedia {
   /**
    * Start continuous Dtmf recognition by subscribing to tones.
    * @param targetParticipant - Target participant.
-   * @param continuousDtmfRecognitionOptions - Additional attributes for continuous Dtmf recognition
+   * @param continuousDtmfRecognitionOptions - Additional attributes for continuous Dtmf recognition.
    * */
   public async startContinuousDtmfRecognition(
     targetParticipant: CommunicationIdentifier,
@@ -205,7 +205,7 @@ export class CallMedia {
   /**
    * Stop continuous Dtmf recognition by unsubscribing to tones.
    * @param targetParticipant - Target participant.
-   * @param continuousDtmfRecognitionOptions - Additional attributes for continuous Dtmf recognition
+   * @param continuousDtmfRecognitionOptions - Additional attributes for continuous Dtmf recognition.
    * */
   public async stopContinuousDtmfRecognition(
     targetParticipant: CommunicationIdentifier,
@@ -224,18 +224,18 @@ export class CallMedia {
 
   /**
    * Send Dtmf tones.
-   * @param targetParticipant - Target participant.
    * @param tones - List of tones to be sent to target participant.
-   * @param continuousDtmfRecognitionOptions - Additional attributes for send Dtmf tones
+   * @param targetParticipant - Target participant.
+   * @param sendDtmfOptions - Additional attributes for send Dtmf tones.
    * */
   public async sendDtmf(
-    targetParticipant: CommunicationIdentifier,
     tones: Tone[],
+    targetParticipant: CommunicationIdentifier,
     sendDtmfOptions: SendDtmfOptions = {}
   ): Promise<void> {
     const sendDtmfRequest: SendDtmfRequest = {
-      targetParticipant: serializeCommunicationIdentifier(targetParticipant),
       tones: tones,
+      targetParticipant: serializeCommunicationIdentifier(targetParticipant),
       operationContext: sendDtmfOptions.operationContext,
     };
     return this.callMedia.sendDtmf(this.callConnectionId, sendDtmfRequest, {});

--- a/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
@@ -607,7 +607,7 @@ export interface RecordingStateChanged {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /**
    * The call recording id
@@ -627,11 +627,11 @@ export interface PlayCompleted {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 
@@ -640,11 +640,11 @@ export interface PlayFailed {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 
@@ -653,7 +653,7 @@ export interface PlayCanceled {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
@@ -664,11 +664,11 @@ export interface RecognizeCompleted {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
   /**
    * Determines the sub-type of the recognize operation.
@@ -722,11 +722,11 @@ export interface RecognizeFailed {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 
@@ -735,7 +735,7 @@ export interface RecognizeCanceled {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
@@ -746,10 +746,12 @@ export interface ContinuousDtmfRecognitionToneFailed {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
 }
 
 export interface ContinuousDtmfRecognitionToneReceived {
@@ -761,8 +763,10 @@ export interface ContinuousDtmfRecognitionToneReceived {
   serverCallId?: string;
   /** Correlation ID for event to call correlation. Also called ChainId or skype chain ID. */
   correlationId?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
 }
 
 /** The information about the tone. */
@@ -770,8 +774,6 @@ export interface ToneInfo {
   /** The sequence id which can be used to determine if the same tone was played multiple times or if any tones were missed. */
   sequenceId: number;
   tone: Tone;
-  /** The id of participant. */
-  participantId?: string;
 }
 
 export interface ContinuousDtmfRecognitionStopped {
@@ -779,11 +781,11 @@ export interface ContinuousDtmfRecognitionStopped {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 
@@ -792,11 +794,11 @@ export interface SendDtmfCompleted {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 
@@ -805,11 +807,11 @@ export interface SendDtmfFailed {
   callConnectionId?: string;
   /** Server call ID. */
   serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  /** Correlation ID for event to call correlation. */
   correlationId?: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
-  /** Contains the resulting SIP code/sub-code and message from NGC services. */
+  /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: ResultInformation;
 }
 

--- a/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
@@ -2199,6 +2199,12 @@ export const ContinuousDtmfRecognitionToneFailed: coreClient.CompositeMapper = {
           name: "Composite",
           className: "ResultInformation"
         }
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -2240,6 +2246,12 @@ export const ContinuousDtmfRecognitionToneReceived: coreClient.CompositeMapper =
           name: "Composite",
           className: "ResultInformation"
         }
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String"
+        }
       }
     }
   }
@@ -2260,12 +2272,6 @@ export const ToneInfo: coreClient.CompositeMapper = {
       tone: {
         serializedName: "tone",
         required: true,
-        type: {
-          name: "String"
-        }
-      },
-      participantId: {
-        serializedName: "participantId",
         type: {
           name: "String"
         }

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -364,13 +364,11 @@ export interface RecognizeCanceled
 }
 
 /** The information about the tone. */
-export interface ToneInfo extends Omit<RestToneInfo, "sequenceId" | "tone" | "participantId"> {
+export interface ToneInfo extends Omit<RestToneInfo, "sequenceId" | "tone"> {
   /** The sequence id which can be used to determine if the same tone was played multiple times or if any tones were missed. */
   sequenceId: number;
   /** Defines values for Tone. */
   tone: Tone;
-  /** The id of participant. */
-  participantId?: string;
 }
 
 /** Event sent when Dtmf tone received from targeted participant in call. */

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -375,7 +375,12 @@ export interface ToneInfo extends Omit<RestToneInfo, "sequenceId" | "tone"> {
 export interface ContinuousDtmfRecognitionToneReceived
   extends Omit<
     RestContinuousDtmfRecognitionToneReceived,
-    "toneInfo | callConnectionId" | "serverCallId" | "correlationId | resultInformation"
+    | "toneInfo"
+    | "callConnectionId"
+    | "serverCallId"
+    | "correlationId"
+    | "operationContext"
+    | "resultInformation"
   > {
   /** Information about Tone. */
   toneInfo: ToneInfo;
@@ -385,6 +390,8 @@ export interface ContinuousDtmfRecognitionToneReceived
   serverCallId: string;
   /** Correlation ID for event to call correlation. Also called ChainId or skype chain ID. */
   correlationId: string;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
   /** Contains the resulting SIP code/sub-code and message from NGC services. */
   resultInformation?: ResultInformation;
   /** kind of this event. */
@@ -395,7 +402,7 @@ export interface ContinuousDtmfRecognitionToneReceived
 export interface ContinuousDtmfRecognitionToneFailed
   extends Omit<
     RestContinuousDtmfRecognitionToneFailed,
-    "callConnectionId" | "serverCallId" | "correlationId | resultInformation"
+    "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"
   > {
   /** Call connection ID. */
   callConnectionId: string;
@@ -403,6 +410,8 @@ export interface ContinuousDtmfRecognitionToneFailed
   serverCallId: string;
   /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
   correlationId: string;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
   /** Contains the resulting SIP code/sub-code and message from NGC services. */
   resultInformation?: ResultInformation;
   /** kind of this event. */
@@ -413,7 +422,7 @@ export interface ContinuousDtmfRecognitionToneFailed
 export interface ContinuousDtmfRecognitionStopped
   extends Omit<
     RestContinuousDtmfRecognitionStopped,
-    "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"
+    "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"
   > {
   /** Call connection ID. */
   callConnectionId: string;
@@ -433,7 +442,7 @@ export interface ContinuousDtmfRecognitionStopped
 export interface SendDtmfCompleted
   extends Omit<
     RestSendDtmfCompleted,
-    "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"
+    "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"
   > {
   /** Call connection ID. */
   callConnectionId: string;
@@ -453,7 +462,7 @@ export interface SendDtmfCompleted
 export interface SendDtmfFailed
   extends Omit<
     RestSendDtmfFailed,
-    "callConnectionId" | "serverCallId" | "correlationId | operationContext | resultInformation"
+    "callConnectionId" | "serverCallId" | "correlationId" | "operationContext" | "resultInformation"
   > {
   /** Call connection ID. */
   callConnectionId: string;

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: V2023-01-15-preview
-input-file: https://raw.githubusercontent.com/williamzhao87/azure-rest-api-specs/366f31cb260cb6c0ef4c8964440e9fee25bdf39f/specification/communication/data-plane/CallAutomation/preview/2023-01-15-preview/communicationservicescallautomation.json
+input-file: https://raw.githubusercontent.com/williamzhao87/azure-rest-api-specs/885b18fa094fbb953b1a0cb77c52536a8d745be5/specification/communication/data-plane/CallAutomation/preview/2023-01-15-preview/communicationservicescallautomation.json
 package-version: 1.0.0-beta.1
 model-date-time-as-string: false
 optional-response-headers: true

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -194,7 +194,7 @@ describe("CallMedia Unit Tests", async function () {
     };
     const tones = ["one", "two", "three", "pound"];
 
-    await callMedia.sendDtmf(targetParticipant, tones, sendDtmfOptions);
+    await callMedia.sendDtmf(tones, targetParticipant, sendDtmfOptions);
     const request = spy.getCall(0).args[0];
     const data = JSON.parse(request.body?.toString() || "");
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/communication-call-automation

### Issues associated with this PR


### Describe the problem that is addressed by this PR
API review fixes for send and continuous DTMF.

Added operation_context in ContinuousDtmfRecognitionToneFailed, ContinuousDtmfRecognitionToneReceived
- Removed participant_id from ToneInfo
- Changed args order for send_dtmf
- Auto generated code as per latest swagger

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-rest-api-specs/commit/25ea7bc8f78804ee079bd41753d237feaf2777d7
https://github.com/Azure/azure-rest-api-specs/commit/885b18fa094fbb953b1a0cb77c52536a8d745be5

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
