### PR TITLE
[Search] Fix constant paths for version bumping

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 12.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.0.0-beta.1 (2023-05-09)
 
 ### Features Added

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -46,12 +46,20 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/generated/data/searchClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "swagger/Service.md",
+        "prefix": "package-version"
       },
       {
-        "path": "src/generated/service/searchServiceClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "swagger/Data.md",
+        "prefix": "package-version"
+      },
+      {
+        "path": "src/generated/data/searchClient.ts",
+        "prefix": "packageDetails"
+      },
+      {
+        "path": "src/generated/service/searchServiceClient.ts",
+        "prefix": "packageDetails"
       },
       {
         "path": "src/constants.ts",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "description": "Azure client library to use Cognitive Search for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/search/search-documents/src/constants.ts
+++ b/sdk/search/search-documents/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.0.0-beta.1";
+export const SDK_VERSION: string = "12.0.0-beta.2";

--- a/sdk/search/search-documents/src/generated/data/searchClient.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClient.ts
@@ -51,7 +51,7 @@ export class SearchClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-search-documents/12.0.0-beta.1`;
+    const packageDetails = `azsdk-js-search-documents/12.0.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
@@ -64,7 +64,7 @@ export class SearchServiceClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-search-documents/12.0.0-beta.1`;
+    const packageDetails = `azsdk-js-search-documents/12.0.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -16,7 +16,7 @@ title: SearchClient
 use-extension:
   "@autorest/typescript": "6.0.0-alpha.17.20220318.1"
 core-http-compat-mode: true
-package-version: 12.0.0-beta.1
+package-version: 12.0.0-beta.2
 disable-async-iterators: true
 api-version-parameter: choice
 v3: true

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -15,7 +15,7 @@ add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0-alpha.17.20220318.1"
 core-http-compat-mode: true
-package-version: 12.0.0-beta.1
+package-version: 12.0.0-beta.2
 disable-async-iterators: true
 api-version-parameter: choice
 v3: true


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Describe the problem that is addressed by this PR

Automatic version bumping was broken because the metadata entries in `package.json` pointed to stale paths. This change corrects those paths to point to the new generated file locations. It also manually bumps the version number of the package.
