### PR TITLE
[engsys][cosmos] switch dev dependency `@sinonjs/fake-timers` to use caret version

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -136,7 +136,7 @@
     "typescript": "~5.0.0",
     "nock": "^12.0.3",
     "@types/sinonjs__fake-timers": "~8.1.2",
-    "@sinonjs/fake-timers": "~10.0.2"
+    "@sinonjs/fake-timers": "^10.0.2"
   },
   "//sampleConfiguration": {
     "skip": [


### PR DESCRIPTION
so it can get non-breaking minor updates from rush automation.
