### PR TITLE
[EngSys] revert using different version of NodeJS for build and test

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -135,8 +135,6 @@ jobs:
         workingDirectory: $(Build.SourcesDirectory)/eng/tools/eng-package-utils
         displayName: "Get package path"
 
-      - template: ../steps/use-node-test-version.yml
-
       # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
       # The default on Windows is "cores - 1" (microsoft/rushstack#436).
       - script: |

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -28,11 +28,9 @@ steps:
       node eng/tools/rush-runner.js build:test "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build test assets"
 
-  - template: ../steps/use-node-test-version.yml
-
   - ${{ if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
-  
+
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
@@ -52,7 +50,7 @@ steps:
         cat $(Build.SourcesDirectory)/test-proxy.log
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
-      
+
   # Unlink node_modules folders to significantly improve performance of subsequent tasks
   # which need to walk the directory tree (and are hardcoded to follow symlinks).
   # Retry for 30 seconds, since this command may fail with error "Another rush command is already

--- a/eng/pipelines/templates/steps/use-node-version.yml
+++ b/eng/pipelines/templates/steps/use-node-version.yml
@@ -1,5 +1,5 @@
 parameters:
-  NodeVersion: $(NodeTestVersion)
+  NodeVersion: $(NodeVersion)
 
 steps:
   - task: NodeTool@0

--- a/eng/pipelines/templates/steps/use-node-version.yml
+++ b/eng/pipelines/templates/steps/use-node-version.yml
@@ -1,5 +1,5 @@
 parameters:
-  NodeVersion: $(NodeVersion)
+  NodeVersion: $(NodeTestVersion)
 
 steps:
   - task: NodeTool@0

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,6 @@
 variables:
   DocWardenVersion: '0.5.0'
+  NodeVersion: $(NodeTestVersion)
   OSVmImage: "ubuntu-20.04"
   skipComponentGovernanceDetection: true
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,5 @@
 variables:
   DocWardenVersion: '0.5.0'
-  NodeVersion: "16.x"
   OSVmImage: "ubuntu-20.04"
   skipComponentGovernanceDetection: true
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]


### PR DESCRIPTION
The original goal was to workaround the issue of not being able to run pnpm on unsupported NodeJS v8.

Currently pnpm v7 that we are using runs fine on v14, v16, v18, and v20. There's no need to have the workaround.
