### PR TITLE
Add NonExhaustive for extensible enums

### DIFF
--- a/design/extensible-enums.md
+++ b/design/extensible-enums.md
@@ -1,0 +1,63 @@
+# Design Document: Extensible Enums in Azure SDK for JavaScript
+
+## Overview
+
+This document proposes a new approach for dealing with extensible enums in TypeScript. By introducing a `NonExhaustive` type in our `core-util` library, we hope to improve the flexibility and developer experience of our APIs.
+
+## Background
+
+Traditionally, Enums are fixed and cannot be extended with arbitrary values. This can lead to limitations when we need to deal with dynamic data or APIs that could evolve over time. For this reason, many Azure Services use a more flexible approach called "extensible enums".
+
+Certainly, here's the updated section of the design document that covers the current approach and the proposed changes:
+
+---
+
+## Current Approach
+
+Currently, the Azure SDK libraries handle enums with a combination of a string type and a traditional enum. This allows for flexibility in accepting any string, while also providing a set of known values. For example:
+
+```typescript
+/**
+ * Known values: "foo", "bar", "baz"
+ */
+type MyValue = string;
+enum KnownMyValueValues {
+  foo = "foo",
+  bar = "bar",
+  baz = "baz",
+}
+```
+
+In this approach, the string alias `MyValue` is used for documenting the suggested values with TSDoc and the `KnownMyValueValues` enum is provided as a helper for users that want to use strongly typed options.
+
+## Proposed Changes
+
+The proposed `NonExhaustive` type seeks to simplify this approach by combining these two separate entities into one. This not only reduces complexity but also enhances the user experience. Instead of defining a string type and an enum separately, we can define an extensible enum like this:
+
+```typescript
+type MyValue = NonExhaustive<"foo" | "bar" | "baz">;
+```
+
+This single `MyValue` type would accept any string, while also suggesting "foo", "bar", and "baz" as autocomplete options in the IDE. This approach would both simplify our codebase and provide a more intuitive and flexible API for our users.
+
+## Impact
+
+The proposed approach will greatly improve our user experience:
+
+1. **Discoverability**: Developers will have the recommended values suggested to them directly in their IDE, which aids in understanding what values they might use.
+
+2. **Flexibility**: Developers will not be limited to the recommended values and can provide any string value as needed. This makes our API more adaptable to various use-cases.
+
+3. **Reduced Errors**: By providing recommended values, we guide developers towards the correct usage, potentially reducing errors from incorrect string values.
+
+4. **Simplicity**: This approach reduces the need for managing multiple string aliases, simplifying our codebase.
+
+## Concerns
+
+The main concern with this approach is that it relies on an advanced TypeScript feature that is not officially supported. There's a risk that future changes to TypeScript could potentially break our implementation.
+
+However, we've considered this risk and feel that it's minimal given TypeScript's strong commitment to backward compatibility. We also plan to mitigate this risk by implementing a robust testing strategy.
+
+## Conclusion
+
+While this approach comes with some trade-offs, we believe the benefits in terms of user experience and API flexibility make it a worthwhile endeavor. We invite feedback and suggestions from the team to refine this proposal.

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.3.3 (Unreleased)
+## 1.4.0 (Unreleased)
 
 ### Features Added
+
+- Added NonExhaustive<T> type to represent extensible enums
 
 ### Breaking Changes
 

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-util",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Core library for shared utility methods",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -7,6 +7,11 @@
 import { AbortSignalLike } from '@azure/abort-controller';
 
 // @public
+export type $NonExhaustive = {
+    [__non_exhaustive]?: never;
+};
+
+// @public
 export function computeSha256Hash(content: string, encoding: "base64" | "hex"): Promise<string>;
 
 // @public
@@ -53,7 +58,13 @@ export function isObject(input: unknown): input is UnknownObject;
 export function isObjectWithProperties<Thing, PropertyName extends string>(thing: Thing, properties: PropertyName[]): thing is Thing & Record<PropertyName, unknown>;
 
 // @public
+export type NonExhaustive<T> = T | (Primitive<T> & $NonExhaustive);
+
+// @public
 export function objectHasProperty<Thing, PropertyName extends string>(thing: Thing, property: PropertyName): thing is Thing & Record<PropertyName, unknown>;
+
+// @public
+export type Primitive<T> = T extends string ? string : T extends number ? number : T extends bigint ? bigint : T extends symbol ? symbol : unknown;
 
 // @public
 export function randomUUID(): string;

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -10,3 +10,4 @@ export { isError, getErrorMessage } from "./error";
 export { computeSha256Hash, computeSha256Hmac } from "./sha256";
 export { isDefined, isObjectWithProperties, objectHasProperty } from "./typeGuards";
 export { randomUUID } from "./uuidUtils";
+export { NonExhaustive, $NonExhaustive, Primitive } from "./nonExhaustiveUnion";

--- a/sdk/core/core-util/src/nonExhaustiveUnion.ts
+++ b/sdk/core/core-util/src/nonExhaustiveUnion.ts
@@ -1,0 +1,29 @@
+/**
+ * Represents a primitive JavaScript type string, number, bigint and symbol.
+ */
+export type Primitive<T> = T extends string
+  ? string
+  : T extends number
+  ? number
+  : T extends bigint
+  ? bigint
+  : T extends symbol
+  ? symbol
+  : unknown;
+
+/**
+ * This is a unique symbol that we declare. This symbol is used as a property key in our $NonExhaustive type.
+ * The use of a unique symbol guarantees that this property won't conflict with any other string-named properties that might exist.
+ */
+declare const __non_exhaustive: unique symbol;
+/**
+ * This is a mapped type that represents an object with a single optional property. The property key is the __non_exhaustive symbol we declared earlier, and the property value is of type never.
+ */
+export type $NonExhaustive = { [__non_exhaustive]?: never };
+/**
+ * This is the main type we will use to define our extensible enums.
+ * It is a union of T and a type intersection of Primitive<T> and $NonExhaustive.
+ * This effectively means that the type can be any value of T or any other value that matches the primitive type of T.
+ * The intersection with $NonExhaustive is what prevents TypeScript from collapsing the union with string into just string.
+ */
+export type NonExhaustive<T> = T | (Primitive<T> & $NonExhaustive);

--- a/sdk/core/core-util/src/nonExhaustiveUnion.ts
+++ b/sdk/core/core-util/src/nonExhaustiveUnion.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Represents a primitive JavaScript type string, number, bigint and symbol.
  */

--- a/sdk/core/core-util/test/internal/nonExhaustive.spec.ts
+++ b/sdk/core/core-util/test/internal/nonExhaustive.spec.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { NonExhaustive } from "../../src/nonExhaustiveUnion";
+import { assert } from "chai";
+
+describe("NonExhaustive", () => {
+  it("should be able to assign a string value", () => {
+    // Testing with strings
+    type Animal = NonExhaustive<"cat" | "dog" | "bird">;
+
+    const cat: Animal = "cat";
+    assert.isDefined(cat);
+
+    const dog: Animal = "dog";
+    assert.isDefined(dog);
+
+    const bird: Animal = "bird";
+    assert.isDefined(bird);
+
+    const elephant: Animal = "elephant";
+    assert.isDefined(elephant);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const num: Animal = 123;
+    assert.isDefined(num);
+  });
+
+  it("should be able to assign a number value", () => {
+    // Testing with numbers
+    type LuckyNumber = NonExhaustive<7 | 13 | 21>;
+
+    const seven: LuckyNumber = 7;
+    assert.isDefined(seven);
+
+    const thirteen: LuckyNumber = 13;
+    assert.isDefined(thirteen);
+
+    const twentyOne: LuckyNumber = 21;
+    assert.isDefined(twentyOne);
+
+    const fortyTwo: LuckyNumber = 42;
+    assert.isDefined(fortyTwo);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const notANumber: LuckyNumber = "not a number";
+    assert.isDefined(notANumber);
+  });
+  it("should be able to assign a BigInt value", () => {
+    // Testing with BigInt
+    type BigNum = NonExhaustive<100n | 200n | 300n>;
+
+    const hundred: BigNum = BigInt(100);
+    assert.isDefined(hundred);
+
+    const twoHundred: BigNum = BigInt(200);
+    assert.isDefined(twoHundred);
+
+    const threeHundred: BigNum = BigInt(300);
+    assert.isDefined(threeHundred);
+
+    const fourHundred: BigNum = BigInt(400);
+    assert.isDefined(fourHundred);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const notABigNum: BigNum = "not a BigInt";
+    assert.isDefined(notABigNum);
+  });
+
+  it("should be able to assign a boolean value", () => {
+    // Testing with symbols
+    const sym1 = Symbol("sym1");
+    const sym2 = Symbol("sym2");
+    const sym3 = Symbol("sym3");
+
+    type SomeSymbol = NonExhaustive<typeof sym1 | typeof sym2 | typeof sym3>;
+
+    const symbol1: SomeSymbol = sym1;
+    assert.isDefined(symbol1);
+
+    const symbol2: SomeSymbol = sym2;
+    assert.isDefined(symbol2);
+
+    const symbol3: SomeSymbol = sym3;
+    assert.isDefined(symbol3);
+
+    const symbol4: SomeSymbol = Symbol("sym4");
+    assert.isDefined(symbol4);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const notASymbol: SomeSymbol = "not a symbol";
+    assert.isDefined(notASymbol);
+  });
+  it("should be able to assign a symbol value", () => {
+    // Testing with mixed types
+    type Mixed = NonExhaustive<"cat" | 7>;
+
+    const catMixed: Mixed = "cat";
+    assert.isDefined(catMixed);
+
+    const sevenMixed: Mixed = 7;
+    assert.isDefined(sevenMixed);
+
+    const dogMixed: Mixed = "dog";
+    assert.isDefined(dogMixed);
+
+    const eightMixed: Mixed = 8;
+    assert.isDefined(eightMixed);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const notAStringOrNumber1: Mixed = true;
+    assert.isDefined(notAStringOrNumber1);
+
+    // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+    const notAStringOrNumber2: Mixed = {};
+    assert.isDefined(notAStringOrNumber2);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-util

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
See [this design doc](https://github.com/joheredi/azure-sdk-for-js/blob/707946a77519c8b4d13366a9c4af23cea93c42a4/design/extensible-enums.md)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

#### Current Approach

Currently, the Azure SDK libraries handle enums with a combination of a string type and a traditional enum. This allows for flexibility in accepting any string, while also providing a set of known values. For example:

```typescript
/**
 * Known values: "foo", "bar", "baz"
 */
type MyValue = string;
enum KnownMyValueValues {
  foo = "foo",
  bar = "bar",
  baz = "baz",
}
```

In this approach, the string alias `MyValue` is used for documenting the suggested values with TSDoc and the `KnownMyValueValues` enum is provided as a helper for users that want to use strongly typed options.

## Proposed Changes

The proposed `NonExhaustive` type seeks to simplify this approach by combining these two separate entities into one. This not only reduces complexity but also enhances the user experience. Instead of defining a string type and an enum separately, we can define an extensible enum like this:

```typescript
type MyValue = NonExhaustive<"foo" | "bar" | "baz">;
```

This single `MyValue` type would accept any string, while also suggesting "foo", "bar", and "baz" as autocomplete options in the IDE. This approach would both simplify our codebase and provide a more intuitive and flexible API for our users.

### Are there test cases added in this PR? _(If not, why?)_
WIP

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A
