### PR TITLE
[Core] remove URL validations on credential scopes

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+- remove the validation that credential scopes must be a valid URL [Issue #25881](https://github.com/Azure/azure-sdk-for-js/issues/25881)
 
 ## 1.7.2 (2023-02-23)
 

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -245,10 +245,7 @@ function createDefaultPipeline(options: ServiceClientOptions): Pipeline {
 
 function getCredentialScopes(options: ServiceClientOptions): string | string[] | undefined {
   if (options.credentialScopes) {
-    const scopes = options.credentialScopes;
-    return Array.isArray(scopes)
-      ? scopes.map((scope) => new URL(scope).toString())
-      : new URL(scopes).toString();
+    return options.credentialScopes;
   }
 
   if (options.endpoint) {

--- a/sdk/core/core-client/test/serviceClient.spec.ts
+++ b/sdk/core/core-client/test/serviceClient.spec.ts
@@ -81,32 +81,6 @@ describe("ServiceClient", function () {
       },
     };
 
-    it("should throw if scopes contain an invalid url", async function () {
-      const credential: TokenCredential = {
-        getToken: async (_scopes) => {
-          return { token: "testToken", expiresOnTimestamp: 11111 };
-        },
-      };
-      try {
-        let request: OperationRequest;
-        const client = new ServiceClient({
-          httpClient: {
-            sendRequest: (req) => {
-              request = req;
-              return Promise.resolve({ request, status: 200, headers: createHttpHeaders() });
-            },
-          },
-          credential,
-          credentialScopes: ["https://microsoft.com", "lalala"],
-        });
-
-        await client.sendOperationRequest(testOperationArgs, testOperationSpec);
-        assert.fail();
-      } catch (error: any) {
-        assert.include(error.message, `Invalid URL`);
-      }
-    });
-
     it("should throw is no scope or endpoint are defined", async function () {
       const credential: TokenCredential = {
         getToken: async (_scopes) => {

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,10 +1,7 @@
 # Release History
-
-## 3.0.0 (Unreleased)
+## 3.0.2 (Unreleased)
 
 ### Features Added
-
-- Add support for `x-ms-text` [PR# 23631](https://github.com/Azure/azure-sdk-for-js/pull/23631)
 
 ### Breaking Changes
 
@@ -12,7 +9,24 @@
 
 ### Other Changes
 
+- remove the validation that credential scopes must be a valid URL [Issue #25881](https://github.com/Azure/azure-sdk-for-js/issues/25881)
+
+## 3.0.1 (2023-04-11)
+
+### Other Changes
+
+- Upgrade dependency `xml2js` version to `^0.5.0`.
+
+## 3.0.0 (2023-02-03)
+
+### Features Added
+
+- Add support for `x-ms-text` [PR# 23631](https://github.com/Azure/azure-sdk-for-js/pull/23631)
+
+### Other Changes
+
 - Update `engines` to `"node": ">=14.0.0"`
+- Remove cookie support [Issue #24654](https://github.com/Azure/azure-sdk-for-js/issues/24654)
 
 ## 2.2.7 (2022-09-01)
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -84,8 +84,8 @@
     "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
-    "test:node": "npm run clean && tsc -p . && npm run unit-test:node && npm run integration-test:node",
-    "test": "npm run clean && tsc -p . && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
+    "test:node": "npm run clean && tsc -p tsconfig.es.json && npm run unit-test:node && npm run integration-test:node",
+    "test": "npm run clean && tsc -p tsconfig.es.json  && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "karma start --single-run",
     "unit-test:node": "cross-env TS_NODE_FILES=true mocha -r esm -r ts-node/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 500000 --full-trace --exclude \"test/**/*.browser.ts\" \"test/**/*.ts\""

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -1065,10 +1065,7 @@ function getCredentialScopes(
   baseUri?: string
 ): string | string[] | undefined {
   if (options?.credentialScopes) {
-    const scopes = options.credentialScopes;
-    return Array.isArray(scopes)
-      ? scopes.map((scope) => new URL(scope).toString())
-      : new URL(scopes).toString();
+    return options.credentialScopes;
   }
 
   if (baseUri) {

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
   /**
    * The core-http version
    */
-  coreHttpVersion: "3.0.0",
+  coreHttpVersion: "3.0.2",
 
   /**
    * Specifies HTTP.

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -77,30 +77,6 @@ describe("ServiceClient", function () {
       },
     };
 
-    it("should throw when there is a non fqdm as credentialScopes", async () => {
-      const cred: TokenCredential = {
-        getToken: async (_scopes) => {
-          return { token: "testToken", expiresOnTimestamp: 11111 };
-        },
-      };
-      let request: WebResource;
-      try {
-        const client = new ServiceClient(cred, {
-          httpClient: {
-            sendRequest: (req) => {
-              request = req;
-              return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
-            },
-          },
-          credentialScopes: ["/lalala//", "https://microsoft.com"],
-        });
-        await client.sendOperationRequest(testArgs, testOperationSpec);
-        assert.fail("Expected to throw");
-      } catch (error: any) {
-        assert.include(error.message, `Invalid URL`);
-      }
-    });
-
     it("should throw when there is no credentialScopes or baseUri", async () => {
       const cred: TokenCredential = {
         getToken: async (_scopes) => {


### PR DESCRIPTION
It is possible that credential scopes are not in the format of valid URL.  It is also noted in the doc that there are shorter form of scope https://learn.microsoft.com/EN-US/azure/active-directory/develop/scopes-oidc

>In requests to the authorization, token or consent endpoints for the Microsoft Identity platform, if the resource identifier is omitted in the scope parameter, the resource is assumed to be Microsoft Graph. For example, `scope=User.Read` is equivalent to `https://graph.microsoft.com/User.Read`.

Related issue: #25881
