### PR TITLE
Add support for Node 20

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -18,6 +18,9 @@
       }
     },
     "NodeTestVersion": [
+      "14.x",
+      "16.x",
+      "18.x",
       "20.x"
     ],
     "TestType": "node",

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -18,9 +18,7 @@
       }
     },
     "NodeTestVersion": [
-      "14.x",
-      "16.x",
-      "18.x"
+      "20.x"
     ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"


### PR DESCRIPTION
Node.js 20 will enter long-term support (LTS) in October, we're adding support for it now (6 months prior)