### PR TITLE
Updates notification-hubs deleteRegistration so that it actually HTTP DELETEs.

### DIFF
--- a/sdk/notificationhubs/notification-hubs/src/api/deleteRegistration.ts
+++ b/sdk/notificationhubs/notification-hubs/src/api/deleteRegistration.ts
@@ -33,7 +33,7 @@ export function deleteRegistration(
       headers.set("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
       headers.set("If-Match", isDefined(options.etag) ? `"${options.etag}"` : "*");
 
-      const request = createRequest(endpoint, "GET", headers, updatedOptions);
+      const request = createRequest(endpoint, "DELETE", headers, updatedOptions);
       const response = await sendRequest(context, request, 200);
 
       return parseNotificationResponse(response);


### PR DESCRIPTION
According to the docs, the delete API expects a `HTTP DELETE /registrations/<registrationId>`, but the got uses `HTTP GET`, hence delete does not work.

https://learn.microsoft.com/en-us/rest/api/notificationhubs/delete-registration
<img width="699" alt="Screenshot 2023-05-17 at 22 49 27" src="https://github.com/Azure/azure-sdk-for-js/assets/86589079/2a4687da-0cc7-4d0b-a758-370ae017ad05">


### Packages impacted by this PR
https://www.npmjs.com/package/@azure/notification-hubs

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
According to the docs, the delete API expects a `HTTP DELETE /registrations/<registrationId>`, but the got uses `HTTP GET`, hence delete does not work.

https://learn.microsoft.com/en-us/rest/api/notificationhubs/delete-registration

### Checklists
- [x] Added impacted package name to the issue description? Yes
- [x] Does this PR needs any fixes in the SDK Generator?**  No
- [x] Added a changelog: Not necessary
