### PR TITLE
Add Ability to Disable Statsbeat in the Exporter

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.0.0-beta.12 (unreleased)
 
-### Features Added
-
-- Add ability to disable statsbeat via environment variable.
-
 ## 1.0.0-beta.11 (2023-02-02)
 
 ### Features Added
@@ -31,7 +27,6 @@
 ### Breaking Changes
 
 - Azure Monitor OpenTelemetry Metrics Exporter Configuration updated.
-
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.12 (unreleased)
+
+### Features Added
+
+- Add ability to disable statsbeat via environment variable.
+
 ## 1.0.0-beta.11 (2023-02-02)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Release History
 
-## 1.0.0-beta.12 (unreleased)
-
 ## 1.0.0-beta.11 (2023-02-02)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -41,6 +41,11 @@ export const ENV_CONNECTION_STRING = "APPLICATIONINSIGHTS_CONNECTION_STRING";
  * @internal
  */
 export const ENV_INSTRUMENTATION_KEY = "APPINSIGHTS_INSTRUMENTATIONKEY";
+/**
+ * Disable Statsbeat environment variable name.
+ * @internal
+ */
+export const ENV_DISABLE_STATSBEAT = "APPLICATION_INSIGHTS_NO_STATSBEAT";
 
 /**
  * QuickPulse metric counter names.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -9,7 +9,11 @@ import { HttpSender, FileSystemPersist } from "../platform";
 import { AzureMonitorExporterOptions } from "../config";
 import { PersistentStorage, Sender } from "../types";
 import { isRetriable, BreezeResponse } from "../utils/breezeUtils";
-import { DEFAULT_BREEZE_ENDPOINT, ENV_CONNECTION_STRING, ENV_DISABLE_STATSBEAT } from "../Declarations/Constants";
+import {
+  DEFAULT_BREEZE_ENDPOINT,
+  ENV_CONNECTION_STRING,
+  ENV_DISABLE_STATSBEAT,
+} from "../Declarations/Constants";
 import { TelemetryItem as Envelope } from "../generated";
 import { NetworkStatsbeatMetrics } from "./statsbeat/networkStatsbeatMetrics";
 import { MAX_STATSBEAT_FAILURES } from "./statsbeat/types";
@@ -92,9 +96,9 @@ export abstract class AzureMonitorBaseExporter {
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
-          code: ExportResultCode.FAILED,
-          error: new Error("Failed to persist envelope in disk."),
-        };
+            code: ExportResultCode.FAILED,
+            error: new Error("Failed to persist envelope in disk."),
+          };
     } catch (ex: any) {
       return { code: ExportResultCode.FAILED, error: ex };
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -9,7 +9,7 @@ import { HttpSender, FileSystemPersist } from "../platform";
 import { AzureMonitorExporterOptions } from "../config";
 import { PersistentStorage, Sender } from "../types";
 import { isRetriable, BreezeResponse } from "../utils/breezeUtils";
-import { DEFAULT_BREEZE_ENDPOINT, ENV_CONNECTION_STRING } from "../Declarations/Constants";
+import { DEFAULT_BREEZE_ENDPOINT, ENV_CONNECTION_STRING, ENV_DISABLE_STATSBEAT } from "../Declarations/Constants";
 import { TelemetryItem as Envelope } from "../generated";
 import { NetworkStatsbeatMetrics } from "./statsbeat/networkStatsbeatMetrics";
 import { MAX_STATSBEAT_FAILURES } from "./statsbeat/types";
@@ -68,7 +68,7 @@ export abstract class AzureMonitorBaseExporter {
     this._sender = new HttpSender(this._endpointUrl, this._options);
     this._persister = new FileSystemPersist(this._instrumentationKey, this._options);
 
-    if (!this._isStatsbeatExporter) {
+    if (!this._isStatsbeatExporter && !process.env[ENV_DISABLE_STATSBEAT]) {
       // Initialize statsbeatMetrics
       this._networkStatsbeatMetrics = new NetworkStatsbeatMetrics({
         instrumentationKey: this._instrumentationKey,
@@ -92,9 +92,9 @@ export abstract class AzureMonitorBaseExporter {
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
-            code: ExportResultCode.FAILED,
-            error: new Error("Failed to persist envelope in disk."),
-          };
+          code: ExportResultCode.FAILED,
+          error: new Error("Failed to persist envelope in disk."),
+        };
     } catch (ex: any) {
       return { code: ExportResultCode.FAILED, error: ex };
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -373,6 +373,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         process.env[ENV_DISABLE_STATSBEAT] = "true";
         const exporter = new TestExporter();
         assert.ok(!exporter["_networkStatsbeatMetrics"]);
+        assert.ok(!exporter["_longIntervalStatsbeatMetrics"]);
         delete process.env[ENV_DISABLE_STATSBEAT];
       });
     })

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -376,6 +376,6 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         assert.ok(!exporter["_longIntervalStatsbeatMetrics"]);
         delete process.env[ENV_DISABLE_STATSBEAT];
       });
-    })
+    });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { failedBreezeResponse, successfulBreezeResponse } from "../utils/breezeTestUtils";
 import { AzureMonitorBaseExporter } from "../../src/index";
-import { DEFAULT_BREEZE_ENDPOINT } from "../../src/Declarations/Constants";
+import { DEFAULT_BREEZE_ENDPOINT, ENV_DISABLE_STATSBEAT } from "../../src/Declarations/Constants";
 import { TelemetryItem as Envelope } from "../../src/generated";
 import nock from "nock";
 import { NetworkStatsbeatMetrics } from "../../src/export/statsbeat/networkStatsbeatMetrics";
@@ -367,5 +367,14 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         delete process.env.LONG_INTERVAL_EXPORT_MILLIS;
       });
     });
+
+    describe("Disable Statsbeat", () => {
+      it("should disable statsbeat when the environement variable is set", () => {
+        process.env[ENV_DISABLE_STATSBEAT] = "true";
+        const exporter = new TestExporter();
+        assert.ok(!exporter["_networkStatsbeatMetrics"]);
+        delete process.env[ENV_DISABLE_STATSBEAT];
+      });
+    })
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This PR allows statsbeat to be disabled via setting an environment variable.

### Are there test cases added in this PR? _(If not, why?)_
Yes, added the relevant test to determine that statsbeat is disabled when the environment variable is set.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
