### PR TITLE
[Azure Monitor OpenTelemetry Exporter] Add OTel resource metric envelope

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/trace.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/trace.ts
@@ -8,6 +8,7 @@ import { AzureMonitorBaseExporter } from "./base";
 import { AzureMonitorExporterOptions } from "../config";
 import { TelemetryItem as Envelope } from "../generated";
 import { readableSpanToEnvelope, spanEventsToEnvelopes } from "../utils/spanUtils";
+import { createResourceMetricEnvelope } from "../utils/common";
 
 /**
  * Azure Monitor OpenTelemetry Trace Exporter.
@@ -44,15 +45,26 @@ export class AzureMonitorTraceExporter extends AzureMonitorBaseExporter implemen
 
     diag.info(`Exporting ${spans.length} span(s). Converting to envelopes...`);
 
-    let envelopes: Envelope[] = [];
-    spans.forEach((span) => {
-      envelopes.push(readableSpanToEnvelope(span, this._instrumentationKey));
-      let spanEventEnvelopes = spanEventsToEnvelopes(span, this._instrumentationKey);
-      if (spanEventEnvelopes.length > 0) {
-        envelopes.push(...spanEventEnvelopes);
+    if (spans.length > 0) {
+      let envelopes: Envelope[] = [];
+      const resourceMetricEnvelope = createResourceMetricEnvelope(
+        spans[0].resource?.attributes,
+        this._instrumentationKey
+      );
+      if (resourceMetricEnvelope) {
+        envelopes.push(resourceMetricEnvelope);
       }
-    });
-    resultCallback(await this._exportEnvelopes(envelopes));
+      spans.forEach((span) => {
+        envelopes.push(readableSpanToEnvelope(span, this._instrumentationKey));
+        let spanEventEnvelopes = spanEventsToEnvelopes(span, this._instrumentationKey);
+        if (spanEventEnvelopes.length > 0) {
+          envelopes.push(...spanEventEnvelopes);
+        }
+      });
+      resultCallback(await this._exportEnvelopes(envelopes));
+    }
+    // No data to export
+    resultCallback({ code: ExportResultCode.SUCCESS });
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
@@ -102,7 +102,8 @@ export const assertTraceExpectation = (actual: Envelope[], expectations: Expecta
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: could not find exported envelope: ${(expectation.data?.baseData as MonitorDomain).name
+        `assertExpectation: could not find exported envelope: ${
+          (expectation.data?.baseData as MonitorDomain).name
         }`
       );
     }
@@ -151,7 +152,8 @@ export const assertMetricExpectation = (actual: Envelope[], expectations: Expect
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: Envelope ${(expectation.data?.baseData as MetricsData).metrics[0].name
+        `assertExpectation: Envelope ${
+          (expectation.data?.baseData as MetricsData).metrics[0].name
         } found ${envelope.length} times.`
       );
     }
@@ -194,7 +196,8 @@ export const assertLogExpectation = (actual: Envelope[], expectations: Expectati
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: could not find exported envelope: ${(expectation.data?.baseData as any).name
+        `assertExpectation: could not find exported envelope: ${
+          (expectation.data?.baseData as any).name
         }`
       );
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
@@ -9,6 +9,7 @@ import {
   RequestData,
   TelemetryItem as Envelope,
   KnownContextTagKeys,
+  MonitorDomain,
 } from "../../src/generated";
 import { TelemetryItem as EnvelopeMapper } from "../../src/generated/models/mappers";
 
@@ -85,11 +86,12 @@ export const assertCount = (actual: Envelope[], expectations: Expectation[]): vo
 export const assertTraceExpectation = (actual: Envelope[], expectations: Expectation[]): void => {
   for (const expectation of expectations) {
     let envelope: any = null;
-    if (expectation.data!.baseData!.name) {
+
+    if (expectation.data?.baseData?.name) {
       envelope = actual.filter((e) => {
         return (
-          (e.data!.baseData as RequestData).name ===
-          (expectation.data!.baseData as RequestData).name
+          (e.data!.baseData as MonitorDomain).name ===
+          (expectation.data!.baseData as MonitorDomain).name
         );
       });
     } else {
@@ -101,7 +103,7 @@ export const assertTraceExpectation = (actual: Envelope[], expectations: Expecta
       assert.ok(
         false,
         `assertExpectation: could not find exported envelope: ${
-          (expectation.data?.baseData as RequestData).name
+          (expectation.data?.baseData as MonitorDomain).name
         }`
       );
     }
@@ -110,8 +112,10 @@ export const assertTraceExpectation = (actual: Envelope[], expectations: Expecta
       const serializedKey = EnvelopeMapper.type.modelProperties![key]?.serializedName ?? undefined;
       switch (key) {
         case "children":
-          assertTrace(actual, expectation);
-          assertTraceExpectation(actual, expectation.children);
+          if (expectation.children.length > 0) {
+            assertTrace(actual, expectation);
+            //assertTraceExpectation(actual, expectation.children);
+          }
           break;
         case "data":
           if (envelope[0].data) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/utils/assert.ts
@@ -102,8 +102,7 @@ export const assertTraceExpectation = (actual: Envelope[], expectations: Expecta
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: could not find exported envelope: ${
-          (expectation.data?.baseData as MonitorDomain).name
+        `assertExpectation: could not find exported envelope: ${(expectation.data?.baseData as MonitorDomain).name
         }`
       );
     }
@@ -114,7 +113,7 @@ export const assertTraceExpectation = (actual: Envelope[], expectations: Expecta
         case "children":
           if (expectation.children.length > 0) {
             assertTrace(actual, expectation);
-            //assertTraceExpectation(actual, expectation.children);
+            assertTraceExpectation(actual, expectation.children);
           }
           break;
         case "data":
@@ -152,8 +151,7 @@ export const assertMetricExpectation = (actual: Envelope[], expectations: Expect
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: Envelope ${
-          (expectation.data?.baseData as MetricsData).metrics[0].name
+        `assertExpectation: Envelope ${(expectation.data?.baseData as MetricsData).metrics[0].name
         } found ${envelope.length} times.`
       );
     }
@@ -196,8 +194,7 @@ export const assertLogExpectation = (actual: Envelope[], expectations: Expectati
     if (envelope.length !== 1) {
       assert.ok(
         false,
-        `assertExpectation: could not find exported envelope: ${
-          (expectation.data?.baseData as any).name
+        `assertExpectation: could not find exported envelope: ${(expectation.data?.baseData as any).name
         }`
       );
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/utils/basic.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/utils/basic.ts
@@ -41,7 +41,14 @@ export class TraceBasicScenario implements Scenario {
       connectionString: `instrumentationkey=${COMMON_ENVELOPE_PARAMS.instrumentationKey}`,
     });
     this._processor = new FlushSpanProcessor(exporter);
-    const provider = new BasicTracerProvider();
+    const resource = new Resource({
+      "service.name": "testServiceName",
+      "k8s.cluster.name": "testClusterName",
+      "k8s.node.name": "testNodeName",
+      "k8s.namespace.name": "testNamespaceName",
+      "k8s.pod.name": "testPodName",
+    });
+    const provider = new BasicTracerProvider({ resource: resource });
     provider.addSpanProcessor(this._processor);
     provider.register();
   }
@@ -92,6 +99,24 @@ export class TraceBasicScenario implements Scenario {
   }
 
   expectation: Expectation[] = [
+    {
+      ...COMMON_ENVELOPE_PARAMS,
+      name: "_APPRESOURCEPREVIEW_",
+      data: {
+        baseType: "MetricData",
+        baseData: {
+          version: 2,
+          properties: {
+            "service.name": "testServiceName",
+            "k8s.cluster.name": "testClusterName",
+            "k8s.namespace.name": "testNamespaceName",
+            "k8s.node.name": "testNodeName",
+            "k8s.pod.name": "testPodName",
+          },
+        } as any,
+      },
+      children: [],
+    },
     {
       ...COMMON_ENVELOPE_PARAMS,
       name: "Microsoft.ApplicationInsights.Request",


### PR DESCRIPTION
Added envelope sent to Breeze endpoint including OpenTelemetry resource attributes