### PR TITLE
[dev-too] Fix migration error for packages without metadata section

### DIFF
--- a/common/tools/dev-tool/src/commands/migrate.ts
+++ b/common/tools/dev-tool/src/commands/migrate.ts
@@ -81,7 +81,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   // We'll just default the date to Jan 1, 1970 because it's convenient to work with an always-defined date.
   const migrationDate = new Date(
-    project.packageJson[METADATA_KEY].migrationDate ?? "1970-01-01T00:00:00Z"
+    project.packageJson[METADATA_KEY]?.migrationDate ?? "1970-01-01T00:00:00Z"
   );
 
   // Bare command with no sub-mode arguments.
@@ -230,7 +230,7 @@ async function startMigrationPass(project: ProjectInfo, migrationDate: Date): Pr
   }
 
   log.info(`Starting migration pass for '${project.name}'.`);
-  log.info(`Last migration: ${project.packageJson[METADATA_KEY].migrationDate ?? "never"}`);
+  log.info(`Last migration: ${project.packageJson[METADATA_KEY]?.migrationDate ?? "never"}`);
 
   return runMigrations(pending, project);
 }

--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -12,10 +12,9 @@ export const commandInfo = makeCommandInfo(
 
 export default leafCommand(commandInfo, async (options) => {
   const projectInfo = await resolveProject(process.cwd());
-  const defaultMochaArgs =
-    `${
-      projectInfo.packageJson.type === "module" ? "" : "-r esm "
-    } --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace`;
+  const defaultMochaArgs = `${
+    projectInfo.packageJson.type === "module" ? "" : "-r esm "
+  } --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt
   );

--- a/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
+++ b/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
@@ -16,7 +16,7 @@ export default createMigration(
   {
     async isApplicable(ctx) {
       // This migration is only applicable to client packages.
-      return ctx.project.packageJson["sdk-type"] === "client";
+      return ctx.project.packageJson["sdk-type"] === "client" && ctx.project.packageJson["//sampleConfiguration"] !== undefined;
     },
 
     async validate(ctx) {
@@ -36,6 +36,9 @@ export default createMigration(
         [METADATA_KEY]: AzureSdkMetadata;
       };
 
+      if (packageJson[METADATA_KEY]) {
+        packageJson[METADATA_KEY] = {};
+      }
       if (packageJson["//sampleConfiguration"]) {
         packageJson[METADATA_KEY].sampleConfiguration = packageJson["//sampleConfiguration"];
 

--- a/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
+++ b/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
@@ -16,7 +16,10 @@ export default createMigration(
   {
     async isApplicable(ctx) {
       // This migration is only applicable to client packages.
-      return ctx.project.packageJson["sdk-type"] === "client" && ctx.project.packageJson["//sampleConfiguration"] !== undefined;
+      return (
+        ctx.project.packageJson["sdk-type"] === "client" &&
+        ctx.project.packageJson["//sampleConfiguration"] !== undefined
+      );
     },
 
     async validate(ctx) {

--- a/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
+++ b/common/tools/dev-tool/src/migrations/sample-config-to-metadata.ts
@@ -33,10 +33,10 @@ export default createMigration(
 
       const packageJson = JSON.parse((await readFile(packageJsonPath)).toString("utf-8")) as {
         "//sampleConfiguration"?: SampleConfiguration;
-        [METADATA_KEY]: AzureSdkMetadata;
+        [METADATA_KEY]?: AzureSdkMetadata;
       };
 
-      if (packageJson[METADATA_KEY]) {
+      if (!packageJson[METADATA_KEY]) {
         packageJson[METADATA_KEY] = {};
       }
       if (packageJson["//sampleConfiguration"]) {

--- a/common/tools/dev-tool/src/util/migrations.ts
+++ b/common/tools/dev-tool/src/util/migrations.ts
@@ -603,7 +603,7 @@ export async function updateMigrationDate(
     packageJson[METADATA_KEY] = {};
   }
   if (
-    packageJson[METADATA_KEY]?.migrationDate &&
+    packageJson[METADATA_KEY].migrationDate &&
     new Date(packageJson[METADATA_KEY].migrationDate) >= migration.date
   ) {
     panic(`${project.name} is being migrated to an older version than the current version.`);

--- a/common/tools/dev-tool/src/util/migrations.ts
+++ b/common/tools/dev-tool/src/util/migrations.ts
@@ -599,6 +599,9 @@ export async function updateMigrationDate(
   const packageJson = JSON.parse((await readFile(packageJsonPath)).toString("utf-8"));
 
   // Defensively check that the current date in package.json is undefined or older than the new date.
+  if (!packageJson[METADATA_KEY]) {
+    packageJson[METADATA_KEY] = {};
+  }
   if (
     packageJson[METADATA_KEY]?.migrationDate &&
     new Date(packageJson[METADATA_KEY].migrationDate) >= migration.date

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -78,7 +78,7 @@ export interface AzureSdkMetadata {
   /**
    * Paths that contain instances of the package's version number that should be updated automatically.
    */
-  constantPaths: Array<{
+  constantPaths?: Array<{
     /** The path to the containing file. */
     path: string;
     /** A line prefix to match */

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -55,7 +55,7 @@ declare global {
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
 
-    [METADATA_KEY]: AzureSdkMetadata;
+    [METADATA_KEY]?: AzureSdkMetadata;
   }
 }
 


### PR DESCRIPTION
It is possible that package.json (e.g., some core packages) doesn't have metadata yet.  This PR handles the case.

### Packages impacted by this PR
dev-tool

