### PR TITLE
[Test][monitor-query] fix an failing test

### DIFF
--- a/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
+++ b/sdk/monitor/monitor-query/test/public/logsQueryClient.spec.ts
@@ -537,10 +537,11 @@ describe("LogsQueryClient live tests - server timeout", function () {
   // query has timed out on purpose.
   it("serverTimeoutInSeconds", async function (this: Context) {
     try {
+      const randomLimit = Math.round((Math.random() + 1) * 10000000000000);
       await logsClient.queryWorkspace(
         monitorWorkspaceId,
         // slow query suggested by Pavel.
-        "range x from 1 to 10000000000 step 1 | count",
+        `range x from 1 to ${randomLimit} step 1 | count`,
         {
           duration: Durations.twentyFourHours,
         },


### PR DESCRIPTION
This particular test sends a query that is supposed to take a long time and sets a one-second timeout limit, in order to catch the expected Gateway timeout error. However, it looks that the service returns the result pretty quickly most of the time, causing the test to fail.

This PR makes the step limit in the query 1000 magintude larger and randomizes it to avoid getting cached query results.
