### PR TITLE
[core-http] export `isNode` from `@azure/core-util`

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Other Changes
 
-- remove the validation that credential scopes must be a valid URL [Issue #25881](https://github.com/Azure/azure-sdk-for-js/issues/25881)
+- Export `isNode` from `@azure/core-util`.
+- Remove the validation that credential scopes must be a valid URL [Issue #25881](https://github.com/Azure/azure-sdk-for-js/issues/25881)
 
 ## 3.0.1 (2023-04-11)
 

--- a/sdk/core/core-http/src/index.ts
+++ b/sdk/core/core-http/src/index.ts
@@ -108,9 +108,9 @@ export {
   promiseToServiceCallback,
   isValidUuid,
   applyMixins,
-  isNode,
   isDuration,
 } from "./util/utils";
+export { isNode } from "@azure/core-util";
 export { URLBuilder, URLQuery } from "./url";
 export { AbortSignalLike } from "@azure/abort-controller";
 export { delay } from "@azure/core-util";

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -33,7 +33,8 @@ import {
   RequestPolicyOptions,
 } from "./policies/requestPolicy";
 import { SerializerOptions, XML_ATTRKEY, XML_CHARKEY } from "./util/serializer.common";
-import { ServiceCallback, isNode } from "./util/utils";
+import { ServiceCallback } from "./util/utils";
+import { isNode } from "@azure/core-util";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import {
   getDefaultUserAgentHeaderName,

--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -12,15 +12,6 @@ const validUuidRegex =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
 
 /**
- * A constant that indicates whether the environment is node.js or browser based.
- */
-export const isNode =
-  typeof process !== "undefined" &&
-  !!process.version &&
-  !!process.versions &&
-  !!process.versions.node;
-
-/**
  * Checks if a parsed URL is HTTPS
  *
  * @param urlToCheck - The url to check


### PR DESCRIPTION
core-http already depends on core-util. This PR removes core-http's `isNode` and export from core-util instead.

### Packages impacted by this PR
`@azure/core-http`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/26003
