### PR TITLE
Communication Resource | API Version Update

### DIFF
--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -58,7 +58,7 @@
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2019-04-01-preview",
+      "apiVersion": "2022-04-01",
       "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
@@ -82,7 +82,7 @@
     },
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryConnectionString]"
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryConnectionString]"
     },
     "COMMUNICATION_SERVICE_ENDPOINT": {
       "type": "string",
@@ -90,7 +90,7 @@
     },
     "COMMUNICATION_SERVICE_ACCESS_KEY": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2021-10-01-preview').primaryKey]"
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryKey]"
     },
     "RESOURCE_GROUP_NAME": {
       "type": "string",


### PR DESCRIPTION
### Packages impacted by this PR
sdk/communication/*

### Issues associated with this PR
Live test pipelines are failing due to the failure of deployment test resources in INT environment for all the modalities across all the platforms since the Communication Services API version : 2020-08-20-preview is obsolete, which was recently removed from support.

### Describe the problem that is addressed by this PR
* Updating CommunicationServices API version to '2023-03-31' since the previous API version : 2020-08-20-preview is obsolete, and recently removed from support.
* Updating resource type 'roleAssignments' in the namespace 'Microsoft.Authorization' to latest api version : '2022-04-01'.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
