### PR TITLE
[Azure Monitor] Add support for Application Insights log events

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/log.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/log.ts
@@ -42,7 +42,10 @@ export class AzureMonitorLogExporter extends AzureMonitorBaseExporter implements
 
     let envelopes: Envelope[] = [];
     logs.forEach((log) => {
-      envelopes.push(logToEnvelope(log, this._instrumentationKey));
+      let envelope = logToEnvelope(log, this._instrumentationKey);
+      if (envelope) {
+        envelopes.push(envelope);
+      }
     });
     resultCallback(await this._exportEnvelopes(envelopes));
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -31,3 +31,16 @@ export enum DependencyTypes {
 }
 
 export const AzureMonitorSampleRate = "_MS.sampleRate";
+export const ApplicationInsightsBaseType = "_MS.baseType";
+
+export const ApplicationInsightsMessageName = "Microsoft.ApplicationInsights.Message";
+export const ApplicationInsightsExceptionName = "Microsoft.ApplicationInsights.Exception";
+export const ApplicationInsightsPageViewName = "Microsoft.ApplicationInsights.PageView";
+export const ApplicationInsightsAvailabilityName = "Microsoft.ApplicationInsights.Availability";
+export const ApplicationInsightsEventName = "Microsoft.ApplicationInsights.Event";
+
+export const ApplicationInsightsMessageBaseType = "MessageData";
+export const ApplicationInsightsExceptionBaseType = "TelemetryExceptionData";
+export const ApplicationInsightsPageViewBaseType = "PageViewData";
+export const ApplicationInsightsAvailabilityBaseType = "AvailabilityData";
+export const ApplicationInsightsEventBaseType = "TelemetryEventData";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -2,10 +2,14 @@
 // Licensed under the MIT license.
 
 import {
+  AvailabilityData,
   TelemetryItem as Envelope,
   KnownContextTagKeys,
   KnownSeverityLevel,
   MessageData,
+  MonitorDomain,
+  PageViewData,
+  TelemetryEventData,
   TelemetryExceptionData,
   TelemetryExceptionDetails,
 } from "../generated";
@@ -14,48 +18,74 @@ import { ReadableLogRecord } from "@opentelemetry/sdk-logs";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 import { Measurements, Properties, Tags } from "../types";
 import { hrTimeToMilliseconds } from "@opentelemetry/core";
+import { diag } from "@opentelemetry/api";
+import {
+  ApplicationInsightsAvailabilityBaseType,
+  ApplicationInsightsAvailabilityName,
+  ApplicationInsightsBaseType,
+  ApplicationInsightsEventBaseType,
+  ApplicationInsightsEventName,
+  ApplicationInsightsExceptionBaseType,
+  ApplicationInsightsExceptionName,
+  ApplicationInsightsMessageBaseType,
+  ApplicationInsightsMessageName,
+  ApplicationInsightsPageViewBaseType,
+  ApplicationInsightsPageViewName,
+} from "./constants/applicationinsights";
 
 /**
  * Log to Azure envelope parsing.
  * @internal
  */
-export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope {
+export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | undefined {
   const time = log.hrTime ? new Date(hrTimeToMilliseconds(log.hrTime)) : new Date();
   let sampleRate = 100;
   const instrumentationKey = ikey;
   const tags = createTagsFromLog(log);
   const [properties, measurements] = createPropertiesFromLog(log);
   let name: string;
-  let baseType: "MessageData" | "TelemetryExceptionData";
-  let baseData: MessageData | TelemetryExceptionData;
-  // Get Exception attributes if available
-  let exceptionType = log.attributes[SemanticAttributes.EXCEPTION_TYPE];
-  if (exceptionType) {
-    let exceptionMessage = log.attributes[SemanticAttributes.EXCEPTION_MESSAGE];
-    let exceptionStacktrace = log.attributes[SemanticAttributes.EXCEPTION_STACKTRACE];
-    name = "Microsoft.ApplicationInsights.Exception";
-    baseType = "TelemetryExceptionData";
-    let exceptionDetails: TelemetryExceptionDetails = {
-      typeName: String(exceptionType),
-      message: String(exceptionMessage),
-      hasFullStack: exceptionStacktrace ? true : false,
-      stack: String(exceptionStacktrace),
-    };
-    const exceptionData: TelemetryExceptionData = {
-      exceptions: [exceptionDetails],
-      severityLevel: String(getSeverity(log.severityNumber)),
-      version: 2,
-    };
-    baseData = exceptionData;
+  let baseType: string;
+  let baseData: MonitorDomain;
+
+  if (!log.attributes[ApplicationInsightsBaseType]) {
+    // Get Exception attributes if available
+    let exceptionType = log.attributes[SemanticAttributes.EXCEPTION_TYPE];
+    if (exceptionType) {
+      let exceptionMessage = log.attributes[SemanticAttributes.EXCEPTION_MESSAGE];
+      let exceptionStacktrace = log.attributes[SemanticAttributes.EXCEPTION_STACKTRACE];
+      name = ApplicationInsightsExceptionName;
+      baseType = ApplicationInsightsExceptionBaseType;
+      let exceptionDetails: TelemetryExceptionDetails = {
+        typeName: String(exceptionType),
+        message: String(exceptionMessage),
+        hasFullStack: exceptionStacktrace ? true : false,
+        stack: String(exceptionStacktrace),
+      };
+      const exceptionData: TelemetryExceptionData = {
+        exceptions: [exceptionDetails],
+        severityLevel: String(getSeverity(log.severityNumber)),
+        version: 2,
+      };
+      baseData = exceptionData;
+    } else {
+      name = ApplicationInsightsMessageName;
+      baseType = ApplicationInsightsMessageBaseType;
+      const messageData: MessageData = {
+        message: String(log.body),
+        severityLevel: String(getSeverity(log.severityNumber)),
+        version: 2,
+      };
+      baseData = messageData;
+    }
   } else {
-    name = "Microsoft.ApplicationInsights.Message";
-    baseType = "MessageData";
-    const messageData: MessageData = {
-      message: String(log.body),
-      severityLevel: String(getSeverity(log.severityNumber)),
-      version: 2,
-    };
-    baseData = messageData;
+    // If Legacy Application Insights Log
+    baseType = String(log.attributes[ApplicationInsightsBaseType]);
+    name = getLegacyApplicationInsightsName(log);
+    baseData = getLegacyApplicationInsightsBaseData(log);
+    if (!baseData) {
+      // Failed to parse log
+      return;
+    }
   }
   return {
     name,
@@ -123,4 +153,56 @@ function getSeverity(severityNumber: number | undefined): KnownSeverityLevel | u
     }
   }
   return;
+}
+
+function getLegacyApplicationInsightsName(log: ReadableLogRecord): string {
+  let name = "";
+  switch (log.attributes[ApplicationInsightsBaseType]) {
+    case ApplicationInsightsAvailabilityBaseType:
+      name = ApplicationInsightsAvailabilityName;
+      break;
+    case ApplicationInsightsExceptionBaseType:
+      name = ApplicationInsightsExceptionName;
+      break;
+    case ApplicationInsightsMessageBaseType:
+      name = ApplicationInsightsMessageName;
+      break;
+    case ApplicationInsightsPageViewBaseType:
+      name = ApplicationInsightsPageViewName;
+      break;
+    case ApplicationInsightsEventBaseType:
+      name = ApplicationInsightsEventName;
+      break;
+  }
+  return name;
+}
+
+function getLegacyApplicationInsightsBaseData(log: ReadableLogRecord): MonitorDomain {
+  let baseData: MonitorDomain = {
+    version: 2,
+  };
+  if (log.body) {
+    try {
+      switch (log.attributes[ApplicationInsightsBaseType]) {
+        case ApplicationInsightsAvailabilityBaseType:
+          baseData = JSON.parse(log.body) as AvailabilityData;
+          break;
+        case ApplicationInsightsExceptionBaseType:
+          baseData = JSON.parse(log.body) as TelemetryExceptionData;
+          break;
+        case ApplicationInsightsMessageBaseType:
+          baseData = JSON.parse(log.body) as MessageData;
+          break;
+        case ApplicationInsightsPageViewBaseType:
+          baseData = JSON.parse(log.body) as PageViewData;
+          break;
+        case ApplicationInsightsEventBaseType:
+          baseData = JSON.parse(log.body) as TelemetryEventData;
+          break;
+      }
+    } catch (err) {
+      diag.error("AzureMonitorLogExporter failed to parse Application Insights Telemetry");
+    }
+  }
+  return baseData;
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
@@ -209,8 +209,8 @@ describe("logUtils.ts", () => {
           {
             message: "detailMessage",
             hasFullStack: false,
-            typeName: "testType"
-          }
+            typeName: "testType",
+          },
         ],
         version: 2,
       };
@@ -236,8 +236,8 @@ describe("logUtils.ts", () => {
           {
             message: "detailMessage",
             hasFullStack: false,
-            typeName: "testType"
-          }
+            typeName: "testType",
+          },
         ],
         version: 2,
         properties: expectedProperties,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Added support for Application Insights events PageView, Availability, Event, Exception and Message