### PR TITLE
[keyvault] CryptographyClient: fall back to remote operations if missing get permission

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where cryptographic operations would fail if the client did not have the get permission on the key, even if it had permission for the underlying operation. Issue [#26001](https://github.com/Azure/azure-sdk-for-js/issues/26001); PR [#26016](https://github.com/Azure/azure-sdk-for-js/issues/26016)
+
 ### Other Changes
 
 ## 4.7.0 (2023-03-09)

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 4.7.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.7.1 (2023-06-06)
 
 ### Bugs Fixed
 
 - Fixed an issue where cryptographic operations would fail if the client did not have the get permission on the key, even if it had permission for the underlying operation. Issue [#26001](https://github.com/Azure/azure-sdk-for-js/issues/26001); PR [#26016](https://github.com/Azure/azure-sdk-for-js/issues/26016)
-
-### Other Changes
 
 ## 4.7.0 (2023-03-09)
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -559,7 +559,7 @@ export class CryptographyClient {
       case "KeyVaultKey":
         return key.value.key!;
       default:
-        return;
+        return undefined;
     }
   }
 

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -39,6 +39,8 @@ import { CryptographyProvider, CryptographyProviderOperation } from "./cryptogra
 import { RsaCryptographyProvider } from "./cryptography/rsaCryptographyProvider";
 import { AesCryptographyProvider } from "./cryptography/aesCryptographyProvider";
 import { tracingClient } from "./tracing";
+import { isRestError } from "@azure/core-rest-pipeline";
+import { logger } from "./log";
 
 /**
  * A client used to perform cryptographic operations on an Azure Key vault key
@@ -142,7 +144,7 @@ export class CryptographyClient {
    * The ID of the key used to perform cryptographic operations for the client.
    */
   get keyID(): string | undefined {
-    if (this.key.kind === "identifier") {
+    if (this.key.kind === "identifier" || this.key.kind === "remoteOnlyIdentifier") {
       return this.key.value;
     } else if (this.key.kind === "KeyVaultKey") {
       return this.key.value.id;
@@ -540,7 +542,7 @@ export class CryptographyClient {
   }
 
   /**
-   * Retrieves the {@link JsonWebKey} from the Key Vault.
+   * Retrieves the {@link JsonWebKey} from the Key Vault, if possible. Returns undefined if the key could not be retrieved due to insufficient permissions.
    *
    * Example usage:
    * ```ts
@@ -548,7 +550,7 @@ export class CryptographyClient {
    * let result = await client.getKeyMaterial();
    * ```
    */
-  private async getKeyMaterial(options: GetKeyOptions): Promise<JsonWebKey> {
+  private async getKeyMaterial(options: GetKeyOptions): Promise<JsonWebKey | undefined> {
     const key = await this.fetchKey(options);
 
     switch (key.kind) {
@@ -557,21 +559,39 @@ export class CryptographyClient {
       case "KeyVaultKey":
         return key.value.key!;
       default:
-        throw new Error("Failed to exchange Key ID for an actual KeyVault Key.");
+        return;
     }
   }
 
   /**
    * Returns the underlying key used for cryptographic operations.
-   * If needed, fetches the key from KeyVault and exchanges the ID for the actual key.
+   * If needed, attempts to fetch the key from KeyVault and exchanges the ID for the actual key.
    * @param options - The additional options.
    */
   private async fetchKey<T extends OperationOptions>(options: T): Promise<CryptographyClientKey> {
     if (this.key.kind === "identifier") {
       // Exchange the identifier with the actual key when needed
-      const key = await this.remoteProvider!.getKey(options);
-      this.key = { kind: "KeyVaultKey", value: key };
+      let key: KeyVaultKey | undefined;
+      try {
+        key = await this.remoteProvider!.getKey(options);
+      } catch (e: unknown) {
+        if (isRestError(e) && e.statusCode === 403) {
+          // If we don't have permission to get the key, we'll fall back to using the remote provider.
+          // Marking the key as a remoteOnlyIdentifier will ensure that we don't attempt to fetch the key again.
+          logger.verbose(
+            `Permission denied to get key ${this.key.value}. Falling back to remote operation.`
+          );
+          this.key = { kind: "remoteOnlyIdentifier", value: this.key.value };
+        } else {
+          throw e;
+        }
+      }
+
+      if (key) {
+        this.key = { kind: "KeyVaultKey", value: key };
+      }
     }
+
     return this.key;
   }
 
@@ -590,11 +610,15 @@ export class CryptographyClient {
   ): Promise<CryptographyProvider> {
     if (!this.providers) {
       const keyMaterial = await this.getKeyMaterial(options);
+      this.providers = [];
+
       // Add local crypto providers as needed
-      this.providers = [
-        new RsaCryptographyProvider(keyMaterial),
-        new AesCryptographyProvider(keyMaterial),
-      ];
+      if (keyMaterial) {
+        this.providers.push(
+          new RsaCryptographyProvider(keyMaterial),
+          new AesCryptographyProvider(keyMaterial)
+        );
+      }
 
       // If the remote provider exists, we're in hybrid-mode. Otherwise we're in local-only mode.
       // If we're in hybrid mode the remote provider is used as a catch-all and should be last in the list.

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -372,11 +372,16 @@ export type DecryptParameters =
  * The key may be an identifier (URL) to a KeyVault key, the actual KeyVault key,
  * or a local-only JsonWebKey.
  *
- * If an identifier is used, it will be exchanged for a {@link KeyVaultKey} during the first operation call.
+ * If an identifier is used, an attempt will be made to exchange it for a {@link KeyVaultKey} during the first operation call. If this attempt fails, the identifier \
+ * will become a remote-only identifier and the {@link CryptographyClient} will only be able to perform remote operations.
  */
 export type CryptographyClientKey =
   | {
       kind: "identifier";
+      value: string;
+    }
+  | {
+      kind: "remoteOnlyIdentifier";
       value: string;
     }
   | {

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -372,7 +372,7 @@ export type DecryptParameters =
  * The key may be an identifier (URL) to a KeyVault key, the actual KeyVault key,
  * or a local-only JsonWebKey.
  *
- * If an identifier is used, an attempt will be made to exchange it for a {@link KeyVaultKey} during the first operation call. If this attempt fails, the identifier \
+ * If an identifier is used, an attempt will be made to exchange it for a {@link KeyVaultKey} during the first operation call. If this attempt fails, the identifier
  * will become a remote-only identifier and the {@link CryptographyClient} will only be able to perform remote operations.
  */
 export type CryptographyClientKey =

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -19,6 +19,12 @@ import { JsonWebKey } from "../../src";
 import { stringToUint8Array } from "../public/utils/crypto";
 import { CryptographyProvider } from "../../src/cryptography/models";
 import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
+import { NoOpCredential } from "@azure-tools/test-credential";
+import {
+  RestError,
+  SendRequest,
+  createHttpHeaders,
+} from "@azure/core-rest-pipeline";
 
 describe("internal crypto tests", () => {
   const tokenCredential: TokenCredential = {
@@ -307,6 +313,42 @@ describe("internal crypto tests", () => {
         // Setup the crypto client with our stubs
         cryptoClient["providers"] = [localProvider, remoteProvider];
         cryptoClient["remoteProvider"] = remoteProvider;
+      });
+
+      describe("when creating the client with an identifier", function () {
+        it.only("falls back to the remote provider when the key cannot be fetched due to permissions", async function () {
+          const sendSignRequest: SendRequest = (request) =>
+            Promise.resolve({
+              status: 200,
+              headers: createHttpHeaders(),
+              request: request,
+              bodyAsText: JSON.stringify({
+                key: {
+                  kid: `https://my_keyvault.vault.azure.net/keys/keyName/id`,
+                  value: "signature",
+                },
+              }),
+            });
+
+          const sendRequest = sinon
+            .stub()
+            .onFirstCall()
+            .returns(Promise.reject(new RestError("Forbidden", { statusCode: 403 })))
+            .onSecondCall()
+            .callsFake(sendSignRequest);
+
+          const idCryptoClient = new CryptographyClient(
+            "https://myvault.vault.azure.net/keys/keyName/id",
+            new NoOpCredential(),
+            {
+              httpClient: {
+                sendRequest,
+              },
+            }
+          );
+
+          await idCryptoClient.signData("RS256", Buffer.from("test"));
+        });
       });
 
       describe("when a local provider errors", function () {

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -20,11 +20,7 @@ import { stringToUint8Array } from "../public/utils/crypto";
 import { CryptographyProvider } from "../../src/cryptography/models";
 import { RemoteCryptographyProvider } from "../../src/cryptography/remoteCryptographyProvider";
 import { NoOpCredential } from "@azure-tools/test-credential";
-import {
-  RestError,
-  SendRequest,
-  createHttpHeaders,
-} from "@azure/core-rest-pipeline";
+import { RestError, SendRequest, createHttpHeaders } from "@azure/core-rest-pipeline";
 
 describe("internal crypto tests", () => {
   const tokenCredential: TokenCredential = {

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -343,7 +343,7 @@ describe("internal crypto tests", () => {
             }
           );
 
-          await idCryptoClient.signData("RS256", new Uint8Array([1, 2, 3]));
+          await idCryptoClient.sign("RS256", new Uint8Array([1, 2, 3]));
         });
       });
 

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -316,7 +316,7 @@ describe("internal crypto tests", () => {
       });
 
       describe("when creating the client with an identifier", function () {
-        it.only("falls back to the remote provider when the key cannot be fetched due to permissions", async function () {
+        it("falls back to the remote provider when the key cannot be fetched due to permissions", async function () {
           const sendSignRequest: SendRequest = (request) =>
             Promise.resolve({
               status: 200,

--- a/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/crypto.spec.ts
@@ -343,7 +343,7 @@ describe("internal crypto tests", () => {
             }
           );
 
-          await idCryptoClient.signData("RS256", Buffer.from("test"));
+          await idCryptoClient.signData("RS256", new Uint8Array([1, 2, 3]));
         });
       });
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-keys`

### Issues associated with this PR

- Fixes #26001

### Describe the problem that is addressed by this PR

Local cryptography relies on having permission to get a key from the Key Vault in order to perform the operation. But it is possible, using a Key Vault access policy, for the get permission to not be granted even if other operations are permitted (e.g. sign, verify, encrypt, decrypt...). This scenario doesn't work at the moment because we assume that the get permission is always present, and don't handle the 403 if we can't get the key.

This PR fixes the issue by handling the error and falling back to remote-only operations if the get permission isn't granted.