### PR TITLE
[@azure/openai] fixed openAI credentials

### DIFF
--- a/sdk/openai/openai/src/rest/openAIClient.ts
+++ b/sdk/openai/openai/src/rest/openAIClient.ts
@@ -21,11 +21,11 @@ export default function createClient(
   const baseUrl = options.baseUrl ?? `${endpoint}/openai`;
   options.apiVersion = options.apiVersion ?? "2023-03-15-preview";
   options = {
-    ...options,
     credentials: {
       scopes: ["https://cognitiveservices.azure.com/.default"],
       apiKeyHeaderName: "api-key",
     },
+    ...options,
   };
 
   const userAgentInfo = `azsdk-js-openai-rest/1.0.0-beta.2`;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/26021

### Describe the problem that is addressed by this PR
It's evident that when we use an OpenAI key
https://github.com/Azure/azure-sdk-for-js/blob/ad7b405ee43d76778f3f65ffd40f898d6481ee7e/sdk/openai/openai/src/OpenAIClient.ts#L113-L119

We set the credentials to use `apiKeyHeaderName: "Authorization"`, however when you create the client it completely overrides the options. This leads to the following error from openAI's API:
```
error: {
    message: "You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.",
    type: 'invalid_request_error',
    param: null,
    code: null
  }
```

