### PR TITLE
[Event Hubs] Prefetch events

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Use Rhea's prefetch window to prefetch events from the service. This improves the performance of the receiver by reducing the number of round trips to the service. The default prefetch window is 3 * `maxBatchSize` events. This can be configured by setting the `prefetchCount` option on the `EventHubConsumerClient` constructor.
+
 ## 5.10.0 (2023-05-01)
 
 ### Bugs Fixed

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 5.10.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.11.0 (2023-06-06)
 
 ### Other Changes
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Use Rhea's prefetch window to prefetch events from the service. This improves the performance of the receiver by reducing the number of round trips to the service. The default prefetch window is 3 * `maxBatchSize` events. This can be configured by setting the `prefetchCount` option on the `EventHubConsumerClient` constructor.
+- Use Rhea's prefetch window to prefetch events from the service. This improves the performance of the receiver by reducing the number of round trips to the service. The default prefetch window is 3 * `maxBatchSize` events. This can be configured by setting the `prefetchCount` option on the `subscribe` method on `EventHubConsumerClient`.
 
 ## 5.10.0 (2023-05-01)
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.10.1",
+  "version": "5.11.0",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -346,6 +346,7 @@ export interface SubscribeOptions {
     maxBatchSize?: number;
     maxWaitTimeInSeconds?: number;
     ownerLevel?: number;
+    prefetchCount?: number;
     skipParsingBodyAsJson?: boolean;
     startPosition?: EventPosition | {
         [partitionId: string]: EventPosition;

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -204,6 +204,10 @@ export interface SubscribeOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * The count of events requested eagerly and queued without regard to whether a read was requested.
+   */
+  prefetchCount?: number;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -128,7 +128,7 @@ export interface EventHubConsumerOptions {
   /**
    * The count of events requested eagerly and queued without regard to whether a read was requested.
    */
-  PrefetchCount?: number;
+  prefetchCount?: number;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -125,6 +125,10 @@ export interface EventHubConsumerOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * The count of events requested eagerly and queued without regard to whether a read was requested.
+   */
+  PrefetchCount?: number;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -91,6 +91,7 @@ export class PartitionPump {
         trackLastEnqueuedEventProperties: this._processorOptions.trackLastEnqueuedEventProperties,
         retryOptions: this._processorOptions.retryOptions,
         skipParsingBodyAsJson: this._processorOptions.skipParsingBodyAsJson,
+        PrefetchCount: this._processorOptions.prefetchCount,
       }
     );
 

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -91,7 +91,7 @@ export class PartitionPump {
         trackLastEnqueuedEventProperties: this._processorOptions.trackLastEnqueuedEventProperties,
         retryOptions: this._processorOptions.retryOptions,
         skipParsingBodyAsJson: this._processorOptions.skipParsingBodyAsJson,
-        PrefetchCount: this._processorOptions.prefetchCount,
+        prefetchCount: this._processorOptions.prefetchCount,
       }
     );
 

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -221,7 +221,7 @@ export function createReceiver(
                 .connect({
                   abortSignal,
                   timeoutInMs: getRetryAttemptTimeoutInMs(options.retryOptions),
-                  prefetchCount: options.PrefetchCount ?? maxMessageCount * 3,
+                  prefetchCount: options.prefetchCount ?? maxMessageCount * 3,
                 })
                 .then(() => {
                   logger.verbose(`setting the wait timer for ${maxWaitTimeInSeconds} seconds`);

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -213,9 +213,7 @@ export function createReceiver(
           cleanupBeforeAbort();
           return Promise.reject(new AbortError(StandardAbortMessage));
         }
-        return obj.isClosed || ctx.wasConnectionCloseCalled
-          ? Promise.resolve(queue.splice(0))
-          : eventsToRetrieveCount === 0
+        return obj.isClosed || ctx.wasConnectionCloseCalled || eventsToRetrieveCount === 0
           ? Promise.resolve(queue.splice(0, maxMessageCount))
           : new Promise<void>((resolve, reject) => {
               obj._onError = reject;
@@ -226,12 +224,8 @@ export function createReceiver(
                   prefetchCount: options.PrefetchCount ?? maxMessageCount * 3,
                 })
                 .then(() => {
-                  return logger.verbose(
-                    `setting the wait timer for ${maxWaitTimeInSeconds} seconds`
-                  );
-                })
-                .then(() =>
-                  waitForEvents(
+                  logger.verbose(`setting the wait timer for ${maxWaitTimeInSeconds} seconds`);
+                  return waitForEvents(
                     maxMessageCount,
                     maxWaitTimeInSeconds * 1000,
                     qReadIntervalInMs,
@@ -253,8 +247,8 @@ export function createReceiver(
                           `no messages received when max wait time in seconds ${maxWaitTimeInSeconds} is over`
                         ),
                     }
-                  )
-                )
+                  );
+                })
                 .catch(reject)
                 .then(resolve);
             })

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.10.1",
+  version: "5.11.0",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -97,7 +97,7 @@ testWithServiceTypes((serviceVersion) => {
         it(`initialize supports cancellation (${caseType})`, async () => {
           const abortSignal = getSignal();
           try {
-            await client.connect({ abortSignal, timeoutInMs: 60000 });
+            await client.connect({ abortSignal, timeoutInMs: 60000, prefetchCount: 1 });
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
@@ -118,7 +118,7 @@ testWithServiceTypes((serviceVersion) => {
 
         it(`receiveBatch supports cancellation when connection already exists (${caseType})`, async () => {
           // Open the connection.
-          await client.connect({ abortSignal: undefined, timeoutInMs: 60000 });
+          await client.connect({ abortSignal: undefined, timeoutInMs: 60000, prefetchCount: 1 });
           try {
             const abortSignal = getSignal();
             await client.receiveBatch(10, undefined, abortSignal);

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -123,10 +123,12 @@ testWithServiceTypes((serviceVersion) => {
           await receiver1.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
+            prefetchCount: 1,
           });
           await receiver2.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
+            prefetchCount: 1,
           });
 
           // We are going to override sender1's close method so that it also invokes receiver2's close method.
@@ -183,10 +185,12 @@ testWithServiceTypes((serviceVersion) => {
           await receiver1.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
+            prefetchCount: 1,
           });
           await receiver2.connect({
             abortSignal: undefined,
             timeoutInMs: 60000,
+            prefetchCount: 1,
           });
 
           // We are going to override sender1's close method so that it also invokes receiver2's close method.


### PR DESCRIPTION
Updates the partition receiver to use Rhea's prefetch window instead of manually fetching the exact number of events needed. It also adds a `subscribe` option, `prefetchCount`, that controls the max number of events to prefetch.

Live run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2814550&view=results

Related issue: https://github.com/Azure/azure-sdk-for-js/issues/26055