### PR TITLE
[dev-tool] await onMigrationSkipped

### DIFF
--- a/common/tools/dev-tool/src/commands/migrate.ts
+++ b/common/tools/dev-tool/src/commands/migrate.ts
@@ -263,7 +263,7 @@ async function runMigrations(pending: Migration[], project: ProjectInfo): Promis
         return false;
       }
       case "skipped": {
-        onMigrationSkipped(project, migration);
+        await onMigrationSkipped(project, migration);
         continue;
       }
       default:


### PR DESCRIPTION
otherwise the ongoing git commit could cause subsequent migration to fail when another git operation is invoked

### Packages impacted by this PR
dev-tool
