### PR TITLE
[EventHubs] fix browser sample

### DIFF
--- a/sdk/eventhub/event-hubs/samples/v5/browser/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/package.json
@@ -32,10 +32,8 @@
   "dependencies": {
     "@azure/event-hubs": "^5.0.0",
     "@azure/identity": "^2.0.1",
-    "buffer": "^6.0.3",
     "os-browserify": "^0.3.0",
-    "path-browserify": "^1.0.1",
-    "process": "^0.11.10"
+    "path-browserify": "^1.0.1"
   },
   "devDependencies": {
     "http-server": "^0.12.1",

--- a/sdk/eventhub/event-hubs/samples/v5/browser/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/package.json
@@ -7,7 +7,9 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "build": "webpack-cli ./src/index.js -o ./dist/app.js",
+    "clean": "rimraf dist/",
+    "build-dev": "webpack --mode development",
+    "build": "webpack --mode production",
     "start": "http-server ./"
   },
   "repository": {
@@ -29,12 +31,16 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/event-hubs": "^5.0.0",
-    "@azure/identity": "^2.0.1"
+    "@azure/identity": "^2.0.1",
+    "buffer": "^6.0.3",
+    "os-browserify": "^0.3.0",
+    "path-browserify": "^1.0.1",
+    "process": "^0.11.10"
   },
   "devDependencies": {
     "http-server": "^0.12.1",
     "rimraf": "^3.0.0",
-    "webpack": "^4.41.5",
-    "webpack-cli": "^3.3.10"
+    "webpack": "^5.85.0",
+    "webpack-cli": "^5.1.1"
   }
 }

--- a/sdk/eventhub/event-hubs/samples/v5/browser/webpack.config.js
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require("webpack");
+const path = require("path");
+
+const config = {
+  entry: "./src/index.js",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "app.js",
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      process: "process/browser",
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
+    }),
+  ],
+  resolve: {
+    extensions: [".ts", ".js"],
+    fallback: {
+      buffer: require.resolve("buffer/"),
+      os: require.resolve("os-browserify"),
+      path: require.resolve("path-browserify"),
+    },
+  },
+};
+
+module.exports = config;


### PR DESCRIPTION
The old version of `buffer` that webpack bundled has a bug causing sample to fail.

https://github.com/feross/buffer/issues/237

This PR upgrades webpack to v5 and adds required polyfills as in v5 they are no longer built-in.
