### PR TITLE
[recorder] Improve error messages

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Other Changes
 
+- Improved some error messages: [#26094](https://github.com/Azure/azure-sdk-for-js/pull/26094)
+  - Clarify error when attempting to redirect a request but the recorder has not been started
+  - Forward mismatch error when recording file cannot be found during `start` call in playback mode
+  - Add more descriptive message in the case that the test proxy has not been started before running the tests
+
 ## 3.0.0 (2023-03-07)
 
 ### Features Added

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -101,7 +101,9 @@ export class Recorder {
           "[Recorder#redirectRequest] Could not redirect request since the recorder was not started",
           request
         );
-        throw new RecorderError("Attempted to redirect a request, but the recorder was not started. Make sure to call Recorder#start before making any requests.");
+        throw new RecorderError(
+          "Attempted to redirect a request, but the recorder was not started. Make sure to call Recorder#start before making any requests."
+        );
       }
 
       logger.info(
@@ -234,9 +236,11 @@ export class Recorder {
         logger.verbose("[Recorder#start] Setting redirect mode");
         try {
           await setRecordingOptions(Recorder.url, this.httpClient, { handleRedirects: !isNode });
-        } catch(e) {
-          if(isRestError(e) && e.message.includes("ECONNREFUSED")) {
-            throw new RecorderError(`Test proxy appears to not be running at ${Recorder.url}. Make sure that you are running your tests using the dev-tool scripts.`)
+        } catch (e) {
+          if (isRestError(e) && e.message.includes("ECONNREFUSED")) {
+            throw new RecorderError(
+              `Test proxy appears to not be running at ${Recorder.url}. Make sure that you are running your tests using the dev-tool scripts.`
+            );
           } else {
             throw e;
           }
@@ -279,7 +283,7 @@ export class Recorder {
         if (rsp.status !== 200) {
           logger.error("[Recorder#start] Could not start the recorder", rsp);
           const mismatchHeader = rsp.headers.get("x-request-mismatch-error");
-          if(mismatchHeader) {
+          if (mismatchHeader) {
             throw new RecorderError(decodeBase64(mismatchHeader));
           } else {
             throw new RecorderError("Start request failed.");

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -4,6 +4,7 @@
 import {
   createDefaultHttpClient,
   HttpClient,
+  isRestError,
   PipelinePolicy,
   PipelineRequest,
   PipelineResponse,
@@ -97,10 +98,10 @@ export class Recorder {
     } else {
       if (this.recordingId === undefined) {
         logger.error(
-          "[Recorder#redirectRequest] Could not redirect request (recording ID not set)",
+          "[Recorder#redirectRequest] Could not redirect request since the recorder was not started",
           request
         );
-        throw new RecorderError("Recording ID must be defined to redirect a request");
+        throw new RecorderError("Attempted to redirect a request, but the recorder was not started. Make sure to call Recorder#start before making any requests.");
       }
 
       logger.info(
@@ -231,7 +232,16 @@ export class Recorder {
 
       if (ensureExistence(this.httpClient, "TestProxyHttpClient.httpClient")) {
         logger.verbose("[Recorder#start] Setting redirect mode");
-        await setRecordingOptions(Recorder.url, this.httpClient, { handleRedirects: !isNode });
+        try {
+          await setRecordingOptions(Recorder.url, this.httpClient, { handleRedirects: !isNode });
+        } catch(e) {
+          if(isRestError(e) && e.message.includes("ECONNREFUSED")) {
+            throw new RecorderError(`Test proxy appears to not be running at ${Recorder.url}. Make sure that you are running your tests using the dev-tool scripts.`)
+          } else {
+            throw e;
+          }
+        }
+
         logger.verbose("[Recorder#start] Sending the start request to the test proxy");
         let rsp = await this.httpClient.sendRequest({
           ...req,
@@ -268,7 +278,12 @@ export class Recorder {
 
         if (rsp.status !== 200) {
           logger.error("[Recorder#start] Could not start the recorder", rsp);
-          throw new RecorderError("Start request failed.");
+          const mismatchHeader = rsp.headers.get("x-request-mismatch-error");
+          if(mismatchHeader) {
+            throw new RecorderError(decodeBase64(mismatchHeader));
+          } else {
+            throw new RecorderError("Start request failed.");
+          }
         }
         const id = rsp.headers.get("x-recording-id");
         if (!id) {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Issues associated with this PR

- Fixes #25946

### Describe the problem that is addressed by this PR

Add some more user-friendly error messages based on recent feedback:
- Clarify error when attempting to redirect a request but the recorder has not been started
- Forward mismatch error when recording file cannot be found during `start` call in playback mode
- Add more descriptive message in the case that the test proxy has not been started before running the tests