### PR TITLE
[Docs][EH,SB] update README to not install buffer and process for browsers

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -65,7 +65,7 @@ In addition to what is described there, this library also needs additional polyf
 
 If you are using Webpack v5, you can install the following dev dependencies
 
-- `npm install --save-dev buffer os-browserify path-browserify process`
+- `npm install --save-dev os-browserify path-browserify`
 
 then add the following into your webpack.config.js
 
@@ -101,7 +101,7 @@ then add the following into your webpack.config.js
 
 If you are using Rollup bundler, install the following dev dependencies
 
-- `npm install --save-dev buffer process @rollup/plugin-commonjs @rollup/plugin-inject @rollup/plugin-node-resolve`
+- `npm install --save-dev @rollup/plugin-commonjs @rollup/plugin-inject @rollup/plugin-node-resolve`
 
 Then include the following in your rollup.config.js
 

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -63,7 +63,7 @@ In addition to what is described there, this library also needs additional polyf
 
 If you are using Webpack v5, you can install the following dev dependencies
 
-- `npm install --save-dev buffer os-browserify path-browserify process`
+- `npm install --save-dev os-browserify path-browserify`
 
 then add the following into your webpack.config.js
 
@@ -99,7 +99,7 @@ then add the following into your webpack.config.js
 
 If you are using Rollup bundler, install the following dev dependencies
 
-- `npm install --save-dev buffer process @rollup/plugin-commonjs @rollup/plugin-inject @rollup/plugin-node-resolve`
+- `npm install --save-dev @rollup/plugin-commonjs @rollup/plugin-inject @rollup/plugin-node-resolve`
 
 Then include the following in your rollup.config.js
 


### PR DESCRIPTION
As they are dependencies of the libraries and will be installed when installing EH or SB packages.
