### PR TITLE
[Event Hubs] Support user-provided client identifier

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features Added
 
-- Adds an option to set the Event Hubs consumer identifier.
+- Adds an option to set an identifier for Event Hubs clients.
+- Adds a property on each Event Hub client that returns the identifier of the client.
 
 ### Other Changes
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 5.11.0 (2023-06-06)
 
+### Features Added
+
+- Adds an option to set the Event Hubs consumer identifier.
+
 ### Other Changes
 
 - Use Rhea's prefetch window to prefetch events from the service. This improves the performance of the receiver by reducing the number of round trips to the service. The default prefetch window is 3 * `maxBatchSize` events. This can be configured by setting the `prefetchCount` option on the `subscribe` method on `EventHubConsumerClient`.

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.11.0 (2023-06-06)
+## 5.11.0 (2023-06-08)
 
 ### Features Added
 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -115,6 +115,7 @@ export class EventHubBufferedProducerClient {
     getEventHubProperties(options?: GetEventHubPropertiesOptions): Promise<EventHubProperties>;
     getPartitionIds(options?: GetPartitionIdsOptions): Promise<Array<string>>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
+    readonly identifier: string;
 }
 
 // @public
@@ -160,6 +161,7 @@ export class EventHubConsumerClient {
     getEventHubProperties(options?: GetEventHubPropertiesOptions): Promise<EventHubProperties>;
     getPartitionIds(options?: GetPartitionIdsOptions): Promise<Array<string>>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
+    readonly identifier: string;
     subscribe(handlers: SubscriptionEventHandlers, options?: SubscribeOptions): Subscription;
     subscribe(partitionId: string, handlers: SubscriptionEventHandlers, options?: SubscribeOptions): Subscription;
 }
@@ -181,6 +183,7 @@ export class EventHubProducerClient {
     getEventHubProperties(options?: GetEventHubPropertiesOptions): Promise<EventHubProperties>;
     getPartitionIds(options?: GetPartitionIdsOptions): Promise<Array<string>>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
+    readonly identifier: string;
     sendBatch(batch: EventData[] | AmqpAnnotatedMessage[], options?: SendBatchOptions): Promise<void>;
     sendBatch(batch: EventDataBatch, options?: OperationOptions): Promise<void>;
 }

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -129,6 +129,7 @@ export interface EventHubBufferedProducerClientOptions extends EventHubClientOpt
 // @public
 export interface EventHubClientOptions {
     customEndpointAddress?: string;
+    identifier?: string;
     retryOptions?: RetryOptions;
     userAgent?: string;
     webSocketOptions?: WebSocketOptions;

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -20,6 +20,7 @@ import { AmqpAnnotatedMessage, delay } from "@azure/core-amqp";
 import { BatchingPartitionChannel } from "./batchingPartitionChannel";
 import { PartitionAssigner } from "./impl/partitionAssigner";
 import { logger } from "./logger";
+import { getRandomName } from "./util/utils";
 
 /**
  * Contains the events that were successfully sent to the Event Hub,
@@ -205,6 +206,12 @@ export class EventHubBufferedProducerClient {
   }
 
   /**
+   * The name used to identify this EventHubBufferedProducerClient.
+   * If not specified or empty, a random unique one will be generated.
+   */
+  public readonly identifier: string;
+
+  /**
    * The `EventHubBufferedProducerClient` class is used to send events to an Event Hub.
    * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
@@ -272,24 +279,27 @@ export class EventHubBufferedProducerClient {
     options4?: EventHubBufferedProducerClientOptions
   ) {
     if (typeof eventHubNameOrOptions2 !== "string") {
-      this._producer = new EventHubProducerClient(
-        fullyQualifiedNamespaceOrConnectionString1,
-        eventHubNameOrOptions2
-      );
+      this.identifier = eventHubNameOrOptions2.identifier ?? getRandomName();
+      this._producer = new EventHubProducerClient(fullyQualifiedNamespaceOrConnectionString1, {
+        ...eventHubNameOrOptions2,
+        identifier: this.identifier,
+      });
       this._clientOptions = { ...eventHubNameOrOptions2 };
     } else if (!isCredential(credentialOrOptions3)) {
+      this.identifier = credentialOrOptions3?.identifier ?? getRandomName();
       this._producer = new EventHubProducerClient(
         fullyQualifiedNamespaceOrConnectionString1,
         eventHubNameOrOptions2,
-        credentialOrOptions3
+        { ...credentialOrOptions3, identifier: this.identifier }
       );
       this._clientOptions = { ...credentialOrOptions3! };
     } else {
+      this.identifier = options4?.identifier ?? getRandomName();
       this._producer = new EventHubProducerClient(
         fullyQualifiedNamespaceOrConnectionString1,
         eventHubNameOrOptions2,
         credentialOrOptions3,
-        options4
+        { ...options4, identifier: this.identifier }
       );
       this._clientOptions = { ...options4! };
     }

--- a/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubBufferedProducerClient.ts
@@ -293,7 +293,6 @@ export class EventHubBufferedProducerClient {
       );
       this._clientOptions = { ...options4! };
     }
-
     // setting internal idempotent publishing option on the standard producer.
     (this._producer as any)._enableIdempotentRetries = this._clientOptions.enableIdempotentRetries;
   }

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -63,7 +63,7 @@ export class EventHubConsumerClient {
    */
   private _clientOptions: EventHubConsumerClientOptions;
   private _partitionGate = new PartitionGate();
-  private _id = getRandomName();
+  private _id: string;
 
   /**
    * The Subscriptions that were spawned by calling `subscribe()`.
@@ -327,6 +327,7 @@ export class EventHubConsumerClient {
         this._clientOptions
       );
     }
+    this._id = this._clientOptions.identifier ?? getRandomName();
     this._loadBalancingOptions = {
       // default options
       strategy: "balanced",

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -63,7 +63,6 @@ export class EventHubConsumerClient {
    */
   private _clientOptions: EventHubConsumerClientOptions;
   private _partitionGate = new PartitionGate();
-  private _id: string;
 
   /**
    * The Subscriptions that were spawned by calling `subscribe()`.
@@ -101,6 +100,12 @@ export class EventHubConsumerClient {
   get fullyQualifiedNamespace(): string {
     return this._context.config.host;
   }
+
+  /**
+   * The name used to identify this EventHubConsumerClient.
+   * If not specified or empty, a random unique one will be generated.
+   */
+  public readonly identifier: string;
 
   /**
    * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
@@ -327,7 +332,7 @@ export class EventHubConsumerClient {
         this._clientOptions
       );
     }
-    this._id = this._clientOptions.identifier ?? getRandomName();
+    this.identifier = this._clientOptions.identifier ?? getRandomName();
     this._loadBalancingOptions = {
       // default options
       strategy: "balanced",
@@ -566,7 +571,7 @@ export class EventHubConsumerClient {
         ownerLevel: getOwnerLevel(options, this._userChoseCheckpointStore),
         // make it so all the event processors process work with the same overarching owner ID
         // this allows the EventHubConsumer to unify all the work for any processors that it spawns
-        ownerId: this._id,
+        ownerId: this.identifier,
         retryOptions: this._clientOptions.retryOptions,
         loadBalancingStrategy,
         loopIntervalInMs: this._loadBalancingOptions.updateIntervalInMs,

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -31,6 +31,7 @@ import { EventHubSender } from "./eventHubSender";
 import { OperationOptions } from "./util/operationOptions";
 import { toSpanOptions, tracingClient } from "./diagnostics/tracing";
 import { instrumentEventData } from "./diagnostics/instrumentEventData";
+import { getRandomName } from "./util/utils";
 
 /**
  * The `EventHubProducerClient` class is used to send events to an Event Hub.
@@ -54,6 +55,8 @@ export class EventHubProducerClient {
    * The options passed by the user when creating the EventHubClient instance.
    */
   private _clientOptions: EventHubClientOptions;
+  /** The client identifier */
+  private _id: string;
   /**
    * Map of partitionId to senders
    */
@@ -165,7 +168,7 @@ export class EventHubProducerClient {
     } else {
       this._clientOptions = options4 || {};
     }
-
+    this._id = this._clientOptions.identifier ?? getRandomName();
     this._sendersMap = new Map();
   }
 
@@ -226,7 +229,7 @@ export class EventHubProducerClient {
       const partitionPublishingOptions = isDefined(partitionId)
         ? this._partitionOptions?.[partitionId]
         : undefined;
-      sender = EventHubSender.create(this._context, {
+      sender = EventHubSender.create(this._context, this._id, {
         enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
         partitionId,
         partitionPublishingOptions,
@@ -288,7 +291,7 @@ export class EventHubProducerClient {
 
     let sender = this._sendersMap.get(partitionId);
     if (!sender) {
-      sender = EventHubSender.create(this._context, {
+      sender = EventHubSender.create(this._context, this._id, {
         enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
         partitionId,
         partitionPublishingOptions: this._partitionOptions?.[partitionId],
@@ -437,7 +440,7 @@ export class EventHubProducerClient {
           const partitionPublishingOptions = isDefined(partitionId)
             ? this._partitionOptions?.[partitionId]
             : undefined;
-          sender = EventHubSender.create(this._context, {
+          sender = EventHubSender.create(this._context, this._id, {
             enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
             partitionId,
             partitionPublishingOptions,

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -55,8 +55,6 @@ export class EventHubProducerClient {
    * The options passed by the user when creating the EventHubClient instance.
    */
   private _clientOptions: EventHubClientOptions;
-  /** The client identifier */
-  private _id: string;
   /**
    * Map of partitionId to senders
    */
@@ -91,6 +89,12 @@ export class EventHubProducerClient {
   get fullyQualifiedNamespace(): string {
     return this._context.config.host;
   }
+
+  /**
+   * The name used to identify this EventHubProducerClient.
+   * If not specified or empty, a random unique one will be generated.
+   */
+  public readonly identifier: string;
 
   /**
    * The `EventHubProducerClient` class is used to send events to an Event Hub.
@@ -168,7 +172,7 @@ export class EventHubProducerClient {
     } else {
       this._clientOptions = options4 || {};
     }
-    this._id = this._clientOptions.identifier ?? getRandomName();
+    this.identifier = this._clientOptions.identifier ?? getRandomName();
     this._sendersMap = new Map();
   }
 
@@ -229,7 +233,7 @@ export class EventHubProducerClient {
       const partitionPublishingOptions = isDefined(partitionId)
         ? this._partitionOptions?.[partitionId]
         : undefined;
-      sender = EventHubSender.create(this._context, this._id, {
+      sender = EventHubSender.create(this._context, this.identifier, {
         enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
         partitionId,
         partitionPublishingOptions,
@@ -291,7 +295,7 @@ export class EventHubProducerClient {
 
     let sender = this._sendersMap.get(partitionId);
     if (!sender) {
-      sender = EventHubSender.create(this._context, this._id, {
+      sender = EventHubSender.create(this._context, this.identifier, {
         enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
         partitionId,
         partitionPublishingOptions: this._partitionOptions?.[partitionId],
@@ -440,7 +444,7 @@ export class EventHubProducerClient {
           const partitionPublishingOptions = isDefined(partitionId)
             ? this._partitionOptions?.[partitionId]
             : undefined;
-          sender = EventHubSender.create(this._context, this._id, {
+          sender = EventHubSender.create(this._context, this.identifier, {
             enableIdempotentProducer: Boolean(this._enableIdempotentRetries),
             partitionId,
             partitionPublishingOptions,

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -288,7 +288,7 @@ export class EventProcessor {
       await this._startPump(ownershipRequest.partitionId, abortSignal);
     } catch (err: any) {
       logger.warning(
-        `[${this.id}] Failed to claim ownership of partition ${ownershipRequest.partitionId}`
+        `[${this._id}] Failed to claim ownership of partition ${ownershipRequest.partitionId}`
       );
       logErrorStackTrace(err);
       await this._handleSubscriptionError(err);
@@ -322,7 +322,7 @@ export class EventProcessor {
         eventHubName: this._eventHubName,
         consumerGroup: this._consumerGroup,
         partitionId: partitionId,
-        eventProcessorId: this.id,
+        eventProcessorId: this._id,
       }
     );
 

--- a/sdk/eventhub/event-hubs/src/logger.ts
+++ b/sdk/eventhub/event-hubs/src/logger.ts
@@ -22,26 +22,28 @@ export function logErrorStackTrace(error: unknown): void {
 }
 
 /**
- * Creates a logger that includes the connectionId, sender or receiver name, and
- * client type.
  * @internal
  */
-export function createLogPrefix(
-  connectionId?: string,
-  type?: "Sender" | "Receiver" | "Management",
-  name?: string
+export function createReceiverLogPrefix(
+  consumerId: string,
+  connectionId: string,
+  partitionId: string
 ): string {
-  const parts: string[] = [];
-  if (connectionId) {
-    parts.push(`[${connectionId}]`);
-  }
-  if (type) {
-    parts.push(type);
-  }
-  if (name) {
-    parts.push(name);
-  }
-  return parts.join(" ");
+  return `[${connectionId}] Receiver P${partitionId}-${consumerId}`;
+}
+
+/**
+ * @internal
+ */
+export function createSenderLogPrefix(senderId: string, connectionId: string): string {
+  return `[${connectionId}] Sender ${senderId}`;
+}
+
+/**
+ * @internal
+ */
+export function createManagementLogPrefix(connectionId: string): string {
+  return `[${connectionId}] Management`;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -22,11 +22,11 @@ import {
   SenderOptions,
 } from "rhea-promise";
 import {
-  createLogPrefix,
   logErrorStackTrace,
   createSimpleLogger,
   logger,
   SimpleLogger,
+  createManagementLogPrefix,
 } from "./logger";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -120,10 +120,6 @@ export class ManagementClient {
    */
   private _mgmtReqResLink?: RequestResponseLink;
   /**
-   * The unique name for the entity (mostly a guid).
-   */
-  private readonly name: string;
-  /**
    * The address in the following form:
    * `"$management"`.
    */
@@ -152,10 +148,9 @@ export class ManagementClient {
    */
   constructor(context: ConnectionContext, { address, audience }: ManagementClientOptions = {}) {
     this.address = address ?? Constants.management;
-    this.name = this.address;
     this.audience = audience ?? context.config.getManagementAudience();
     this._context = context;
-    const logPrefix = createLogPrefix(this._context.connectionId, "Management", this.name);
+    const logPrefix = createManagementLogPrefix(this._context.connectionId);
     this.logger = createSimpleLogger(logger, logPrefix);
     this.entityPath = context.config.entityPath as string;
   }

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -94,7 +94,7 @@ export interface CommonEventProcessorOptions
  * ```
  * @internal
  */
-export interface EventHubConsumerOptions {
+export interface PartitionReceiverOptions {
   /**
    * The owner level associated with an exclusive consumer.
    *

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -139,6 +139,10 @@ export interface EventHubClientOptions {
    * Value that is appended to the built in user agent string that is passed to the Event Hubs service.
    */
   userAgent?: string;
+  /**
+   * A unique name used to identify the consumer.  If not provided, a GUID will be used as the identifier
+   */
+  identifier?: string;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -140,7 +140,7 @@ export interface EventHubClientOptions {
    */
   userAgent?: string;
   /**
-   * A unique name used to identify the consumer.  If not provided, a GUID will be used as the identifier
+   * A unique name used to identify the client.  If not provided, a GUID will be used as the identifier
    */
   identifier?: string;
 }

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -84,6 +84,7 @@ export class PartitionPump {
     this._receiver = createReceiver(
       this._context,
       this._partitionProcessor.consumerGroup,
+      this._partitionProcessor.eventProcessorId,
       partitionId,
       currentEventPosition,
       {

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -19,6 +19,9 @@ export const idempotentProducerAmqpPropertyNames = {
   producerSequenceNumber: "com.microsoft:producer-sequence-number",
 } as const;
 
+/** @internal */
+export const receiverIdPropertyName = "com.microsoft:receiver-name";
+
 /**
  * @internal
  */

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -82,6 +82,7 @@ testWithServiceTypes((serviceVersion) => {
         client = createReceiver(
           context,
           "$default", // consumer group
+          "ID",
           "0", // partition id
           {
             enqueuedOn: Date.now(),
@@ -134,7 +135,7 @@ testWithServiceTypes((serviceVersion) => {
     describe("EventHubSender", () => {
       let client: EventHubSender;
       beforeEach("instantiate EventHubSender", () => {
-        client = new EventHubSender(context, { enableIdempotentProducer: false });
+        client = new EventHubSender(context, "Sender1", { enableIdempotentProducer: false });
       });
 
       afterEach("close EventHubSender", () => {

--- a/sdk/eventhub/event-hubs/test/internal/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/client.spec.ts
@@ -151,6 +151,17 @@ testWithServiceTypes((serviceVersion) => {
   });
 
   describe("Create EventHubProducerClient", function (): void {
+    it("the identifier options can be set", async function (): Promise<void> {
+      const identifier = "Test1";
+      const client = new EventHubProducerClient(
+        "Endpoint=sb://test.servicebus.windows.net;SharedAccessKeyName=b;SharedAccessKey=c",
+        "my-event-hub-name",
+        {
+          identifier,
+        }
+      );
+      client.identifier.should.equal(identifier, "The client identifier wasn't set correctly");
+    });
     it("throws when no EntityPath in connection string ", function (): void {
       const connectionString = "Endpoint=sb://abc";
       const test = function (): EventHubProducerClient {

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -64,7 +64,9 @@ testWithServiceTypes((serviceVersion) => {
        */
       it("send works after disconnect", async () => {
         const context = createConnectionContext(service.connectionString, service.path);
-        const sender = EventHubSender.create(context, { enableIdempotentProducer: false });
+        const sender = EventHubSender.create(context, "Sender1", {
+          enableIdempotentProducer: false,
+        });
 
         // Create the sender link via getMaxMessageSize() so we can check when 'send' is about to be called on it.
         await sender.getMaxMessageSize();
@@ -101,19 +103,25 @@ testWithServiceTypes((serviceVersion) => {
           const receiver1 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
+            "Consumer1",
             partitionIds[0],
             latestEventPosition
           );
           const receiver2 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
+            "Consumer2",
             partitionIds[1],
             latestEventPosition
           );
 
           // Add 2 senders.
-          const sender1 = new EventHubSender(context, { enableIdempotentProducer: false });
-          const sender2 = new EventHubSender(context, { enableIdempotentProducer: false });
+          const sender1 = new EventHubSender(context, "Sender1", {
+            enableIdempotentProducer: false,
+          });
+          const sender2 = new EventHubSender(context, "Sender2", {
+            enableIdempotentProducer: false,
+          });
 
           // Initialize sender links
           await sender1["_getLink"]();
@@ -163,19 +171,25 @@ testWithServiceTypes((serviceVersion) => {
           const receiver1 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
+            "Consumer1",
             partitionIds[0],
             latestEventPosition
           );
           const receiver2 = createReceiver(
             context,
             EventHubConsumerClient.defaultConsumerGroupName,
+            "Consumer2",
             partitionIds[1],
             latestEventPosition
           );
 
           // Add 2 senders.
-          const sender1 = new EventHubSender(context, { enableIdempotentProducer: false });
-          const sender2 = new EventHubSender(context, { enableIdempotentProducer: false });
+          const sender1 = new EventHubSender(context, "Sender1", {
+            enableIdempotentProducer: false,
+          });
+          const sender2 = new EventHubSender(context, "Sender2", {
+            enableIdempotentProducer: false,
+          });
 
           // Initialize sender links
           await sender1["_getLink"]();

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -88,6 +88,7 @@ testWithServiceTypes((serviceVersion) => {
         const receiver = createReceiver(
           consumerClient["_context"],
           EventHubConsumerClient.defaultConsumerGroupName,
+          "Consumer",
           partitionId,
           startPosition,
           {
@@ -143,6 +144,7 @@ testWithServiceTypes((serviceVersion) => {
         const receiver = createReceiver(
           consumerClient["_context"],
           EventHubConsumerClient.defaultConsumerGroupName,
+          "Consumer",
           partitionId,
           startPosition,
           {

--- a/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubBufferedProducerClient.spec.ts
@@ -58,6 +58,20 @@ testWithServiceTypes((serviceVersion) => {
       }
     });
 
+    describe("client options", function (): void {
+      it("the identifier option can be set", async function (): Promise<void> {
+        const identifier = "Test1";
+        client = new EventHubBufferedProducerClient(connectionString, eventHubName, {
+          identifier,
+          async onSendEventsErrorHandler() {
+            throw new Error("Should not have been called");
+          },
+          maxWaitTimeInMs: 1000,
+        });
+        client.identifier.should.equal(identifier, "The client identifier wasn't set correctly");
+      });
+    });
+
     describe("enqueueEvent", () => {
       afterEach("close EventHubBufferedProducerClient", () => {
         return client?.close({ flush: false });

--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -96,6 +96,21 @@ testWithServiceTypes((serviceVersion) => {
         clients = [];
       });
 
+      describe("client options", function (): void {
+        it("the identifier option can be set", async function (): Promise<void> {
+          const identifier = "Test1";
+          const client = new EventHubConsumerClient(
+            EventHubConsumerClient.defaultConsumerGroupName,
+            service.connectionString,
+            service.path,
+            {
+              identifier,
+            }
+          );
+          client.identifier.should.equal(identifier, "The client identifier wasn't set correctly");
+        });
+      });
+
       describe("#close()", function (): void {
         it("stops any actively running subscriptions", async function (): Promise<void> {
           const client = new EventHubConsumerClient(


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-js/issues/16406

Related to https://github.com/Azure/azure-sdk-for-js/issues/26057

Adds an option to set the client identifier.

Live run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2827224&view=results