### PR TITLE
[eslint-plugin] update rule to allow .cjs main entry

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md
+++ b/common/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md
@@ -1,6 +1,6 @@
 # ts-package-json-main-is-cjs
 
-Requires `main` in `package.json` to be point to a CommonJS or UMD module. In this case, its assumed that it points to `"dist/index.js"`.
+Requires `main` in `package.json` to be point to a CommonJS or UMD module. In this case, its assumed that it points to `"dist/index.js"` or `"dist/index.cjs"`.
 
 This rule is fixable using the `--fix` option.
 
@@ -11,6 +11,14 @@ This rule is fixable using the `--fix` option.
 ```json
 {
   "main": "dist/index.js"
+}
+```
+
+### Good
+
+```json
+{
+  "main": "dist/index.cjs"
 }
 ```
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -45,10 +45,10 @@ export = {
             const nodeValue = node.value as Literal;
             const main = nodeValue.value as string;
 
-            if (!/^(\.\/)?dist\/index\.js$/.test(main)) {
+            if (!/^(\.\/)?dist\/index\.(c)?js$/.test(main)) {
               context.report({
                 node: nodeValue,
-                message: `main is set to ${main} when it should be set to dist/index.js`,
+                message: `main is set to ${main} when it should be set to dist/index.js or dist/index.cjs`,
                 fix: (fixer: Rule.RuleFixer): Rule.Fix =>
                   fixer.replaceText(nodeValue, `"dist/index.js"`),
               });

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
@@ -260,6 +260,16 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
     },
     {
+      // correct format #3
+      code: '{"main": "dist/index.cjs"}',
+      filename: "package.json",
+    },
+    {
+      // correct format #4
+      code: '{"main": "./dist/index.cjs"}',
+      filename: "package.json",
+    },
+    {
       // a full example package.json (taken from https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/eventhub/event-hubs/package.json with "scripts" removed for testing purposes)
       code: examplePackageGood,
       filename: "package.json",
@@ -296,7 +306,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to dist//index.js when it should be set to dist/index.js",
+          message:
+            "main is set to dist//index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -306,7 +317,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to .dist/index.js when it should be set to dist/index.js",
+          message:
+            "main is set to .dist/index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -316,7 +328,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to /dist/index.js when it should be set to dist/index.js",
+          message:
+            "main is set to /dist/index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -327,7 +340,7 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to dist when it should be set to dist/index.js",
+          message: "main is set to dist when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -337,7 +350,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to index.js when it should be set to dist/index.js",
+          message:
+            "main is set to index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -347,7 +361,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to dist/src/index.js when it should be set to dist/index.js",
+          message:
+            "main is set to dist/src/index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: '{"main": "dist/index.js"}',
@@ -358,7 +373,8 @@ ruleTester.run("ts-package-json-main-is-cjs", rule, {
       filename: "package.json",
       errors: [
         {
-          message: "main is set to index.js when it should be set to dist/index.js",
+          message:
+            "main is set to index.js when it should be set to dist/index.js or dist/index.cjs",
         },
       ],
       output: examplePackageGood,


### PR DESCRIPTION
currently only index.js is allowed.
