### PR TITLE
Fix: Handle empty DirectoryFolder metadata property

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -10,10 +10,8 @@ $PackageRepositoryUri = "https://www.npmjs.com/package"
 
 . "$PSScriptRoot/docs/Docs-ToC.ps1"
 
-function Confirm-NodeInstallation
-{
-  if (!(Get-Command npm -ErrorAction SilentlyContinue))
-  {
+function Confirm-NodeInstallation {
+  if (!(Get-Command npm -ErrorAction SilentlyContinue)) {
     LogError "Could not locate npm. Install NodeJS (includes npm and npx) https://nodejs.org/en/download"
     exit 1
   }
@@ -121,7 +119,10 @@ function Get-javascript-PackageInfoFromPackageFile ($pkg, $workingDirectory) {
 }
 
 function Get-javascript-DocsMsMetadataForPackage($PackageInfo) { 
-  $docsReadmeName = Split-Path -Path $PackageInfo.DirectoryPath -Leaf
+  $docsReadmeName = "" 
+  if ($PackageInfo.DirectoryPath) { 
+    $docsReadmeName = Split-Path -Path $PackageInfo.DirectoryPath -Leaf
+  }
   Write-Host "Docs.ms Readme name: $($docsReadmeName)"
   New-Object PSObject -Property @{ 
     DocsMsReadMeName      = $docsReadmeName


### PR DESCRIPTION
In the past we've been able to assume that all packages which had metadata JSON files had shipped from our repos/engsys and had a `DirectoryPath` field with useful information in it. In the case of ToC, we use that `DirectoryPath` field to arrive at a package-level readme filename for use in the ToC. However, if that field is empty we want to fall back on other heuristics of arriving at the filename. 

Sample broken build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2824162&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=51aa7976-5924-5040-41de-f124a4debc20&l=162

Sample working build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2827344&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739 (canceled before it kicks off the daily docs build, that's not relevant here)

Changes to reference-unified.yml -- https://github.com/MicrosoftDocs/azure-docs-sdk-node/commit/ed17e684544f308768df906d7006323515a280f4#diff-594596e7bb045eeccea024715d4bb660b147569f1de067a3ed9d27d7a8dc4992 ... Note no erroneous `/-readme.md` in the `href` fields for services, this is what would have happened if the errors were directly checked in. 