### PR TITLE
Do not rely on BlobEndpoint host to getAccountName if it is already s…

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -221,7 +221,11 @@ export function extractConnectionStringParts(connectionString: string): Connecti
     // SAS connection string
 
     const accountSas = getValueInConnString(connectionString, "SharedAccessSignature");
-    const accountName = getAccountNameFromUrl(blobEndpoint);
+    let accountName = getValueInConnString(connectionString, "AccountName");
+    // if accountName is empty, try to read it from BlobEndpoint
+    if (!accountName) {
+      accountName = getAccountNameFromUrl(blobEndpoint);
+    }
     if (!blobEndpoint) {
       throw new Error("Invalid BlobEndpoint in the provided SAS Connection String");
     } else if (!accountSas) {

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -598,11 +598,11 @@ export function isIpEndpointStyle(parsedUrl: URLBuilder): boolean {
     parsedUrl.getHost()! + (parsedUrl.getPort() === undefined ? "" : ":" + parsedUrl.getPort());
 
   // Case 1: Ipv6, use a broad regex to find out candidates whose host contains two ':'.
-  // Case 2: localhost(:port), use broad regex to match port part.
+  // Case 2: localhost(:port) or host.docker.internal, use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
   return (
-    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+    /^.*:.*:.*$|^(localhost|host.docker.internal)(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
       host
     ) ||
     (parsedUrl.getPort() !== undefined && PathStylePorts.includes(parsedUrl.getPort()!))

--- a/sdk/storage/storage-blob/test/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/utils.spec.ts
@@ -109,6 +109,67 @@ describe("Utility Helpers", () => {
     );
   });
 
+  it("extractConnectionStringParts parses sas connection string with local domain", async () => {
+    const localDomain = `http://localhost:10000/devstoreaccount1`;
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature}`;
+    const connectionStringParts = extractConnectionStringParts(sasConnectionString);
+    assert.equal(
+      "SASConnString",
+      connectionStringParts.kind,
+      "extractConnectionStringParts().kind is different than expected."
+    );
+    assert.equal(
+      localDomain,
+      connectionStringParts.url,
+      "extractConnectionStringParts().url is different than expected."
+    );
+    assert.equal(
+      "devstoreaccount1",
+      connectionStringParts.accountName,
+      "extractConnectionStringParts().accountName is different than expected."
+    );
+  });
+
+  it("extractConnectionStringParts parses sas connection string with localhost and custom port", async () => {
+    const localDomain = `http://localhost:20000`;
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature}`;
+    try {
+      extractConnectionStringParts(sasConnectionString);
+      assert.fail();
+    } catch (err) {
+      assert.equal(
+        (err as Error).message,
+        "Unable to extract accountName with provided information.",
+        "extractConnectionStringParts() should throw"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts parses sas connection string with custom domain", async () => {
+    const localDomain = `http://host.docker.internal:10000`;
+    const localAccountName = "devstoreaccount1";
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature};AccountName=${localAccountName}`;
+    const connectionStringParts = extractConnectionStringParts(sasConnectionString);
+    assert.equal(
+      "SASConnString",
+      connectionStringParts.kind,
+      "extractConnectionStringParts().kind is different than expected."
+    );
+    assert.equal(
+      localDomain,
+      connectionStringParts.url,
+      "extractConnectionStringParts().url is different than expected."
+    );
+    assert.equal(
+      localAccountName,
+      connectionStringParts.accountName,
+      "extractConnectionStringParts().accountName is different than expected."
+    );
+  });
+
   it("isIpEndpointStyle", async () => {
     assert.equal(
       isIpEndpointStyle(


### PR DESCRIPTION
### Packages impacted by this PR
@azure/storage-blob

### Issues associated with this PR
A similar issue has been entered in azure-sdk-for-net: https://github.com/Azure/azure-sdk-for-net/issues/21956

### Describe the problem that is addressed by this PR
This PR handles a special case were we generate a SASConnectionString working with a custom domain that is local, but not localhost, like `host.docker.internal` or `my-workstation-hostname`, by extracting the AccountName from the AccountName value in the SasConnectionString, if present, instead of assuming it should be in the service EndPoint.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

To fix the actual issue we encountered, we could have extended the Regex in `isIpEndpointStyle()` (utils.common.ts:625) to include `(localhost|host.docker.internal)`.
But this is limiting and handling a special case only for `host.docker.internal`.

If current PR is not satisfying, I can make another one with just this change.

### Are there test cases added in this PR? _(If not, why?)_

I added a couple of unit test to check that AccountName can be read from SasConnectionString if present.

### Provide a list of related PRs _(if any)_
No related PR as far as I know

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_ NO
- [x] Added a changelog (if necessary)
