### PR TITLE
[engsys] Add bootstrap script for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,26 +28,30 @@
   "overrideCommand": false,
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/home/codespace/workspace",
-  "mounts": ["source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"],
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged"],
-
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+  ],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--privileged"
+  ],
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "GitHub.vscode-pull-request-github",
     "MS-vsliveshare.vsliveshare",
     "VisualStudioExptTeam.vscodeintellicode"
   ],
-  "postCreateCommand": "npm install -g @microsoft/rush", // This both overrides Oryx build which will run npm install and create a phantom node_modules directory and ensures that rush is available for use.
-
+  "postCreateCommand": "bash .devcontainer/init.sh",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   "customizations": {
     "codespaces": {
       "repositories": {
         "Azure/azure-sdk-assets": {
           "permissions": {
-            "contents": "write" 
+            "contents": "write"
           }
         }
       }

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Install and use nvm version from .nvmrc
+source $NVM_DIR/nvm.sh
+nvm install
+nvm use
+# Set default node to version we just installed so that new shells start with it
+nvm alias default $(node --version)
+
+# Install utilities
+npm install -g @microsoft/rush autorest
+rush update
+
+# Install PowerShell. PowerShell is needed for the test proxy asset sync migration scripts,
+# and is also useful for running scripts in eng/common/scripts and eng/common/TestResources.
+# Update the list of packages
+sudo apt-get update
+# Install pre-requisite packages.
+sudo apt-get install -y wget apt-transport-https software-properties-common
+# Download the Microsoft repository GPG keys
+wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+# Register the Microsoft repository GPG keys
+sudo dpkg -i packages-microsoft-prod.deb
+# Delete the the Microsoft repository GPG keys file
+rm packages-microsoft-prod.deb
+# Update the list of packages after we added packages.microsoft.com
+sudo apt-get update
+# Install PowerShell
+sudo apt-get install -y powershell

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -8,7 +8,7 @@ nvm use
 nvm alias default $(node --version)
 
 # Install utilities
-npm install -g @microsoft/rush autorest
+npm install -g @microsoft/rush autorest @typespec/compiler
 rush update
 
 # Install PowerShell. PowerShell is needed for the test proxy asset sync migration scripts,


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Adds a script `init.sh` to bootstrap new Codespaces. At the moment, the script does the following:
- Installs Node LTS based on the version in `.nvmrc` and sets it as the default Node version
- Installs Rush and Autorest
- Runs `rush update`
- Installs Powershell (for running engsys scripts and asset sync migration)