### PR TITLE
[storage] Port PR #24759 from storage/stable

### DIFF
--- a/sdk/storage/storage-file-share/assets.json
+++ b/sdk/storage/storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/storage/storage-file-share",
-  "Tag": "js/storage/storage-file-share_855e9e8ec6"
+  "Tag": "js/storage/storage-file-share_82dfdd1fcb"
 }

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -130,7 +130,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.10.1",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.1.1",
+    "@azure/core-util": "^1.3.3",
     "@azure/core-xml": "^1.3.2",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -76,8 +76,6 @@ import {
   DirectoryDeleteHeaders,
   DirectorySetMetadataHeaders,
   DirectoryListFilesAndDirectoriesSegmentHeaders,
-  ListFilesAndDirectoriesSegmentResponse,
-  ListHandlesResponse,
   DirectoryListHandlesHeaders,
   DirectoryRenameHeaders,
   FileCreateHeaders,
@@ -92,7 +90,11 @@ import {
   FileListHandlesHeaders,
   RawFileDownloadResponse,
 } from "./generatedModels";
-import { FileRenameHeaders } from "./generated/src/models";
+import {
+  FileRenameHeaders,
+  ListFilesAndDirectoriesSegmentResponse as GeneratedListFilesAndDirectoriesSegmentResponse,
+  ListHandlesResponse as GeneratedListHandlesResponse,
+} from "./generated/src/models";
 import { Share, Directory, File } from "./generated/src/operationsInterfaces";
 import {
   newPipeline,
@@ -120,6 +122,8 @@ import {
   setURLPath,
   setURLQueries,
   EscapePath,
+  ConvertInternalResponseOfListFiles,
+  ConvertInternalResponseOfListHandles,
   WithResponse,
   assertResponse,
 } from "./utils/utils.common";
@@ -2261,16 +2265,25 @@ export class ShareDirectoryClient extends StorageClient {
       "ShareDirectoryClient-listFilesAndDirectoriesSegment",
       options,
       async (updatedOptions) => {
-        return assertResponse<
-          DirectoryListFilesAndDirectoriesSegmentHeaders & ListFilesAndDirectoriesSegmentResponse,
+        const rawResponse = assertResponse<
+          DirectoryListFilesAndDirectoriesSegmentHeaders &
+            GeneratedListFilesAndDirectoriesSegmentResponse,
           DirectoryListFilesAndDirectoriesSegmentHeaders,
-          ListFilesAndDirectoriesSegmentResponse
+          GeneratedListFilesAndDirectoriesSegmentResponse
         >(
           await this.context.listFilesAndDirectoriesSegment({
             ...updatedOptions,
             marker,
           })
         );
+        const wrappedResponse: DirectoryListFilesAndDirectoriesSegmentResponse = {
+          ...ConvertInternalResponseOfListFiles(rawResponse),
+          _response: {
+            ...rawResponse._response,
+            parsedBody: ConvertInternalResponseOfListFiles(rawResponse._response.parsedBody),
+          }, // _response is made non-enumerable
+        };
+        return wrappedResponse;
       }
     );
   }
@@ -2444,9 +2457,9 @@ export class ShareDirectoryClient extends StorageClient {
       async (updatedOptions) => {
         marker = marker === "" ? undefined : marker;
         const response = assertResponse<
-          DirectoryListHandlesHeaders & ListHandlesResponse,
+          DirectoryListHandlesHeaders & GeneratedListHandlesResponse,
           DirectoryListHandlesHeaders,
-          ListHandlesResponse
+          GeneratedListHandlesResponse
         >(
           await this.context.listHandles({
             ...updatedOptions,
@@ -2459,7 +2472,15 @@ export class ShareDirectoryClient extends StorageClient {
         if ((response.handleList as any) === "") {
           response.handleList = undefined;
         }
-        return response;
+        const wrappedResponse: DirectoryListHandlesResponse = {
+          ...ConvertInternalResponseOfListHandles(response),
+          _response: {
+            ...response._response,
+            parsedBody: ConvertInternalResponseOfListHandles(response._response.parsedBody),
+          },
+        };
+
+        return wrappedResponse;
       }
     );
   }
@@ -4684,9 +4705,9 @@ export class ShareFileClient extends StorageClient {
       async (updatedOptions) => {
         marker = marker === "" ? undefined : marker;
         const response = assertResponse<
-          FileListHandlesHeaders & ListHandlesResponse,
+          FileListHandlesHeaders & GeneratedListHandlesResponse,
           FileListHandlesHeaders,
-          ListHandlesResponse
+          GeneratedListHandlesResponse
         >(
           await this.context.listHandles({
             ...updatedOptions,
@@ -4699,7 +4720,16 @@ export class ShareFileClient extends StorageClient {
         if ((response.handleList as any) === "") {
           response.handleList = undefined;
         }
-        return response;
+
+        const wrappedResponse: DirectoryListHandlesResponse = {
+          ...ConvertInternalResponseOfListHandles(response),
+          _response: {
+            ...response._response,
+            parsedBody: ConvertInternalResponseOfListHandles(response._response.parsedBody),
+          },
+        };
+
+        return wrappedResponse;
       }
     );
   }

--- a/sdk/storage/storage-file-share/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/models/index.ts
@@ -161,14 +161,20 @@ export interface ListFilesAndDirectoriesSegmentResponse {
   serviceEndpoint: string;
   shareName: string;
   shareSnapshot?: string;
+  encoded?: boolean;
   directoryPath: string;
-  prefix: string;
+  prefix: StringEncoded;
   marker?: string;
   maxResults?: number;
   /** Abstract for entries that can be listed from Directory. */
   segment: FilesAndDirectoriesListSegment;
   continuationToken: string;
   directoryId?: string;
+}
+
+export interface StringEncoded {
+  encoded?: boolean;
+  content?: string;
 }
 
 /** Abstract for entries that can be listed from Directory. */
@@ -179,7 +185,7 @@ export interface FilesAndDirectoriesListSegment {
 
 /** A listed directory item. */
 export interface DirectoryItem {
-  name: string;
+  name: StringEncoded;
   fileId?: string;
   /** File properties. */
   properties?: FileProperty;
@@ -201,7 +207,7 @@ export interface FileProperty {
 
 /** A listed file item. */
 export interface FileItem {
-  name: string;
+  name: StringEncoded;
   fileId?: string;
   /** File properties. */
   properties: FileProperty;
@@ -219,8 +225,7 @@ export interface ListHandlesResponse {
 export interface HandleItem {
   /** XSMB service handle ID */
   handleId: string;
-  /** File or directory name including full path starting from share root */
-  path: string;
+  path: StringEncoded;
   /** FileId uniquely identifies the file or directory. */
   fileId: string;
   /** ParentId uniquely identifies the parent directory of the object. */

--- a/sdk/storage/storage-file-share/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/models/mappers.ts
@@ -656,6 +656,14 @@ export const ListFilesAndDirectoriesSegmentResponse: coreClient.CompositeMapper 
           name: "String"
         }
       },
+      encoded: {
+        serializedName: "Encoded",
+        xmlName: "Encoded",
+        xmlIsAttribute: true,
+        type: {
+          name: "Boolean"
+        }
+      },
       directoryPath: {
         serializedName: "DirectoryPath",
         required: true,
@@ -667,10 +675,10 @@ export const ListFilesAndDirectoriesSegmentResponse: coreClient.CompositeMapper 
       },
       prefix: {
         serializedName: "Prefix",
-        required: true,
         xmlName: "Prefix",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "StringEncoded"
         }
       },
       marker: {
@@ -706,6 +714,32 @@ export const ListFilesAndDirectoriesSegmentResponse: coreClient.CompositeMapper 
       directoryId: {
         serializedName: "DirectoryId",
         xmlName: "DirectoryId",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const StringEncoded: coreClient.CompositeMapper = {
+  serializedName: "StringEncoded",
+  type: {
+    name: "Composite",
+    className: "StringEncoded",
+    modelProperties: {
+      encoded: {
+        serializedName: "Encoded",
+        xmlName: "Encoded",
+        xmlIsAttribute: true,
+        type: {
+          name: "Boolean"
+        }
+      },
+      content: {
+        serializedName: "content",
+        xmlName: "content",
+        xmlIsMsText: true,
         type: {
           name: "String"
         }
@@ -764,10 +798,10 @@ export const DirectoryItem: coreClient.CompositeMapper = {
     modelProperties: {
       name: {
         serializedName: "Name",
-        required: true,
         xmlName: "Name",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "StringEncoded"
         }
       },
       fileId: {
@@ -872,10 +906,10 @@ export const FileItem: coreClient.CompositeMapper = {
     modelProperties: {
       name: {
         serializedName: "Name",
-        required: true,
         xmlName: "Name",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "StringEncoded"
         }
       },
       fileId: {
@@ -962,10 +996,10 @@ export const HandleItem: coreClient.CompositeMapper = {
       },
       path: {
         serializedName: "Path",
-        required: true,
         xmlName: "Path",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "StringEncoded"
         }
       },
       fileId: {

--- a/sdk/storage/storage-file-share/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/models/parameters.ts
@@ -99,7 +99,7 @@ export const timeoutInSeconds: OperationQueryParameter = {
 export const version: OperationParameter = {
   parameterPath: "version",
   mapper: {
-    defaultValue: "2021-10-04",
+    defaultValue: "2021-12-02",
     isConstant: true,
     serializedName: "x-ms-version",
     type: {

--- a/sdk/storage/storage-file-share/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClient.ts
@@ -54,7 +54,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     this.url = url;
 
     // Assigning values to Constant parameters
-    this.version = options.version || "2021-10-04";
+    this.version = options.version || "2021-12-02";
     this.fileRangeWriteFromUrl = options.fileRangeWriteFromUrl || "update";
     this.service = new ServiceImpl(this);
     this.share = new ShareImpl(this);

--- a/sdk/storage/storage-file-share/src/generatedModels.ts
+++ b/sdk/storage/storage-file-share/src/generatedModels.ts
@@ -18,6 +18,7 @@ import {
   FileGetPropertiesHeaders,
   FileGetRangeListHeaders,
   FileListHandlesHeaders,
+  FileProperty,
   FileRenameHeaders,
   FileServiceProperties,
   FileSetHttpHeadersHeaders,
@@ -25,8 +26,6 @@ import {
   FileStartCopyHeaders,
   FileUploadRangeFromURLHeaders,
   FileUploadRangeHeaders,
-  ListFilesAndDirectoriesSegmentResponse,
-  ListHandlesResponse,
   ServiceGetPropertiesHeaders,
   ServiceSetPropertiesHeaders,
   ShareCreateHeaders,
@@ -215,16 +214,13 @@ export type FileRenameResponse = WithResponse<FileRenameHeaders, FileRenameHeade
 export {
   CopyStatusType,
   DeleteSnapshotsOptionType,
-  DirectoryItem,
   FileDownloadHeaders,
   FileDownloadOptionalParams,
   FileGetRangeListHeaders,
-  FileItem,
   FileLastWrittenMode,
   FileServiceProperties,
   FileUploadRangeFromURLOptionalParams,
   PermissionCopyModeType,
-  HandleItem,
   ListSharesIncludeType,
   FileRange as RangeModel,
   ShareGetAccessPolicyHeaders,
@@ -236,10 +232,7 @@ export {
   DirectoryCreateHeaders,
   DirectoryDeleteHeaders,
   DirectoryGetPropertiesHeaders,
-  FilesAndDirectoriesListSegment,
-  ListFilesAndDirectoriesSegmentResponse,
   DirectoryListFilesAndDirectoriesSegmentHeaders,
-  ListHandlesResponse,
   DirectoryRenameHeaders,
   DirectoryListHandlesHeaders,
   DirectorySetMetadataHeaders,
@@ -304,3 +297,70 @@ export type ShareSetQuotaResponse = WithResponse<ShareSetQuotaHeaders, ShareSetQ
  * Defines headers for setQuota operation.
  */
 export type ShareSetQuotaHeaders = ShareSetPropertiesHeaders;
+
+/** A listed file item. */
+export interface FileItem {
+  name: string;
+  fileId?: string;
+  /** File properties. */
+  properties: FileProperty;
+  attributes?: string;
+  permissionKey?: string;
+}
+
+/** A listed directory item. */
+export interface DirectoryItem {
+  name: string;
+  fileId?: string;
+  /** File properties. */
+  properties?: FileProperty;
+  attributes?: string;
+  permissionKey?: string;
+}
+
+/** Abstract for entries that can be listed from Directory. */
+export interface FilesAndDirectoriesListSegment {
+  directoryItems: DirectoryItem[];
+  fileItems: FileItem[];
+}
+
+/** An enumeration of directories and files. */
+export interface ListFilesAndDirectoriesSegmentResponse {
+  serviceEndpoint: string;
+  shareName: string;
+  shareSnapshot?: string;
+  directoryPath: string;
+  prefix: string;
+  marker?: string;
+  maxResults?: number;
+  /** Abstract for entries that can be listed from Directory. */
+  segment: FilesAndDirectoriesListSegment;
+  continuationToken: string;
+  directoryId?: string;
+}
+
+/** A listed Azure Storage handle item. */
+export interface HandleItem {
+  /** XSMB service handle ID */
+  handleId: string;
+  /** File or directory name including full path starting from share root */
+  path: string;
+  /** FileId uniquely identifies the file or directory. */
+  fileId: string;
+  /** ParentId uniquely identifies the parent directory of the object. */
+  parentId?: string;
+  /** SMB session ID in context of which the file handle was opened */
+  sessionId: string;
+  /** Client IP that opened the handle */
+  clientIp: string;
+  /** Time when the session that previously opened the handle has last been reconnected. (UTC) */
+  openTime: Date;
+  /** Time handle was last connected to (UTC) */
+  lastReconnectTime?: Date;
+}
+
+/** An enumeration of handles. */
+export interface ListHandlesResponse {
+  handleList?: HandleItem[];
+  continuationToken: string;
+}

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export const SDK_VERSION: string = "12.20.0";
-export const SERVICE_VERSION: string = "2021-10-04";
+export const SERVICE_VERSION: string = "2021-12-02";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB
 export const FILE_RANGE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024; // 4MB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -12,7 +12,7 @@ enable-xml: true
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e432d9cc87bfed320d8feead4b448be9481c9181/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-06-08/file.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/0cd0d5c070e85ea7d5816df056eddadc939b898a/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-12-02/file.json
 model-date-time-as-string: true
 optional-response-headers: true
 v3: true
@@ -844,15 +844,6 @@ directive:
     where: $["parameters"]["AccessTierOptional"]["x-ms-enum"]
     transform: >
       $["modelAsString"] = false;
-```
-
-### Update service version from "2018-06-08" to "2021-10-04"
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2021-10-04" ];
 ```
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2Fstorage-file-share%2Fswagger%2FREADME.png)

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -3,10 +3,11 @@
 
 import { getBSU, getUniqueName, recorderEnvSetup, uriSanitizers } from "./utils";
 import { ShareClient, ShareDirectoryClient, FileSystemAttributes } from "../src";
-import { Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode } from "@azure-tools/test-recorder";
 import { DirectoryCreateResponse } from "../src/generated/src/models";
 import { truncatedISO8061Date } from "../src/utils/utils.common";
 import { assert, getYieldedValue } from "@azure/test-utils";
+import { isBrowser } from "@azure/core-util";
 import { Context } from "mocha";
 
 describe("DirectoryClient", () => {
@@ -420,6 +421,184 @@ describe("DirectoryClient", () => {
     }
   });
 
+  it.only("listFilesAndDirectories - with invalid char", async function (this: Context) {
+    if (isBrowser && isLiveMode()) {
+      // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
+      this.skip();
+    }
+    const subDirClients = [];
+    const subDirNames = [];
+
+    const dirNameWithInvalidChar = recorder.variable("dir1", getUniqueName("dir1\uFFFE"));
+    const dirWithInvalidChar = shareClient.getDirectoryClient(dirNameWithInvalidChar);
+    await dirWithInvalidChar.create();
+
+    for (let i = 0; i < 3; i++) {
+      const subDirClient = dirWithInvalidChar.getDirectoryClient(
+        recorder.variable("dir", getUniqueName(`dir\uFFFE${i}`))
+      );
+      await subDirClient.create();
+      subDirClients.push(subDirClient);
+      subDirNames.push(subDirClient.name);
+    }
+
+    const subFileClients = [];
+    const subFileNames = [];
+    for (let i = 0; i < 3; i++) {
+      const subFileClient = dirWithInvalidChar.getFileClient(
+        recorder.variable("file", getUniqueName(`file\uFFFE${i}`))
+      );
+      await subFileClient.create(1024);
+      subFileClients.push(subFileClient);
+      subFileNames.push(subFileClient.name);
+    }
+
+    // List all
+    let result = (
+      await dirWithInvalidChar
+        .listFilesAndDirectories({
+          prefix: "",
+          includeTimestamps: true,
+          includeEtag: true,
+          includeAttributes: true,
+          includePermissionKey: true,
+          includeExtendedInfo: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+
+    assert.ok(result.serviceEndpoint.length > 0);
+    assert.ok(shareClient.url.indexOf(result.shareName));
+    assert.deepStrictEqual(result.continuationToken, "");
+    assert.deepStrictEqual(result.segment.directoryItems.length, subDirClients.length);
+    assert.deepStrictEqual(result.segment.fileItems.length, subFileClients.length);
+    assert.deepStrictEqual(result.directoryPath, dirNameWithInvalidChar);
+
+    let resultDirNames = [];
+    for (const entry of result.segment.directoryItems) {
+      resultDirNames.push(entry.name);
+      assert.ok(entry.fileId);
+      assert.ok(entry.attributes);
+      assert.ok(entry.permissionKey);
+      assert.ok(entry.properties.creationTime);
+      assert.ok(entry.properties.lastAccessTime);
+      assert.ok(entry.properties.changeTime);
+      assert.ok(entry.properties.lastModified);
+      assert.ok(entry.properties.etag);
+    }
+
+    for (const subDirName of subDirNames) {
+      assert.ok(resultDirNames.includes(subDirName));
+    }
+
+    let resultFileNames = [];
+    for (const entry of result.segment.fileItems) {
+      resultFileNames.push(entry.name);
+      assert.ok(entry.fileId);
+      assert.ok(entry.attributes);
+      assert.ok(entry.permissionKey);
+      assert.ok(entry.properties.creationTime);
+      assert.ok(entry.properties.lastAccessTime);
+      assert.ok(entry.properties.changeTime);
+      assert.ok(entry.properties.lastModified);
+      assert.ok(entry.properties.etag);
+    }
+
+    for (const subFileName of subFileNames) {
+      assert.ok(resultFileNames.includes(subFileName));
+    }
+
+    // List with dir prefix
+    result = (
+      await dirWithInvalidChar
+        .listFilesAndDirectories({
+          prefix: "dir\uFFFE",
+          includeTimestamps: true,
+          includeEtag: true,
+          includeAttributes: true,
+          includePermissionKey: true,
+          includeExtendedInfo: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+
+    assert.ok(result.serviceEndpoint.length > 0);
+    assert.ok(shareClient.url.indexOf(result.shareName));
+    assert.deepStrictEqual(result.continuationToken, "");
+    assert.deepStrictEqual(result.segment.directoryItems.length, subDirClients.length);
+    assert.deepStrictEqual(result.segment.fileItems.length, 0);
+    assert.deepStrictEqual(result.prefix, "dir\uFFFE");
+    assert.deepStrictEqual(result.directoryPath, dirNameWithInvalidChar);
+
+    resultDirNames = [];
+    for (const entry of result.segment.directoryItems) {
+      resultDirNames.push(entry.name);
+      assert.ok(entry.fileId);
+      assert.ok(entry.attributes);
+      assert.ok(entry.permissionKey);
+      assert.ok(entry.properties.creationTime);
+      assert.ok(entry.properties.lastAccessTime);
+      assert.ok(entry.properties.changeTime);
+      assert.ok(entry.properties.lastModified);
+      assert.ok(entry.properties.etag);
+    }
+
+    for (const subDirName of subDirNames) {
+      assert.ok(resultDirNames.includes(subDirName));
+    }
+
+    // List with file prefix
+    result = (
+      await dirWithInvalidChar
+        .listFilesAndDirectories({
+          prefix: "file\uFFFE",
+          includeTimestamps: true,
+          includeEtag: true,
+          includeAttributes: true,
+          includePermissionKey: true,
+          includeExtendedInfo: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+
+    assert.ok(result.serviceEndpoint.length > 0);
+    assert.ok(shareClient.url.indexOf(result.shareName));
+    assert.deepStrictEqual(result.continuationToken, "");
+    assert.deepStrictEqual(result.segment.directoryItems.length, 0);
+    assert.deepStrictEqual(result.segment.fileItems.length, subFileClients.length);
+    assert.deepStrictEqual(result.prefix, "file\uFFFE");
+    assert.deepStrictEqual(result.directoryPath, dirNameWithInvalidChar);
+
+    resultFileNames = [];
+    for (const entry of result.segment.fileItems) {
+      resultFileNames.push(entry.name);
+      assert.ok(entry.fileId);
+      assert.ok(entry.attributes);
+      assert.ok(entry.permissionKey);
+      assert.ok(entry.properties.creationTime);
+      assert.ok(entry.properties.lastAccessTime);
+      assert.ok(entry.properties.changeTime);
+      assert.ok(entry.properties.lastModified);
+      assert.ok(entry.properties.etag);
+    }
+
+    for (const subFileName of subFileNames) {
+      assert.ok(resultFileNames.includes(subFileName));
+    }
+
+    for (const subFile of subFileClients) {
+      await subFile.delete();
+    }
+    for (const subDir of subDirClients) {
+      await subDir.delete();
+    }
+
+    dirWithInvalidChar.delete();
+  });
+
   it("listFilesAndDirectories under root directory", async () => {
     const subDirClients = [];
     const rootDirClient = shareClient.getDirectoryClient("");
@@ -812,6 +991,29 @@ describe("DirectoryClient", () => {
     // TODO: Open or create a handle; Currently can only be done manually; No REST APIs for creating handles
 
     const result = (await dirClient.listHandles().byPage().next()).value;
+
+    if (result.handleList !== undefined && result.handleList.length > 0) {
+      const handle = result.handleList[0];
+      assert.notDeepEqual(handle.handleId, undefined);
+      assert.notDeepEqual(handle.path, undefined);
+      assert.notDeepEqual(handle.fileId, undefined);
+      assert.notDeepEqual(handle.sessionId, undefined);
+      assert.notDeepEqual(handle.clientIp, undefined);
+      assert.notDeepEqual(handle.openTime, undefined);
+    }
+  });
+
+  it.only("listHandles for directory with Invalid Char should work", async function (this: Context) {
+    if (isBrowser && isLiveMode()) {
+      // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
+      this.skip();
+    }
+
+    const dirNameWithInvalidChar = recorder.variable("dir2", getUniqueName("dir2\uFFFE"));
+    const dirWithInvalidChar = shareClient.getDirectoryClient(dirNameWithInvalidChar);
+    await dirWithInvalidChar.create();
+
+    const result = (await dirWithInvalidChar.listHandles().byPage().next()).value;
 
     if (result.handleList !== undefined && result.handleList.length > 0) {
       const handle = result.handleList[0];

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -435,8 +435,11 @@ describe("DirectoryClient", () => {
 
     for (let i = 0; i < 3; i++) {
       const subDirClient = dirWithInvalidChar.getDirectoryClient(
-        recorder.variable("dir", getUniqueName(`dir\uFFFE${i}`))
+        recorder.variable(`dir${i}-1`, getUniqueName(`dir\uFFFE${i}-1`))
       );
+      if (await subDirClient.exists()) {
+        await subDirClient.delete();
+      }
       await subDirClient.create();
       subDirClients.push(subDirClient);
       subDirNames.push(subDirClient.name);
@@ -446,7 +449,7 @@ describe("DirectoryClient", () => {
     const subFileNames = [];
     for (let i = 0; i < 3; i++) {
       const subFileClient = dirWithInvalidChar.getFileClient(
-        recorder.variable("file", getUniqueName(`file\uFFFE${i}`))
+        recorder.variable(`file${i}`, getUniqueName(`file\uFFFE${i}`))
       );
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -421,7 +421,7 @@ describe("DirectoryClient", () => {
     }
   });
 
-  it.only("listFilesAndDirectories - with invalid char", async function (this: Context) {
+  it("listFilesAndDirectories - with invalid char", async function (this: Context) {
     if (isBrowser && isLiveMode()) {
       // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
       this.skip();
@@ -1006,7 +1006,7 @@ describe("DirectoryClient", () => {
     }
   });
 
-  it.only("listHandles for directory with Invalid Char should work", async function (this: Context) {
+  it("listHandles for directory with Invalid Char should work", async function (this: Context) {
     if (isBrowser && isLiveMode()) {
       // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
       this.skip();

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -895,7 +895,6 @@ describe("FileClient", () => {
     await fileWithInvalidChar.create(10);
 
     const result = (await fileWithInvalidChar.listHandles().byPage().next()).value;
-    assert.ok(result.handleList !== undefined && result.handleList.length > 0);
     if (result.handleList !== undefined && result.handleList.length > 0) {
       const handle = result.handleList[0];
       assert.notDeepEqual(handle.handleId, undefined);

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -883,7 +883,7 @@ describe("FileClient", () => {
     );
   });
 
-  it.only("listHandles for file with Invalid Char should work", async function (this: Context) {
+  it("listHandles for file with Invalid Char should work", async function (this: Context) {
     if (isBrowser && isLiveMode()) {
       // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
       this.skip();

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AbortController } from "@azure/abort-controller";
-import { isNode } from "@azure/core-util";
+import { isNode, isBrowser } from "@azure/core-util";
 import { delay, isLiveMode, Recorder } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 import { assert } from "@azure/test-utils";
@@ -881,6 +881,30 @@ describe("FileClient", () => {
       { closedHandlesCount: 0, closeFailureCount: 0 },
       "Error in forceCloseAllHandles"
     );
+  });
+
+  it.only("listHandles for file with Invalid Char should work", async function (this: Context) {
+    if (isBrowser && isLiveMode()) {
+      // Skipped for now as the generating new version SAS token is not supported in pipeline yet.
+      this.skip();
+    }
+    const fileNameWithInvalidChar = recorder.variable("file", getUniqueName("file\uFFFE"));
+    const fileWithInvalidChar = shareClient
+      .getDirectoryClient("")
+      .getFileClient(fileNameWithInvalidChar);
+    await fileWithInvalidChar.create(10);
+
+    const result = (await fileWithInvalidChar.listHandles().byPage().next()).value;
+    assert.ok(result.handleList !== undefined && result.handleList.length > 0);
+    if (result.handleList !== undefined && result.handleList.length > 0) {
+      const handle = result.handleList[0];
+      assert.notDeepEqual(handle.handleId, undefined);
+      assert.notDeepEqual(handle.path, undefined);
+      assert.notDeepEqual(handle.fileId, undefined);
+      assert.notDeepEqual(handle.sessionId, undefined);
+      assert.notDeepEqual(handle.clientIp, undefined);
+      assert.notDeepEqual(handle.openTime, undefined);
+    }
   });
 
   it("forceCloseHandle should work", async function () {

--- a/sdk/storage/storage-file-share/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-share/test/utils/testutils.common.ts
@@ -3,13 +3,10 @@
 
 import { Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 import { Pipeline } from "@azure/core-rest-pipeline";
+import { isBrowser } from "@azure/core-util";
 import { StorageClient } from "../../src/StorageClient";
 
 type UriSanitizers = Required<RecorderStartOptions>["sanitizerOptions"]["uriSanitizers"];
-
-export function isBrowser(): boolean {
-  return typeof self !== "undefined";
-}
 
 export function configureStorageClient(recorder: Recorder, client: StorageClient): void {
   const options = recorder.configureClientOptions({});
@@ -35,7 +32,7 @@ const mockSDAccountName = "fakesdaccount";
 const mockSas =
   "?sv=2015-04-05&ss=bfqt&srt=sco&sp=rwdlacup&se=2023-01-31T18%3A51%3A40.0000000Z&sig=foobar";
 const sasParams = ["se", "sig", "sip", "sp", "spr", "srt", "ss", "sr", "st", "sv"];
-if (isBrowser()) {
+if (isBrowser) {
   sasParams.push("_");
 }
 export const uriSanitizers: UriSanitizers = sasParams.map(getUriSanitizerForQueryParam);
@@ -75,9 +72,9 @@ export function getUniqueName(prefix: string): string {
 }
 
 export function base64encode(content: string): string {
-  return isBrowser() ? btoa(content) : Buffer.from(content).toString("base64");
+  return isBrowser ? btoa(content) : Buffer.from(content).toString("base64");
 }
 
 export function base64decode(encodedString: string): string {
-  return isBrowser() ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
+  return isBrowser ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
 }


### PR DESCRIPTION
- port tests
- use isBrowser from core-util
- port the source changes
- re-generate client
- update test resource names to use different variable names. New recorder
  unique names are slightly different from previous version and cause same name to 
  be retrieved for "dir" variable.
- add recordings
