### PR TITLE
fix bug when reusing an options object

### DIFF
--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -156,6 +156,7 @@ export class TableServiceClient {
       | TableServiceClientOptions,
     options?: TableServiceClientOptions
   ) {
+    options = { ... options };
     this.url = url;
     const credential = isCredential(credentialOrOptions) ? credentialOrOptions : undefined;
     const clientOptions =


### PR DESCRIPTION
### Packages impacted by this PR

[@azure/data-tables](https://www.npmjs.com/package/@azure/data-tables)

### Issues associated with this PR


### Describe the problem that is addressed by this PR

When reuse `options` object, even with different connection string, different instances had same url.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

no (no time, sorry)

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
