### PR TITLE
Update @azure/communication-common dependency to fix download recording auth bug

### DIFF
--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-common": "^2.2.0",
+    "@azure/communication-common": "3.0.0-beta.1",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",
     "@azure/core-paging": "^1.1.1",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/communication-call-automation

### Issues associated with this PR

Unable to download call recording video using communication-call-automation and event grid webhook  - #26154

### Describe the problem that is addressed by this PR

Any attempt to download a recording failed with a 401 - Unauthorized response. This was due to the bug #25347 in the @azure/communication-common package.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
This was the only resolution.

### Are there test cases added in this PR? _(If not, why?)_
No. Requires an actual download to test.

### Provide a list of related PRs _(if any)_
* #25347

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
