### PR TITLE
Fixing undefined status and substatus code in response of client.getDataBaseAccount() call

### DIFF
--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -622,7 +622,13 @@ export class ClientContext {
 
     const databaseAccount = new DatabaseAccount(result, headers);
 
-    return { result: databaseAccount, headers, diagnostics };
+    return {
+      result: databaseAccount,
+      headers,
+      diagnostics,
+      code: result.code,
+      substatus: result.substatus,
+    };
   }
 
   public getWriteEndpoint(): Promise<string> {

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -614,7 +614,7 @@ export class ClientContext {
 
     request.headers = await this.buildHeaders(request);
     // await options.beforeOperation({ endpoint, request, headers: requestHeaders });
-    const { result, headers, diagnostics } = await executePlugins(
+    const { result, headers, code, substatus, diagnostics } = await executePlugins(
       request,
       RequestHandler.request,
       PluginOn.operation
@@ -626,8 +626,8 @@ export class ClientContext {
       result: databaseAccount,
       headers,
       diagnostics,
-      code: result.code,
-      substatus: result.substatus,
+      code: code,
+      substatus: substatus,
     };
   }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -120,7 +120,8 @@ export class CosmosClient {
       response.result,
       response.headers,
       response.code,
-      response.diagnostics
+      response.diagnostics,
+      response.substatus
     );
   }
 

--- a/sdk/cosmosdb/cosmos/test/public/functional/databaseaccount.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/databaseaccount.spec.ts
@@ -21,7 +21,7 @@ describe("NodeJS CRUD Tests", function (this: Suite) {
 
   describe("validate database account functionality", function () {
     it("nativeApi Should get database account successfully name based", async function () {
-      const { resource: databaseAccount, headers } = await client.getDatabaseAccount();
+      const { resource: databaseAccount, headers, statusCode } = await client.getDatabaseAccount();
       assert.equal(databaseAccount.DatabasesLink, "/dbs/");
       assert.equal(databaseAccount.MediaLink, "/media/");
       assert.equal(
@@ -33,6 +33,7 @@ describe("NodeJS CRUD Tests", function (this: Suite) {
         headers["x-ms-media-storage-usage-mb"]
       );
       assert(databaseAccount.ConsistencyPolicy !== undefined);
+      assert(statusCode !== undefined);
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/25932

### Describe the problem that is addressed by this PR
Currently, status and substatus code are returned as undefined whenever call client.getDataBaseAccount() is made. This PR fixes up this issue by setting up these fields in the response

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
