### PR TITLE
[core-xml] increment version after release

### DIFF
--- a/eng/tools/versioning/VersionUtils.js
+++ b/eng/tools/versioning/VersionUtils.js
@@ -9,7 +9,7 @@ var spawnSync = require("child_process").spawnSync,
 // as well
 async function updatePackageConstants(packagePath, packageJson, newVersion) {
   // No constant metadata, skip
-  if (!("//metadata" in packageJson)) {
+  if (!("//metadata" in packageJson) || !packageJson["//metadata"].constantPaths) {
     return;
   }
 

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.3.5 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.3.4 (2023-06-20)
 
 ### Other Changes

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Our dev-tool migration adds metadata section to package.json if they don't have them yet. But the added metadata section doesn't contain the `constantPaths`. This broke the version increment script for some core packages, including core-xml.

This PR fixes the script so it can increment those affected packages properly.
