### PR TITLE
[Search] Fix all clients adding one or more duplicate user agents

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix all clients adding one or more duplicate user agents. [#]()
+- Fix all clients adding one or more duplicate user agents. [#26298](https://github.com/Azure/azure-sdk-for-js/pull/26298)
 
 ### Other Changes
 

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix all clients adding one or more duplicate user agents. [#]()
+
 ### Other Changes
 
 ## 12.0.0-beta.1 (2023-05-09)

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -8,7 +8,6 @@ import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
 import { SearchClient as GeneratedClient } from "./generated/data/searchClient";
 import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { createSearchApiKeyCredentialPolicy } from "./searchApiKeyCredentialPolicy";
-import { SDK_VERSION } from "./constants";
 import { logger } from "./logger";
 import {
   AutocompleteRequest,
@@ -152,16 +151,6 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
   ) {
     this.endpoint = endpoint;
     this.indexName = indexName;
-
-    const libInfo = `azsdk-js-search-documents/${SDK_VERSION}`;
-    if (!options.userAgentOptions) {
-      options.userAgentOptions = {};
-    }
-    if (options.userAgentOptions.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
-    }
 
     const internalClientPipelineOptions: InternalClientPipelineOptions = {
       ...options,

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -6,7 +6,6 @@
 import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { InternalClientPipelineOptions } from "@azure/core-client";
 import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
-import { SDK_VERSION } from "./constants";
 import { AnalyzeResult } from "./generated/service/models";
 import { SearchServiceClient as GeneratedClient } from "./generated/service/searchServiceClient";
 import { logger } from "./logger";
@@ -133,18 +132,8 @@ export class SearchIndexClient {
     this.credential = credential;
     this.options = options;
 
-    const libInfo = `azsdk-js-search-documents/${SDK_VERSION}`;
-    if (!options.userAgentOptions) {
-      options.userAgentOptions = {};
-    }
-    if (options.userAgentOptions.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
-    }
-
     const internalClientPipelineOptions: InternalClientPipelineOptions = {
-      ...options,
+      ...this.options,
       ...{
         loggingOptions: {
           logger: logger.info,
@@ -161,7 +150,7 @@ export class SearchIndexClient {
     };
 
     this.serviceVersion =
-      options.serviceVersion ?? options.apiVersion ?? utils.defaultServiceVersion;
+      this.options.serviceVersion ?? this.options.apiVersion ?? utils.defaultServiceVersion;
     this.apiVersion = this.serviceVersion;
 
     this.client = new GeneratedClient(
@@ -171,8 +160,8 @@ export class SearchIndexClient {
     );
 
     if (isTokenCredential(credential)) {
-      const scope: string = options.audience
-        ? `${options.audience}/.default`
+      const scope: string = this.options.audience
+        ? `${this.options.audience}/.default`
         : `${KnownSearchAudience.AzurePublicCloud}/.default`;
 
       this.client.pipeline.addPolicy(

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -4,7 +4,6 @@
 import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { InternalClientPipelineOptions } from "@azure/core-client";
 import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
-import { SDK_VERSION } from "./constants";
 import { SearchIndexerStatus } from "./generated/service/models";
 import { SearchServiceClient as GeneratedClient } from "./generated/service/searchServiceClient";
 import { logger } from "./logger";
@@ -114,16 +113,6 @@ export class SearchIndexerClient {
     options: SearchIndexerClientOptions = {}
   ) {
     this.endpoint = endpoint;
-
-    const libInfo = `azsdk-js-search-documents/${SDK_VERSION}`;
-    if (!options.userAgentOptions) {
-      options.userAgentOptions = {};
-    }
-    if (options.userAgentOptions.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
-    }
 
     const internalClientPipelineOptions: InternalClientPipelineOptions = {
       ...options,


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents
### Issues associated with this PR

#26293
### Describe the problem that is addressed by this PR

A user reported `SearchIndexClient` sharing a `userAgentPolicy` with the `SearchClient`s it creates through `SearchIndexClient.getSearchClient`. This client is not cached, and the constructors of both types of clients modify the `userAgentPolicy` in place, causing a user agent to be recursively prepended until the request exceeds the maximum size allowed by the service. 

Adding the SDK version as a user agent is now handled by the generated library, so this change just removes the buggy implementation in the authored clients. 

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
