### PR TITLE
[core-amqp] Update TokenProvider to use native crypto

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -877,6 +877,26 @@ packages:
       - encoding
     dev: false
 
+  /@azure/core-amqp/3.3.0:
+    resolution: {integrity: sha512-RYIyC8PtGpMzZRiSokADw0ezFgNq1eUkCPV8rd7tJ85dn8CAhYDEYapzMYxAwIBLWidshu14m9UWjQS7hKYDpA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-util': 1.3.2
+      '@azure/logger': 1.0.4
+      buffer: 6.0.3
+      events: 3.3.0
+      jssha: 3.3.0
+      process: 0.11.10
+      rhea: 3.0.2
+      rhea-promise: 3.0.1
+      tslib: 2.5.3
+      util: 0.12.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@azure/core-auth/1.4.0:
     resolution: {integrity: sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==}
     engines: {node: '>=12.0.0'}
@@ -2631,7 +2651,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/chai-as-promised/7.1.5:
@@ -2653,7 +2673,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/cookie/0.4.1:
@@ -2663,7 +2683,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/debug/4.1.8:
@@ -2675,7 +2695,7 @@ packages:
   /@types/decompress/4.2.4:
     resolution: {integrity: sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/eslint/8.4.10:
@@ -2696,7 +2716,7 @@ packages:
   /@types/express-serve-static-core/4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -2714,13 +2734,13 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/inquirer/8.2.6:
@@ -2733,7 +2753,7 @@ packages:
   /@types/is-buffer/2.0.0:
     resolution: {integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/json-schema/7.0.12:
@@ -2747,13 +2767,13 @@ packages:
   /@types/jsonwebtoken/9.0.2:
     resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/jws/3.2.5:
     resolution: {integrity: sha512-xGTxZH34xOryaTN8CMsvhh9lfNqFuHiMoRvsLYWQdBJHqiECyfInXVl2eK8Jz2emxZWMIn5RBlmr3oDVPeWujw==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/linkify-it/3.0.2:
@@ -2812,20 +2832,20 @@ packages:
   /@types/mysql/2.15.19:
     resolution: {integrity: sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       form-data: 3.0.1
     dev: false
 
   /@types/node-fetch/2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       form-data: 3.0.1
     dev: false
 
@@ -2858,7 +2878,7 @@ packages:
   /@types/pg/8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       pg-protocol: 1.6.0
       pg-types: 2.2.0
     dev: false
@@ -2886,7 +2906,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/semaphore/1.1.1:
@@ -2905,14 +2925,14 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/serve-static/1.15.1:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/shimmer/1.0.2:
@@ -2938,13 +2958,13 @@ packages:
   /@types/stoppable/1.1.1:
     resolution: {integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/tough-cookie/4.0.2:
@@ -2958,7 +2978,7 @@ packages:
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/underscore/1.11.5:
@@ -2976,19 +2996,19 @@ packages:
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/ws/8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/xml2js/0.4.11:
     resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
 
   /@types/yargs-parser/21.0.0:
@@ -3005,7 +3025,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
     dev: false
     optional: true
 
@@ -4247,7 +4267,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.3
     dev: false
 
   /debug/3.2.7:
@@ -4425,7 +4445,7 @@ packages:
       cosmiconfig: 7.1.0
       debug: 4.3.4
       deps-regex: 0.1.4
-      ignore: 5.1.9
+      ignore: 5.2.4
       is-core-module: 2.12.1
       js-yaml: 3.14.1
       json5: 2.2.3
@@ -4457,7 +4477,7 @@ packages:
       '@pnpm/crypto.base32-hash': 1.0.1
       '@pnpm/types': 8.9.0
       encode-registry: 3.0.0
-      semver: 7.3.8
+      semver: 7.5.2
     dev: false
 
   /deps-regex/0.1.4:
@@ -4566,7 +4586,7 @@ packages:
     dependencies:
       semver: 7.5.2
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230620
+      typescript: 5.2.0-dev.20230622
     dev: false
 
   /duplexer3/0.1.5:
@@ -4628,7 +4648,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -5611,7 +5631,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -6020,7 +6040,7 @@ packages:
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
-      figures: 3.0.0
+      figures: 3.2.0
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
@@ -7775,7 +7795,7 @@ packages:
       pkg-dir: 5.0.0
       preferred-pm: 3.0.3
       rc-config-loader: 4.1.3
-      semver: 7.3.8
+      semver: 7.5.2
       semver-diff: 3.1.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -8482,7 +8502,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 14.18.51
+      '@types/node': 16.18.36
       long: 5.2.3
     dev: false
 
@@ -10021,8 +10041,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/5.2.0-dev.20230620:
-    resolution: {integrity: sha512-b+xpXf2CUaS00FbWW5+Kz2oYW27rHb6axYghK9+yR4QInoFy0PBdtkEU7zqm/uGXuULB5EfxbtNGlW9+2vsbSg==}
+  /typescript/5.2.0-dev.20230622:
+    resolution: {integrity: sha512-rVTuiLuyezBKAEAvkvDRvO/tA+nk5DXwnWk3vpKXzDtuv7JJ22iBPkehusg9m5AQ6To+ZJ7+mFJ+mNE6yPr9zQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -17880,7 +17900,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-tLTuanYeAiCjfwmtRrbAi7nmkm3RWB39vzztApCKVrkvgOPtX4ix96Hju3MUF9h9tRpM4k42a3JyCWZZdOVarA==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-1ouZrCFj4zfd8bS8G/XOkyGNHmEiMda0qhVyQGjXupWVtywcNe+8bBiAqgsXQj3RvnxxXsUsIkhiiGcuwePOmg==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -18644,10 +18664,11 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-0Nqv5Ig4SW6AFQc46f3Pbe1XePFzSkOwZrFWDKxjJm+S2GtbFYYU7PdokB+3nZYVz3vAYcYxIFO869rHhQQ8dA==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-gWIMpjnSkfrpV7EzfgC5kS8aJBGGlh8UX3AVbY/Te1giyKgWRqQv+GrniPZBKqQ3ZQRxZurj+wWIER0NKmgUiQ==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
+      '@azure/core-amqp': 3.3.0
       '@azure/identity': 2.1.0
       '@microsoft/api-extractor': 7.36.0_@types+node@14.18.51
       '@rollup/plugin-commonjs': 24.1.0_rollup@2.79.1
@@ -20160,10 +20181,11 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-hPrRCQksJllekVjFWjLEvKOWGZhKxGdHv75rKDWVEXyvtnfy1P4xHLHWSmlZNxZ1YZzjuDSVIiV4u8nw3zSOrw==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-yDUxx5/mQupZ5b5hsZ5XR6UBBKB4T+apbYuXmX/YF93KDn2jL8UqU6sXMIJOr3+CbU66IOYkmp0SGUkvlyPtqQ==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
+      '@azure/core-amqp': 3.3.0
       '@types/node': 14.18.51
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
@@ -20869,10 +20891,11 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-URLURUHMJPON8vKLzid4wZpWVdIXTZvqBpYDyWDpD0/AibDsexVxMhXR8bAjU7RenCAlsfPARqxrx5F99BdIwA==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-2eI8I6JGOycPNqYaSXxosSC3Hyi4xY452HrQHlKcGgdhgQIS1jH6mXYzUO92lGN7nQsIvJDdfBtZRmtNJ9QnEg==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
+      '@azure/core-amqp': 3.3.0
       '@azure/identity': 2.1.0
       '@microsoft/api-extractor': 7.36.0_@types+node@14.18.51
       '@rollup/plugin-commonjs': 24.1.0_rollup@2.79.1

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features Added
 
-- Changed `TokenCredential` to use native crypto libraries.  This changes the signature from `getToken` from being sync to async.
+- Changed `TokenProvider` to use native crypto libraries.  This changes the signature from `getToken` from being sync to async.
 
 ### Breaking Changes
 
-- The `TokenCredential` and the `getToken` method has been changed to be async as it uses the underlying native crypto which is async.
+- The `TokenProvider` and the `getToken` method has been changed to be async as it uses the underlying native crypto which is async.
 
 ### Bugs Fixed
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 3.3.1 (Unreleased)
+## 4.0.0 (Unreleased)
 
 ### Features Added
 
+- Changed `TokenCredential` to use native crypto libraries.  This changes the signature from `getToken` from being sync to async.
+
 ### Breaking Changes
+
+- The `TokenCredential` and the `getToken` method has been changed to be async as it uses the underlying native crypto which is async.
 
 ### Bugs Fixed
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "3.3.1",
+  "version": "4.0.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -22,6 +22,7 @@
   },
   "browser": {
     "./dist-esm/src/util/checkNetworkConnection.js": "./dist-esm/src/util/checkNetworkConnection.browser.js",
+    "./dist-esm/src/util/hmacSha256.js": "./dist-esm/src/util/hmacSha256.browser.js",
     "./dist-esm/src/util/runtimeInfo.js": "./dist-esm/src/util/runtimeInfo.browser.js",
     "buffer": "buffer"
   },
@@ -77,7 +78,6 @@
     "@azure/logger": "^1.0.0",
     "buffer": "^6.0.0",
     "events": "^3.0.0",
-    "jssha": "^3.1.0",
     "process": "^0.11.10",
     "rhea": "^3.0.0",
     "rhea-promise": "^3.0.0",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -551,7 +551,7 @@ export interface RetryOptions {
 
 // @public
 export interface SasTokenProvider {
-    getToken(audience: string): AccessToken;
+    getToken(audience: string): Promise<AccessToken>;
     isSasTokenProvider: true;
 }
 

--- a/sdk/core/core-amqp/src/auth/tokenProvider.ts
+++ b/sdk/core/core-amqp/src/auth/tokenProvider.ts
@@ -83,7 +83,7 @@ export class SasTokenProviderImpl implements SasTokenProvider {
    */
   async getToken(audience: string): Promise<AccessToken> {
     if (isNamedKeyCredential(this._credential)) {
-      return await createToken(
+      return createToken(
         this._credential.name,
         this._credential.key,
         Math.floor(Date.now() / 1000) + 3600,
@@ -106,11 +106,15 @@ export class SasTokenProviderImpl implements SasTokenProvider {
  * @param audience - The audience for which the token is desired.
  * @internal
  */
-async function createToken(keyName: string, key: string, expiry: number, audience: string): Promise<AccessToken> {
+async function createToken(
+  keyName: string,
+  key: string,
+  expiry: number,
+  audience: string
+): Promise<AccessToken> {
   audience = encodeURIComponent(audience);
   keyName = encodeURIComponent(keyName);
   const stringToSign = audience + "\n" + expiry;
-
 
   const sig = await signString(key, stringToSign);
   return {

--- a/sdk/core/core-amqp/src/auth/tokenProvider.ts
+++ b/sdk/core/core-amqp/src/auth/tokenProvider.ts
@@ -8,7 +8,7 @@ import {
   isNamedKeyCredential,
   isSASCredential,
 } from "@azure/core-auth";
-import jssha from "jssha";
+import { signString } from "../util/hmacSha256";
 
 /**
  * A SasTokenProvider provides an alternative to TokenCredential for providing an `AccessToken`.
@@ -26,7 +26,7 @@ export interface SasTokenProvider {
    *
    * @param audience - The audience for which the token is desired.
    */
-  getToken(audience: string): AccessToken;
+  getToken(audience: string): Promise<AccessToken>;
 }
 
 /**
@@ -81,9 +81,9 @@ export class SasTokenProviderImpl implements SasTokenProvider {
    * Gets the sas token for the specified audience
    * @param audience - The audience for which the token is desired.
    */
-  getToken(audience: string): AccessToken {
+  async getToken(audience: string): Promise<AccessToken> {
     if (isNamedKeyCredential(this._credential)) {
-      return createToken(
+      return await createToken(
         this._credential.name,
         this._credential.key,
         Math.floor(Date.now() / 1000) + 3600,
@@ -106,15 +106,13 @@ export class SasTokenProviderImpl implements SasTokenProvider {
  * @param audience - The audience for which the token is desired.
  * @internal
  */
-function createToken(keyName: string, key: string, expiry: number, audience: string): AccessToken {
+async function createToken(keyName: string, key: string, expiry: number, audience: string): Promise<AccessToken> {
   audience = encodeURIComponent(audience);
   keyName = encodeURIComponent(keyName);
   const stringToSign = audience + "\n" + expiry;
 
-  const shaObj = new jssha("SHA-256", "TEXT");
-  shaObj.setHMACKey(key, "TEXT");
-  shaObj.update(stringToSign);
-  const sig = encodeURIComponent(shaObj.getHMAC("B64"));
+
+  const sig = await signString(key, stringToSign);
   return {
     token: `SharedAccessSignature sr=${audience}&sig=${sig}&se=${expiry}&skn=${keyName}`,
     expiresOnTimestamp: expiry,

--- a/sdk/core/core-amqp/src/util/hmacSha256.browser.ts
+++ b/sdk/core/core-amqp/src/util/hmacSha256.browser.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+declare global {
+  class TextEncoder {
+    encode(input?: string): Uint8Array;
+  }
+
+  interface HmacImportParams {
+    name: string;
+    hash: { name: string };
+  }
+
+  interface CryptoKey {
+    algorithm: HmacImportParams;
+    type: string;
+    extractable: boolean;
+    usages: string[];
+  }
+  
+  function btoa(input: string): string;
+}
+
+declare const globalThis: {
+  crypto: {
+    subtle: {
+      importKey(format: string, keyData: Uint8Array, algorithm: HmacImportParams, extractable: boolean, usages: string[]): Promise<CryptoKey>;
+      sign(algorithm: HmacImportParams, key: CryptoKey, data: Uint8Array): Promise<ArrayBuffer>;
+    };
+  }
+};
+
+export async function signString(key: string, toSign: string): Promise<string> {
+  const enc = new TextEncoder();
+  const algorithm: HmacImportParams = { name: "HMAC", hash: { name: "SHA-256" } };
+
+  const extractedKey = await globalThis.crypto.subtle.importKey(
+    "raw",
+    enc.encode(key),
+    algorithm,
+    false,
+    ["sign", "verify"]
+  );
+  const signature = await globalThis.crypto.subtle.sign(
+    algorithm,
+    extractedKey,
+    enc.encode(toSign)
+  );
+  const digest = btoa(String.fromCharCode(...new Uint8Array(signature)));
+
+  return encodeURIComponent(digest);
+}

--- a/sdk/core/core-amqp/src/util/hmacSha256.browser.ts
+++ b/sdk/core/core-amqp/src/util/hmacSha256.browser.ts
@@ -17,17 +17,23 @@ declare global {
     extractable: boolean;
     usages: string[];
   }
-  
+
   function btoa(input: string): string;
 }
 
 declare const globalThis: {
   crypto: {
     subtle: {
-      importKey(format: string, keyData: Uint8Array, algorithm: HmacImportParams, extractable: boolean, usages: string[]): Promise<CryptoKey>;
+      importKey(
+        format: string,
+        keyData: Uint8Array,
+        algorithm: HmacImportParams,
+        extractable: boolean,
+        usages: string[]
+      ): Promise<CryptoKey>;
       sign(algorithm: HmacImportParams, key: CryptoKey, data: Uint8Array): Promise<ArrayBuffer>;
     };
-  }
+  };
 };
 
 export async function signString(key: string, toSign: string): Promise<string> {

--- a/sdk/core/core-amqp/src/util/hmacSha256.ts
+++ b/sdk/core/core-amqp/src/util/hmacSha256.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createHmac } from "crypto";
+
+export async function signString(key: string, toSign: string): Promise<string> {
+  const hmac = createHmac("sha256", key).update(toSign).digest("base64");
+  return encodeURIComponent(hmac);
+}

--- a/sdk/core/core-amqp/test/tokenProvider.spec.ts
+++ b/sdk/core/core-amqp/test/tokenProvider.spec.ts
@@ -14,7 +14,7 @@ describe("SasTokenProvider", function (): void {
       const key = "importantValue";
       const tokenProvider = createSasTokenProvider(new AzureNamedKeyCredential(keyName, key));
       const expiry = Math.floor(Date.now() / 1000) + 3600;
-      const tokenInfo = tokenProvider.getToken("myaudience");
+      const tokenInfo = await tokenProvider.getToken("myaudience");
       tokenInfo.token.should.match(
         /SharedAccessSignature sr=myaudience&sig=(.*)&se=\d{10}&skn=myKeyName/g
       );
@@ -30,7 +30,7 @@ describe("SasTokenProvider", function (): void {
         sharedAccessKey: "sak",
       });
       const expiry = Math.floor(Date.now() / 1000) + 3600;
-      const tokenInfo = tokenProvider.getToken("sb://hostname.servicebus.windows.net/");
+      const tokenInfo = await tokenProvider.getToken("sb://hostname.servicebus.windows.net/");
       tokenInfo.token.should.match(
         /SharedAccessSignature sr=sb%3A%2F%2Fhostname.servicebus.windows.net%2F&sig=(.*)&se=\d{10}&skn=sakName/g
       );
@@ -44,7 +44,7 @@ describe("SasTokenProvider", function (): void {
     const sasTokenProvider = createSasTokenProvider(
       new AzureSASCredential("SharedAccessSignature se=<blah>")
     );
-    const accessToken = sasTokenProvider.getToken("audience isn't used");
+    const accessToken = await sasTokenProvider.getToken("audience isn't used");
 
     should.equal(
       accessToken.token,
@@ -62,7 +62,7 @@ describe("SasTokenProvider", function (): void {
   it("should work as expected with `sharedAccessSignature`", async function (): Promise<void> {
     // This is how createSasTokenProvider will be called if the shared access signature is passed through a connection string.
     const tokenProvider = createSasTokenProvider({ sharedAccessSignature: "<blah>" });
-    const tokenInfo = tokenProvider.getToken("sb://hostname.servicebus.windows.net/");
+    const tokenInfo = await tokenProvider.getToken("sb://hostname.servicebus.windows.net/");
     tokenInfo.token.should.match(/<blah>/g);
     tokenInfo.expiresOnTimestamp.should.equal(0);
   });


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-amqp

### Issues associated with this PR


### Describe the problem that is addressed by this PR

This migrates the core-amqp project to use the native crypto from both the web and Node/Deno/Bun so that we can use the [SubtleCrypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) for platforms that support it, as well as the Node.js crypto library.  This removes the jssha npm package which currently has issues with ESM and TypeScript types.

This change forces the `TokenProvider` to change with the `getToken` to be async as the SubleCrypto methods used of `sign` and `importKey` are both async methods. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
