### PR TITLE
[Search] Fix `serializerOptions` and `onResponse` options for `SearchClient` methods

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fix all clients adding one or more duplicate user agents. [#26298](https://github.com/Azure/azure-sdk-for-js/pull/26298)
+- Fix serializerOptions and onResponse options for SearchClient methods. [#26327](https://github.com/Azure/azure-sdk-for-js/pull/26327)
 
 ### Other Changes
 

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -325,7 +325,12 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
         updatedOptions
       );
 
-      const { results, nextLink, nextPageParameters, ...restResult } = result;
+      const {
+        results,
+        nextLink,
+        nextPageParameters: resultNextPageParameters,
+        ...restResult
+      } = result;
 
       const modifiedResults = utils.generatedSearchResultToPublicSearchResult<TModel, Fields>(
         results
@@ -334,7 +339,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
       const converted: SearchDocumentsPageResult<TModel, Fields> = {
         ...restResult,
         results: modifiedResults,
-        continuationToken: this.encodeContinuationToken(nextLink, nextPageParameters),
+        continuationToken: this.encodeContinuationToken(nextLink, resultNextPageParameters),
       };
 
       return deserialize<SearchDocumentsPageResult<TModel, Fields>>(converted);

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -3,7 +3,7 @@
 
 /// <reference lib="esnext.asynciterable" />
 
-import { InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
+import { InternalClientPipelineOptions } from "@azure/core-client";
 import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
 import { SearchClient as GeneratedClient } from "./generated/data/searchClient";
 import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
@@ -14,6 +14,7 @@ import {
   AutocompleteResult,
   IndexDocumentsResult,
   SuggestRequest,
+  SearchRequest as GeneratedSearchRequest,
 } from "./generated/data/models";
 import { createSpan } from "./tracing";
 import { deserialize, serialize } from "./serialization";
@@ -264,8 +265,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
     suggesterName: string,
     options: AutocompleteOptions<TModel> = {}
   ): Promise<AutocompleteResult> {
-    const { operationOptions, restOptions } = this.extractOperationOptions({ ...options });
-    const { searchFields, ...nonFieldOptions } = restOptions;
+    const { searchFields, ...nonFieldOptions } = options;
     const fullOptions: AutocompleteRequest = {
       searchText: searchText,
       suggesterName: suggesterName,
@@ -281,7 +281,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
       throw new RangeError("suggesterName must be provided.");
     }
 
-    const { span, updatedOptions } = createSpan("SearchClient-autocomplete", operationOptions);
+    const { span, updatedOptions } = createSpan("SearchClient-autocomplete", options);
 
     try {
       const result = await this.client.documents.autocompletePost(fullOptions, updatedOptions);
@@ -302,42 +302,39 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
     options: SearchOptions<TModel, Fields> = {},
     nextPageParameters: SearchRequest = {}
   ): Promise<SearchDocumentsPageResult<TModel, Fields>> {
-    const { operationOptions, restOptions } = this.extractOperationOptions({ ...options });
-    const { select, searchFields, orderBy, semanticFields, ...nonFieldOptions } = restOptions;
-    const fullOptions: SearchRequest = {
+    const { searchFields, semanticFields, select, orderBy, includeTotalCount, ...restOptions } =
+      options;
+    const fullOptions: GeneratedSearchRequest = {
       searchFields: this.convertSearchFields(searchFields),
       semanticFields: this.convertSemanticFields(semanticFields),
       select: this.convertSelect<Fields>(select) || "*",
       orderBy: this.convertOrderBy(orderBy),
-      ...nonFieldOptions,
+      includeTotalResultCount: includeTotalCount,
+      ...restOptions,
       ...nextPageParameters,
     };
 
-    const { span, updatedOptions } = createSpan("SearchClient-searchDocuments", operationOptions);
+    const { span, updatedOptions } = createSpan("SearchClient-searchDocuments", options);
 
     try {
       const result = await this.client.documents.searchPost(
         {
           ...fullOptions,
-          includeTotalResultCount: fullOptions.includeTotalCount,
           searchText: searchText,
         },
         updatedOptions
       );
 
-      const { results, count, coverage, facets, answers, nextLink } = result;
+      const { results, nextLink, nextPageParameters, ...restResult } = result;
 
       const modifiedResults = utils.generatedSearchResultToPublicSearchResult<TModel, Fields>(
         results
       );
 
       const converted: SearchDocumentsPageResult<TModel, Fields> = {
+        ...restResult,
         results: modifiedResults,
-        count,
-        coverage,
-        facets,
-        answers,
-        continuationToken: this.encodeContinuationToken(nextLink, result.nextPageParameters),
+        continuationToken: this.encodeContinuationToken(nextLink, nextPageParameters),
       };
 
       return deserialize<SearchDocumentsPageResult<TModel, Fields>>(converted);
@@ -515,8 +512,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
     suggesterName: string,
     options: SuggestOptions<TModel, Fields> = {}
   ): Promise<SuggestDocumentsResult<TModel, Fields>> {
-    const { operationOptions, restOptions } = this.extractOperationOptions({ ...options });
-    const { select, searchFields, orderBy, ...nonFieldOptions } = restOptions;
+    const { select, searchFields, orderBy, ...nonFieldOptions } = options;
     const fullOptions: SuggestRequest = {
       searchText: searchText,
       suggesterName: suggesterName,
@@ -534,7 +530,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
       throw new RangeError("suggesterName must be provided.");
     }
 
-    const { span, updatedOptions } = createSpan("SearchClient-suggest", operationOptions);
+    const { span, updatedOptions } = createSpan("SearchClient-suggest", options);
 
     try {
       const result = await this.client.documents.suggestPost(fullOptions, updatedOptions);
@@ -804,27 +800,8 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  private extractOperationOptions<T extends OperationOptions>(
-    obj: T
-  ): {
-    operationOptions: OperationOptions;
-    restOptions: any;
-  } {
-    const { abortSignal, requestOptions, tracingOptions, ...restOptions } = obj;
-
-    return {
-      operationOptions: {
-        abortSignal,
-        requestOptions,
-        tracingOptions,
-      },
-      restOptions,
-    };
-  }
-
   private convertSelect<Fields extends SelectFields<TModel>>(
-    select?: Fields[]
+    select?: readonly Fields[]
   ): string | undefined {
     if (select) {
       return select.join(",");
@@ -832,7 +809,7 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
     return select;
   }
 
-  private convertSearchFields(searchFields?: SelectFields<TModel>[]): string | undefined {
+  private convertSearchFields(searchFields?: readonly SelectFields<TModel>[]): string | undefined {
     if (searchFields) {
       return searchFields.join(",");
     }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Describe the problem that is addressed by this PR

Some core client options were not being passed to the generated client. This was caused by a few options not being extracted by a helper `extractOperationOptions`, which has been removed in this PR since duck typing seems to be sufficient here. Removing the function and using duck typing with the user-provided options should prevent options that we expose from being left out in the future.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
