### PR TITLE
Using the right type of Recognition

### DIFF
--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -248,7 +248,7 @@ export class CallMedia {
         dtmfOptions: dtmfOptionsInternal,
       };
       return {
-        recognizeInputType: KnownRecognizeInputType.Speech,
+        recognizeInputType: KnownRecognizeInputType.SpeechOrDtmf,
         playPrompt: recognizeOptions.playPrompt
           ? this.createPlaySourceInternal(recognizeOptions.playPrompt)
           : undefined,


### PR DESCRIPTION
Example of Call using this fix:
https://ngc.skype.net/call/0716907d-3e06-44dd-a85d-16d0479f8522/

New request sent:
```json
{
  "recognizeinputtype": "speechOrDtmf",
  ...
}
```

Event Received:
```json
[
    {
        "id": "edcca2d3-7997-4d4a-bcb5-8cb5c6b08bef",
        "source": "calling/callConnections/411f0b00-56cd-47c6-9388-05f08399937b",
        "type": "Microsoft.Communication.RecognizeCompleted",
        "data": {
            "operationContext": "context",
            "resultInformation": {
                "code": 200,
                "subCode": 8531,
                "message": "Action completed, max digits received."
            },
            "recognitionType": "dtmf",
            "collectTonesResult": {
                "tones": [
                    "two"
                ]
            },
            "dtmfResult": {
                "tones": [
                    "two"
                ]
            },
            ...
    }
]
```

### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
