### PR TITLE
[Keyvault Secrets] [Perf Tests] Fix build

### DIFF
--- a/sdk/keyvault/perf-tests/keyvault-secrets/test/secretTest.ts
+++ b/sdk/keyvault/perf-tests/keyvault-secrets/test/secretTest.ts
@@ -10,7 +10,7 @@ export abstract class SecretTest<TOptions = Record<string, unknown>> extends Per
     this.secretClient = new SecretClient(
       keyVaultUri,
       credential,
-      this.configureClientOptionsCoreV1({})
+      this.configureClientOptions({})
     );
   }
 

--- a/sdk/test-utils/perf/GettingStarted.md
+++ b/sdk/test-utils/perf/GettingStarted.md
@@ -275,15 +275,9 @@ Example: Currently `@azure/<service-sdk>` is at 12.4.0 on master and you want to
 To be able to leverage the powers of playing back the requests using the test proxy, add the following to your code.
 
       ```ts
-      /// Core V1 SDKs - For services depending on core-http
-      /// Call this.configureClientOptionsCoreV1 method on your client options
-      this.blobServiceClient = BlobServiceClient.fromConnectionString(connectionString, this.configureClientOptionsCoreV1({}));
-
-      /// Core V2 SDKs - For services depending on core-rest-pipeline
       /// this.configureClientOptions call to modify your client
       this.client = TableClient.fromConnectionString(connectionString, tableName, this.configureClientOptions({}));
 
-      // Not all core-v1 SDKs allow passing httpClient option.
       // Please reach out if your service/SDK doesn't support or if you face difficulties in this area.
       ```
 


### PR DESCRIPTION
`configureClientOptionsCoreV1` was removed in the perf framework along with the core-http removal from the repo.

But the keyvault perf test builds were excluded, which left this unnoticed.