### PR TITLE
[Communication] Update ACS test-resources to fix executing samples in pipeline

### DIFF
--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -80,6 +80,10 @@
       "type": "String",
       "value": "[parameters('testApplicationSecret')]"
     },
+    "COMMUNICATION_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31-preview').primaryConnectionString]"
+    },
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryConnectionString]"

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -82,7 +82,7 @@
     },
     "COMMUNICATION_CONNECTION_STRING": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31-preview').primaryConnectionString]"
+      "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryConnectionString]"
     },
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
       "type": "string",


### PR DESCRIPTION
ACS SDKs test pipelines are failing in executing samples. The `"COMMUNICATION_CONNECTION_STRING"` is missing from the test resources from the previous changes.

Add the `"COMMUNICATION_CONNECTION_STRING"` into the test resources to fix the test pipeline.
