### PR TITLE
Fix method name in `@azure/communication-chat` documentation

### DIFF
--- a/sdk/communication/communication-chat/README.md
+++ b/sdk/communication/communication-chat/README.md
@@ -69,7 +69,7 @@ const chatClient = new ChatClient(endpointUrl, tokenCredential);
 
 ### Create a thread with two users
 
-Use the `createThread` method to create a chat thread.
+Use the `createChatThread` method to create a chat thread.
 
 `createChatThreadRequest` is used to describe the thread request:
 


### PR DESCRIPTION
`createChatThread`, not `createThread`, is the method that we use to create a new chat thread using the `@azure/communication-chat` package.

### Packages impacted by this PR
`@azure/communication-chat`

### Issues associated with this PR
None.

### Describe the problem that is addressed by this PR
This pull request fixes a typo in the package documentation.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
(Not applicable.)

### Are there test cases added in this PR? _(If not, why?)_
No test cases were added, as they weren't required.

### Provide a list of related PRs _(if any)_
(Not applicable.)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
(Not applicable.)

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
