### PR TITLE
[Search] Hotfix for nested select and searchFields

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix all clients adding one or more duplicate user agents. [#26298](https://github.com/Azure/azure-sdk-for-js/pull/26298)
 - Fix `serializerOptions` and `onResponse` options for SearchClient methods. [#26327](https://github.com/Azure/azure-sdk-for-js/pull/26327)
 - Fix discarded user-defined `onResponse` callback. [#24479](https://github.com/Azure/azure-sdk-for-js/pull/24479)
+- Fix type error on `select` statement with nested fields. [#26407](https://github.com/Azure/azure-sdk-for-js/pull/26407)
 
 ### Other Changes
 

--- a/sdk/search/search-documents/assets.json
+++ b/sdk/search/search-documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/search/search-documents",
-  "Tag": "js/search/search-documents_b657e18df0"
+  "Tag": "js/search/search-documents_0c82404ebe"
 }

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -55,16 +55,16 @@ export interface AutocompleteItem {
 export type AutocompleteMode = "oneTerm" | "twoTerms" | "oneTermWithContext";
 
 // @public
-export type AutocompleteOptions<TFields = string> = OperationOptions & AutocompleteRequest<TFields>;
+export type AutocompleteOptions<TFields> = OperationOptions & AutocompleteRequest<TFields>;
 
 // @public
-export interface AutocompleteRequest<TFields = string> {
+export interface AutocompleteRequest<TFields> {
     autocompleteMode?: AutocompleteMode;
     filter?: string;
     highlightPostTag?: string;
     highlightPreTag?: string;
     minimumCoverage?: number;
-    searchFields?: TFields[];
+    searchFields?: TFields[] | string[];
     top?: number;
     useFuzzyMatching?: boolean;
 }
@@ -488,7 +488,7 @@ export type GetDataSourceConnectionOptions = OperationOptions;
 
 // @public
 export interface GetDocumentOptions<TFields> extends OperationOptions {
-    selectedFields?: TFields[];
+    selectedFields?: TFields[] | string[];
 }
 
 // @public
@@ -1521,18 +1521,18 @@ export type ScoringStatistics = "local" | "global";
 export class SearchClient<TModel> implements IndexDocumentsClient<TModel> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
-    autocomplete<TFields extends string = string>(searchText: string, suggesterName: string, options?: AutocompleteOptions): Promise<AutocompleteResult>;
+    autocomplete<TFields extends keyof TModel>(searchText: string, suggesterName: string, options?: AutocompleteOptions<TFields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: TModel[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     deleteDocuments(keyName: keyof TModel, keyValues: string[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     readonly endpoint: string;
-    getDocument<TFields extends string>(key: string, options?: GetDocumentOptions<TFields>): Promise<TModel>;
+    getDocument<TFields extends Extract<keyof TModel, string>>(key: string, options?: GetDocumentOptions<TFields>): Promise<TModel>;
     getDocumentsCount(options?: CountDocumentsOptions): Promise<number>;
     indexDocuments(batch: IndexDocumentsBatch<TModel>, options?: IndexDocumentsOptions): Promise<IndexDocumentsResult>;
     readonly indexName: string;
     mergeDocuments(documents: TModel[], options?: MergeDocumentsOptions): Promise<IndexDocumentsResult>;
     mergeOrUploadDocuments(documents: TModel[], options?: MergeOrUploadDocumentsOptions): Promise<IndexDocumentsResult>;
-    search<TFields extends string>(searchText?: string, options?: SearchOptions<TFields>): Promise<SearchDocumentsResult<TModel>>;
-    suggest<TFields extends string = never>(searchText: string, suggesterName: string, options?: SuggestOptions<TFields>): Promise<SuggestDocumentsResult<TModel>>;
+    search<TFields extends keyof TModel>(searchText?: string, options?: SearchOptions<TFields>): Promise<SearchDocumentsResult<Pick<TModel, TFields>>>;
+    suggest<TFields extends keyof TModel = never>(searchText: string, suggesterName: string, options?: SuggestOptions<TFields>): Promise<SuggestDocumentsResult<Pick<TModel, TFields>>>;
     uploadDocuments(documents: TModel[], options?: UploadDocumentsOptions): Promise<IndexDocumentsResult>;
 }
 
@@ -1874,9 +1874,9 @@ export interface SearchRequestOptions<TFields> {
     scoringParameters?: string[];
     scoringProfile?: string;
     scoringStatistics?: ScoringStatistics;
-    searchFields?: string[];
+    searchFields?: TFields[] | string[];
     searchMode?: SearchMode;
-    select?: TFields[];
+    select?: TFields[] | string[];
     sessionId?: string;
     skip?: number;
     top?: number;
@@ -1894,7 +1894,9 @@ export interface SearchResourceEncryptionKey {
 // @public
 export type SearchResult<TModel> = {
     readonly score: number;
-    readonly highlights?: Record<string, string[]>;
+    readonly highlights?: {
+        [k in keyof TModel]?: string[];
+    };
     document: TModel;
 };
 
@@ -2060,8 +2062,8 @@ export interface SuggestRequest<TFields> {
     highlightPreTag?: string;
     minimumCoverage?: number;
     orderBy?: string[];
-    searchFields?: string[];
-    select?: TFields[];
+    searchFields?: TFields[] | string[];
+    select?: TFields[] | string[];
     top?: number;
     useFuzzyMatching?: boolean;
 }

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -55,10 +55,10 @@ export interface AutocompleteItem {
 export type AutocompleteMode = "oneTerm" | "twoTerms" | "oneTermWithContext";
 
 // @public
-export type AutocompleteOptions<TFields> = OperationOptions & AutocompleteRequest<TFields>;
+export type AutocompleteOptions<TFields = string> = OperationOptions & AutocompleteRequest<TFields>;
 
 // @public
-export interface AutocompleteRequest<TFields> {
+export interface AutocompleteRequest<TFields = string> {
     autocompleteMode?: AutocompleteMode;
     filter?: string;
     highlightPostTag?: string;
@@ -1521,18 +1521,18 @@ export type ScoringStatistics = "local" | "global";
 export class SearchClient<TModel> implements IndexDocumentsClient<TModel> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential | TokenCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
-    autocomplete<TFields extends keyof TModel>(searchText: string, suggesterName: string, options?: AutocompleteOptions<TFields>): Promise<AutocompleteResult>;
+    autocomplete<TFields extends string = string>(searchText: string, suggesterName: string, options?: AutocompleteOptions): Promise<AutocompleteResult>;
     deleteDocuments(documents: TModel[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     deleteDocuments(keyName: keyof TModel, keyValues: string[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     readonly endpoint: string;
-    getDocument<TFields extends Extract<keyof TModel, string>>(key: string, options?: GetDocumentOptions<TFields>): Promise<TModel>;
+    getDocument<TFields extends string>(key: string, options?: GetDocumentOptions<TFields>): Promise<TModel>;
     getDocumentsCount(options?: CountDocumentsOptions): Promise<number>;
     indexDocuments(batch: IndexDocumentsBatch<TModel>, options?: IndexDocumentsOptions): Promise<IndexDocumentsResult>;
     readonly indexName: string;
     mergeDocuments(documents: TModel[], options?: MergeDocumentsOptions): Promise<IndexDocumentsResult>;
     mergeOrUploadDocuments(documents: TModel[], options?: MergeOrUploadDocumentsOptions): Promise<IndexDocumentsResult>;
-    search<TFields extends keyof TModel>(searchText?: string, options?: SearchOptions<TFields>): Promise<SearchDocumentsResult<Pick<TModel, TFields>>>;
-    suggest<TFields extends keyof TModel = never>(searchText: string, suggesterName: string, options?: SuggestOptions<TFields>): Promise<SuggestDocumentsResult<Pick<TModel, TFields>>>;
+    search<TFields extends string>(searchText?: string, options?: SearchOptions<TFields>): Promise<SearchDocumentsResult<TModel>>;
+    suggest<TFields extends string = never>(searchText: string, suggesterName: string, options?: SuggestOptions<TFields>): Promise<SuggestDocumentsResult<TModel>>;
     uploadDocuments(documents: TModel[], options?: UploadDocumentsOptions): Promise<IndexDocumentsResult>;
 }
 
@@ -1874,7 +1874,7 @@ export interface SearchRequestOptions<TFields> {
     scoringParameters?: string[];
     scoringProfile?: string;
     scoringStatistics?: ScoringStatistics;
-    searchFields?: TFields[];
+    searchFields?: string[];
     searchMode?: SearchMode;
     select?: TFields[];
     sessionId?: string;
@@ -1894,9 +1894,7 @@ export interface SearchResourceEncryptionKey {
 // @public
 export type SearchResult<TModel> = {
     readonly score: number;
-    readonly highlights?: {
-        [k in keyof TModel]?: string[];
-    };
+    readonly highlights?: Record<string, string[]>;
     document: TModel;
 };
 
@@ -2062,7 +2060,7 @@ export interface SuggestRequest<TFields> {
     highlightPreTag?: string;
     minimumCoverage?: number;
     orderBy?: string[];
-    searchFields?: TFields[];
+    searchFields?: string[];
     select?: TFields[];
     top?: number;
     useFuzzyMatching?: boolean;

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -19,7 +19,7 @@ export type CountDocumentsOptions = OperationOptions;
 /**
  * Options for retrieving completion text for a partial searchText.
  */
-export type AutocompleteOptions<TFields> = OperationOptions & AutocompleteRequest<TFields>;
+export type AutocompleteOptions<TFields = string> = OperationOptions & AutocompleteRequest<TFields>;
 /**
  * Options for committing a full search request.
  */
@@ -344,7 +344,7 @@ export interface SearchRequestOptions<TFields> {
    * fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each
    * fielded search expression take precedence over any field names listed in this parameter.
    */
-  searchFields?: TFields[];
+  searchFields?: string[];
   /**
    * A value that specifies whether any or all of the search terms must be matched in order to
    * count the document as a match. Possible values include: 'any', 'all'
@@ -398,7 +398,7 @@ export type SearchResult<TModel> = {
    * applicable field; null if hit highlighting was not enabled for the query.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly highlights?: { [k in keyof TModel]?: string[] };
+  readonly highlights?: Record<string, string[]>;
 
   document: TModel;
 };
@@ -502,7 +502,7 @@ export interface SuggestRequest<TFields> {
    * The comma-separated list of field names to search for the specified search text. Target fields
    * must be included in the specified suggester.
    */
-  searchFields?: TFields[];
+  searchFields?: string[];
   /**
    * The list of fields to retrieve. If unspecified, only the key field will be
    * included in the results.
@@ -547,7 +547,7 @@ export interface SuggestDocumentsResult<TModel> {
 /**
  * Parameters for fuzzy matching, and other autocomplete query behaviors.
  */
-export interface AutocompleteRequest<TFields> {
+export interface AutocompleteRequest<TFields = string> {
   /**
    * Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles
    * and 'oneTermWithContext' to use the current context while producing auto-completed terms.

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -19,7 +19,7 @@ export type CountDocumentsOptions = OperationOptions;
 /**
  * Options for retrieving completion text for a partial searchText.
  */
-export type AutocompleteOptions<TFields = string> = OperationOptions & AutocompleteRequest<TFields>;
+export type AutocompleteOptions<TFields> = OperationOptions & AutocompleteRequest<TFields>;
 /**
  * Options for committing a full search request.
  */
@@ -94,7 +94,7 @@ export interface GetDocumentOptions<TFields> extends OperationOptions {
    * List of field names to retrieve for the document; Any field not retrieved will be missing from
    * the returned document.
    */
-  selectedFields?: TFields[];
+  selectedFields?: TFields[] | string[];
 }
 
 /**
@@ -344,7 +344,7 @@ export interface SearchRequestOptions<TFields> {
    * fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each
    * fielded search expression take precedence over any field names listed in this parameter.
    */
-  searchFields?: string[];
+  searchFields?: TFields[] | string[];
   /**
    * A value that specifies whether any or all of the search terms must be matched in order to
    * count the document as a match. Possible values include: 'any', 'all'
@@ -368,7 +368,7 @@ export interface SearchRequestOptions<TFields> {
    * The list of fields to retrieve. If unspecified, all fields marked as
    * retrievable in the schema are included.
    */
-  select?: TFields[];
+  select?: TFields[] | string[];
   /**
    * The number of search results to skip. This value cannot be greater than 100,000. If you need
    * to scan documents in sequence, but cannot use skip due to this limitation, consider using
@@ -398,7 +398,7 @@ export type SearchResult<TModel> = {
    * applicable field; null if hit highlighting was not enabled for the query.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly highlights?: Record<string, string[]>;
+  readonly highlights?: { [k in keyof TModel]?: string[] };
 
   document: TModel;
 };
@@ -502,12 +502,12 @@ export interface SuggestRequest<TFields> {
    * The comma-separated list of field names to search for the specified search text. Target fields
    * must be included in the specified suggester.
    */
-  searchFields?: string[];
+  searchFields?: TFields[] | string[];
   /**
    * The list of fields to retrieve. If unspecified, only the key field will be
    * included in the results.
    */
-  select?: TFields[];
+  select?: TFields[] | string[];
   /**
    * The number of suggestions to retrieve. This must be a value between 1 and 100. The default is
    * 5.
@@ -547,7 +547,7 @@ export interface SuggestDocumentsResult<TModel> {
 /**
  * Parameters for fuzzy matching, and other autocomplete query behaviors.
  */
-export interface AutocompleteRequest<TFields = string> {
+export interface AutocompleteRequest<TFields> {
   /**
    * Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles
    * and 'oneTermWithContext' to use the current context while producing auto-completed terms.
@@ -588,7 +588,7 @@ export interface AutocompleteRequest<TFields = string> {
    * The comma-separated list of field names to consider when querying for auto-completed terms.
    * Target fields must be included in the specified suggester.
    */
-  searchFields?: TFields[];
+  searchFields?: TFields[] | string[];
   /**
    * The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The
    * default is 5.

--- a/sdk/search/search-documents/test/public/node/searchClient.spec.ts
+++ b/sdk/search/search-documents/test/public/node/searchClient.spec.ts
@@ -72,6 +72,7 @@ versionsToTest(serviceVersions, {}, (serviceVersion, onVersions) => {
         skip: 0,
         top: 5,
         includeTotalCount: true,
+        select: ["address/streetAddress"],
       });
       assert.equal(searchResults.count, 6);
     });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Describe the problem that is addressed by this PR

Pending #23627 being validated and merged into stable, customers are blocked on the inability to select fields that aren't at the top level of a document. This change is a stopgap measure - `select` and `searchFields` have been declared with `string[]` type. This removes the existing type narrowing, but introduces that missing behavior.

Depends on #25583 

### Checklists

- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
