### PR TITLE
[@azure-rest/core-client] Correctly handle allowInsecureConnection override

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.4 (Unreleased)
+## 1.1.4 (2023-07-07)
 
 ### Features Added
 

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `timeout`, `onUploadProgress`, `onDownloadProgress`, `abortSignal`, `tracingOptions`, `onResponse` in the `RequestParameters` for better RLC user experience.
 - Add `OperationOptions` for better modular user experience.
+- Correctly handle `allowInsecureConnection` handling when `undefined` is passed in `RequestParameters`. See https://github.com/Azure/autorest.typescript/issues/1916 for details.
 
 ## 1.1.3 (2023-05-04)
 

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.4 (2023-07-07)
+## 1.1.4 (2023-07-06)
 
 ### Features Added
 

--- a/sdk/core/core-client-rest/src/getClient.ts
+++ b/sdk/core/core-client-rest/src/getClient.ts
@@ -162,13 +162,14 @@ function buildOperation(
   allowInsecureConnection?: boolean,
   httpClient?: HttpClient
 ): StreamableMethod {
+  allowInsecureConnection = options.allowInsecureConnection ?? allowInsecureConnection;
   return {
     then: function (onFulfilled, onrejected) {
       return sendRequest(
         method,
         url,
         pipeline,
-        { allowInsecureConnection, ...options },
+        { ...options, allowInsecureConnection },
         httpClient
       ).then(onFulfilled, onrejected);
     },
@@ -177,7 +178,7 @@ function buildOperation(
         method,
         url,
         pipeline,
-        { allowInsecureConnection, ...options },
+        { ...options, allowInsecureConnection },
         httpClient
       );
     },
@@ -186,7 +187,7 @@ function buildOperation(
         method,
         url,
         pipeline,
-        { allowInsecureConnection, ...options },
+        { ...options, allowInsecureConnection },
         httpClient
       );
     },


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/core-client`

### Issues associated with this PR

https://github.com/Azure/autorest.typescript/issues/1916

### Describe the problem that is addressed by this PR

Since we were using spread syntax on `RequestParameters` if an `undefined` value was passed this would take precedence over the client option, which was not expected.

This PR switches the order of when the spread happens while still pulling the value from `RequestParameters` when present.

### Are there test cases added in this PR? _(If not, why?)_

Yes!