### PR TITLE
[dev-tool] Honor exports when bundling.

### DIFF
--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -70,7 +70,7 @@ export default leafCommand(commandInfo, async (options) => {
 
     try {
       const bundle = await rollup.rollup(baseConfig);
-      const cjsOutput = info.packageJson.main;
+      const cjsOutput = info.packageJson.main ?? info.packageJson.exports?.["."]?.require;
       if (!cjsOutput) {
         throw new Error("Expecting valid main entry");
       }

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -31,6 +31,14 @@ declare global {
     description: string;
     main: string;
     types: string;
+    exports?: {
+      [path: string]: {
+        import?: string;
+        require?: string;
+        types?: string;
+        [extraTypes: `types@${string}`]: string;
+      }
+    },
     typesVersions?: {
       [k: string]: {
         [k: string]: string[];


### PR DESCRIPTION
This package modifies the bundling logic slightly so that after checking for a package.json `main` field it will also look at the package.json `exports["."].require` field.
