### PR TITLE
[ACS][CallAutomation] Fixing duplicated lib info fix

### DIFF
--- a/sdk/communication/communication-call-automation/src/callAutomationClient.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationClient.ts
@@ -11,7 +11,6 @@ import {
   CommunicationUserIdentifier,
 } from "@azure/communication-common";
 import { logger } from "./models/logger";
-import { SDK_VERSION } from "./models/constants";
 import {
   AnswerCallRequest,
   CallAutomationApiClient,
@@ -94,16 +93,9 @@ export class CallAutomationClient {
     const options = isCallAutomationClientOptions(credentialOrOptions)
       ? credentialOrOptions
       : maybeOptions;
-    const libInfo = `azsdk-js-communication-call-automation/${SDK_VERSION}`;
 
     if (!options?.userAgentOptions) {
       options.userAgentOptions = {};
-    }
-
-    if (options?.userAgentOptions?.userAgentPrefix) {
-      options.userAgentOptions.userAgentPrefix = `${options.userAgentOptions.userAgentPrefix} ${libInfo}`;
-    } else {
-      options.userAgentOptions.userAgentPrefix = libInfo;
     }
 
     this.internalPipelineOptions = {

--- a/sdk/communication/communication-call-automation/src/generated/src/callAutomationApiClient.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/callAutomationApiClient.ts
@@ -65,7 +65,7 @@ export class CallAutomationApiClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-communication-call-automation/1.0.0-beta.1`;
+    const packageDetails = `azsdk-js-communication-call-automation/1.0.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -5,7 +5,7 @@
 ## Configuration
 
 ```yaml
-package-name: azure-communication-call-automation
+package-name: "@azure/communication-call-automation"
 title: CallAutomationApiClient
 description: Call Automation Client
 generate-metadata: false


### PR DESCRIPTION
- Duplicated lib info in UserAgent.
- Fixed naming of package in autorest to be correct