### PR TITLE
[Azure Monitor] Fix issue with connection string provided through env variable

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/client.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/client.ts
@@ -32,14 +32,6 @@ export class AzureMonitorOpenTelemetryClient {
    */
   constructor(options?: AzureMonitorOpenTelemetryOptions) {
     this._config = new AzureMonitorOpenTelemetryConfig(options);
-    if (
-      !this._config?.azureMonitorExporterConfig?.connectionString ||
-      this._config?.azureMonitorExporterConfig?.connectionString === ""
-    ) {
-      throw new Error(
-        "Connection String not found, please provide it before starting Azure Monitor OpenTelemetry Client."
-      );
-    }
     this._setStatsbeatFeatures();
     this._metricHandler = new MetricHandler(this._config);
     this._traceHandler = new TraceHandler(this._config, this._metricHandler);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

Connection string provided through env variable would be ignored, parsing is triggered in Azure Monitor Exporters, distro should not have any extra validation for it.