### PR TITLE
[Azure Monitor OpenTelemetry] Add MeterProvider and LoggerProvider as global

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/client.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/client.ts
@@ -87,6 +87,7 @@ export class AzureMonitorOpenTelemetryClient {
     try {
       await this._traceHandler.flush();
       await this._metricHandler.flush();
+      await this._logHandler.flush();
     } catch (err) {
       InternalLogger.getInstance().error("Failed to flush telemetry", err);
     }

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -3,6 +3,7 @@
 
 import { AzureMonitorLogExporter } from "@azure/monitor-opentelemetry-exporter";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { logs } from "@opentelemetry/api-logs";
 import {
   LoggerProvider,
   BatchLogRecordProcessor,
@@ -51,7 +52,7 @@ export class LogHandler {
       const otlpLogProcessor = new BatchLogRecordProcessor(this._otlpExporter);
       this._loggerProvider.addLogRecordProcessor(otlpLogProcessor);
     }
-
+    logs.setGlobalLoggerProvider(this._loggerProvider);
     this._logger = this._loggerProvider.getLogger("AzureMonitorLogger", undefined) as OtelLogger;
   }
 

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AzureMonitorMetricExporter } from "@azure/monitor-opentelemetry-exporter";
-import { Meter } from "@opentelemetry/api";
+import { Meter, metrics } from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import {
   MeterProvider,
@@ -55,14 +55,6 @@ export class MetricHandler {
     this._metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
     this._meterProvider.addMetricReader(this._metricReader);
 
-    const metricExporter = new OTLPMetricExporter({});
-    metricReaderOptions = {
-      exporter: metricExporter,
-      exportIntervalMillis: options?.collectionInterval || this._collectionInterval,
-    };
-    this._metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
-    this._meterProvider.addMetricReader(this._metricReader);
-
     if (config.otlpMetricExporterConfig?.enabled) {
       this._otlpExporter = new OTLPMetricExporter(config.otlpMetricExporterConfig);
       const otlpMetricReader = new PeriodicExportingMetricReader({
@@ -71,7 +63,7 @@ export class MetricHandler {
       });
       this._meterProvider.addMetricReader(otlpMetricReader);
     }
-
+    metrics.setGlobalMeterProvider(this._meterProvider);
     this._meter = this._meterProvider.getMeter("AzureMonitorMeter");
   }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

Fixed issue of OTLP exporter enabled even if configured off
Fixed issue of Logs not being flush when client was flushed