### PR TITLE
Add missing service label entries to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -870,10 +870,10 @@
 /sdk/dnsresolver/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Monitor
-/sdk/monitor/monitor-ingestion/ @KarishmaGhiya @sarangan12 
+/sdk/monitor/monitor-ingestion/ @KarishmaGhiya @sarangan12
 /sdk/monitor/monitor-opentelemetry @hectorhdzg @JacksonWeber
 /sdk/monitor/monitor-opentelemetry-exporter @hectorhdzg @JacksonWeber
-/sdk/monitor/monitor-query/ @KarishmaGhiya @sarangan12 
+/sdk/monitor/monitor-query/ @KarishmaGhiya @sarangan12
 
 # ServiceLabel: %AAD %Service Attention
 #/<NotInRepo>/          @adamedx
@@ -1003,6 +1003,9 @@
 
 # ServiceLabel: %Cognitive - Mgmt %Service Attention
 #/<NotInRepo>/          @yangyuan
+
+# ServiceLabel: %Cognitive - QnA Maker
+#/<NotInRepo>/          @bingisbestest @nerajput1607
 
 # ServiceLabel: %Commerce %Service Attention
 #/<NotInRepo>/          @ms-premp @qiaozha


### PR DESCRIPTION
The FabricBot rule for @ mentioning people based upon the service label when the Service Attention label was added should have been generated from the CODEOWNERS file for each repository. At some point and time this stopped happening and changes were made directly to FabricBot. What I'm doing is getting the last FabricBot.json file for this repository, that was removed as part of the [PR where github-event-processor was enabled](https://github.com/Azure/azure-sdk-for-js/pull/25511) and adding any entries that were in the FabricBot rule that are missing from the CODEOWNERS file.