### PR TITLE
Use sparse checkout in Compliance job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -72,6 +72,27 @@ jobs:
       name: azsdk-pool-mms-win-2022-general
       vmImage: MMS2022
     steps:
+      # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
+      # as we require the GitHub service connection to be loaded.
+      - ${{ if not(contains(variables['Build.DefinitionName'], 'js-pr')) }}:
+        # For PullRequests CredScan will be run against the files changed in the PR.
+        # For non-pull requests CredScan runs against the service directory.
+        - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          - pwsh: |
+              $changedFiles = & "eng/common/scripts/get-changedfiles.ps1"
+              $tmp = ConvertTo-Json @($changedFiles | Sort-Object | Get-Unique) -Compress
+              Write-Host "##vso[task.setvariable variable=SparseCheckoutDirectories;]$tmp"
+
+          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+            parameters:
+              Paths: $(SparseCheckoutDirectories)
+
+        - ${{ else }}:
+          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+            parameters:
+              Paths: 
+                - "sdk/${{ parameters.ServiceDirectory }}"
+
       - template: /eng/common/pipelines/templates/steps/credscan.yml
         parameters:
           ServiceDirectory: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -75,6 +75,9 @@ jobs:
       # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
       # as we require the GitHub service connection to be loaded.
       - ${{ if not(contains(variables['Build.DefinitionName'], 'js-pr')) }}:
+        # First checkout the eng folder to get the common scripts
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+
         # For PullRequests CredScan will be run against the files changed in the PR.
         # For non-pull requests CredScan runs against the service directory.
         - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -86,12 +89,14 @@ jobs:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
             parameters:
               Paths: $(SparseCheckoutDirectories)
+              SkipCheckoutNone: true
 
         - ${{ else }}:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
             parameters:
               Paths: 
                 - "sdk/${{ parameters.ServiceDirectory }}"
+              SkipCheckoutNone: true
 
       - template: /eng/common/pipelines/templates/steps/credscan.yml
         parameters:


### PR DESCRIPTION
_Replication of https://github.com/Azure/azure-sdk-for-java/pull/35835 and https://github.com/Azure/azure-sdk-for-java/pull/35867 from the `azure-sdk-for-java` repository._

Updates the `Compliance` CI job to use sparse checkout instead of full repository checkout when running compliance for non-private repository jobs. When running `Compliance` for pull requests sparse checkout will only checkout the files changed by the PR, replicating what CredScan validates, and for scheduled or manually triggered jobs it will checkout all files in the service directory specified by the CI configuration, again replicating what CredScan validates.

This reduces the amount of files, and time, the CredScan job spends checking out code from about a few minutes to a few seconds. In the Java repository, and likely similar in this repository, the checkout time reduced from about 3-5 minutes to 20-30 seconds.