### PR TITLE
[keyvault-secrets] Change incorrectly named `expires` property to `expiresOn` in README

### DIFF
--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -205,7 +205,7 @@ the following attributes:
 - `contentType`: Any string that can be used to help the receiver of the secret understand how to use the secret value.
 - `enabled`: A boolean value that determines whether the secret value can be read or not.
 - `notBefore`: A given date after which the secret value can be retrieved.
-- `expires`: A given date after which the secret value cannot be retrieved.
+- `expiresOn`: A given date after which the secret value cannot be retrieved.
 
 An object with these attributes can be sent as the third parameter of
 `setSecret`, right after the secret's name and value, as follows:


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-secrets`

### Issues associated with this PR

- Fixes #26431

### Describe the problem that is addressed by this PR

Documentation fix as reported in #26431.

