### PR TITLE
Enable nightly build pipeline failure on docs.ms validation failure

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -320,3 +320,5 @@ stages:
               - ci-configs/packages-latest.json
               - ci-configs/packages-preview.json
             DocValidationImageId: "$(DocValidationImageId)"
+
+        - template: /eng/common/pipelines/templates/steps/docsms-ensure-validation.yml

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -450,6 +450,8 @@ function GetExistingPackageVersions ($PackageName, $GroupId = $null) {
   }
 }
 
+# Defined in common.ps1 as:
+# $ValidateDocsMsPackagesFn = "Validate-${Language}-DocMsPackages" 
 function Validate-javascript-DocMsPackages ($PackageInfo, $PackageInfos, $DocRepoLocation, $DocValidationImageId) { 
   if (!$PackageInfos) {
     $PackageInfos = @($PackageInfo)
@@ -484,5 +486,15 @@ function Validate-javascript-DocMsPackages ($PackageInfo, $PackageInfos, $DocRep
     $outputPackages += $outputPackage
   }
 
-  ValidatePackagesForDocs -packages $outputPackages -DocValidationImageId $DocValidationImageId
+  $validationResults = ValidatePackagesForDocs `
+    -packages $outputPackages `
+    -DocValidationImageId $DocValidationImageId
+
+  foreach ($result in $validationResults) { 
+    if (!$result.Success) { 
+      return $false
+    }
+  }
+
+  return $true
 }


### PR DESCRIPTION
Builds: 

* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2931582&view=results
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2931583&view=results