### PR TITLE
[storage] port HNS permission support from storage/stable

### DIFF
--- a/sdk/storage/storage-blob/assets.json
+++ b/sdk/storage/storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/storage/storage-blob",
-  "Tag": "js/storage/storage-blob_8c8488b395"
+  "Tag": "js/storage/storage-blob_0dfb9bf85a"
 }

--- a/sdk/storage/storage-blob/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/parameters.ts
@@ -102,7 +102,7 @@ export const timeoutInSeconds: OperationQueryParameter = {
 export const version: OperationParameter = {
   parameterPath: "version",
   mapper: {
-    defaultValue: "2021-12-02",
+    defaultValue: "2023-01-03",
     isConstant: true,
     serializedName: "x-ms-version",
     type: {

--- a/sdk/storage/storage-blob/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClient.ts
@@ -67,7 +67,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     this.url = url;
 
     // Assigning values to Constant parameters
-    this.version = options.version || "2021-12-02";
+    this.version = options.version || "2023-01-03";
     this.service = new ServiceImpl(this);
     this.container = new ContainerImpl(this);
     this.blob = new BlobImpl(this);

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export const SDK_VERSION: string = "12.20.0";
-export const SERVICE_VERSION: string = "2021-10-04";
+export const SERVICE_VERSION: string = "2023-01-03";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB
 export const BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES: number = 4000 * 1024 * 1024; // 4000MB

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -1464,4 +1464,13 @@ directive:
         ];
 ```
 
+### Update service version from "2021-12-02" to "2023-01-03"
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.ApiVersionParameter
+    transform: $.enum = [ "2023-01-03" ];
+```
+
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2Fstorage-blob%2Fswagger%2FREADME.png)

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -24,7 +24,7 @@ import {
 } from "../utils";
 import { TokenCredential } from "@azure/core-auth";
 import { assertClientUsesTokenCredential } from "../utils/assert";
-import { Recorder } from "@azure-tools/test-recorder";
+import { Recorder, isLiveMode } from "@azure-tools/test-recorder";
 import { Test_CPK_INFO } from "../utils/fakeTestSecrets";
 import { Context } from "mocha";
 
@@ -37,6 +37,8 @@ describe("AppendBlobClient Node.js only", () => {
   let recorder: Recorder;
 
   let blobServiceClient: BlobServiceClient;
+  const timeoutForLargeFileUploadingTest = 20 * 60 * 1000;
+
   beforeEach(async function (this: Context) {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderEnvSetup);
@@ -339,4 +341,23 @@ describe("AppendBlobClient Node.js only", () => {
     assert.equal(await bodyToString(downloadResponse, content.length * 2), content + content);
     assert.equal(downloadResponse.contentLength!, content.length * 2);
   });
+
+  it.only("appendBlock - append large block", async function (this:Context) {
+    if (!isLiveMode()) {
+      // Recorder file larger than github limitation
+      this.skip();
+    }
+    await appendBlobClient.create();
+
+    const largeBlockSize = 100 * 1024 * 1024;
+    const content = new Uint8Array(largeBlockSize);
+    for (let i = 0; i < largeBlockSize; i = i + 1000) {
+      content[i] = i;
+    }
+    await appendBlobClient.appendBlock(content, content.length);
+
+    const downloadResponse = await appendBlobClient.downloadToBuffer(0);
+    assert.deepStrictEqual(downloadResponse, content);
+    assert.equal(downloadResponse.length, content.length);
+  }).timeout(timeoutForLargeFileUploadingTest);
 });

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -342,7 +342,7 @@ describe("AppendBlobClient Node.js only", () => {
     assert.equal(downloadResponse.contentLength!, content.length * 2);
   });
 
-  it.only("appendBlock - append large block", async function (this:Context) {
+  it("appendBlock - append large block", async function (this: Context) {
     if (!isLiveMode()) {
       // Recorder file larger than github limitation
       this.skip();

--- a/sdk/storage/storage-file-datalake/assets.json
+++ b/sdk/storage/storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/storage/storage-file-datalake",
-  "Tag": "js/storage/storage-file-datalake_1bed51a03a"
+  "Tag": "js/storage/storage-file-datalake_0d90641797"
 }

--- a/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
+++ b/sdk/storage/storage-file-datalake/review/storage-file-datalake.api.md
@@ -665,6 +665,8 @@ export interface FileReadHeaders {
     // (undocumented)
     fileContentMD5?: Uint8Array;
     // (undocumented)
+    group?: string;
+    // (undocumented)
     isServerEncrypted?: boolean;
     // (undocumented)
     lastModified?: Date;
@@ -676,6 +678,10 @@ export interface FileReadHeaders {
     leaseStatus?: LeaseStatusType;
     // (undocumented)
     metadata?: Metadata;
+    // (undocumented)
+    owner?: string;
+    // (undocumented)
+    permissions?: PathPermissions;
     // (undocumented)
     requestId?: string;
     // (undocumented)
@@ -1453,6 +1459,8 @@ export interface PathGetPropertiesHeaders {
     etag?: string;
     expiresOn?: Date;
     // (undocumented)
+    group?: string;
+    // (undocumented)
     isIncrementalCopy?: boolean;
     // (undocumented)
     isServerEncrypted?: boolean;
@@ -1466,6 +1474,10 @@ export interface PathGetPropertiesHeaders {
     leaseStatus?: LeaseStatusType;
     // (undocumented)
     metadata?: Metadata;
+    // (undocumented)
+    owner?: string;
+    // (undocumented)
+    permissions?: PathPermissions;
     // (undocumented)
     requestId?: string;
     // (undocumented)

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -103,7 +103,7 @@ import {
   assertResponse,
   ensureCpkIfSpecified,
   getURLPathAndQuery,
-  ParseEncryptionContextHeaderValue,
+  ParsePathGetPropertiesExtraHeaderValues,
   setURLPath,
   setURLQueries,
 } from "./utils/utils.common";
@@ -677,7 +677,7 @@ export class DataLakePathClient extends StorageClient {
           customerProvidedKey: toBlobCpkInfo(options.customerProvidedKey),
           tracingOptions: updatedOptions.tracingOptions,
         });
-        return ParseEncryptionContextHeaderValue(response as PathGetPropertiesResponse);
+        return ParsePathGetPropertiesExtraHeaderValues(response as PathGetPropertiesResponse);
       }
     );
   }
@@ -1230,7 +1230,7 @@ export class DataLakeFileClient extends DataLakePathClient {
         customerProvidedKey: toBlobCpkInfo(updatedOptions.customerProvidedKey),
       });
 
-      const response = ParseEncryptionContextHeaderValue(
+      const response = ParsePathGetPropertiesExtraHeaderValues(
         rawResponse as FileReadResponse
       ) as FileReadResponse;
       if (!isNode && !response.contentAsBlob) {

--- a/sdk/storage/storage-file-datalake/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/models/parameters.ts
@@ -113,7 +113,7 @@ export const timeout: OperationQueryParameter = {
 export const version: OperationParameter = {
   parameterPath: "version",
   mapper: {
-    defaultValue: "2022-11-02",
+    defaultValue: "2023-01-03",
     isConstant: true,
     serializedName: "x-ms-version",
     type: {

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
@@ -63,7 +63,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
     this.url = url;
 
     // Assigning values to Constant parameters
-    this.version = options.version || "2022-11-02";
+    this.version = options.version || "2023-01-03";
     this.resource = options.resource || "filesystem";
     this.service = new ServiceImpl(this);
     this.fileSystemOperations = new FileSystemOperationsImpl(this);

--- a/sdk/storage/storage-file-datalake/src/models.ts
+++ b/sdk/storage/storage-file-datalake/src/models.ts
@@ -975,6 +975,9 @@ export interface PathGetPropertiesHeaders {
    * Optional. Specifies the encryption context to set on the file.
    */
   encryptionContext?: string;
+  owner?: string;
+  group?: string;
+  permissions?: PathPermissions;
 }
 
 export type PathGetPropertiesResponse = WithResponse<
@@ -1195,6 +1198,9 @@ export interface FileReadHeaders {
    * Specifies the encryption context to set on the file.
    */
   encryptionContext?: string;
+  owner?: string;
+  group?: string;
+  permissions?: PathPermissions;
 }
 
 export type FileReadResponse = WithResponse<

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 export const SDK_VERSION: string = "12.20.0";
-export const SERVICE_VERSION: string = "2021-12-02";
+export const SERVICE_VERSION: string = "2023-01-03";
 
 export const KB: number = 1024;
 export const MB: number = KB * 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -354,5 +354,5 @@ directive:
 directive:
   - from: swagger-document
     where: $.parameters.ApiVersionParameter
-    transform: $.enum = [ "2022-11-02" ];
+    transform: $.enum = [ "2023-01-03" ];
 ```

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -67,7 +67,7 @@ describe("DataLakePathClient Node.js only", () => {
     await recorder.stop();
   });
 
-  it("DataLakeFileClient create with owner", async () => {
+  it.only("DataLakeFileClient create with owner", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const owner = "25fb43dd-e251-48a8-903b-e924f405299a";
@@ -75,9 +75,13 @@ describe("DataLakePathClient Node.js only", () => {
     await testFileClient.create({ owner: owner });
     const result = await testFileClient.getAccessControl();
     assert.equal(result.owner, owner);
+
+    const properties = await testFileClient.getProperties();
+    assert.equal(properties.owner, owner);
+    assert.equal(properties.group, "$superuser");
   });
 
-  it("DataLakeFileClient create with group", async () => {
+  it.only("DataLakeFileClient create with group", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const group = "67089e35-dc13-458b-b06e-d873b8406284";
@@ -85,9 +89,13 @@ describe("DataLakePathClient Node.js only", () => {
     await testFileClient.create({ group: group });
     const result = await testFileClient.getAccessControl();
     assert.equal(result.group, group);
+
+    const properties = await testFileClient.getProperties();
+    assert.equal(properties.owner, "$superuser");
+    assert.equal(properties.group, group);
   });
 
-  it("DataLakeFileClient create with acl", async () => {
+  it.only("DataLakeFileClient create with acl", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const acl: PathAccessControlItem[] = [
@@ -148,6 +156,54 @@ describe("DataLakePathClient Node.js only", () => {
       },
     });
     assert.deepStrictEqual(permissions.acl, acl);
+
+    const properties = await testFileClient.getProperties();
+
+    assert.deepStrictEqual(properties.owner, "$superuser");
+    assert.deepStrictEqual(properties.group, "$superuser");
+    assert.deepStrictEqual(properties.permissions, {
+      extendedAcls: false,
+      stickyBit: false,
+      owner: {
+        read: true,
+        write: true,
+        execute: true,
+      },
+      group: {
+        read: true,
+        write: false,
+        execute: true,
+      },
+      other: {
+        read: false,
+        write: true,
+        execute: false,
+      },
+    });
+
+    const readResult = await testFileClient.read();
+
+    assert.deepStrictEqual(readResult.owner, "$superuser");
+    assert.deepStrictEqual(readResult.group, "$superuser");
+    assert.deepStrictEqual(readResult.permissions, {
+      extendedAcls: false,
+      stickyBit: false,
+      owner: {
+        read: true,
+        write: true,
+        execute: true,
+      },
+      group: {
+        read: true,
+        write: false,
+        execute: true,
+      },
+      other: {
+        read: false,
+        write: true,
+        execute: false,
+      },
+    });
   });
 
   it("DataLakeFileClient createIfNotExists with owner", async () => {
@@ -233,7 +289,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.deepStrictEqual(permissions.acl, acl);
   });
 
-  it("DataLakeDirectoryClient create with owner", async () => {
+  it.only("DataLakeDirectoryClient create with owner", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const owner = "25fb43dd-e251-48a8-903b-e924f405299a";
@@ -241,9 +297,12 @@ describe("DataLakePathClient Node.js only", () => {
     await testDirClient.create({ owner: owner });
     const result = await testDirClient.getAccessControl();
     assert.equal(result.owner, owner);
+
+    const properties = await testDirClient.getProperties();
+    assert.equal(properties.owner, owner);
   });
 
-  it("DataLakeDirectoryClient create with group", async () => {
+  it.only("DataLakeDirectoryClient create with group", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const group = "67089e35-dc13-458b-b06e-d873b8406284";
@@ -251,9 +310,12 @@ describe("DataLakePathClient Node.js only", () => {
     await testDirClient.create({ group: group });
     const result = await testDirClient.getAccessControl();
     assert.equal(result.group, group);
+
+    const properties = await testDirClient.getProperties();
+    assert.equal(properties.group, group);
   });
 
-  it("DataLakeDirectoryClient create with acl", async () => {
+  it.only("DataLakeDirectoryClient create with acl", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const acl: PathAccessControlItem[] = [
@@ -290,11 +352,7 @@ describe("DataLakePathClient Node.js only", () => {
     ];
     await testDirClient.create({ acl: acl });
 
-    const permissions = await testDirClient.getAccessControl();
-
-    assert.deepStrictEqual(permissions.owner, "$superuser");
-    assert.deepStrictEqual(permissions.group, "$superuser");
-    assert.deepStrictEqual(permissions.permissions, {
+    const permissions = {
       extendedAcls: false,
       stickyBit: false,
       owner: {
@@ -312,8 +370,18 @@ describe("DataLakePathClient Node.js only", () => {
         write: true,
         execute: false,
       },
-    });
-    assert.deepStrictEqual(permissions.acl, acl);
+    };
+
+    const aclResult = await testDirClient.getAccessControl();
+    assert.deepStrictEqual(aclResult.owner, "$superuser");
+    assert.deepStrictEqual(aclResult.group, "$superuser");
+    assert.deepStrictEqual(aclResult.permissions, permissions);
+    assert.deepStrictEqual(aclResult.acl, acl);
+
+    const propertiesResult = await testDirClient.getProperties();
+    assert.deepStrictEqual(propertiesResult.owner, "$superuser");
+    assert.deepStrictEqual(propertiesResult.group, "$superuser");
+    assert.deepStrictEqual(propertiesResult.permissions, permissions);
   });
 
   it("DataLakeDirectoryClient createIfNotExists with owner", async () => {

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -67,7 +67,7 @@ describe("DataLakePathClient Node.js only", () => {
     await recorder.stop();
   });
 
-  it.only("DataLakeFileClient create with owner", async () => {
+  it("DataLakeFileClient create with owner", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const owner = "25fb43dd-e251-48a8-903b-e924f405299a";
@@ -81,7 +81,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.equal(properties.group, "$superuser");
   });
 
-  it.only("DataLakeFileClient create with group", async () => {
+  it("DataLakeFileClient create with group", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const group = "67089e35-dc13-458b-b06e-d873b8406284";
@@ -95,7 +95,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.equal(properties.group, group);
   });
 
-  it.only("DataLakeFileClient create with acl", async () => {
+  it("DataLakeFileClient create with acl", async () => {
     const testFileName = recorder.variable("testfile", getUniqueName("testfile"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const acl: PathAccessControlItem[] = [
@@ -289,7 +289,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.deepStrictEqual(permissions.acl, acl);
   });
 
-  it.only("DataLakeDirectoryClient create with owner", async () => {
+  it("DataLakeDirectoryClient create with owner", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const owner = "25fb43dd-e251-48a8-903b-e924f405299a";
@@ -302,7 +302,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.equal(properties.owner, owner);
   });
 
-  it.only("DataLakeDirectoryClient create with group", async () => {
+  it("DataLakeDirectoryClient create with group", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const group = "67089e35-dc13-458b-b06e-d873b8406284";
@@ -315,7 +315,7 @@ describe("DataLakePathClient Node.js only", () => {
     assert.equal(properties.group, group);
   });
 
-  it.only("DataLakeDirectoryClient create with acl", async () => {
+  it("DataLakeDirectoryClient create with acl", async () => {
     const testDirName = recorder.variable("testdir", getUniqueName("testdir"));
     const testDirClient = fileSystemClient.getDirectoryClient(testDirName);
     const acl: PathAccessControlItem[] = [

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -259,7 +259,7 @@ describe("DataLakePathClient", () => {
     assert.ok(!(await testFileClient.exists()));
   });
 
-  it("DataLakeFileClient create with all parameters", async () => {
+  it.only("DataLakeFileClient create with all parameters", async () => {
     const metadata = {
       a: "a",
       b: "b",
@@ -294,19 +294,6 @@ describe("DataLakePathClient", () => {
       encryptionContext,
     });
 
-    const result = await testFileClient.getProperties();
-    assert.deepStrictEqual(result.metadata, metadata);
-    assert.equal(result.createdOn!.getTime() + 1000 * 60, result.expiresOn!.getTime());
-    assert.equal(result.leaseDuration, "fixed");
-    assert.equal(result.leaseState, "leased");
-    assert.equal(result.leaseStatus, "locked");
-    assert.equal(result.cacheControl, httpHeader.cacheControl);
-    assert.equal(result.contentEncoding, httpHeader.contentEncoding);
-    assert.equal(result.contentLanguage, httpHeader.contentLanguage);
-    assert.equal(result.contentDisposition, httpHeader.contentDisposition);
-    assert.equal(result.contentType, httpHeader.contentType);
-    assert.equal(result.encryptionContext, encryptionContext);
-    const aclResult = await testFileClient.getAccessControl();
     const permissions = {
       owner: {
         read: true,
@@ -326,6 +313,21 @@ describe("DataLakePathClient", () => {
       stickyBit: false,
       extendedAcls: false,
     };
+
+    const result = await testFileClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+    assert.equal(result.createdOn!.getTime() + 1000 * 60, result.expiresOn!.getTime());
+    assert.equal(result.leaseDuration, "fixed");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+    assert.equal(result.cacheControl, httpHeader.cacheControl);
+    assert.equal(result.contentEncoding, httpHeader.contentEncoding);
+    assert.equal(result.contentLanguage, httpHeader.contentLanguage);
+    assert.equal(result.contentDisposition, httpHeader.contentDisposition);
+    assert.equal(result.contentType, httpHeader.contentType);
+    assert.equal(result.encryptionContext, encryptionContext);
+    assert.deepEqual(result.permissions, permissions);
+    const aclResult = await testFileClient.getAccessControl();
     assert.deepEqual(aclResult.permissions, permissions);
   });
 
@@ -548,7 +550,7 @@ describe("DataLakePathClient", () => {
     assert.equal(result.leaseStatus, "locked");
   });
 
-  it("DataLakeDirectoryClient create with all parameters", async () => {
+  it.only("DataLakeDirectoryClient create with all parameters", async () => {
     const metadata = {
       a: "a",
       b: "b",
@@ -588,7 +590,6 @@ describe("DataLakePathClient", () => {
     assert.equal(result.contentLanguage, httpHeader.contentLanguage);
     assert.equal(result.contentDisposition, httpHeader.contentDisposition);
     assert.equal(result.contentType, httpHeader.contentType);
-    const aclResult = await testDirClient.getAccessControl();
     const permissions = {
       owner: {
         read: true,
@@ -608,6 +609,9 @@ describe("DataLakePathClient", () => {
       stickyBit: false,
       extendedAcls: false,
     };
+    assert.deepEqual(result.permissions, permissions);
+
+    const aclResult = await testDirClient.getAccessControl();
     assert.deepEqual(aclResult.permissions, permissions);
   });
 
@@ -774,6 +778,38 @@ describe("DataLakePathClient", () => {
     assert.exists(result.createdOn);
   });
 
+  it.only("read a file with permissions set", async () => {
+    const testFileName = recorder.variable("file1", getUniqueName("file1"));
+    const testFileClient = fileSystemClient.getFileClient(testFileName);
+    const permissionString = "0777";
+    const umask = "0057";
+    await testFileClient.create({ permissions: permissionString, umask: umask });
+    await testFileClient.append(content, 0, content.length);
+    await testFileClient.flush(content.length);
+    const result = await testFileClient.read();
+    const permissions = {
+      owner: {
+        read: true,
+        write: true,
+        execute: true,
+      },
+      group: {
+        read: false,
+        write: true,
+        execute: false,
+      },
+      other: {
+        read: false,
+        write: false,
+        execute: false,
+      },
+      stickyBit: false,
+      extendedAcls: false,
+    };
+    assert.deepEqual(result.permissions, permissions);
+    assert.deepStrictEqual(await bodyToString(result, content.length), content);
+    assert.exists(result.createdOn);
+  });
   it("read should not have aborted error after read finishes", async () => {
     const aborter = new AbortController();
     const result = await fileClient.read(0, undefined, { abortSignal: aborter.signal });

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -259,7 +259,7 @@ describe("DataLakePathClient", () => {
     assert.ok(!(await testFileClient.exists()));
   });
 
-  it.only("DataLakeFileClient create with all parameters", async () => {
+  it("DataLakeFileClient create with all parameters", async () => {
     const metadata = {
       a: "a",
       b: "b",
@@ -550,7 +550,7 @@ describe("DataLakePathClient", () => {
     assert.equal(result.leaseStatus, "locked");
   });
 
-  it.only("DataLakeDirectoryClient create with all parameters", async () => {
+  it("DataLakeDirectoryClient create with all parameters", async () => {
     const metadata = {
       a: "a",
       b: "b",
@@ -778,7 +778,7 @@ describe("DataLakePathClient", () => {
     assert.exists(result.createdOn);
   });
 
-  it.only("read a file with permissions set", async () => {
+  it("read a file with permissions set", async () => {
     const testFileName = recorder.variable("file1", getUniqueName("file1"));
     const testFileClient = fileSystemClient.getFileClient(testFileName);
     const permissionString = "0777";


### PR DESCRIPTION
Port PR https://github.com/Azure/azure-sdk-for-js/pull/25675

- update blob service version to 2023-01-03
- add "appendBlock - append large block" test
- port file-datalake source changes
- port file-datalake tests and add recordings
