### PR TITLE
[Identity] fix bug related to managed identity - set app token provider callback scopes

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -266,7 +266,7 @@ export class ManagedIdentityCredential implements TokenCredential {
               };
               logger.info(
                 `authenticateManagedIdentity invoked with scopes- ${JSON.stringify(
-                  scopes
+                  appTokenProviderParameters.scopes
                 )} and getTokenOptions - ${JSON.stringify(getTokenOptions)}`
               );
               const resultToken = await this.authenticateManagedIdentity(

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -23,6 +23,8 @@ import { appServiceMsi2019 } from "./appServiceMsi2019";
 import { AppTokenProviderParameters, ConfidentialClientApplication } from "@azure/msal-node";
 import { DeveloperSignOnClientId } from "../../constants";
 import { MsalResult, MsalToken } from "../../msal/types";
+import { getMSALLogLevel } from "../../msal/utils";
+import { getLogLevel } from "@azure/logger";
 
 const logger = credentialLogger("ManagedIdentityCredential");
 
@@ -134,6 +136,11 @@ export class ManagedIdentityCredential implements TokenCredential {
         authorityMetadata:
           '{"token_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/common/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/{tenantid}/v2.0","request_uri_parameter_supported":false,"userinfo_endpoint":"https://graph.microsoft.com/oidc/userinfo","authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","device_authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/devicecode","http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/logout","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"kerberos_endpoint":"https://login.microsoftonline.com/common/kerberos","tenant_region_scope":null,"cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}',
       },
+      system: {
+        loggerOptions: {
+          logLevel: getMSALLogLevel(getLogLevel()),
+        },
+      },
     });
   }
 
@@ -242,43 +249,51 @@ export class ManagedIdentityCredential implements TokenCredential {
             scopes: Array.isArray(scopes) ? scopes : [scopes],
             claims: options?.claims,
           };
+
           // Added a check to see if SetAppTokenProvider was already defined.
-          // Don't redefine it if it's already defined, since it should be static method.
+          // Don't redefine it if it's already defined.
           if (!this.isAppTokenProviderInitialized) {
-            this.confidentialApp.SetAppTokenProvider(
-              async (appTokenProviderParameters = appTokenParameters) => {
+            this.confidentialApp.SetAppTokenProvider(async (appTokenProviderParameters) => {
+              logger.info(
+                `SetAppTokenProvider invoked with parameters- ${JSON.stringify(
+                  appTokenProviderParameters
+                )}`
+              );
+              const getTokenOptions: GetTokenOptions = {
+                claims: appTokenProviderParameters.claims,
+                ...updatedOptions,
+                ...appTokenProviderParameters,
+              };
+              logger.info(
+                `authenticateManagedIdentity invoked with scopes- ${JSON.stringify(
+                  scopes
+                )} and getTokenOptions - ${JSON.stringify(getTokenOptions)}`
+              );
+              const resultToken = await this.authenticateManagedIdentity(
+                appTokenProviderParameters.scopes,
+                getTokenOptions
+              );
+
+              if (resultToken) {
+                logger.info(`SetAppTokenProvider will save the token in cache`);
+
+                const expiresInSeconds = resultToken?.expiresOnTimestamp
+                  ? Math.floor((resultToken.expiresOnTimestamp - Date.now()) / 1000)
+                  : 0;
+                return {
+                  accessToken: resultToken?.token,
+                  expiresInSeconds,
+                };
+              } else {
                 logger.info(
-                  `SetAppTokenProvider invoked with parameters- ${JSON.stringify(
-                    appTokenProviderParameters
-                  )}`
+                  `SetAppTokenProvider token has "no_access_token_returned" as the saved token`
                 );
-
-                const resultToken = await this.authenticateManagedIdentity(scopes, {
-                  ...updatedOptions,
-                  ...appTokenProviderParameters,
-                });
-
-                if (resultToken) {
-                  logger.info(`SetAppTokenProvider has saved the token in cache`);
-
-                  const expiresInSeconds = resultToken?.expiresOnTimestamp
-                    ? Math.floor((resultToken.expiresOnTimestamp - Date.now()) / 1000)
-                    : 0;
-                  return {
-                    accessToken: resultToken?.token,
-                    expiresInSeconds,
-                  };
-                } else {
-                  logger.info(
-                    `SetAppTokenProvider token has "no_access_token_returned" as the saved token`
-                  );
-                  return {
-                    accessToken: "no_access_token_returned",
-                    expiresInSeconds: 0,
-                  };
-                }
+                return {
+                  accessToken: "no_access_token_returned",
+                  expiresInSeconds: 0,
+                };
               }
-            );
+            });
             this.isAppTokenProviderInitialized = true;
           }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Fixes #https://github.com/Azure/azure-sdk-for-js/issues/25989
Fixes #https://github.com/Azure/azure-sdk-for-js/issues/26395
Fixes #https://github.com/Azure/azure-sdk-for-js/pull/26566

### Describe the problem that is addressed by this PR
The `authenticateManagedIdentity` method inside of `SetAppTokenProvider` callback wasn't taking the current scopes as the parameter- it was taking the scopes of the `getMethod` call at the time this `SetAppTokenProvider` callback was defined. As a result, when a successive `getToken` call is made with a different scope for another service, this new scope doesn't get passed in the `authenticateManagedIdentity` method call, instead it used the `scope` from the time of defining, resulting in the Invalid Audience error from the service.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
