### PR TITLE
[keyvault] keyvault-keys: bump minimum version of core-rest-pipeline

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -106,7 +106,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.8.0",
+    "@azure/core-rest-pipeline": "^1.8.1",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-util": "^1.0.0",
     "@azure/core-lro": "^2.2.0",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-keys`

### Issues associated with this PR

- #26001

### Describe the problem that is addressed by this PR

Bump version of `core-rest-pipeline` dependency to include `isRestError` type guard which is used as part of fix in #26001.