### PR TITLE
interactiveBrowserCredentialOptions added to deploy fnc

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-tools/CHANGELOG.md
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/CHANGELOG.md
@@ -4,11 +4,22 @@
 
 ### Features Added
 
+- "parentLocation" object is being sent with "secrets" trough askForSecrets function call, it contains location info of the Developer Portal window - href, origin, pathname, search...
+- Node function "deploy" now accepts JSON config object with two options
+  - interactiveBrowserCredentialOptions 
+    - config object for InteractiveBrowserCredential function from @azure/identity package, you can find the accepted values [here](https://learn.microsoft.com/en-us/javascript/api/@azure/identity/interactivebrowsercredentialnodeoptions?view=azure-node-latest)
+    - by default: { redirectUri: "http://localhost:1337" }
+  - rootLocal 
+    - relative path from where the script will load your local builded files
+    - by default: "./dist/"
+
 ### Breaking Changes
+
+- Node function "deploy" no longer accepts a fourth optional "rootLocal" string parameter, but an optional "config" object parameter which contains multiple options to configure the function. The "rootLocal" param was moved into the object.
 
 ### Bugs Fixed
 
-### Other Changes
+- crash of the Node "deploy" function on Mac on incorrect "redirectUri" being sent to "InteractiveBrowserCredential" class.
 
 ## 1.0.0-beta.1 (2022-08-03)
 

--- a/sdk/apimanagement/api-management-custom-widgets-tools/review/api-management-custom-widgets-tools.api.md
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/review/api-management-custom-widgets-tools.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { InteractiveBrowserCredentialNodeOptions } from '@azure/identity';
+
 // @public
 export const APIM_ASK_FOR_SECRETS_MESSAGE_KEY = "askForSecretsMSAPIM";
 
@@ -38,7 +40,13 @@ export function buildBlobDataPath(name: string): string;
 export function buildOnChange<Values extends ValuesCommon>(): OnChange<Values>;
 
 // @public
-export function deployNodeJS(serviceInformation: ServiceInformation, name: string, fallbackConfigPath?: string, rootLocal?: string): Promise<void>;
+export type DeployConfig = {
+    rootLocal?: string;
+    interactiveBrowserCredentialOptions?: InteractiveBrowserCredentialNodeOptions;
+};
+
+// @public
+export function deployNodeJS(serviceInformation: ServiceInformation, name: string, fallbackConfigPath?: string, { rootLocal, interactiveBrowserCredentialOptions }?: DeployConfig): Promise<void>;
 
 // @public
 export interface EditorData<Values extends ValuesCommon> extends PortalData {
@@ -75,6 +83,16 @@ export type Secrets = {
     apiVersion: string;
     userId?: string;
     token?: string;
+    parentLocation: {
+        host: string;
+        hostname: string;
+        href: string;
+        origin: string;
+        pathname: string;
+        port: string;
+        protocol: string;
+        search: string;
+    };
 };
 
 // @public

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/index.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/index.ts
@@ -36,4 +36,4 @@ export {
 
 import deployNodeJS from "./node/deploy";
 export { deployNodeJS };
-export type { ServiceInformation } from "./node/deploy";
+export type { ServiceInformation, DeployConfig } from "./node/deploy";

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/node/deploy.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/node/deploy.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import CustomWidgetBlobService, { Config } from "./CustomWidgetBlobService";
+import { InteractiveBrowserCredentialNodeOptions } from "@azure/identity";
 import { APIM_CONFIG_FILE_NAME } from "../paths";
 import fs from "fs";
 import getStorageSasUrl from "./getStorageSasUrl";
@@ -21,24 +22,41 @@ export type ServiceInformation = {
 };
 
 /**
+ * Optional options object for configuring the deployment function.
+ *
+ * @param rootLocal - optional, root of the local folder with compiled project to be exported (by default "./dist")
+ * @param interactiveBrowserCredentialOptions - options for InteractiveBrowserCredential for Node or InBrowser from \@azure/identity
+ */
+export type DeployConfig = {
+  rootLocal?: string;
+  interactiveBrowserCredentialOptions?: InteractiveBrowserCredentialNodeOptions;
+};
+
+/**
  * Deploys everything from /dist folder to the API Management DevPortals' blob storage.
  *
  * @param serviceInformation - service information for deployment
  * @param name - name of the widget to be deployed
  * @param fallbackConfigPath - local path to the config file (by default "./static/config.msapim.json")
- * @param rootLocal - optional, root of the local folder with compiled project to be exported (by default "./dist")
+ * @param config - optional config obj
  */
 async function deploy(
   serviceInformation: ServiceInformation,
   name: string,
   fallbackConfigPath = "./static/" + APIM_CONFIG_FILE_NAME,
-  rootLocal: string = "./dist/"
+  {
+    rootLocal = "./dist/",
+    interactiveBrowserCredentialOptions = { redirectUri: "http://localhost:1337" }
+  }: DeployConfig = {}
 ): Promise<void> {
   console.log("\n\n");
   console.log("Starting deploy process of custom widget: " + name);
   console.log("Please, sign in to your Azure account when prompted\n");
 
-  const blobStorageUrl = await getStorageSasUrl(serviceInformation);
+  const blobStorageUrl = await getStorageSasUrl(
+    serviceInformation,
+    interactiveBrowserCredentialOptions
+  );
   const customWidgetBlobService = new CustomWidgetBlobService(blobStorageUrl, name);
 
   let config: Config | undefined;

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/utils.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/utils.ts
@@ -150,13 +150,23 @@ export function buildOnChange<Values extends ValuesCommon>(): OnChange<Values> {
  */
 export type TargetModule = "app" | "editor";
 /**
- * Secrets needed for communication with Dev Portal back-end
+ * Secrets needed for communication with Dev Portal back-end and other runtime data
  */
 export type Secrets = {
   managementApiUrl: string;
   apiVersion: string;
   userId?: string;
   token?: string;
+  parentLocation: {
+    host: string,
+    hostname: string,
+    href: string,
+    origin: string,
+    pathname: string,
+    port: string,
+    protocol: string,
+    search: string,
+  },
 };
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR
api-management-custom-widgets-tools

### Describe the problem that is addressed by this PR
- exposing interactiveBrowserCredentialOptions to deploy function so it's configurable to customers specific needs 
- customers were not able to access parent location object of injected custom widgets, added it as "parentLocation"

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?
- [x] Added a changelog (if necessary)
