### PR TITLE
fix upsert /id generation

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -341,17 +341,15 @@ export class Items {
     body: T,
     options: RequestOptions = {}
   ): Promise<ItemResponse<T>> {
-    const { diagnosticContext, partitionKeyDefinition } = await readAndRecordPartitionKeyDefinition(
-      this.container
-    );
-    const partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
-
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
     if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
       body.id = uuid();
     }
-
+    const { diagnosticContext, partitionKeyDefinition } = await readAndRecordPartitionKeyDefinition(
+      this.container
+    );
+    const partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
     const err = {};
     if (!isItemResourceValid(body, err)) {
       throw err;

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
@@ -522,7 +522,7 @@ describe("Create, Upsert, Read, Update, Replace, Delete Operations on Item", fun
   });
 
   describe("Upsert when collection partitioned on id", async () => {
-    //https://github.com/Azure/azure-sdk-for-js/issues/21383
+    // https://github.com/Azure/azure-sdk-for-js/issues/21383
     it("should create a new resource if /id is not passed", async function () {
       const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
       const { resource: resource } = await container.items.upsert({ key1: 0, key2: 0 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
@@ -520,7 +520,39 @@ describe("Create, Upsert, Read, Update, Replace, Delete Operations on Item", fun
     const { resource } = await container.items.create({});
     assert.ok(resource.id);
   });
+
+  describe("Upsert when collection partitioned on id", async () => {
+    //https://github.com/Azure/azure-sdk-for-js/issues/21383
+    it("should create a new resource if /id is not passed", async function () {
+      const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
+      const { resource: resource } = await container.items.upsert({ key1: 0, key2: 0 });
+      assert.ok(resource.id);
+    });
+
+    it("should create a new resource if /id is passed and resource doesn't exist", async function () {
+      const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
+      const { resource: resource } = await container.items.upsert({
+        id: "1ee929e0-40aa-4143-978c-8415914056d4",
+        key1: 0,
+        key2: 0,
+      });
+      assert.ok(resource.id);
+    });
+    it("should update a resource if /id is passed and exists in container", async function () {
+      const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
+      const { resource: resource1 } = await container.items.upsert({ key1: 0, key2: 1 });
+      assert.ok(resource1.id);
+
+      const { resource: resource2 } = await container.items.upsert({
+        id: resource1.id,
+        key1: 0,
+        key2: 2,
+      });
+      assert.strictEqual(resource1.id, resource2.id);
+    });
+  });
 });
+
 // TODO: Non-deterministic test. We can't guarantee we see any response with a 429 status code since the retries happen within the response
 describe("item read retries", async function () {
   it("retries on 429", async function () {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#21383

### Describe the problem that is addressed by this PR
Upsert operation was failing when partition key of container is /id and id is missing in the object body. This fix generates the uuid before extracting partition key from the body, similar to create operation.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
