### PR TITLE
[core] Fix TypeError when setting user agent string in React Native

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fix a TypeError in React Native when `Platform.constants` is undefined [Issue #26609](https://github.com/Azure/azure-sdk-for-js/issues/26609)
+
 ### Other Changes
 
 ## 1.11.0 (2023-06-01)

--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.native.ts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform.native.ts
@@ -17,7 +17,9 @@ export function getHeaderName(): string {
  * @internal
  */
 export function setPlatformSpecificData(map: Map<string, string>): void {
-  const { major, minor, patch } = Platform.constants.reactNativeVersion;
-  map.set("react-native", `${major}.${minor}.${patch}`);
+  if (Platform.constants?.reactNativeVersion) {
+    const { major, minor, patch } = Platform.constants.reactNativeVersion;
+    map.set("react-native", `${major}.${minor}.${patch}`);
+  }
   map.set("OS", `${Platform.OS}-${Platform.Version}`);
 }


### PR DESCRIPTION
`Platform.constants` was introduced in React Native version v0.63. This PR adds a check before accessing the property.

### Packages impacted by this PR
`@azure/core-rest-pipeline`

### Issues associated with this PR
#26609
