### PR TITLE
Fix for issues/26618 -  @azure/logger should be a depenency

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -93,6 +93,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.2.0",
+    "@azure/logger": "^1.0.0",
     "@azure/core-tracing": "^1.0.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.1.0",
@@ -109,7 +110,6 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^2.0.1",
-    "@azure/logger": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/debug": "^4.1.4",
     "@types/mocha": "^7.0.2",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR

[26618](https://github.com/Azure/azure-sdk-for-js/issues/26618)

### Describe the problem that is addressed by this PR

@azure/logger is specified as a dev dependency and is used inside the source code inside dist.
Since this is a phantom dependency, it works fine if you donot specify hoist in the .npmrc file. On the other hand, if you specify the below lines in .npmrc file, @azure/cosmos will break with the error Error: Cannot find module '@azure/logger'
[@azure/cosmos](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/cosmos_3.17.3/sdk/cosmosdb/cosmos/package.json#L112)

**.npmrc file:**
`hoist=true`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
