### PR TITLE
Added entropy to database names created across bulk tests for @azure/cosmso

### DIFF
--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -783,7 +783,7 @@ describe("test bulk operations", async function () {
         readItemId = addEntropy("item1");
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
-          dbName: addEntropy('respects order'),
+          dbName: addEntropy("respects order"),
           documentToCreate: [{ id: readItemId, key: "A", class: "2010" }],
           operations: [
             {
@@ -813,7 +813,7 @@ describe("test bulk operations", async function () {
       it("424 errors for operations after an error", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
-          dbName: addEntropy('424 errors'),
+          dbName: addEntropy("424 errors"),
           documentToCreate: [],
           operations: [
             {
@@ -837,7 +837,7 @@ describe("test bulk operations", async function () {
       it("Continues after errors with continueOnError true", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
-          dbName: addEntropy('continueOnError'),
+          dbName: addEntropy("continueOnError"),
           documentToCreate: [],
           bulkOperationOptions: {
             continueOnError: true,
@@ -865,7 +865,7 @@ describe("test bulk operations", async function () {
       it("autogenerates IDs for Create operations", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
-          dbName: addEntropy('autogenerateIDs'),
+          dbName: addEntropy("autogenerateIDs"),
           operations: [
             {
               description: "Operation should fail with invalid ttl.",
@@ -886,7 +886,7 @@ describe("test bulk operations", async function () {
         const item3Id = addEntropy("item2");
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
-          dbName: addEntropy('handle special partition keys'),
+          dbName: addEntropy("handle special partition keys"),
           documentToCreate: [
             { id: item1Id, key: null, class: "2010" },
             { id: item2Id, key: 0 },

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -783,6 +783,7 @@ describe("test bulk operations", async function () {
         readItemId = addEntropy("item1");
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
+          dbName: addEntropy('respects order'),
           documentToCreate: [{ id: readItemId, key: "A", class: "2010" }],
           operations: [
             {
@@ -812,6 +813,7 @@ describe("test bulk operations", async function () {
       it("424 errors for operations after an error", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
+          dbName: addEntropy('424 errors'),
           documentToCreate: [],
           operations: [
             {
@@ -835,6 +837,7 @@ describe("test bulk operations", async function () {
       it("Continues after errors with continueOnError true", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
+          dbName: addEntropy('continueOnError'),
           documentToCreate: [],
           bulkOperationOptions: {
             continueOnError: true,
@@ -862,6 +865,7 @@ describe("test bulk operations", async function () {
       it("autogenerates IDs for Create operations", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
+          dbName: addEntropy('autogenerateIDs'),
           operations: [
             {
               description: "Operation should fail with invalid ttl.",
@@ -882,6 +886,7 @@ describe("test bulk operations", async function () {
         const item3Id = addEntropy("item2");
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
+          dbName: addEntropy('handle special partition keys'),
           documentToCreate: [
             { id: item1Id, key: null, class: "2010" },
             { id: item2Id, key: 0 },


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmso

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Few tests in `sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts` share name of database created. This could result in race condition, where one test deletes on database while the other tests expects it to be there.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
