### PR TITLE
[storage-file-share] Fix DirectoryClient `exists` test

### DIFF
--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -1921,7 +1921,7 @@ describe("DirectoryClient - AllowingTrailingDots - True", () => {
   });
 
   it("exists", async () => {
-    assert.ok(dirClient.exists(), "The directory with trailing dot should exists");
+    assert.ok(await dirClient.exists(), "The directory with trailing dot should exists");
   });
 
   it("deleteIfExists", async () => {
@@ -2189,7 +2189,7 @@ describe("DirectoryClient - AllowingTrailingDots - False", () => {
   });
 
   it("exists", async () => {
-    assert.ok(dirClient.exists(), "The directory with trailing dot should exists");
+    assert.ok(await dirClient.exists(), "The directory with trailing dot should exists");
   });
 
   it("deleteIfExists", async () => {


### PR DESCRIPTION
Two tests are not awaiting on `dirClient.exists()` calls, which some times caused weird test failure probably due to different timing in async calls where test recorder couldn't find recording for some tests.

This PR adds await for the two calls.
