### PR TITLE
[storage] port accountName from SAS connect string support from storage/stable

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -224,7 +224,11 @@ export function extractConnectionStringParts(connectionString: string): Connecti
     // SAS connection string
 
     let accountSas = getValueInConnString(connectionString, "SharedAccessSignature");
-    const accountName = getAccountNameFromUrl(blobEndpoint);
+    let accountName = getValueInConnString(connectionString, "AccountName");
+    // if accountName is empty, try to read it from BlobEndpoint
+    if (!accountName) {
+      accountName = getAccountNameFromUrl(blobEndpoint);
+    }
     if (!blobEndpoint) {
       throw new Error("Invalid BlobEndpoint in the provided SAS Connection String");
     } else if (!accountSas) {
@@ -623,11 +627,11 @@ export function isIpEndpointStyle(parsedUrl: URL): boolean {
   const host = parsedUrl.host;
 
   // Case 1: Ipv6, use a broad regex to find out candidates whose host contains two ':'.
-  // Case 2: localhost(:port), use broad regex to match port part.
+  // Case 2: localhost(:port) or host.docker.internal, use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
   return (
-    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+    /^.*:.*:.*$|^(localhost|host.docker.internal)(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
       host
     ) ||
     (Boolean(parsedUrl.port) && PathStylePorts.includes(parsedUrl.port))

--- a/sdk/storage/storage-blob/test/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/utils.spec.ts
@@ -145,6 +145,73 @@ describe("Utility Helpers", () => {
     );
   });
 
+  it("extractConnectionStringParts parses sas connection string with local domain", async () => {
+    const localDomain = `http://localhost:10000/devstoreaccount1`;
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature}`;
+    const connectionStringParts = extractConnectionStringParts(sasConnectionString);
+    assert.equal(
+      "SASConnString",
+      connectionStringParts.kind,
+      "extractConnectionStringParts().kind is different than expected."
+    );
+    assert.equal(
+      localDomain,
+      connectionStringParts.url,
+      "extractConnectionStringParts().url is different than expected."
+    );
+    assert.equal(
+      "devstoreaccount1",
+      connectionStringParts.accountName,
+      "extractConnectionStringParts().accountName is different than expected."
+    );
+  });
+
+  it("extractConnectionStringParts parses sas connection string with localhost and custom port", async () => {
+    const localDomain = `http://localhost:20000`;
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature}`;
+    const connectionStringParts = extractConnectionStringParts(sasConnectionString);
+    assert.equal(
+      "SASConnString",
+      connectionStringParts.kind,
+      "extractConnectionStringParts().kind is different than expected."
+    );
+    assert.equal(
+      localDomain,
+      connectionStringParts.url,
+      "extractConnectionStringParts().url is different than expected."
+    );
+    assert.equal(
+      "",
+      connectionStringParts.accountName,
+      "extractConnectionStringParts().accountName is different than expected."
+    );
+  });
+
+  it("extractConnectionStringParts parses sas connection string with custom domain", async () => {
+    const localDomain = `http://host.docker.internal:10000`;
+    const localAccountName = "devstoreaccount1";
+    const sasConnectionString = `BlobEndpoint=${localDomain};
+    SharedAccessSignature=${sharedAccessSignature};AccountName=${localAccountName}`;
+    const connectionStringParts = extractConnectionStringParts(sasConnectionString);
+    assert.equal(
+      "SASConnString",
+      connectionStringParts.kind,
+      "extractConnectionStringParts().kind is different than expected."
+    );
+    assert.equal(
+      localDomain,
+      connectionStringParts.url,
+      "extractConnectionStringParts().url is different than expected."
+    );
+    assert.equal(
+      localAccountName,
+      connectionStringParts.accountName,
+      "extractConnectionStringParts().accountName is different than expected."
+    );
+  });
+
   it("isIpEndpointStyle", async function () {
     assert.equal(
       isIpEndpointStyle(new URL("https://192.0.0.10:1900/accountName/containerName/blobName")),

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -196,7 +196,11 @@ export function extractConnectionStringParts(connectionString: string): Connecti
     // SAS connection string
 
     const accountSas = getValueInConnString(connectionString, "SharedAccessSignature");
-    const accountName = getAccountNameFromUrl(blobEndpoint);
+    let accountName = getValueInConnString(connectionString, "AccountName");
+    // if accountName is empty, try to read it from BlobEndpoint
+    if (!accountName) {
+      accountName = getAccountNameFromUrl(blobEndpoint);
+    }
     if (!blobEndpoint) {
       throw new Error("Invalid BlobEndpoint in the provided SAS Connection String");
     } else if (!accountSas) {
@@ -547,11 +551,11 @@ export function isIpEndpointStyle(parsedUrl: URL): boolean {
   const host = parsedUrl.host;
 
   // Case 1: Ipv6, use a broad regex to find out candidates whose host contains two ':'.
-  // Case 2: localhost(:port), use broad regex to match port part.
+  // Case 2: localhost(:port) or host.docker.internal, use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
   return (
-    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+    /^.*:.*:.*$|^(localhost|host.docker.internal)(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
       host
     ) ||
     (Boolean(parsedUrl.port) && PathStylePorts.includes(parsedUrl.port))

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -173,7 +173,11 @@ export function extractConnectionStringParts(connectionString: string): Connecti
   } else {
     // SAS connection string
     const accountSas = getValueInConnString(connectionString, "SharedAccessSignature");
-    const accountName = getAccountNameFromUrl(fileEndpoint);
+    let accountName = getValueInConnString(connectionString, "AccountName");
+    // if accountName is empty, try to read it from BlobEndpoint
+    if (!accountName) {
+      accountName = getAccountNameFromUrl(fileEndpoint);
+    }
     if (!fileEndpoint) {
       throw new Error("Invalid FileEndpoint in the provided SAS Connection String");
     } else if (!accountSas) {
@@ -474,11 +478,11 @@ export function isIpEndpointStyle(parsedUrl: URL): boolean {
   const host = parsedUrl.host;
 
   // Case 1: Ipv6, use a broad regex to find out candidates whose host contains two ':'.
-  // Case 2: localhost(:port), use broad regex to match port part.
+  // Case 2: localhost(:port) or host.docker.internal, use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
   return (
-    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+    /^.*:.*:.*$|^(localhost|host.docker.internal)(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
       host
     ) ||
     (Boolean(parsedUrl.port) && PathStylePorts.includes(parsedUrl.port))

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -259,7 +259,11 @@ export function extractConnectionStringParts(connectionString: string): Connecti
     // SAS connection string
 
     const accountSas = getValueInConnString(connectionString, "SharedAccessSignature");
-    const accountName = getAccountNameFromUrl(queueEndpoint);
+    let accountName = getValueInConnString(connectionString, "AccountName");
+    // if accountName is empty, try to read it from BlobEndpoint
+    if (!accountName) {
+      accountName = getAccountNameFromUrl(queueEndpoint);
+    }
     if (!queueEndpoint) {
       throw new Error("Invalid QueueEndpoint in the provided SAS Connection String");
     } else if (!accountSas) {
@@ -389,11 +393,11 @@ export function isIpEndpointStyle(parsedUrl: URL): boolean {
   const host = parsedUrl.host;
 
   // Case 1: Ipv6, use a broad regex to find out candidates whose host contains two ':'.
-  // Case 2: localhost(:port), use broad regex to match port part.
+  // Case 2: localhost(:port) or host.docker.internal, use broad regex to match port part.
   // Case 3: Ipv4, use broad regex which just check if host contains Ipv4.
   // For valid host please refer to https://man7.org/linux/man-pages/man7/hostname.7.html.
   return (
-    /^.*:.*:.*$|^localhost(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
+    /^.*:.*:.*$|^(localhost|host.docker.internal)(:[0-9]+)?$|^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])(\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])){3}(:[0-9]+)?$/.test(
       host
     ) ||
     (Boolean(parsedUrl.port) && PathStylePorts.includes(parsedUrl.port))


### PR DESCRIPTION
Port PR https://github.com/Azure/azure-sdk-for-js/pull/26159

- port source and test change for blob

- update one negative test. We used to throw an error when splting an undefined `parsedUrl.pathname` in `getAccountNameFromUrl`.  In core v2 we changed to use `URL` instead of `URLBuilder`. `parsedUrl.pathname` is now an empty string, an empty `accountName` is returned instead of error thrown.

- duplicate source change for other storage package as we currently are doing for internal util methods.

