### PR TITLE
[storage-file-share] Fix empty continuation token with list methods

### DIFF
--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -122,6 +122,7 @@ import {
   ConvertInternalResponseOfListHandles,
   WithResponse,
   assertResponse,
+  removeEmptyString,
 } from "./utils/utils.common";
 import { Credential } from "../../storage-blob/src/credentials/Credential";
 import { StorageSharedKeyCredential } from "../../storage-blob/src/credentials/StorageSharedKeyCredential";
@@ -2278,10 +2279,13 @@ export class ShareDirectoryClient extends StorageClient {
        * Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.iterateFilesAndDirectoriesSegments(settings.continuationToken, {
-          maxResults: settings.maxPageSize,
-          ...updatedOptions,
-        });
+        return this.iterateFilesAndDirectoriesSegments(
+          removeEmptyString(settings.continuationToken),
+          {
+            maxResults: settings.maxPageSize,
+            ...updatedOptions,
+          }
+        );
       },
     };
   }
@@ -2470,7 +2474,7 @@ export class ShareDirectoryClient extends StorageClient {
        * Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.iterateHandleSegments(settings.continuationToken, {
+        return this.iterateHandleSegments(removeEmptyString(settings.continuationToken), {
           maxResults: settings.maxPageSize,
           ...options,
         });
@@ -4883,7 +4887,7 @@ export class ShareFileClient extends StorageClient {
        * Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.iterateHandleSegments(settings.continuationToken, {
+        return this.iterateHandleSegments(removeEmptyString(settings.continuationToken), {
           maxPageSize: settings.maxPageSize,
           ...options,
         });

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -25,6 +25,7 @@ import {
   appendToURLPath,
   extractConnectionStringParts,
   assertResponse,
+  removeEmptyString,
 } from "./utils/utils.common";
 import { Credential } from "../../storage-blob/src/credentials/Credential";
 import { StorageSharedKeyCredential } from "../../storage-blob/src/credentials/StorageSharedKeyCredential";
@@ -604,7 +605,7 @@ export class ShareServiceClient extends StorageClient {
        * Return an AsyncIterableIterator that works a page at a time
        */
       byPage: (settings: PageSettings = {}) => {
-        return this.listSegments(settings.continuationToken, {
+        return this.listSegments(removeEmptyString(settings.continuationToken), {
           maxResults: settings.maxPageSize,
           ...updatedOptions,
         });

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -754,3 +754,14 @@ export function ConvertInternalResponseOfListHandles(
 
   return wrappedResponse;
 }
+
+/**
+ * A small helper to handle converting an empty string "" into undefined
+ * This is used in the case of query parameters (like continuation token) where
+ * we don't want to send an empty query parameter to the service since the signing
+ * policy for shared key will fail.
+ * @internal
+ */
+export function removeEmptyString(value: string | undefined): string | undefined {
+  return value ? value : undefined;
+}


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/storage-file-share`

### Describe the problem that is addressed by this PR

When the empty string was passed as a continuationToken to the `byPage` method of any `list` operation, the constructed url would have an empty marker parameter `&marker=&`. 

This was causing issues with SharedKey authentication since we now share the same credential signing logic as `storage-blob` and the implementation of `getURLQueries` in storage-blob ignores query parameters without a value: 
https://github.com/Azure/azure-sdk-for-js/blob/b4e1a63cd2499016f91852c7208f0c4c569651d4/sdk/storage/storage-blob/src/utils/utils.common.ts#L371

However, the previous copy of this method in `storage-file-share` did not: 
https://github.com/Azure/azure-sdk-for-js/blob/b4e1a63cd2499016f91852c7208f0c4c569651d4/sdk/storage/storage-file-share/src/utils/utils.common.ts#L306

Notice the missing `&& lastIndexOfEqual < value.length - 1` in the second implementation.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

While it is possible to change the way storage-blob does this signing to match storage-file-share, given that storage-blob is a far more popular package, there is considerable risk to changing behavior there.

Since existing storage-file-share customers (such as Storage Explorer) may be already passing the empty string today, there is a strong desire to maintain that contract. 

Rather than diverge the signing logic around SharedKeyCredential again, I believe the least invasive fix is to have the list methods in storage-file-share ignore the empty string as demonstrated in this PR.