### PR TITLE
[storage-file-share] update core-util version to ^1.4.0

### DIFF
--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -130,7 +130,7 @@
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.10.1",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.3.3",
+    "@azure/core-util": "^1.4.0",
     "@azure/core-xml": "^1.3.2",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",


### PR DESCRIPTION
as we have bumped core-util minor version, v1.3.3 no longer exists
