### PR TITLE
[keyvault] Remove timeout tests

### DIFF
--- a/sdk/keyvault/keyvault-certificates/assets.json
+++ b/sdk/keyvault/keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-certificates",
-  "Tag": "js/keyvault/keyvault-certificates_43821e21b3"
+  "Tag": "js/keyvault/keyvault-certificates_dff8f6c5fd"
 }

--- a/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/CRUD.spec.ts
@@ -85,23 +85,6 @@ describe("Certificates client - create, read, update and delete", () => {
     });
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can create a certificate with requestOptions timeout", async function (this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    await assertThrowsAbortError(async () => {
-      await client.beginCreateCertificate(certificateName, basicCertificatePolicy, {
-        ...testPollerProperties,
-        requestOptions: {
-          timeout: 1,
-        },
-      });
-    });
-  });
-
   it("cannot create a certificate with an empty name", async function () {
     const certificateName = "";
     try {
@@ -181,31 +164,6 @@ describe("Certificates client - create, read, update and delete", () => {
 
     result = await client.getCertificateVersion(certificateName, version);
     assert.equal(result.properties.enabled, false);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can update certificate with requestOptions timeout", async function (this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-
-    const poller = await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const { version } = poller.getResult()!.properties;
-
-    await assertThrowsAbortError(async () => {
-      await client.updateCertificateProperties(certificateName, version || "", {
-        tags: {
-          customTag: "value",
-        },
-        requestOptions: { timeout: 1 },
-      });
-    });
   });
 
   it("can get a certificate", async function (this: Context) {
@@ -303,23 +261,6 @@ describe("Certificates client - create, read, update and delete", () => {
     assert.equal(base64CER, base64PublicCertificate);
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get a certificate with requestOptions timeout", async function (this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await assertThrowsAbortError(async () => {
-      await client.getCertificate(certificateName, { requestOptions: { timeout: 1 } });
-    });
-  });
-
   it("can retrieve the latest version of a certificate value", async function (this: Context) {
     const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
     await client.beginCreateCertificate(
@@ -377,28 +318,6 @@ describe("Certificates client - create, read, update and delete", () => {
     }
 
     await poller.pollUntilDone();
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can delete a certificate with requestOptions timeout", async function (this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteCertificate(certificateName, {
-        ...testPollerProperties,
-        requestOptions: {
-          timeout: 1,
-        },
-      });
-    });
   });
 
   it("can delete a certificate (Non Existing)", async function (this: Context) {

--- a/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/list.spec.ts
@@ -3,11 +3,9 @@
 
 import { Context } from "mocha";
 import { assert } from "@azure/test-utils";
-import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure-tools/test-recorder";
-import { isNode } from "@azure/core-util";
+import { env, Recorder, isRecordMode } from "@azure-tools/test-recorder";
 
 import { CertificateClient } from "../../src";
-import { assertThrowsAbortError } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import { getServiceVersion } from "./utils/common";
@@ -141,16 +139,6 @@ describe("Certificates client - list certificates in various ways", () => {
     assert.equal(found, 2, "Unexpected number of certificates found by listCertificates.");
   });
 
-  if (isNode && !isPlaybackMode()) {
-    // On playback mode, the tests happen too fast for the timeout to work
-    it("can get several inserted certificates with requestOptions timeout", async function () {
-      const iter = client.listPropertiesOfCertificates({ requestOptions: { timeout: 1 } });
-      await assertThrowsAbortError(async () => {
-        await iter.next();
-      });
-    });
-  }
-
   it("can list deleted certificates by page", async function (this: Context) {
     const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
     const certificateNames = [`${certificateName}0`, `${certificateName}1`];
@@ -179,17 +167,6 @@ describe("Certificates client - list certificates in various ways", () => {
     for (const name of certificateNames) {
       await testClient.purgeCertificate(name);
     }
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("list deleted certificates with requestOptions timeout", async function () {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-    const iter = client.listDeletedCertificates({ requestOptions: { timeout: 1 } });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("can retrieve all versions of a certificate", async function (this: Context) {
@@ -235,20 +212,6 @@ describe("Certificates client - list certificates in various ways", () => {
     versions.sort(comp);
 
     assert.deepEqual(results, versions);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get the versions of a certificate with requestOptions timeout", async function () {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-
-    const iter = client.listPropertiesOfCertificateVersions("doesn't matter", {
-      requestOptions: { timeout: 1 },
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("can list certificate versions (non existing)", async function (this: Context) {

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
@@ -3,11 +3,10 @@
 
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
-import { env, isPlaybackMode, Recorder } from "@azure-tools/test-recorder";
+import { env, Recorder } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../../src";
-import { assertThrowsAbortError } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import { getServiceVersion } from "./utils/common";
@@ -112,30 +111,5 @@ describe("Certificates client - LRO - recoverDelete", () => {
     assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.flushCertificate(certificateName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can recover a deleted certificate with requestOptions timeout", async function (this: Context) {
-    if (isPlaybackMode()) {
-      this.skip();
-    }
-
-    const certificateName = testClient.formatName(
-      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
-    );
-    const createPoller = await client.beginCreateCertificate(
-      certificateName,
-      DefaultCertificatePolicy,
-      testPollerProperties
-    );
-    await createPoller.pollUntilDone();
-    const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedCertificate(certificateName, {
-        requestOptions: { timeout: 1 },
-        ...testPollerProperties,
-      });
-    });
   });
 });

--- a/sdk/keyvault/keyvault-keys/assets.json
+++ b/sdk/keyvault/keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-keys",
-  "Tag": "js/keyvault/keyvault-keys_ebe5390b7f"
+  "Tag": "js/keyvault/keyvault-keys_57c90c0ceb"
 }

--- a/sdk/keyvault/keyvault-keys/test/internal/recoverBackupRestore.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/internal/recoverBackupRestore.spec.ts
@@ -5,15 +5,9 @@ import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
 import { isNode } from "@azure/core-util";
 import { KeyClient } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "../public/utils/common";
+import { getServiceVersion } from "../public/utils/common";
 import { testPollerProperties } from "../public/utils/recorderUtils";
-import {
-  Recorder,
-  env,
-  isPlaybackMode,
-  isRecordMode,
-  isLiveMode,
-} from "@azure-tools/test-recorder";
+import { Recorder, env, isPlaybackMode, isRecordMode } from "@azure-tools/test-recorder";
 import { authenticate, envSetupForPlayback } from "../public/utils/testAuthentication";
 import TestClient from "../public/utils/testClient";
 import { RestoreKeyBackupPoller } from "../public/utils/lro/restore/poller";
@@ -89,17 +83,6 @@ describe("Keys client - restore keys and recover backups", () => {
     await testClient.flushKey(keyName);
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can generate a backup of a key with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      console.log("Timeout tests don't work on playback mode.");
-      this.skip();
-    }
-    await assertThrowsAbortError(async () => {
-      await client.backupKey("doesntmatter", { requestOptions: { timeout: 1 } });
-    });
-  });
-
   it("fails to generate a backup of a non-existing key", async function (this: Context) {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     let error;
@@ -142,23 +125,6 @@ describe("Keys client - restore keys and recover backups", () => {
       await testClient.flushKey(keyName);
     });
   }
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can restore a key with requestOptions timeout", async function (this: Context) {
-    if (!isLiveMode()) {
-      console.log("Timeout tests don't work on playback mode.");
-      this.skip();
-    }
-
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
-    const backup = await client.backupKey(keyName);
-    await testClient.flushKey(keyName);
-
-    await assertThrowsAbortError(async () => {
-      await client.restoreKeyBackup(backup!, { requestOptions: { timeout: 1 } });
-    });
-  });
 
   it("fails to restore a key with a malformed backup", async function () {
     const backup = new Uint8Array(8693);

--- a/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/list.spec.ts
@@ -3,10 +3,10 @@
 
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
-import { Recorder, env, isRecordMode, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, env, isRecordMode } from "@azure-tools/test-recorder";
 
 import { KeyClient } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "./utils/common";
+import { getServiceVersion } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate, envSetupForPlayback } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -77,21 +77,6 @@ describe("Keys client - list keys in various ways", () => {
     }
     assert.equal(totalVersions, expectedVersions, `Unexpected total versions for key ${keyName}`);
     await testClient.flushKey(keyName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get the versions of a key with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      console.log("Skipping, timeout tests don't work on playback mode.");
-      this.skip();
-    }
-
-    const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
-      requestOptions: { timeout: 1 },
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("can get the versions of a key (paged)", async function (this: Context) {
@@ -170,19 +155,6 @@ describe("Keys client - list keys in various ways", () => {
     }
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get several inserted keys with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      console.log(`Skipping, timeout tests don't work on playback mode.`);
-      this.skip();
-    }
-    const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
-
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
-
   it("can get several inserted keys (paged)", async function (this: Context) {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const keyNames = [`${keyName}-0`, `${keyName}-1`];
@@ -229,18 +201,6 @@ describe("Keys client - list keys in various ways", () => {
     for (const name of keyNames) {
       await testClient.purgeKey(name);
     }
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("list deleted keys with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      console.log("Skipping, timeout tests don't work on playback mode.");
-      this.skip();
-    }
-    const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("list deleted keys (paged)", async function (this: Context) {

--- a/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/lro.recoverDelete.spec.ts
@@ -3,10 +3,10 @@
 
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
-import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 
 import { DeletedKey, KeyClient } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "./utils/common";
+import { getServiceVersion } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate, envSetupForPlayback } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -91,24 +91,5 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.flushKey(keyName);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can recover a deleted key with requestOptions timeout", async function (this: Context) {
-    if (!isLiveMode()) {
-      console.log("Timeout tests don't work on playback mode.");
-      this.skip();
-    }
-
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
-    const deletePoller = await client.beginDeleteKey(keyName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedKey(keyName, {
-        requestOptions: { timeout: 1 },
-        ...testPollerProperties,
-      });
-    });
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
@@ -3,21 +3,6 @@
 
 import { SupportedVersions, TestFunctionWrapper, supports } from "@azure/test-utils";
 import { env } from "@azure-tools/test-recorder";
-import { assert } from "@azure/test-utils";
-
-export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<void> {
-  let passed = false;
-  try {
-    await cb();
-    passed = true;
-  } catch (e: any) {
-    console.log(`name: ${e.name}, message: ${e.message}`);
-    assert.equal(e.name, "AbortError");
-  }
-  if (passed) {
-    throw new Error("Expected cb to throw an AbortError");
-  }
-}
 
 /**
  * The known API versions that we support.

--- a/sdk/keyvault/keyvault-secrets/assets.json
+++ b/sdk/keyvault/keyvault-secrets/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-secrets",
-  "Tag": "js/keyvault/keyvault-secrets_1a3f6657bd"
+  "Tag": "js/keyvault/keyvault-secrets_dcfbe931b3"
 }

--- a/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/CRUD.spec.ts
@@ -3,7 +3,7 @@
 
 import { Context } from "mocha";
 import { assert } from "@azure/test-utils";
-import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { AbortController } from "@azure/abort-controller";
 
 import { SecretClient } from "../../src";
@@ -54,24 +54,6 @@ describe("Secret client - create, read, update and delete operations", () => {
     await assertThrowsAbortError(async () => {
       await client.setSecret(secretName, secretValue, {
         abortSignal: controller.signal,
-      });
-    });
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can timeout adding a secret", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await assertThrowsAbortError(async () => {
-      await client.setSecret(secretName, secretValue, {
-        requestOptions: {
-          timeout: 1,
-        },
       });
     });
   });
@@ -135,29 +117,6 @@ describe("Secret client - create, read, update and delete operations", () => {
     );
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can timeout updating a secret", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    const expiryDate = new Date("3000-01-01");
-    expiryDate.setMilliseconds(0);
-
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.updateSecretProperties(secretName, "", {
-        expiresOn: expiryDate,
-        requestOptions: {
-          timeout: 1,
-        },
-      });
-    });
-  });
-
   it("can update a disabled secret", async function (this: Context) {
     const secretName = testClient.formatName(
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
@@ -186,25 +145,6 @@ describe("Secret client - create, read, update and delete operations", () => {
     const result = await client.getSecret(secretName);
     assert.equal(result.name, secretName, "Unexpected secret name in result from setSecret().");
     assert.equal(result.value, secretValue, "Unexpected secret value in result from setSecret().");
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can timeout getting a secret", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.getSecret(secretName, {
-        requestOptions: {
-          timeout: 1,
-        },
-      });
-    });
   });
 
   it("can't get a disabled secret", async function (this: Context) {
@@ -282,26 +222,6 @@ describe("Secret client - create, read, update and delete operations", () => {
         throw e;
       }
     }
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can timeout deleting a secret", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteSecret(secretName, {
-        requestOptions: {
-          timeout: 1,
-        },
-        ...testPollerProperties,
-      });
-    });
   });
 
   it("can delete a secret (Non Existing)", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/list.spec.ts
@@ -6,7 +6,7 @@ import { Context } from "mocha";
 import { Recorder, env, isRecordMode, isLiveMode } from "@azure-tools/test-recorder";
 
 import { SecretClient } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "./utils/common";
+import { getServiceVersion } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -76,20 +76,6 @@ describe("Secret client - list secrets in various ways", () => {
     assert.equal(found, 2, "Unexpected number of secrets found by getSecrets.");
   });
 
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get secret properties with requestOptions timeout", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const iter = client.listPropertiesOfSecrets({
-      requestOptions: { timeout: 1 },
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
-
   it("can list deleted secrets", async function (this: Context) {
     const secretName = testClient.formatName(
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
@@ -111,20 +97,6 @@ describe("Secret client - list secrets in various ways", () => {
     }
 
     assert.equal(found, 2, "Unexpected number of secrets found by getDeletedSecrets.");
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get the deleted secrets with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const iter = client.listDeletedSecrets({
-      requestOptions: { timeout: 1 },
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("can retrieve all versions of a secret", async function (this: Context) {
@@ -159,20 +131,6 @@ describe("Secret client - list secrets in various ways", () => {
     versions.sort(comp);
 
     assert.deepEqual(results, versions);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can get versions of a secret with requestOptions timeout", async function () {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const iter = client.listPropertiesOfSecretVersions("doesntmatter", {
-      requestOptions: { timeout: 1 },
-    });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
   });
 
   it("can list secret versions (non existing)", async function (this: Context) {

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.delete.spec.ts
@@ -3,11 +3,11 @@
 
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
-import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { DeletedSecret, SecretClient } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "./utils/common";
+import { getServiceVersion } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -81,20 +81,5 @@ describe("Secrets client - Long Running Operations - delete", () => {
     const deletedSecret: DeletedSecret = await resumePoller.pollUntilDone();
     assert.equal(deletedSecret.name, secretName);
     assert.ok(resumePoller.getOperationState().isCompleted);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can attempt to delete a secret with requestOptions timeout", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "value");
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteSecret(secretName, { requestOptions: { timeout: 1 } });
-    });
   });
 });

--- a/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/lro.recover.spec.ts
@@ -3,11 +3,11 @@
 
 import { assert } from "@azure/test-utils";
 import { Context } from "mocha";
-import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, env } from "@azure-tools/test-recorder";
 import { PollerStoppedError } from "@azure/core-lro";
 
 import { SecretClient, SecretProperties } from "../../src";
-import { assertThrowsAbortError, getServiceVersion } from "./utils/common";
+import { getServiceVersion } from "./utils/common";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -90,25 +90,5 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
     const secretProperties: SecretProperties = await resumePoller.pollUntilDone();
     assert.equal(secretProperties.name, secretName);
     assert.ok(resumePoller.getOperationState().isCompleted);
-  });
-
-  // On playback mode, the tests happen too fast for the timeout to work
-  it("can attempt to recover a deleted secret with requestOptions timeout", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "value");
-    const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedSecret(secretName, {
-        requestOptions: { timeout: 1 },
-        ...testPollerProperties,
-      });
-    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`
- `@azure/keyvault-keys`
- `@azure/keyvault-secrets`

### Issues associated with this PR

- Fix #26601
- Fix https://github.com/Azure/azure-sdk-for-js/issues/26229
- Fix https://github.com/Azure/azure-sdk-for-js/issues/26644
- Fix https://github.com/Azure/azure-sdk-for-js/issues/26157
- Fix https://github.com/Azure/azure-sdk-for-js/issues/25853
- Fix https://github.com/Azure/azure-sdk-for-js/issues/26182
- Fix https://github.com/Azure/azure-sdk-for-js/issues/23997
- Fix https://github.com/Azure/azure-sdk-for-js/issues/24755
- Fix https://github.com/Azure/azure-sdk-for-js/issues/23580

### Describe the problem that is addressed by this PR

See [the issue](https://github.com/Azure/azure-sdk-for-js/issues/26601), but basically these tests are super flaky and don't add any value -- they're testing the transport, not Key Vault. Removing them will make the pipelines much greener (and make rerecording much much easier).