### PR TITLE
[core-lro] Logging statement to clarify pollingUrl/operation location

### DIFF
--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -90,6 +90,7 @@ export function inferLroMode(inputs: {
   const pollingUrl = getOperationLocationPollingUrl({ operationLocation, azureAsyncOperation });
   const location = getLocationHeader(rawResponse);
   const normalizedRequestMethod = requestMethod?.toLocaleUpperCase();
+  logger.verbose(`LRO: inferLroMode: pollingUrl: ${pollingUrl}, location: ${location}, requestPath: ${requestPath}`);
   if (pollingUrl !== undefined) {
     return {
       mode: "OperationLocation",

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -90,7 +90,9 @@ export function inferLroMode(inputs: {
   const pollingUrl = getOperationLocationPollingUrl({ operationLocation, azureAsyncOperation });
   const location = getLocationHeader(rawResponse);
   const normalizedRequestMethod = requestMethod?.toLocaleUpperCase();
-  logger.verbose(`LRO: inferLroMode: pollingUrl: ${pollingUrl}, location: ${location}, requestPath: ${requestPath}`);
+  logger.verbose(
+    `LRO: inferLroMode: pollingUrl: ${pollingUrl}, location: ${location}, requestPath: ${requestPath}`
+  );
   if (pollingUrl !== undefined) {
     return {
       mode: "OperationLocation",


### PR DESCRIPTION
## Context
We recently encountered an issue with AppConfig where the "Operation-Location" header is not added to the "Access - Control - Expose - Headers" list.
As a result, the polling for snapshot creation was broken in the browsers because the browser cannot access the header.

## Log message for clarity
Adding this log message might help in future encounters of the same problem, by showing exactly where the polling in the browsers is broken/deviated from that of node.