### PR TITLE
[ai-form-recognizer] 5.0.0 changes

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -1,27 +1,39 @@
 # Release History
 
-## 4.1.0 (Unreleased)
+## 5.0.0 (2023-08-07)
 
 ### Features Added
 
-- `AnalyzeDocumentOptions.features` allows three new features compared to the last beta version:
+- Updated the SDK to use the latest Generally Available (GA) version of the Form Recognizer REST API: `2023-07-31`.
+- `AnalyzeDocumentOptions.features` accepts three new features compared to the last beta version:
   - `barcodes`: enables the detection of barcodes in the document.
   - `keyValuePairs`: enable the detection of general key value pairs (form fields) in the document.
   - `languages`: enables the detection of the text content language.
-- `beginBuildDocumentModel` has a new overload that accepts a `DocumentModelContentSource` in place of a raw `containerUrl`. This allows training document models using the new Azure Blob file list source (that is already supported by document classifiers). The `DocumentModelContentSource` is an object that contains a `containerUrl` property, and if a `fileList` property is also provided it is interpreted as an Azure Blob file list source. Otherwise it is interpreted as an Azure Blob content source with an optional `prefix` property.
+- `beginBuildDocumentModel` has a new overload that accepts a `DocumentModelSource` in place of a raw `containerUrl`. This allows training document models using the new Blob File List source (that is already supported by document classifiers). Like with classifiers, the source inputs are specified as an object containing an `azureFileListSource` property or an `azureBlobSource` property containing the respective details of each source type.
 
 ### Breaking Changes
 
-- `DocumentAnalysisClient` and `DocumentModelAdministrationClient` now target service API version `2023-07-31` by default. Version `2023-02-28-preview` is not supported.
+From the last stable release (4.0.0):
+
+- Support for passing alternative API versions has been removed from the client. In practice, the client only supported
+  using a single API version, but types and options for specifying an API version were provided. In version 5.0.0, these options and their associated types were removed:
+  - The `apiVersion` option that was previously accepted by the `DocumentAnalysisClient` and `DocumentModelAdministrationClient` constructors was removed. This option previously only had one valid value in version 4.0.0, and supporting multiple API versions in a single package weakens the type constraints, so we have chosen to only support the latest Generally Available version of the service in this SDK package. Support for multiple API versions may be reintroduced in a future version.
+  - The `FormRecognizerApiVersion` type and enum were removed as they no longer serve any purpose.
+  - The type of `apiVersion` properties of result objects was changed from `FormRecognizerApiVersion` to `string`. This type is more accurate, as these fields reflect the API version used to create the model or start the analysis operation, and not necessarily an API version that the client instance is aware of.
+  - The `FormRecognizerCommonClientOptions` interface, which both `DocumentAnalysisClientOptions` and `DocumentModelAdministrationClientOptions` inherited from was removed, as it only carried the `apiVersion` option that no longer exists.
+- The `languages` and `keyValuePairs` properties of `AnalyzeResult` that were previously returned when using the `prebuilt-document` model are no longer returned unless the corresponding `features` are specified when making the analysis request.
+
+From the last beta release (4.1.0-beta.1):
+
 - `AnalyzeDocumentOptions.features` changed the following feature names:
   - `ocr.highResolution` renamed to `ocrHighResolution`.
   - `ocr.formula` renamed to `formulas`.
   - `ocr.font` renamed to `styleFont`.
-- The following fields have been removed
+- The following fields have been removed:
   - `AnalyzeDocumentOptions.queryFields`
   - `DocumentPage.kind` and `DocumentPage.images` (`DocumentPageKind` and `DocumentImage` types have been removed too.)
   - `DocumentKeyValuePair.commonName`
-- Changed how content sources are provided when creating document classifiers. The type of content source (`azureBlobContentSource` or `azureBlobFileListSource`) is no longer required in the content source input, and the type is now inferred automatically. If a `fileList` property is provided, it is interpreted as a file list source, and otherwise it is interpreted as a blob content source with optional `prefix`.
+- The type of the `docTypes` parameter of `beginBuildDocumentClassifier` was refined slightly. The type will no longer accept _both_ `azureBlobSource` and `azureFileListSource`
 
 ## 4.1.0-beta.1 (2023-04-11)
 

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.0.0 (2023-08-07)
+## 5.0.0 (2023-08-08)
 
 ### Features Added
 

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Form Recognizer service.",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "keywords": [
     "node",
     "azure",

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/buildClassifier.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/buildClassifier.ts
@@ -42,10 +42,14 @@ async function main() {
       type1: {
         // `azureBlobSource` isn't the only way to provide training data to the service. For more information, see
         // the documentation of the `ClassifierDocumentTypeDetails` type.
-        containerUrl: trainingDataSasUrl1,
+        azureBlobSource: {
+          containerUrl: trainingDataSasUrl1,
+        },
       },
       type2: {
-        containerUrl: trainingDataSasUrl2,
+        azureBlobSource: {
+          containerUrl: trainingDataSasUrl2,
+        },
       },
     },
     {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/buildModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/buildModel.ts
@@ -36,7 +36,11 @@ async function main() {
 
   const poller = await client.beginBuildDocumentModel(
     modelId,
-    trainingDataSasUrl,
+    {
+      azureBlobSource: {
+        containerUrl: trainingDataSasUrl,
+      },
+    },
     DocumentModelBuildMode.Template
   );
   const model = await poller.pollUntilDone();

--- a/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
@@ -10,4 +10,6 @@ export const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.def
 /**
  * @internal
  */
-export const SDK_VERSION = "4.1.0";
+export const SDK_VERSION = "5.0.0";
+
+export const FORM_RECOGNIZER_API_VERSION = "2023-07-31";

--- a/sdk/formrecognizer/ai-form-recognizer/src/documentAnalysisClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/documentAnalysisClient.ts
@@ -4,7 +4,7 @@
 import { KeyCredential, TokenCredential } from "@azure/core-auth";
 import { createTracingClient } from "@azure/core-tracing";
 import { TracingClient } from "@azure/core-tracing";
-import { SDK_VERSION } from "./constants";
+import { FORM_RECOGNIZER_API_VERSION, SDK_VERSION } from "./constants";
 import {
   AnalyzeDocumentRequest,
   AnalyzeResultOperation,
@@ -23,11 +23,7 @@ import {
 } from "./lro/analysis";
 import { OperationContext, lro } from "./lro/util/poller";
 import { AnalyzeDocumentOptions } from "./options/AnalyzeDocumentOptions";
-import {
-  DEFAULT_GENERATED_CLIENT_OPTIONS,
-  DocumentAnalysisClientOptions,
-  FormRecognizerApiVersion,
-} from "./options/FormRecognizerClientOptions";
+import { DocumentAnalysisClientOptions } from "./options/FormRecognizerClientOptions";
 import { DocumentModel } from "./documentModel";
 import { makeServiceClient, Mappers, SERIALIZER } from "./util";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -66,7 +62,6 @@ import { ClassifyDocumentOptions } from "./options/ClassifyDocumentOptions";
 export class DocumentAnalysisClient {
   private _restClient: GeneratedClient;
   private _tracing: TracingClient;
-  private _apiVersion: FormRecognizerApiVersion;
 
   /**
    * Create a `DocumentAnalysisClient` instance from a resource endpoint and a an Azure Identity `TokenCredential`.
@@ -137,8 +132,6 @@ export class DocumentAnalysisClient {
       packageVersion: SDK_VERSION,
       namespace: "Microsoft.CognitiveServices",
     });
-
-    this._apiVersion = options.apiVersion ?? DEFAULT_GENERATED_CLIENT_OPTIONS.apiVersion;
   }
 
   // #region Analysis
@@ -418,12 +411,13 @@ export class DocumentAnalysisClient {
       ? { modelId: model, apiVersion: undefined, transformResult: (v: AnalyzeResult) => v }
       : model;
 
-    if (requestApiVersion && requestApiVersion !== this._apiVersion) {
+    if (requestApiVersion && requestApiVersion !== FORM_RECOGNIZER_API_VERSION) {
       throw new Error(
         [
-          `API Version mismatch: the provided model wants version: ${requestApiVersion}, but the client is using ${this._apiVersion}.`,
+          `API Version mismatch: the provided model wants version: ${requestApiVersion},`,
+          `but the client is using ${FORM_RECOGNIZER_API_VERSION}.`,
           "The API version of the model must match the client's API version.",
-        ].join("\n")
+        ].join(" ")
       );
     }
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/documentModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/documentModel.ts
@@ -4,7 +4,6 @@
 import { DocumentFieldSchema, DocumentModelDetails } from "./generated";
 import { AnalyzedDocument, AnalyzeResult } from "./lro/analysis";
 import { DocumentField } from "./models/fields";
-import { FormRecognizerApiVersion } from "./options";
 import { isAcronymic, uncapitalize } from "./util";
 
 /**
@@ -21,7 +20,7 @@ export interface DocumentModel<Result> {
   /**
    * The API version of the model.
    */
-  apiVersion?: FormRecognizerApiVersion;
+  apiVersion?: string;
   /**
    * An associated transformation that is used to conver the base (weak) Result type to the strong version.
    */
@@ -94,7 +93,7 @@ export function createModelFromSchema(
 ): DocumentModel<AnalyzeResult<unknown>> {
   return {
     modelId: schema.modelId,
-    apiVersion: schema.apiVersion as FormRecognizerApiVersion,
+    apiVersion: schema.apiVersion,
     transformResult(baseResult: AnalyzeResult): AnalyzeResult<unknown> {
       const hasDocuments = Object.entries(schema.docTypes ?? {}).length > 0;
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
@@ -49,7 +49,7 @@ export class GeneratedClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-ai-form-recognizer/4.1.0`;
+    const packageDetails = `azsdk-js-ai-form-recognizer/5.0.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
@@ -9,6 +9,9 @@
 import * as coreClient from "@azure/core-client";
 import * as coreRestPipeline from "@azure/core-rest-pipeline";
 
+/**
+ * Details about any of several different types of Form Recognizer management operations.
+ */
 export type OperationDetailsUnion =
   | OperationDetails
   | DocumentModelBuildOperationDetails
@@ -698,8 +701,7 @@ export interface DocumentModelCopyToOperationDetails extends OperationDetails {
 }
 
 /** Get Operation response object. */
-export interface DocumentClassifierBuildOperationDetails
-  extends OperationDetails {
+export interface DocumentClassifierBuildOperationDetails extends OperationDetails {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   kind: "documentClassifierBuild";
   /** Operation result upon success. */
@@ -749,7 +751,7 @@ export enum KnownStringIndexType {
   /** Character unit represented by a single unicode code point.  Used by Python 3. */
   UnicodeCodePoint = "unicodeCodePoint",
   /** Character unit represented by a 16-bit Unicode code unit.  Used by JavaScript, Java, and .NET. */
-  Utf16CodeUnit = "utf16CodeUnit"
+  Utf16CodeUnit = "utf16CodeUnit",
 }
 
 /**
@@ -776,7 +778,7 @@ export enum KnownDocumentAnalysisFeature {
   /** Enable the detection of general key value pairs (form fields) in the document. */
   KeyValuePairs = "keyValuePairs",
   /** Enable the recognition of various font styles. */
-  StyleFont = "styleFont"
+  StyleFont = "styleFont",
 }
 
 /**
@@ -798,7 +800,7 @@ export enum KnownLengthUnit {
   /** Length unit for image files. */
   Pixel = "pixel",
   /** Length unit for PDF files. */
-  Inch = "inch"
+  Inch = "inch",
 }
 
 /**
@@ -816,7 +818,7 @@ export enum KnownSelectionMarkState {
   /** The selection mark is selected, often indicated by a check ✓ or cross X inside the selection mark. */
   Selected = "selected",
   /** The selection mark is not selected. */
-  Unselected = "unselected"
+  Unselected = "unselected",
 }
 
 /**
@@ -864,7 +866,7 @@ export enum KnownDocumentBarcodeKind {
   /** Data matrix code, as defined in ISO/IEC 16022:2006. */
   DataMatrix = "DataMatrix",
   /** MaxiCode, as defined in ISO/IEC 16023:2000. */
-  MaxiCode = "MaxiCode"
+  MaxiCode = "MaxiCode",
 }
 
 /**
@@ -897,7 +899,7 @@ export enum KnownDocumentFormulaKind {
   /** A formula embedded within the content of a paragraph. */
   Inline = "inline",
   /** A formula in display mode that takes up an entire line. */
-  Display = "display"
+  Display = "display",
 }
 
 /**
@@ -925,7 +927,7 @@ export enum KnownParagraphRole {
   /** A note usually placed after the main content on a page. */
   Footnote = "footnote",
   /** A block of formulas, often with shared alignment. */
-  FormulaBlock = "formulaBlock"
+  FormulaBlock = "formulaBlock",
 }
 
 /**
@@ -954,7 +956,7 @@ export enum KnownDocumentTableCellKind {
   /** Describes the row headers, usually located at the top left corner of a table. */
   StubHead = "stubHead",
   /** Describes the content in (parts of) the table. */
-  Description = "description"
+  Description = "description",
 }
 
 /**
@@ -975,7 +977,7 @@ export enum KnownFontStyle {
   /** Characters are represented normally. */
   Normal = "normal",
   /** Characters are visually slanted to the right. */
-  Italic = "italic"
+  Italic = "italic",
 }
 
 /**
@@ -993,7 +995,7 @@ export enum KnownFontWeight {
   /** Characters are represented normally. */
   Normal = "normal",
   /** Characters are represented with thicker strokes. */
-  Bold = "bold"
+  Bold = "bold",
 }
 
 /**
@@ -1035,7 +1037,7 @@ export enum KnownDocumentFieldType {
   /** Parsed address. */
   Address = "address",
   /** Boolean value, normalized to true or false. */
-  Boolean = "boolean"
+  Boolean = "boolean",
 }
 
 /**
@@ -1065,7 +1067,7 @@ export enum KnownDocumentSignatureType {
   /** A signature is detected. */
   Signed = "signed",
   /** No signatures are detected. */
-  Unsigned = "unsigned"
+  Unsigned = "unsigned",
 }
 
 /**
@@ -1083,7 +1085,7 @@ export enum KnownDocumentBuildMode {
   /** Target documents with similar visual templates. */
   Template = "template",
   /** Support documents with diverse visual templates. */
-  Neural = "neural"
+  Neural = "neural",
 }
 
 /**
@@ -1105,7 +1107,7 @@ export enum KnownOperationKind {
   /** Copy an existing document model to potentially a different resource, region, or subscription. */
   DocumentModelCopyTo = "documentModelCopyTo",
   /** Build a new custom classifier model. */
-  DocumentClassifierBuild = "documentClassifierBuild"
+  DocumentClassifierBuild = "documentClassifierBuild",
 }
 
 /**
@@ -1132,18 +1134,9 @@ export type ContentType =
   | "image/png"
   | "image/tiff";
 /** Defines values for AnalyzeResultOperationStatus. */
-export type AnalyzeResultOperationStatus =
-  | "notStarted"
-  | "running"
-  | "failed"
-  | "succeeded";
+export type AnalyzeResultOperationStatus = "notStarted" | "running" | "failed" | "succeeded";
 /** Defines values for OperationStatus. */
-export type OperationStatus =
-  | "notStarted"
-  | "running"
-  | "failed"
-  | "succeeded"
-  | "canceled";
+export type OperationStatus = "notStarted" | "running" | "failed" | "succeeded" | "canceled";
 
 /** Optional parameters. */
 export interface DocumentModelsAnalyzeDocument$binaryOptionalParams
@@ -1188,22 +1181,19 @@ export interface DocumentModelsAnalyzeDocument$jsonOptionalParams
 export type DocumentModelsAnalyzeDocumentResponse = DocumentModelsAnalyzeDocumentHeaders;
 
 /** Optional parameters. */
-export interface DocumentModelsGetAnalyzeResultOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsGetAnalyzeResultOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the getAnalyzeResult operation. */
 export type DocumentModelsGetAnalyzeResultResponse = AnalyzeResultOperation;
 
 /** Optional parameters. */
-export interface DocumentModelsBuildModelOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsBuildModelOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the buildModel operation. */
 export type DocumentModelsBuildModelResponse = DocumentModelsBuildModelHeaders;
 
 /** Optional parameters. */
-export interface DocumentModelsComposeModelOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsComposeModelOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the composeModel operation. */
 export type DocumentModelsComposeModelResponse = DocumentModelsComposeModelHeaders;
@@ -1216,54 +1206,46 @@ export interface DocumentModelsAuthorizeModelCopyOptionalParams
 export type DocumentModelsAuthorizeModelCopyResponse = CopyAuthorization;
 
 /** Optional parameters. */
-export interface DocumentModelsCopyModelToOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsCopyModelToOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the copyModelTo operation. */
 export type DocumentModelsCopyModelToResponse = DocumentModelsCopyModelToHeaders;
 
 /** Optional parameters. */
-export interface DocumentModelsListModelsOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsListModelsOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the listModels operation. */
 export type DocumentModelsListModelsResponse = GetDocumentModelsResponse;
 
 /** Optional parameters. */
-export interface DocumentModelsGetModelOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsGetModelOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the getModel operation. */
 export type DocumentModelsGetModelResponse = DocumentModelDetails;
 
 /** Optional parameters. */
-export interface DocumentModelsDeleteModelOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsDeleteModelOptionalParams extends coreClient.OperationOptions {}
 
 /** Optional parameters. */
-export interface DocumentModelsListModelsNextOptionalParams
-  extends coreClient.OperationOptions {}
+export interface DocumentModelsListModelsNextOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the listModelsNext operation. */
 export type DocumentModelsListModelsNextResponse = GetDocumentModelsResponse;
 
 /** Optional parameters. */
-export interface MiscellaneousListOperationsOptionalParams
-  extends coreClient.OperationOptions {}
+export interface MiscellaneousListOperationsOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the listOperations operation. */
 export type MiscellaneousListOperationsResponse = GetOperationsResponse;
 
 /** Optional parameters. */
-export interface MiscellaneousGetOperationOptionalParams
-  extends coreClient.OperationOptions {}
+export interface MiscellaneousGetOperationOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the getOperation operation. */
 export type MiscellaneousGetOperationResponse = OperationDetailsUnion;
 
 /** Optional parameters. */
-export interface MiscellaneousGetResourceInfoOptionalParams
-  extends coreClient.OperationOptions {}
+export interface MiscellaneousGetResourceInfoOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the getResourceInfo operation. */
 export type MiscellaneousGetResourceInfoResponse = ResourceDetails;
@@ -1322,7 +1304,8 @@ export interface DocumentClassifiersClassifyDocument$jsonOptionalParams
 }
 
 /** Contains response data for the classifyDocument operation. */
-export type DocumentClassifiersClassifyDocumentResponse = DocumentClassifiersClassifyDocumentHeaders;
+export type DocumentClassifiersClassifyDocumentResponse =
+  DocumentClassifiersClassifyDocumentHeaders;
 
 /** Optional parameters. */
 export interface DocumentClassifiersGetClassifyResultOptionalParams
@@ -1339,8 +1322,7 @@ export interface DocumentClassifiersListClassifiersNextOptionalParams
 export type DocumentClassifiersListClassifiersNextResponse = GetDocumentClassifiersResponse;
 
 /** Optional parameters. */
-export interface GeneratedClientOptionalParams
-  extends coreClient.ServiceClientOptions {
+export interface GeneratedClientOptionalParams extends coreClient.ServiceClientOptions {
   /** Method used to compute string offset and length. */
   stringIndexType?: StringIndexType;
   /** Api Version */

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/analysis.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/analysis.ts
@@ -12,7 +12,7 @@ import {
   DocumentStyle,
 } from "../generated";
 import { DocumentField, toAnalyzedDocumentFieldsFromGenerated } from "../models/fields";
-import { FormRecognizerApiVersion, PollerOptions } from "../options";
+import { PollerOptions } from "../options";
 import { AnalyzeDocumentOptions } from "../options/AnalyzeDocumentOptions";
 import {
   toBoundingPolygon,
@@ -102,7 +102,7 @@ export interface AnalyzeResultCommon {
   /**
    * The service API version used to produce this result.
    */
-  apiVersion: FormRecognizerApiVersion;
+  apiVersion: string;
 
   /**
    * The unique ID of the model that was used to produce this result.
@@ -372,7 +372,7 @@ export type AnalysisPoller<Result = AnalyzeResult<AnalyzedDocument>> = PollerLik
  */
 export function toAnalyzeResultFromGenerated(result: GeneratedAnalyzeResult): AnalyzeResult {
   return {
-    apiVersion: result.apiVersion as FormRecognizerApiVersion,
+    apiVersion: result.apiVersion,
     modelId: result.modelId,
     content: result.content,
     pages: result.pages.map((page) => toDocumentPageFromGenerated(page)),

--- a/sdk/formrecognizer/ai-form-recognizer/src/models/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models/index.ts
@@ -40,8 +40,11 @@ export {
 } from "./documentElements";
 
 export {
-  DocumentModelContentSource,
-  DocumentClassifierContentSource,
-  AzureBlobFileListContentSource,
-  AzureBlobContentSource,
+  DocumentModelSource,
+  DocumentClassifierSource,
+  DocumentClassifierDocumentTypeSources,
+  AzureBlobSource,
+  AzureBlobSourceDetails,
+  AzureBlobFileListSource,
+  AzureBlobFileListSourceDetails,
 } from "./contentSource";

--- a/sdk/formrecognizer/ai-form-recognizer/src/options/AnalyzeDocumentOptions.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/options/AnalyzeDocumentOptions.ts
@@ -21,6 +21,9 @@ export type FormRecognizerFeature =
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});
 
+/**
+ * Known feature flags supported by the Form Recognizer clients.
+ */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const FormRecognizerFeature = {
   /**
@@ -83,5 +86,5 @@ export interface AnalyzeDocumentOptions<Result = AnalyzeResult<AnalyzedDocument>
    *
    * For more information about the features available in Form Recognizer, see the service documentation: https://aka.ms/azsdk/formrecognizer/features
    */
-  features?: string[];
+  features?: FormRecognizerFeature[];
 }

--- a/sdk/formrecognizer/ai-form-recognizer/src/options/FormRecognizerClientOptions.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/options/FormRecognizerClientOptions.ts
@@ -4,37 +4,6 @@
 import { CommonClientOptions } from "@azure/core-client";
 
 /**
- * Valid values of the Form Recognizer service REST API version.
- */
-export type FormRecognizerApiVersion =
-  (typeof FormRecognizerApiVersion)[keyof typeof FormRecognizerApiVersion];
-
-/**
- * Supported and common values of FormRecognizerApiVersion.
- */
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FormRecognizerApiVersion = {
-  /**
-   * The newest version of the service known to be supported by the client (default).
-   *
-   * If using a beta package version, this will be identical to the latest preview version. Otherwise, it will be
-   * identical to the latest stable version.
-   */
-  Latest: "2023-07-31",
-
-  /**
-   * The newest stable version of the service known to be supported by the package. This will be a Generally Available
-   * (GA) version, even if the package version is a beta.
-   */
-  Stable: "2023-07-31",
-
-  /**
-   * Form Recognizer API version 2022-08-31 (GA).
-   */
-  "2022-08-31": "2022-08-31",
-} as const;
-
-/**
  * Valid string index types supported by the Form Recognizer service and SDK clients.
  */
 export type StringIndexType = (typeof StringIndexType)[keyof typeof StringIndexType];
@@ -61,28 +30,12 @@ export const StringIndexType = {
  */
 export const DEFAULT_GENERATED_CLIENT_OPTIONS = {
   stringIndexType: StringIndexType.Utf16CodeUnit,
-  apiVersion: FormRecognizerApiVersion.Latest,
 } as const;
-
-/**
- * Configurable options for the Form Recognizer service clients (DocumentAnalysisClient and
- * DocumentModelAdministrationClient).
- */
-export interface FormRecognizerCommonClientOptions extends CommonClientOptions {
-  /**
-   * The version of the Form Recognizer REST API to call. Service versions 2.1 and lower (non-date-based versions) are
-   * not supported by this client. To use API version 2.1, please use version 3 of the Azure Form Recognizer SDK for
-   * JavaScript (\@azure/ai-form-recognizer\@^3.2.0).
-   *
-   * Default: FormRecognizerApiVersion.Stable ("2022-08-31")
-   */
-  apiVersion?: FormRecognizerApiVersion;
-}
 
 /**
  * Configurable options for DocumentAnalysisClient.
  */
-export interface DocumentAnalysisClientOptions extends FormRecognizerCommonClientOptions {
+export interface DocumentAnalysisClientOptions extends CommonClientOptions {
   /**
    * The unit of string offset/length values that the service returns.
    *
@@ -97,5 +50,4 @@ export interface DocumentAnalysisClientOptions extends FormRecognizerCommonClien
 /**
  * Configurable options for DocumentModelAdministrationClient.
  */
-export interface DocumentModelAdministrationClientOptions
-  extends FormRecognizerCommonClientOptions {}
+export interface DocumentModelAdministrationClientOptions extends CommonClientOptions {}

--- a/sdk/formrecognizer/ai-form-recognizer/src/options/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/options/index.ts
@@ -14,8 +14,6 @@ import { DeleteDocumentModelOptions } from "./DeleteModelOptions";
 import {
   DocumentAnalysisClientOptions,
   DocumentModelAdministrationClientOptions,
-  FormRecognizerApiVersion,
-  FormRecognizerCommonClientOptions,
   StringIndexType,
 } from "./FormRecognizerClientOptions";
 import { GetCopyAuthorizationOptions } from "./GetCopyAuthorizationOptions";
@@ -38,7 +36,6 @@ export {
   CommonModelCreationOptions,
   BeginCopyModelOptions,
   DocumentModelBuildMode,
-  FormRecognizerCommonClientOptions,
   DocumentAnalysisClientOptions,
   DocumentModelAdministrationClientOptions,
   GetCopyAuthorizationOptions,
@@ -50,7 +47,6 @@ export {
   ListOperationsOptions,
   PollerOptions,
   StringIndexType,
-  FormRecognizerApiVersion,
   BeginBuildDocumentClassifierOptions,
   ClassifyDocumentOptions,
   FormRecognizerFeature,

--- a/sdk/formrecognizer/ai-form-recognizer/src/util.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/util.ts
@@ -4,7 +4,7 @@
 import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { bearerTokenAuthenticationPolicy } from "@azure/core-rest-pipeline";
 import { createFormRecognizerAzureKeyCredentialPolicy } from "./azureKeyCredentialPolicy";
-import { DEFAULT_COGNITIVE_SCOPE } from "./constants";
+import { DEFAULT_COGNITIVE_SCOPE, FORM_RECOGNIZER_API_VERSION } from "./constants";
 import { GeneratedClient, GeneratedClientOptionalParams } from "./generated";
 import { DEFAULT_GENERATED_CLIENT_OPTIONS } from "./options/FormRecognizerClientOptions";
 
@@ -14,9 +14,6 @@ export { Mappers };
 
 // This is used for URL request processing.
 export const SERIALIZER = createSerializer(Mappers, false);
-
-/** @internal */
-export const identity = <T>(x: T): T => x;
 
 /**
  * Type-strong uncapitalization.
@@ -59,6 +56,7 @@ export function makeServiceClient(
   const client = new GeneratedClient(endpoint?.replace(/\/$/, ""), {
     ...DEFAULT_GENERATED_CLIENT_OPTIONS,
     ...options,
+    apiVersion: FORM_RECOGNIZER_API_VERSION,
   });
 
   const authPolicy = isTokenCredential(credential)

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -16,7 +16,7 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/sp
 override-client-name: GeneratedClient
 add-credentials: false
 typescript: true
-package-version: "4.1.0"
+package-version: "5.0.0"
 use-extension:
   "@autorest/typescript": "6.0.0-alpha.20.20220622.1"
 ```
@@ -89,14 +89,4 @@ directive:
     where: $.parameters.PathOperationId
     transform: >
       delete $["format"];
-```
-
-### Mark `kind` optional
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $.definitions.DocumentPage
-    transform: >
-      $.required = $.required.filter((r) => r !== "kind");
 ```

--- a/sdk/formrecognizer/ai-form-recognizer/test/public/node/classifiers.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/public/node/classifiers.spec.ts
@@ -76,16 +76,14 @@ matrix([[true, false]] as const, async (useAad) => {
           {
             // TODO: use a different container for each test
             foo: {
-              // containerUrl: assertEnvironmentVariable(
-              //   "FORM_RECOGNIZER_SELECTION_MARK_STORAGE_CONTAINER_SAS_URL"
-              // ),
-              containerUrl: containerSasUrl(),
+              azureBlobSource: {
+                containerUrl: containerSasUrl(),
+              },
             },
             bar: {
-              // containerUrl: assertEnvironmentVariable(
-              //   "FORM_RECOGNIZER_SELECTION_MARK_STORAGE_CONTAINER_SAS_URL"
-              // ),
-              containerUrl: containerSasUrl(),
+              azureBlobSource: {
+                containerUrl: containerSasUrl(),
+              },
             },
           },
           { ...testPollingOptions, description: customClassifierDescription }

--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/ai-form-recognizer": "^4.0.0",
+    "@azure/ai-form-recognizer": "^5.0.0",
     "@azure/identity": "^2.0.1",
     "@azure/test-utils-perf": "^1.0.0",
     "@azure/core-util": "^1.3.1",


### PR DESCRIPTION
This PR makes several changes related to the impending 5.0.0 release of Document Intelligence (f.k.a. Form Recognizer).

- The major version revision signals a breaking change in which key-value pairs and extracted languages will not be returned unless a special `feature` is provided when making the analysis request.
- Support for explicit API version was removed. This functionality never worked very well in TypeScript, and the major version revision gives us an opportunity to remove it and avoid its inherent complexity until a better solution is available.

This also addresses some issues with the way that training data content sources were represented and named. The new representation is stricter about providing only one of the two possible source type fields: `azureBlobSource` or `azureBlobFileListSource`.