### PR TITLE
[engsys] upgrade `eslint-config-prettier` version to `^9.0.0`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2828,7 +2828,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/chai-as-promised/7.1.5:
@@ -2850,7 +2850,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/cookie/0.4.1:
@@ -2860,7 +2860,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/debug/4.1.8:
@@ -2872,7 +2872,7 @@ packages:
   /@types/decompress/4.2.4:
     resolution: {integrity: sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/eslint/8.4.10:
@@ -2893,7 +2893,7 @@ packages:
   /@types/express-serve-static-core/4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -2911,13 +2911,13 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/http-errors/2.0.1:
@@ -2934,7 +2934,7 @@ packages:
   /@types/is-buffer/2.0.0:
     resolution: {integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/json-schema/7.0.12:
@@ -2948,13 +2948,13 @@ packages:
   /@types/jsonwebtoken/9.0.2:
     resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/jws/3.2.5:
     resolution: {integrity: sha512-xGTxZH34xOryaTN8CMsvhh9lfNqFuHiMoRvsLYWQdBJHqiECyfInXVl2eK8Jz2emxZWMIn5RBlmr3oDVPeWujw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/linkify-it/3.0.2:
@@ -3013,20 +3013,20 @@ packages:
   /@types/mysql/2.15.19:
     resolution: {integrity: sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       form-data: 3.0.1
     dev: false
 
   /@types/node-fetch/2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       form-data: 3.0.1
     dev: false
 
@@ -3059,7 +3059,7 @@ packages:
   /@types/pg/8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       pg-protocol: 1.6.0
       pg-types: 2.2.0
     dev: false
@@ -3087,7 +3087,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/resolve/1.20.2:
@@ -3110,7 +3110,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/serve-static/1.15.2:
@@ -3118,7 +3118,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/shimmer/1.0.2:
@@ -3138,13 +3138,13 @@ packages:
   /@types/stoppable/1.1.1:
     resolution: {integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/tough-cookie/4.0.2:
@@ -3158,7 +3158,7 @@ packages:
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/underscore/1.11.6:
@@ -3176,19 +3176,19 @@ packages:
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/ws/8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/xml2js/0.4.11:
     resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
 
   /@types/yargs-parser/21.0.0:
@@ -3205,7 +3205,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
     dev: false
     optional: true
 
@@ -4482,7 +4482,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.3
     dev: false
 
   /debug/3.2.7:
@@ -4661,7 +4661,7 @@ packages:
       cosmiconfig: 7.1.0
       debug: 4.3.4
       deps-regex: 0.1.4
-      ignore: 5.1.9
+      ignore: 5.2.4
       is-core-module: 2.13.0
       js-yaml: 3.14.1
       json5: 2.2.3
@@ -4864,7 +4864,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -5020,8 +5020,8 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier/8.10.0_eslint@8.46.0:
-    resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
+  /eslint-config-prettier/9.0.0_eslint@8.46.0:
+    resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -5853,7 +5853,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -6178,7 +6178,7 @@ packages:
   /ignore-walk/3.0.4:
     resolution: {integrity: sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==}
     dependencies:
-      minimatch: 3.0.8
+      minimatch: 3.1.2
     dev: false
 
   /ignore/5.1.9:
@@ -6271,7 +6271,7 @@ packages:
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
-      figures: 3.0.0
+      figures: 3.2.0
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
@@ -8746,7 +8746,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 14.18.54
+      '@types/node': 16.18.39
       long: 5.2.3
     dev: false
 
@@ -18988,7 +18988,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-1BcMs+eWGkYSduR5dqJXW8hw6DaSMifti4CZnS1ismrG0k+ulUlgRigW3XLwMDacq2LUwEnYG22HoaPZUVnvng==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-L3uloVI2ws3p86I91/55Vnc6GYIp7dNf+M9tMr6Q+4bMHYES34URLx3TBE0StUh18rIHRSkksiXcxhO7RMGKyA==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19004,7 +19004,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.57.1_typescript@5.0.4
       chai: 4.3.7
       eslint: 8.46.0
-      eslint-config-prettier: 8.10.0_eslint@8.46.0
+      eslint-config-prettier: 9.0.0_eslint@8.46.0
       eslint-plugin-import: 2.28.0_eslint@8.46.0
       eslint-plugin-markdown: 3.0.1_eslint@8.46.0
       eslint-plugin-no-only-tests: 3.1.0

--- a/common/tools/dev-tool/src/commands/migrate.ts
+++ b/common/tools/dev-tool/src/commands/migrate.ts
@@ -354,7 +354,7 @@ async function runMigrations(pending: Migration[], project: ProjectInfo): Promis
 async function onMigrationSuccess(
   project: ProjectInfo,
   migration: Migration,
-  quiet: boolean = false
+  quiet: boolean = false // eslint-disable-line @typescript-eslint/no-inferrable-types
 ): Promise<void> {
   await updateMigrationDate(project, migration);
 
@@ -370,7 +370,7 @@ async function onMigrationSuccess(
 async function onMigrationSkipped(
   project: ProjectInfo,
   migration: Migration,
-  quiet: boolean = false
+  quiet: boolean = false // eslint-disable-line @typescript-eslint/no-inferrable-types
 ): Promise<void> {
   await updateMigrationDate(project, migration);
 
@@ -447,7 +447,10 @@ function printMigrationSuspendedWarning(migration: Migration, status: MigrationS
  * @param project - the working project
  * @returns true on success, otherwise false
  */
-async function abortMigration(project: ProjectInfo, quiet: boolean = false): Promise<boolean> {
+async function abortMigration(
+  project: ProjectInfo,
+  quiet: boolean = false // eslint-disable-line @typescript-eslint/no-inferrable-types
+): Promise<boolean> {
   const suspendedMigration = await validateSuspendedState(project);
   if (!suspendedMigration) return false;
 

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -37,8 +37,8 @@ declare global {
         require?: string;
         types?: string;
         [extraTypes: `types@${string}`]: string;
-      }
-    },
+      };
+    };
     typesVersions?: {
       [k: string]: {
         [k: string]: string[];

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -219,7 +219,8 @@ export async function isProxyToolActive(): Promise<boolean> {
     await axios.get(`http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000}/info/available`);
 
     log.info(
-      `Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000
+      `Proxy tool seems to be active at http://localhost:${
+        process.env.TEST_PROXY_HTTP_PORT ?? 5000
       }\n`
     );
     return true;

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/typescript-estree": "~5.57.0",
     "@types/eslint": "~8.4.0",
     "@types/estree": "~1.0.0",
-    "eslint-config-prettier": "^8.0.0",
+    "eslint-config-prettier": "^9.0.0",
     "glob": "^9.0.0",
     "json-schema": "^0.4.0",
     "typescript": "~5.0.0",


### PR DESCRIPTION
The breaking change in v9 is related to how BOM is handled. It doesn't affect our usage.

While validating the change I found some false-positive linter errors in dev-tool and suppressed them.
