### PR TITLE
[engsys] upgrade dev dependency `@sinonjs/fake-timers` to `^11.0.0`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2763,6 +2763,12 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: false
 
+  /@sinonjs/fake-timers/11.0.0:
+    resolution: {integrity: sha512-bqiI/5ur6ZOozG06BeJjbplIqHY/KftV1zaewbZHORH902GrHURKwl7H1G/4OC5EaxDYQJlrD0OLJ1XD6x01dQ==}
+    dependencies:
+      '@sinonjs/commons': 3.0.0
+    dev: false
+
   /@sinonjs/samsam/8.0.0:
     resolution: {integrity: sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==}
     dependencies:
@@ -18732,13 +18738,13 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-ZHND9SD/Ugb8uAIAGt7mqKwyEstUI0Sj/RYHBEHzlGrLs+28leaE3VFnc2VKWrE+kHQHMwzLS+J6sTVM/aflFQ==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-76eZIXGsWzW8wSfkQh+OMkhTgXYHKU4eDhk1H7ecna5F4bxhp+TBnGFeA5Ns9Ya1aFPFPXgCOhrnHvL+CyZzDw==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
       '@microsoft/api-extractor': 7.36.3_@types+node@14.18.54
-      '@sinonjs/fake-timers': 10.3.0
+      '@sinonjs/fake-timers': 11.0.0
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
       '@types/node': 14.18.54

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -136,7 +136,7 @@
     "typescript": "~5.0.0",
     "nock": "^12.0.3",
     "@types/sinonjs__fake-timers": "~8.1.2",
-    "@sinonjs/fake-timers": "^10.0.2"
+    "@sinonjs/fake-timers": "^11.0.0"
   },
   "//sampleConfiguration": {
     "skip": [


### PR DESCRIPTION
per https://github.com/sinonjs/fake-timers/blob/main/CHANGELOG.md, v11.0.0 is a release of 10.2.0. So it should be fine since what we've been installing with `^10.0.2` is working fine.
