### PR TITLE
[engsys] upgrade rush to 5.101.0 and pnpm to 8.6.12

### DIFF
--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -360,6 +360,23 @@ function _getRushTempFolder(rushCommonFolder) {
     }
 }
 /**
+ * Compare version strings according to semantic versioning.
+ * Returns a positive integer if "a" is a later version than "b",
+ * a negative integer if "b" is later than "a",
+ * and 0 otherwise.
+ */
+function _compareVersionStrings(a, b) {
+    const aParts = a.split(/[.-]/);
+    const bParts = b.split(/[.-]/);
+    const numberOfParts = Math.max(aParts.length, bParts.length);
+    for (let i = 0; i < numberOfParts; i++) {
+        if (aParts[i] !== bParts[i]) {
+            return (Number(aParts[i]) || 0) - (Number(bParts[i]) || 0);
+        }
+    }
+    return 0;
+}
+/**
  * Resolve a package specifier to a static version
  */
 function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
@@ -379,12 +396,23 @@ function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
             (0,_utilities_npmrcUtilities__WEBPACK_IMPORTED_MODULE_4__.syncNpmrc)(sourceNpmrcFolder, rushTempFolder, undefined, logger);
             const npmPath = getNpmPath();
             // This returns something that looks like:
-            //  @microsoft/rush@3.0.0 '3.0.0'
-            //  @microsoft/rush@3.0.1 '3.0.1'
-            //  ...
-            //  @microsoft/rush@3.0.20 '3.0.20'
-            //  <blank line>
-            const npmVersionSpawnResult = child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(npmPath, ['view', `${name}@${version}`, 'version', '--no-update-notifier'], {
+            // ```
+            // [
+            //   "3.0.0",
+            //   "3.0.1",
+            //   ...
+            //   "3.0.20"
+            // ]
+            // ```
+            //
+            // if multiple versions match the selector, or
+            //
+            // ```
+            // "3.0.0"
+            // ```
+            //
+            // if only a single version matches.
+            const npmVersionSpawnResult = child_process__WEBPACK_IMPORTED_MODULE_0__.spawnSync(npmPath, ['view', `${name}@${version}`, 'version', '--no-update-notifier', '--json'], {
                 cwd: rushTempFolder,
                 stdio: []
             });
@@ -392,16 +420,21 @@ function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
                 throw new Error(`"npm view" returned error code ${npmVersionSpawnResult.status}`);
             }
             const npmViewVersionOutput = npmVersionSpawnResult.stdout.toString();
-            const versionLines = npmViewVersionOutput.split('\n').filter((line) => !!line);
-            const latestVersion = versionLines[versionLines.length - 1];
+            const parsedVersionOutput = JSON.parse(npmViewVersionOutput);
+            const versions = Array.isArray(parsedVersionOutput)
+                ? parsedVersionOutput
+                : [parsedVersionOutput];
+            let latestVersion = versions[0];
+            for (let i = 1; i < versions.length; i++) {
+                const version = versions[i];
+                if (_compareVersionStrings(version, latestVersion) > 0) {
+                    latestVersion = version;
+                }
+            }
             if (!latestVersion) {
                 throw new Error('No versions found for the specified version range.');
             }
-            const versionMatches = latestVersion.match(/^.+\s\'(.+)\'$/);
-            if (!versionMatches) {
-                throw new Error(`Invalid npm output ${latestVersion}`);
-            }
-            return versionMatches[1];
+            return latestVersion;
         }
         catch (e) {
             throw new Error(`Unable to resolve version ${version} of package ${name}: ${e}`);

--- a/rush.json
+++ b/rush.json
@@ -23,7 +23,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "7.32.2",
+  "pnpmVersion": "8.6.12",
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",
   /**

--- a/rush.json
+++ b/rush.json
@@ -14,7 +14,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.100.2",
+  "rushVersion": "5.101.0",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process

--- a/sdk/purview/purview-sharing-rest/package.json
+++ b/sdk/purview/purview-sharing-rest/package.json
@@ -68,7 +68,6 @@
     "@azure/core-paging": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.10.3",
     "@azure/logger": "^1.0.0",
-    "@microsoft/rush": "^5.98.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- upgrade `rush` and `pnpm` to their latest versions
- remove a dependency on `@microsoft/rush` that was likely added accidentally.