### PR TITLE
[dev-tool] Fix check-node-versions

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -190,12 +190,15 @@ async function runDockerContainer(
     containerWorkspace,
     "-v",
     `${dockerContextDirectory}:${containerWorkspace}`,
+    "--entrypoint",
+    "sh",
     dockerImageName,
     "./run_samples.sh",
   ];
   const dockerContainerRunProcess = pr.spawn("docker", args, {
     cwd: dockerContextDirectory,
   });
+  log.debug(`Running docker container with the following args: ${args.join(" ")}`);
   log.info(`Started running the docker container ${dockerContainerName}`);
   dockerContainerRunProcess.stdout.on("data", stdoutListener);
   dockerContainerRunProcess.stderr.on("data", stderrListener);


### PR DESCRIPTION
The docker images we pull force node as the default command. This PR overrides that command to be shell instead.