### PR TITLE
Add skipPublishDocMs to false error reports in docs heuristics

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -307,7 +307,8 @@ stages:
           parameters:
             PackageInfoLocations:
               - ${{ each artifact in parameters.Artifacts }}:
-                - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+                - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
+                  - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
             RepoId: Azure/azure-sdk-for-js
             WorkingDirectory: $(System.DefaultWorkingDirectory)
             TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -82,8 +82,6 @@ function DockerValidation() {
   return GetResult $true $Package $installOutput
 }
 
-if ($Package)
-
 if (!$DocValidationImageId) {
   FallbackValidation
 } 

--- a/eng/scripts/validate-docs-package.ps1
+++ b/eng/scripts/validate-docs-package.ps1
@@ -82,6 +82,7 @@ function DockerValidation() {
   return GetResult $true $Package $installOutput
 }
 
+if ($Package)
 
 if (!$DocValidationImageId) {
   FallbackValidation

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -48,12 +48,12 @@ extends:
         safeName: azurecoreclient
       - name: azure-rest-core-client
         safeName: azurerestcoreclient
-        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
         skipPublishDocMs: true
       - name: azure-core-http
         safeName: azurecorehttp
       - name: azure-core-rest-pipeline
         safeName: azurecorerestpipeline
+        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
       - name: azure-core-lro
         safeName: azurecorelro
       - name: azure-core-paging

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -48,6 +48,8 @@ extends:
         safeName: azurecoreclient
       - name: azure-rest-core-client
         safeName: azurerestcoreclient
+        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
+        skipPublishDocMs: true
       - name: azure-core-http
         safeName: azurecorehttp
       - name: azure-core-rest-pipeline

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -54,6 +54,7 @@ extends:
       - name: azure-core-rest-pipeline
         safeName: azurecorerestpipeline
         # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
+        skipPublishDocMs: true
       - name: azure-core-lro
         safeName: azurecorelro
       - name: azure-core-paging

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -48,7 +48,6 @@ extends:
         safeName: azurecoreclient
       - name: azure-rest-core-client
         safeName: azurerestcoreclient
-        skipPublishDocMs: true
       - name: azure-core-http
         safeName: azurecorehttp
       - name: azure-core-rest-pipeline

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -30,5 +30,9 @@ extends:
         safeName: azureidentity
       - name: azure-identity-cache-persistence
         safeName: azureidentitycachepersistence
+        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
+        skipPublishDocMs: true
       - name: azure-identity-vscode
         safeName: azureidentityvscode
+        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
+        skipPublishDocMs: true


### PR DESCRIPTION
Example pipeline fixed by this change: 

* Identity -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2995011&view=results
* Core -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2995180&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b

Work item to undo this when we integrate `@microsoft/type2docfx` https://github.com/Azure/azure-sdk-for-js/issues/26770