### PR TITLE
[Search] Add Swagger transform for `SearchRequest.vector`

### DIFF
--- a/sdk/search/search-documents/assets.json
+++ b/sdk/search/search-documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/search/search-documents",
-  "Tag": "js/search/search-documents_f51bdb507c"
+  "Tag": "js/search/search-documents_b60d52b8dd"
 }

--- a/sdk/search/search-documents/src/generated/data/models/index.ts
+++ b/sdk/search/search-documents/src/generated/data/models/index.ts
@@ -172,8 +172,6 @@ export interface SearchRequest {
   captions?: QueryCaptionType;
   /** The comma-separated list of field names used for semantic search. */
   semanticFields?: string;
-  /** The query parameters for vector and hybrid search queries. */
-  vector?: Vector;
   /** The query parameters for multi-vector search queries. */
   vectors?: Vector[];
 }

--- a/sdk/search/search-documents/src/generated/data/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/data/models/mappers.ts
@@ -386,13 +386,6 @@ export const SearchRequest: coreClient.CompositeMapper = {
           name: "String"
         }
       },
-      vector: {
-        serializedName: "vector",
-        type: {
-          name: "Composite",
-          className: "Vector"
-        }
-      },
       vectors: {
         serializedName: "vectors",
         type: {

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -331,18 +331,11 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
       select: this.convertSelect<TFields>(select) || "*",
       orderBy: this.convertOrderBy(orderBy),
       includeTotalResultCount: includeTotalCount,
-      vector: undefined,
-      vectors: undefined,
+      vectors: vectors?.map(this.convertVector.bind(this)),
       answers: this.convertAnswers(answers),
       semanticErrorHandling: semanticErrorHandlingMode,
       debug: debugMode,
     };
-
-    if (vectors?.length === 1) {
-      fullOptions.vector = this.convertVector(vectors[0]);
-    } else {
-      fullOptions.vectors = vectors?.map(this.convertVector.bind(this));
-    }
 
     const { span, updatedOptions } = createSpan("SearchClient-searchDocuments", options);
 

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -630,19 +630,15 @@ export function generatedSearchIndexerToPublicSearchIndexer(
 export function generatedSearchRequestToPublicSearchRequest<Model extends object>(
   request: GeneratedSearchRequest
 ): SearchRequest<Model> {
-  const { semanticErrorHandling, debug, vector, vectors, ...props } = request;
+  const { semanticErrorHandling, debug, vectors, ...props } = request;
   const publicRequest: SearchRequest<Model> = {
     semanticErrorHandlingMode: semanticErrorHandling as `${KnownSemanticErrorHandling}` | undefined,
     debugMode: debug as `${KnownQueryDebugMode}` | undefined,
+    vectors: vectors
+      ?.map(convertVectorToPublic<Model>)
+      .filter((v): v is Vector<Model> => v !== undefined),
     ...props,
   };
-
-  if (vector || vectors) {
-    const concatenatedVectors = [vector, ...(vectors ?? [])]
-      .map(convertVectorToPublic<Model>)
-      .filter((v): v is Vector<Model> => v !== undefined);
-    publicRequest.vectors = concatenatedVectors;
-  }
 
   return publicRequest;
 }

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -117,3 +117,14 @@ directive:
   where: $.definitions.QueryResultDocumentSemanticFieldState
   transform: $["x-ms-enum"].name = "SemanticFieldState";
 ```
+
+### Remove `Vector` Property
+
+ Remove the `Vector` Property from `SearchRequest` in favor of the `Vectors` Array
+
+```yaml
+directive:
+- from: searchindex.json
+  where: $.definitions.SearchRequest
+  transform: delete $.properties.vector;
+```


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents
### Describe the problem that is addressed by this PR

The `SearchRequest.vector` property will soon be removed from the REST API surface, so we're getting ahead of that and rolling it into `SearchRequest.vectors`.
