### PR TITLE
[engsys] workaround for `vscode-eslint` extension in workspace

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -264,6 +264,7 @@ specifiers:
   '@rush-temp/developer-devcenter': file:./projects/developer-devcenter.tgz
   '@rush-temp/digital-twins-core': file:./projects/digital-twins-core.tgz
   '@rush-temp/eslint-plugin-azure-sdk': file:./projects/eslint-plugin-azure-sdk.tgz
+  '@rush-temp/eslint-plugin-azure-sdk-helper': file:./projects/eslint-plugin-azure-sdk-helper.tgz
   '@rush-temp/event-hubs': file:./projects/event-hubs.tgz
   '@rush-temp/eventgrid': file:./projects/eventgrid.tgz
   '@rush-temp/eventhubs-checkpointstore-blob': file:./projects/eventhubs-checkpointstore-blob.tgz
@@ -618,6 +619,7 @@ dependencies:
   '@rush-temp/developer-devcenter': file:projects/developer-devcenter.tgz
   '@rush-temp/digital-twins-core': file:projects/digital-twins-core.tgz
   '@rush-temp/eslint-plugin-azure-sdk': file:projects/eslint-plugin-azure-sdk.tgz
+  '@rush-temp/eslint-plugin-azure-sdk-helper': file:projects/eslint-plugin-azure-sdk-helper.tgz
   '@rush-temp/event-hubs': file:projects/event-hubs.tgz
   '@rush-temp/eventgrid': file:projects/eventgrid.tgz
   '@rush-temp/eventhubs-checkpointstore-blob': file:projects/eventhubs-checkpointstore-blob.tgz
@@ -2492,7 +2494,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/chai-as-promised/7.1.5:
@@ -2514,7 +2516,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/cookie/0.4.1:
@@ -2524,7 +2526,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/debug/4.1.8:
@@ -2536,7 +2538,7 @@ packages:
   /@types/decompress/4.2.4:
     resolution: {integrity: sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/eslint/8.4.10:
@@ -2557,7 +2559,7 @@ packages:
   /@types/express-serve-static-core/4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -2575,13 +2577,13 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/http-errors/2.0.1:
@@ -2598,7 +2600,7 @@ packages:
   /@types/is-buffer/2.0.0:
     resolution: {integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/json-schema/7.0.12:
@@ -2612,13 +2614,13 @@ packages:
   /@types/jsonwebtoken/9.0.2:
     resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/jws/3.2.5:
     resolution: {integrity: sha512-xGTxZH34xOryaTN8CMsvhh9lfNqFuHiMoRvsLYWQdBJHqiECyfInXVl2eK8Jz2emxZWMIn5RBlmr3oDVPeWujw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/linkify-it/3.0.2:
@@ -2669,13 +2671,13 @@ packages:
   /@types/mysql/2.15.19:
     resolution: {integrity: sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/node-fetch/2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       form-data: 3.0.1
     dev: false
 
@@ -2700,7 +2702,7 @@ packages:
   /@types/pg/8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       pg-protocol: 1.6.0
       pg-types: 2.2.0
     dev: false
@@ -2728,7 +2730,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/resolve/1.20.2:
@@ -2751,7 +2753,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/serve-static/1.15.2:
@@ -2759,7 +2761,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/shimmer/1.0.2:
@@ -2779,13 +2781,13 @@ packages:
   /@types/stoppable/1.1.1:
     resolution: {integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/tough-cookie/4.0.2:
@@ -2799,7 +2801,7 @@ packages:
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/underscore/1.11.6:
@@ -2817,19 +2819,19 @@ packages:
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/ws/8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/xml2js/0.4.11:
     resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
 
   /@types/yargs-parser/21.0.0:
@@ -2846,7 +2848,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: false
     optional: true
 
@@ -3884,7 +3886,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.3
     dev: false
 
   /debug/3.2.7:
@@ -4115,7 +4117,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230809
+      typescript: 5.3.0-dev.20230810
     dev: false
 
   /ecdsa-sig-formatter/1.0.11:
@@ -4166,7 +4168,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -5096,7 +5098,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -7424,7 +7426,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       long: 5.2.3
     dev: false
 
@@ -8700,8 +8702,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/5.3.0-dev.20230809:
-    resolution: {integrity: sha512-AhrbSEcL6ar5+jdeqwrmrQrvxCX5iK4Zb/YtlCaft0xEr4HOeKWtixh8FRIqugc83bSHqE7noQ0BhLZa9Biazw==}
+  /typescript/5.3.0-dev.20230810:
+    resolution: {integrity: sha512-cD+0wvHU1AJDHnbOizHt2iJ9nEpJAa7t5WXbu6NaNeX3ZWO0lIt0A5TFgWsD4ZbXPHdxq6Uw6IKvTn8W0arAmA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -17298,6 +17300,25 @@ packages:
       - debug
       - supports-color
       - utf-8-validate
+    dev: false
+
+  file:projects/eslint-plugin-azure-sdk-helper.tgz:
+    resolution: {integrity: sha512-jvdDp29Jz2Q68BQK/UeTXUsgrL5l0YnTeBdXjcN0ymNvAMUqOzTfizSsP3migr/5KN1fRkXoBYpw5NMwYcMYDg==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    name: '@rush-temp/eslint-plugin-azure-sdk-helper'
+    version: 0.0.0
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.57.1_p3h2c2fjusw6yq7jtcr3msv72a
+      '@typescript-eslint/experimental-utils': 5.57.1_qjkw45b3tljvcusgfgkwdbduhu
+      '@typescript-eslint/parser': 5.57.1_qjkw45b3tljvcusgfgkwdbduhu
+      eslint: 8.46.0
+      eslint-plugin-import: 2.28.0_eslint@8.46.0
+      eslint-plugin-markdown: 3.0.1_eslint@8.46.0
+      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-promise: 6.1.1_eslint@8.46.0
+      eslint-plugin-tsdoc: 0.2.17
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:

--- a/common/tools/eslint-plugin-azure-sdk-helper/package.json
+++ b/common/tools/eslint-plugin-azure-sdk-helper/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@azure-tool/eslint-plugin-azure-sdk-helper",
+  "version": "1.0.0",
+  "description": "Helper project to allow vscode-eslint extension to resolve plugins",
+  "sdk-type": "utility",
+  "private": true,
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "~5.57.0",
+    "@typescript-eslint/parser": "~5.57.0",
+    "eslint": "^8.0.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-no-only-tests": "^3.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-tsdoc": "^0.2.10",
+    "eslint-plugin-markdown": "~3.0.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/experimental-utils": "~5.57.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "typescript": "~5.0.0"
+  }
+}

--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -318,6 +318,9 @@
     "typescript.tsdk": "core-http/node_modules/typescript/lib",
     "files.exclude": {
       "**/node_modules": true
+    },
+    "eslint.options": {
+      "resolvePluginsRelativeTo": "../../../common/tools/eslint-plugin-azure-sdk-helper"
     }
   },
   "extensions": {

--- a/rush.json
+++ b/rush.json
@@ -786,6 +786,11 @@
       "versionPolicyName": "utility"
     },
     {
+      "packageName": "@azure-tool/eslint-plugin-azure-sdk-helper",
+      "projectFolder": "common/tools/eslint-plugin-azure-sdk-helper",
+      "versionPolicyName": "utility"
+    },
+    {
       "packageName": "@azure-tools/test-recorder",
       "projectFolder": "sdk/test-utils/recorder",
       "versionPolicyName": "utility"

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -110,12 +110,12 @@ describe("AbortController", () => {
 
     const acks: string[] = [];
     try {
-      const onAbortFoo = () => {
+      const onAbortFoo = (): void => {
         acks.push("foo");
         signal.removeEventListener("abort", onAbortFoo);
       };
 
-      const onAbortBar = () => {
+      const onAbortBar = (): void => {
         acks.push("bar");
         signal.removeEventListener("abort", onAbortBar);
       };


### PR DESCRIPTION
ESlint plugins are resolved relative to the config file. In our repo that means ESLint would try resolving plugins from `sdk` folder or individual package folder if it contains a config file. The plugins needed are actually installed under `common/tools/eslint-plugin-azure-sdk`. Linting works when running cli because `NODE_PATH` is set to contain a bunch of directories, including `common/temp/node_modules/.pnpm/node_modules`, and ESLint is able to find plugins.

When the `dataplane.code-workspace` is opened in VS Code, ESLint in `vscode-eslint` extension attempts to load plugins but couldn't because there's no `NODE_PATH` or equivalent. As a result, the extension crashes.

This PR provides a workaround utilizing the
`eslint.options.resolvePluginsRelativeTo` setting and a empty rush project whose sole purpose is to provide symlinks to eslint dependencies so that ESLint from the VS Code extension can loads them.

Bonus change includes some fixes done by the `vscode-eslint` extension UI.

After `rush update`, build `eslint-plugin-azure-sdk` project first then open/re-open `dataplane.code-workspace`
