### PR TITLE
[monitor-opentelemetry-exporter] Fix Nested Object Serialization

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.15 (Unreleased)
+## 1.0.0-beta.15
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.15 (unreleased)
+## 1.0.0-beta.15 (Unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.15 (unreleased)
+
+### Bugs Fixed
+
+- Fix an issue with serializing nested log messages.
+
 ## 1.0.0-beta.14 (2023-06-15)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -200,7 +200,7 @@ function getLegacyApplicationInsightsBaseData(log: ReadableLogRecord): MonitorDo
           baseData = JSON.parse(log.body) as TelemetryEventData;
           break;
       }
-      if (typeof(baseData?.message) === "object") {
+      if (typeof baseData?.message === "object") {
         baseData.message = JSON.stringify(baseData.message);
       }
     } catch (err) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -200,6 +200,9 @@ function getLegacyApplicationInsightsBaseData(log: ReadableLogRecord): MonitorDo
           baseData = JSON.parse(log.body) as TelemetryEventData;
           break;
       }
+      if (typeof(baseData?.message) === "object") {
+        baseData.message = JSON.stringify(baseData.message);
+      }
     } catch (err) {
       diag.error("AzureMonitorLogExporter failed to parse Application Insights Telemetry");
     }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
@@ -402,7 +402,7 @@ describe("logUtils.ts", () => {
       severityNumber: 12,
       attributes: {
         "_MS.baseType": "MessageData",
-      }
+      },
     });
     const expectedTime = new Date(hrTimeToMilliseconds(log.hrTime));
     log.setAttributes({

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.test.ts
@@ -395,4 +395,43 @@ describe("logUtils.ts", () => {
       );
     });
   });
+
+  it("should parse objects if passed as the message field of a legacy ApplicationInsights log", () => {
+    const log = new LogRecord(logger, {
+      body: '{"message":{"nested":{"nested2":{"test":"test"}}},"severityLevel":"Information","version":2}',
+      severityNumber: 12,
+      attributes: {
+        "_MS.baseType": "MessageData",
+      }
+    });
+    const expectedTime = new Date(hrTimeToMilliseconds(log.hrTime));
+    log.setAttributes({
+      "extra.attribute": "foo",
+      [SemanticAttributes.MESSAGE_TYPE]: "test message type",
+    });
+    const expectedProperties = {
+      "extra.attribute": "foo",
+      [SemanticAttributes.MESSAGE_TYPE]: "test message type",
+    };
+    const expectedBaseData: Partial<MessageData> = {
+      message: '{"nested":{"nested2":{"test":"test"}}}',
+      severityLevel: `Information`,
+      version: 2,
+      properties: expectedProperties,
+      measurements: {},
+    };
+
+    const envelope = logToEnvelope(log, "ikey");
+    console.log("TEST ENVELOPE!!!", envelope);
+    assertEnvelope(
+      envelope,
+      "Microsoft.ApplicationInsights.Message",
+      100,
+      "MessageData",
+      expectedProperties,
+      emptyMeasurements,
+      expectedBaseData,
+      expectedTime
+    );
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
https://github.com/microsoft/ApplicationInsights-node.js/issues/1169

### Describe the problem that is addressed by this PR
Fixes an issue with serializing legacy Application Insights logs with nested objects.

### Are there test cases added in this PR? _(If not, why?)_
Yes, added in the `logUtils.tests` file.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
