### PR TITLE
[core-rest-pipeline] set init.duplex to "half" when streaming body via fetch 

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Set `init.duplex` to `"half"` when streaming body via `fetch()`
+- Set `init.duplex` to `"half"` when streaming body via `fetch()` [PR #26890](https://github.com/Azure/azure-sdk-for-js/pull/26890)
 
 ## 1.12.0 (2023-08-08)
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Set `init.duplex` to `"half"` when streaming body via `fetch()`
+
 ## 1.12.0 (2023-08-08)
 
 ### Features Added

--- a/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
@@ -75,7 +75,22 @@ async function makeRequest(request: PipelineRequest): Promise<PipelineResponse> 
 
   try {
     const headers = buildFetchHeaders(request.headers);
-    const requestBody = buildRequestBody(request);
+    const { streaming, body: requestBody} = buildRequestBody(request);
+    const requestInit: RequestInit = {
+      body: requestBody,
+      method: request.method,
+      headers: headers,
+      signal: abortController.signal,
+      credentials: request.withCredentials ? "include" : "same-origin",
+      cache: "no-store",
+    }
+
+    // According to https://fetch.spec.whatwg.org/#fetch-method,
+    // init.duplex must be set when body is a ReadableStream object.
+    // currently "half" is the only valid value.
+    if (streaming) {
+      (requestInit as any).duplex = "half";
+    }
 
     /**
      * Developers of the future:
@@ -83,14 +98,7 @@ async function makeRequest(request: PipelineRequest): Promise<PipelineResponse> 
      * of request options.
      * It will not work as you expect.
      */
-    const response = await fetch(request.url, {
-      body: requestBody,
-      method: request.method,
-      headers: headers,
-      signal: abortController.signal,
-      credentials: request.withCredentials ? "include" : "same-origin",
-      cache: "no-store",
-    });
+    const response = await fetch(request.url, requestInit);
     // If we're uploading a blob, we need to fire the progress event manually
     if (isBlob(request.body) && request.onUploadProgress) {
       request.onUploadProgress({ loadedBytes: request.body.size });
@@ -220,7 +228,7 @@ function buildRequestBody(request: PipelineRequest) {
     throw new Error("Node streams are not supported in browser environment.");
   }
 
-  return isReadableStream(body) ? buildBodyStream(body, request.onUploadProgress) : body;
+  return isReadableStream(body) ? { streaming: true, body: buildBodyStream(body, request.onUploadProgress)} : { streaming: false, body};
 }
 
 /**

--- a/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
@@ -75,7 +75,7 @@ async function makeRequest(request: PipelineRequest): Promise<PipelineResponse> 
 
   try {
     const headers = buildFetchHeaders(request.headers);
-    const { streaming, body: requestBody} = buildRequestBody(request);
+    const { streaming, body: requestBody } = buildRequestBody(request);
     const requestInit: RequestInit = {
       body: requestBody,
       method: request.method,
@@ -83,7 +83,7 @@ async function makeRequest(request: PipelineRequest): Promise<PipelineResponse> 
       signal: abortController.signal,
       credentials: request.withCredentials ? "include" : "same-origin",
       cache: "no-store",
-    }
+    };
 
     // According to https://fetch.spec.whatwg.org/#fetch-method,
     // init.duplex must be set when body is a ReadableStream object.
@@ -228,7 +228,9 @@ function buildRequestBody(request: PipelineRequest) {
     throw new Error("Node streams are not supported in browser environment.");
   }
 
-  return isReadableStream(body) ? { streaming: true, body: buildBodyStream(body, request.onUploadProgress)} : { streaming: false, body};
+  return isReadableStream(body)
+    ? { streaming: true, body: buildBodyStream(body, request.onUploadProgress) }
+    : { streaming: false, body };
 }
 
 /**

--- a/sdk/core/core-rest-pipeline/test/browser/fetchHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/fetchHttpClient.spec.ts
@@ -341,6 +341,7 @@ describe("FetchHttpClient", function () {
           typeof (body as ReadableStream).tee === "function",
         "expecting ReadableStream request body"
       );
+      assert.strictEqual(options.duplex, "half");
       const reader = (body as ReadableStream).getReader();
       const data = await reader.read();
       assert.equal(data.value, requestText, "unexpected request text");


### PR DESCRIPTION
According to WHATWG fetch spec (https://fetch.spec.whatwg.org/#fetch-method) when body is a ReadableStream object, init.duplex must be set and currently the only valid value is "half".  This PR sets the property when request body is a ReadableStream.
