### PR TITLE
[core] Defer Error construction

### DIFF
--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
@@ -13,10 +13,6 @@ import {
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResource } from "../webResource";
 
-const DisbleResponseDecompressionNotSupportedInBrowser = new Error(
-  "DisableResponseDecompressionPolicy is not supported in browser environment"
-);
-
 /**
  * {@link DisableResponseDecompressionPolicy} is not supported in browser and attempting
  * to use it will results in error being thrown.
@@ -24,7 +20,7 @@ const DisbleResponseDecompressionNotSupportedInBrowser = new Error(
 export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw DisbleResponseDecompressionNotSupportedInBrowser;
+      throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
     },
   };
 }
@@ -32,10 +28,10 @@ export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
 export class DisableResponseDecompressionPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw DisbleResponseDecompressionNotSupportedInBrowser;
+    throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
   }
 
   public async sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
-    throw DisbleResponseDecompressionNotSupportedInBrowser;
+    throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
   }
 }

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
@@ -13,6 +13,8 @@ import {
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResource } from "../webResource";
 
+const errorMessage = "DisableResponseDecompressionPolicy is not supported in browser environment";
+
 /**
  * {@link DisableResponseDecompressionPolicy} is not supported in browser and attempting
  * to use it will results in error being thrown.
@@ -20,7 +22,7 @@ import { WebResource } from "../webResource";
 export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
+      throw new Error(errorMessage);
     },
   };
 }
@@ -28,10 +30,10 @@ export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
 export class DisableResponseDecompressionPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
+    throw new Error(errorMessage);
   }
 
   public async sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
-    throw new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
+    throw new Error(errorMessage);
   }
 }

--- a/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
@@ -11,8 +11,6 @@ import { HttpOperationResponse } from "../httpOperationResponse";
 import { ProxySettings } from "../serviceClient";
 import { WebResourceLike } from "../webResource";
 
-const proxyNotSupportedInBrowser = new Error("ProxyPolicy is not supported in browser environment");
-
 export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined {
   return undefined;
 }
@@ -20,7 +18,7 @@ export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | und
 export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw proxyNotSupportedInBrowser;
+      throw new Error("ProxyPolicy is not supported in browser environment");
     },
   };
 }
@@ -28,10 +26,10 @@ export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactor
 export class ProxyPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw proxyNotSupportedInBrowser;
+    throw new Error("ProxyPolicy is not supported in browser environment");
   }
 
   public sendRequest(_request: WebResourceLike): Promise<HttpOperationResponse> {
-    throw proxyNotSupportedInBrowser;
+    throw new Error("ProxyPolicy is not supported in browser environment");
   }
 }

--- a/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
@@ -11,6 +11,8 @@ import { HttpOperationResponse } from "../httpOperationResponse";
 import { ProxySettings } from "../serviceClient";
 import { WebResourceLike } from "../webResource";
 
+const errorMessage = "ProxyPolicy is not supported in browser environment";
+
 export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined {
   return undefined;
 }
@@ -18,7 +20,7 @@ export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | und
 export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw new Error("ProxyPolicy is not supported in browser environment");
+      throw new Error(errorMessage);
     },
   };
 }
@@ -26,10 +28,10 @@ export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactor
 export class ProxyPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw new Error("ProxyPolicy is not supported in browser environment");
+    throw new Error(errorMessage);
   }
 
   public sendRequest(_request: WebResourceLike): Promise<HttpOperationResponse> {
-    throw new Error("ProxyPolicy is not supported in browser environment");
+    throw new Error(errorMessage);
   }
 }

--- a/sdk/core/core-rest-pipeline/src/policies/decompressResponsePolicy.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/decompressResponsePolicy.browser.ts
@@ -5,8 +5,6 @@
  * NOTE: When moving this file, please update "browser" section in package.json
  */
 
-const NotSupported = new Error("decompressResponsePolicy is not supported in browser environment");
-
 export const decompressResponsePolicyName = "decompressResponsePolicy";
 
 /**
@@ -14,5 +12,5 @@ export const decompressResponsePolicyName = "decompressResponsePolicy";
  * to use it will raise an error.
  */
 export function decompressResponsePolicy(): never {
-  throw NotSupported;
+  throw new Error("decompressResponsePolicy is not supported in browser environment");
 }

--- a/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.browser.ts
@@ -6,9 +6,10 @@
  */
 
 export const proxyPolicyName = "proxyPolicy";
+const errorMessage = "proxyPolicy is not supported in browser environment";
 
 export function getDefaultProxySettings(): never {
-  throw new Error("proxyPolicy is not supported in browser environment");
+  throw new Error(errorMessage);
 }
 
 /**
@@ -16,7 +17,7 @@ export function getDefaultProxySettings(): never {
  * to use it will raise an error.
  */
 export function proxyPolicy(): never {
-  throw new Error("proxyPolicy is not supported in browser environment");
+  throw new Error(errorMessage);
 }
 
 /**
@@ -26,5 +27,5 @@ export function proxyPolicy(): never {
  * @internal
  */
 export function resetCachedProxyAgents(): never {
-  throw new Error("proxyPolicy is not supported in browser environment");
+  throw new Error(errorMessage);
 }

--- a/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/proxyPolicy.browser.ts
@@ -5,12 +5,10 @@
  * NOTE: When moving this file, please update "browser" section in package.json
  */
 
-const NotSupported = new Error("proxyPolicy is not supported in browser environment");
-
 export const proxyPolicyName = "proxyPolicy";
 
 export function getDefaultProxySettings(): never {
-  throw NotSupported;
+  throw new Error("proxyPolicy is not supported in browser environment");
 }
 
 /**
@@ -18,7 +16,7 @@ export function getDefaultProxySettings(): never {
  * to use it will raise an error.
  */
 export function proxyPolicy(): never {
-  throw NotSupported;
+  throw new Error("proxyPolicy is not supported in browser environment");
 }
 
 /**
@@ -28,5 +26,5 @@ export function proxyPolicy(): never {
  * @internal
  */
 export function resetCachedProxyAgents(): never {
-  throw NotSupported;
+  throw new Error("proxyPolicy is not supported in browser environment");
 }


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-rest-pipeline`
`@azure/core-http`

### Issues associated with this PR

Partner report of memory leak in test bench.

### Describe the problem that is addressed by this PR

Eager error construction on module load can cause trouble when the Error constructor is hooked/cached by development tooling. This PR changes the pattern of caching the Error object to a more typical new-on-throw pattern. This should also improve the stack trace to be more accurate on the thrown Error.

