### PR TITLE
[EngSys] add stub NPM scripts to eslint-plugin-helper

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk-helper/package.json
+++ b/common/tools/eslint-plugin-azure-sdk-helper/package.json
@@ -18,5 +18,24 @@
     "@typescript-eslint/experimental-utils": "~5.57.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "typescript": "~5.0.0"
+  },
+  "scripts": {
+    "audit": "echo skipped",
+    "build:test": "echo skipped",
+    "build": "echo skipped",
+    "check-format": "echo skipped",
+    "clean": "echo skipped",
+    "format": "echo skipped",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
+    "lint:fix": "echo skipped",
+    "lint": "echo skipped",
+    "test:browser": "echo skipped",
+    "test:node": "echo skipped",
+    "test": "echo skipped",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "echo skipped",
+    "unit-test": "echo skipped"
   }
 }


### PR DESCRIPTION
so that rush commands like "rush build" and "rush lint" won't be broken.
