### PR TITLE
[core-http] Port changes from PR #26897 Defer Error construction

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.0.3 (2023-08-31)
+
+### Other Changes
+
+- Defer error object creation
+
 ## 3.0.2 (2023-06-01)
 
 ### Other Changes

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-http",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
@@ -13,9 +13,7 @@ import {
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResource } from "../webResource";
 
-const DisbleResponseDecompressionNotSupportedInBrowser = new Error(
-  "DisableResponseDecompressionPolicy is not supported in browser environment"
-);
+const errorMessage = "DisableResponseDecompressionPolicy is not supported in browser environment";
 
 /**
  * {@link DisableResponseDecompressionPolicy} is not supported in browser and attempting
@@ -24,7 +22,7 @@ const DisbleResponseDecompressionNotSupportedInBrowser = new Error(
 export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw DisbleResponseDecompressionNotSupportedInBrowser;
+      throw new Error(errorMessage);
     },
   };
 }
@@ -32,10 +30,10 @@ export function disableResponseDecompressionPolicy(): RequestPolicyFactory {
 export class DisableResponseDecompressionPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw DisbleResponseDecompressionNotSupportedInBrowser;
+    throw new Error(errorMessage);
   }
 
   public async sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
-    throw DisbleResponseDecompressionNotSupportedInBrowser;
+    throw new Error(errorMessage);
   }
 }

--- a/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
@@ -11,7 +11,7 @@ import { HttpOperationResponse } from "../httpOperationResponse";
 import { ProxySettings } from "../serviceClient";
 import { WebResourceLike } from "../webResource";
 
-const proxyNotSupportedInBrowser = new Error("ProxyPolicy is not supported in browser environment");
+const errorMessage = "ProxyPolicy is not supported in browser environment";
 
 export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined {
   return undefined;
@@ -20,7 +20,7 @@ export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | und
 export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactory {
   return {
     create: (_nextPolicy: RequestPolicy, _options: RequestPolicyOptions) => {
-      throw proxyNotSupportedInBrowser;
+      throw new Error(errorMessage);
     },
   };
 }
@@ -28,10 +28,10 @@ export function proxyPolicy(_proxySettings?: ProxySettings): RequestPolicyFactor
 export class ProxyPolicy extends BaseRequestPolicy {
   constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
-    throw proxyNotSupportedInBrowser;
+    throw new Error(errorMessage);
   }
 
   public sendRequest(_request: WebResourceLike): Promise<HttpOperationResponse> {
-    throw proxyNotSupportedInBrowser;
+    throw new Error(errorMessage);
   }
 }

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
   /**
    * The core-http version
    */
-  coreHttpVersion: "3.0.2",
+  coreHttpVersion: "3.0.3",
 
   /**
    * Specifies HTTP.


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-http`

### Issues associated with this PR

Partner report of memory leak in test bench.

### Describe the problem that is addressed by this PR

Eager error construction on module load can cause trouble when the Error constructor is hooked/cached by development tooling. This PR changes the pattern of caching the Error object to a more typical new-on-throw pattern. This should also improve the stack trace to be more accurate on the thrown Error.
