### PR TITLE
[Communication] ACS Chat 1.3.2 Release

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -907,8 +907,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/communication-signaling/1.0.0-beta.16:
-    resolution: {integrity: sha512-EcwDgD7tmxY4rZif/T7YK1JMNjIfaBVrJvu2BBZDlnyRtBbhQbkzDH5wCm1c7mgsWAZTeR/BsCffUOSWFXw8JQ==}
+  /@azure/communication-signaling/1.0.0-beta.20:
+    resolution: {integrity: sha512-Vjsiv6lWiVFqTG51cKNOAwnhuUhKbb6oOsQ833NEaWl9MwlqEQtxSOMJPYsoSCjb+pnIYvbioC+hIHkKfkAxbQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       '@azure/core-http': 2.3.2
@@ -16594,12 +16594,12 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-wp4HL14lnFtVns/1qmxpsw0kwnlIX9Yvb7oh9mu2C8XpH3F0jTuGuGQZBAmx4fF8sB+hewCXbwnDolvZKg+uiA==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-2lbV09MTvQOFhBj4wbaTLnBdu8R29yfzrZBFdGdk+DPG5SMG/nu3fl2CC3+rQp7sy+s8tGpjsPpcsAhnb1gRqw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
       '@azure/communication-common': 2.2.1
-      '@azure/communication-signaling': 1.0.0-beta.16
+      '@azure/communication-signaling': 1.0.0-beta.20
       '@microsoft/api-extractor': 7.36.4_@types+node@14.18.54
       '@types/chai': 4.3.5
       '@types/mocha': 7.0.2

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Updated to @azure/communication-signaling@1.0.0-beta.20. Added EUDB real-time notification support. `https://*.trouter.teams.microsoft.com` and `teams.microsoft.com` needs to be allowed for real-time notifications.
+- Updated to @azure/communication-signaling@1.0.0-beta.20. Added EUDB real-time notification support. `https://*.trouter.teams.microsoft.com` and `https://teams.microsoft.com` needs to be allowed for real-time notifications.
 
 ## 1.3.1 (2023-02-28)
 

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.3.2 (Unreleased)
+## 1.3.2 (2023-08-24)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Updated to @azure/communication-signaling@1.0.0-beta.20. Added EUDB real-time notification support. `https://*.trouter.teams.microsoft.com` and `teams.microsoft.com` needs to be allowed for real-time notifications.
 
 ## 1.3.1 (2023-02-28)
 

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-common": "^2.2.0",
-    "@azure/communication-signaling": "1.0.0-beta.16",
+    "@azure/communication-signaling": "1.0.0-beta.20",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.3.0",
     "@azure/core-paging": "^1.1.1",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/communication-chat

### Describe the problem that is addressed by this PR
Updated to @azure/communication-signaling@1.0.0-beta.20. Added EUDB real-time notification support. `https://*.trouter.teams.microsoft.com` and `teams.microsoft.com` needs to be allowed for real-time notifications.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
