### PR TITLE
[ServiceBus] wait and throw error if sender link is not sendable

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Check whether we can send messages before making management requests
+- Check whether we can send messages before making management requests. [PR #26927](https://github.com/Azure/azure-sdk-for-js/pull/26927)
 
 ## 7.9.0 (2023-04-11)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Check whether we can send messages before making management requests
+
 ## 7.9.0 (2023-04-11)
 
 ### Bugs Fixed

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -257,12 +257,12 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
       this._initLock,
       async () => {
         managementClientLogger.verbose(
-          `{this._logPrefix} lock acquired for initializing replyTo address and link`
+          `${this.logPrefix} lock acquired for initializing replyTo address and link`
         );
         if (!this.isOpen()) {
           this.replyTo = generate_uuid();
           managementClientLogger.verbose(
-            `{this._logPrefix} new replyTo address: ${this.replyTo} generated`
+            `${this.logPrefix} new replyTo address: ${this.replyTo} generated`
           );
         }
         const { abortSignal } = options ?? {};

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -17,14 +17,13 @@ import {
   RetryConfig,
   RetryOperationType,
   RetryOptions,
-  delay,
   retry,
   AmqpAnnotatedMessage,
 } from "@azure/core-amqp";
 import { ServiceBusMessage, toRheaMessage } from "../serviceBusMessage";
 import { ConnectionContext } from "../connectionContext";
 import { LinkEntity } from "./linkEntity";
-import { getUniqueName, waitForTimeoutOrAbortOrResolve } from "../util/utils";
+import { getUniqueName, waitForSendable, waitForTimeoutOrAbortOrResolve } from "../util/utils";
 import { throwErrorIfConnectionClosed } from "../util/errors";
 import { ServiceBusMessageBatch, ServiceBusMessageBatchImpl } from "../serviceBusMessageBatch";
 import { CreateMessageBatchOptions } from "../models";
@@ -205,41 +204,16 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
         this.link?.session?.outgoing?.available()
       );
 
-      let waitTimeForSendable = 1000;
-      if (!this.link?.sendable() && timeoutInMs - timeTakenByInit > waitTimeForSendable) {
-        logger.verbose(
-          "%s Sender '%s', waiting for 1 second for sender to become sendable",
-          this.logPrefix,
-          this.name
-        );
+      const waitingTime = await waitForSendable(
+        logger,
+        this.logPrefix,
+        this.name,
+        timeoutInMs - timeTakenByInit,
+        this.link,
+        this.link?.session?.outgoing?.available()
+      );
 
-        await delay(waitTimeForSendable);
-
-        logger.verbose(
-          "%s Sender '%s' after waiting for a second, credit: %d available: %d",
-          this.logPrefix,
-          this.name,
-          this.link?.credit,
-          this.link?.session?.outgoing?.available()
-        );
-      } else {
-        waitTimeForSendable = 0;
-      }
-
-      if (!this.link?.sendable()) {
-        // let us retry to send the message after some time.
-        const msg =
-          `[${this.logPrefix}] Sender "${this.name}", ` +
-          `cannot send the message right now. Please try later.`;
-        logger.warning(msg);
-        const amqpError: AmqpError = {
-          condition: ErrorNameConditionMapper.SenderBusyError,
-          description: msg,
-        };
-        throw translateServiceBusError(amqpError);
-      }
-
-      if (timeoutInMs <= timeTakenByInit + waitTimeForSendable) {
+      if (timeoutInMs <= timeTakenByInit + waitingTime) {
         const desc: string =
           `${this.logPrefix} Sender "${this.name}" ` +
           `with address "${this.address}", was not able to send the message right now, due ` +
@@ -255,7 +229,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
       try {
         const delivery = await this.link!.send(encodedMessage, {
           format: sendBatch ? 0x80013700 : 0,
-          timeoutInSeconds: (timeoutInMs - timeTakenByInit - waitTimeForSendable) / 1000,
+          timeoutInSeconds: (timeoutInMs - timeTakenByInit - waitingTime) / 1000,
           abortSignal,
         });
         logger.verbose(


### PR DESCRIPTION
We already have the logic in `MessageSender._trySend()`.  This PR adds the same to `ManagementClient._makeManagementRequest()` so that when the link is not sendable, we wait for one second then check again.  A `SendBusyError` is thrown if we still cannot send messages.

### Packages impacted by this PR
`@azure/service-bus`

### Issues associated with this PR

#26855 
