### PR TITLE
[keyvault] Make Managed HSM tests only weekly

### DIFF
--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -15,6 +15,12 @@ stages:
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
+
+      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
+        # Due to the high cost of Managed HSMs, which keyvault-admin requires, we only want to run
+        # the live tests weekly.
+        MatrixFilters:
+          - ArmTemplateParameters=^(?!.*enableHsm.*true)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -16,7 +16,7 @@ stages:
           Selection: sparse
           GenerateVMJobs: true
 
-      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
+      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
         # Due to the high cost of Managed HSMs, which keyvault-admin requires, we only want to run
         # the live tests weekly.
         MatrixFilters:

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -11,16 +11,14 @@ stages:
       # live tests against a single instance.
       Location: eastus2
       MatrixConfigs:
-        - Name: Keyvault_live_test_base
-          Path: sdk/keyvault/keyvault-admin/platform-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
-
-      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
         # Due to the high cost of Managed HSMs, which keyvault-admin requires, we only want to run
         # the live tests weekly.
-        MatrixFilters:
-          - ArmTemplateParameters=^(?!.*enableHsm.*true)
+        ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
+          - Name: Keyvault_live_test_base
+            Path: sdk/keyvault/keyvault-admin/platform-matrix.json
+            Selection: sparse
+            GenerateVMJobs: true
+
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -11,14 +11,16 @@ stages:
       # live tests against a single instance.
       Location: eastus2
       MatrixConfigs:
+        - Name: Keyvault_live_test_base
+          Path: sdk/keyvault/keyvault-admin/platform-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
+
+      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
         # Due to the high cost of Managed HSMs, which keyvault-admin requires, we only want to run
         # the live tests weekly.
-        ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly'))}}:
-          - Name: Keyvault_live_test_base
-            Path: sdk/keyvault/keyvault-admin/platform-matrix.json
-            Selection: sparse
-            GenerateVMJobs: true
-
+        MatrixFilters:
+          - ArmTemplateParameters=^(?!.*enableHsm.*true)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -28,6 +28,11 @@ stages:
           Path: sdk/keyvault/keyvault-keys/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
+
+      # Due to the high cost of Managed HSMs, we only want to test using them weekly.
+      ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
+        MatrixFilters:
+          - ArmTemplateParameters=^(?!.*enableHsm.*true)
       EnvVars:
         AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
         AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)


### PR DESCRIPTION
Fixes #25734.

Running tests which use Managed HSM only weekly to reduce cost.