### PR TITLE
[engsys] remove some deprecated dev dependencies

### DIFF
--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -136,7 +136,6 @@
     "karma-sourcemap-loader": "^0.3.8",
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^2.0.0",
-    "mocha-testdata": "^1.2.0",
     "nyc": "^15.0.0",
     "prettier": "^2.5.1",
     "process": "^0.11.10",

--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.spec.ts
@@ -14,7 +14,6 @@ import { CommunicationIdentityClient, TokenScope } from "../../src";
 import { Context } from "mocha";
 import { assert } from "chai";
 import { matrix } from "@azure/test-utils";
-import { given } from "mocha-testdata";
 
 matrix([[true, false]], async function (useAad: boolean) {
   describe(`CommunicationIdentityClient [Playback/Live]${useAad ? " [AAD]" : ""}`, function () {
@@ -43,28 +42,32 @@ matrix([[true, false]], async function (useAad: boolean) {
       assert.isString(user.communicationUserId);
     });
 
-    given([
+    [
       { scopes: chatScope, description: "chat scope" },
       { scopes: voipScope, description: "voip scope" },
       { scopes: multipleScopes, description: "multiple scopes" },
-    ]).it("successfully creates a user and token", async function (input) {
-      const { user: newUser, token, expiresOn } = await client.createUserAndToken(input.scopes);
-      assert.isTrue(isCommunicationUserIdentifier(newUser));
-      assert.isString(newUser.communicationUserId);
-      assert.isString(token);
-      assert.instanceOf(expiresOn, Date);
-    });
+    ].forEach((input) =>
+      it(`successfully creates a user and token <${input.description}>`, async function () {
+        const { user: newUser, token, expiresOn } = await client.createUserAndToken(input.scopes);
+        assert.isTrue(isCommunicationUserIdentifier(newUser));
+        assert.isString(newUser.communicationUserId);
+        assert.isString(token);
+        assert.instanceOf(expiresOn, Date);
+      })
+    );
 
-    given([
+    [
       { scopes: chatScope, description: "chat scope" },
       { scopes: voipScope, description: "voip scope" },
       { scopes: multipleScopes, description: "multiple scopes" },
-    ]).it("successfully gets a token for a user", async function (input) {
-      const user: CommunicationUserIdentifier = await client.createUser();
-      const { token, expiresOn } = await client.getToken(user, input.scopes);
-      assert.isString(token);
-      assert.instanceOf(expiresOn, Date);
-    });
+    ].forEach((input) =>
+      it(`successfully gets a token for a user <${input.description}>`, async function () {
+        const user: CommunicationUserIdentifier = await client.createUser();
+        const { token, expiresOn } = await client.getToken(user, input.scopes);
+        assert.isString(token);
+        assert.instanceOf(expiresOn, Date);
+      })
+    );
 
     it("successfully revokes tokens issued for a user", async function () {
       const { user } = await client.createUserAndToken(multipleScopes);

--- a/sdk/communication/communication-identity/test/public/node/getTokenForTeamsUser.node.spec.ts
+++ b/sdk/communication/communication-identity/test/public/node/getTokenForTeamsUser.node.spec.ts
@@ -15,7 +15,6 @@ import { PublicClientApplication } from "@azure/msal-node";
 import { matrix } from "@azure/test-utils";
 import { Context } from "mocha";
 import { assert } from "chai";
-import { given } from "mocha-testdata";
 
 matrix([[true, false]], async function (useAad) {
   describe(`Get Token For Teams User [Playback/Live]${useAad ? " [AAD]" : ""}`, function () {
@@ -85,73 +84,79 @@ matrix([[true, false]], async function (useAad) {
       assert.instanceOf(expiresOn, Date);
     }).timeout(5000);
 
-    given([
+    [
       { teamsUserAadToken: "", description: "an empty teamsUserAadToken" },
       { teamsUserAadToken: "invalid", description: "an invalid teamsUserAadToken" },
       {
         teamsUserAadToken: env.COMMUNICATION_EXPIRED_TEAMS_TOKEN ?? "",
         description: "an expired teamsUserAadToken",
       },
-    ]).it("throws an error when attempting to exchange", async function (input) {
-      try {
-        if (isPlaybackMode()) {
-          input.teamsUserAadToken = sanitizedValue;
+    ].forEach((input) =>
+      it(`throws an error when attempting to exchange <${input.description}>`, async function () {
+        try {
+          if (isPlaybackMode()) {
+            input.teamsUserAadToken = sanitizedValue;
+          }
+          await client.getTokenForTeamsUser({
+            teamsUserAadToken: input.teamsUserAadToken,
+            clientId: options.clientId,
+            userObjectId: options.clientId,
+          });
+        } catch (e: any) {
+          assert.equal(e.statusCode, 401);
+          return;
         }
-        await client.getTokenForTeamsUser({
-          teamsUserAadToken: input.teamsUserAadToken,
-          clientId: options.clientId,
-          userObjectId: options.clientId,
-        });
-      } catch (e: any) {
-        assert.equal(e.statusCode, 401);
-        return;
-      }
 
-      assert.fail("Should have thrown an error");
-    });
+        assert.fail("Should have thrown an error");
+      })
+    );
 
-    given([
+    [
       { clientId: "", description: "an empty clientId" },
       { clientId: "invalid", description: "an invalid clientId" },
       { clientId: options.userObjectId, description: "a wrong clientId" },
-    ]).it("throws an error when attempting to exchange", async function (input) {
-      try {
-        if (isPlaybackMode()) {
-          input.clientId = sanitizedValue;
+    ].forEach((input) =>
+      it(`throws an error when attempting to exchange <${input.description}>`, async function () {
+        try {
+          if (isPlaybackMode()) {
+            input.clientId = sanitizedValue;
+          }
+          await client.getTokenForTeamsUser({
+            teamsUserAadToken: options.teamsUserAadToken,
+            clientId: input.clientId,
+            userObjectId: options.userObjectId,
+          });
+        } catch (e: any) {
+          assert.equal(e.statusCode, 400);
+          return;
         }
-        await client.getTokenForTeamsUser({
-          teamsUserAadToken: options.teamsUserAadToken,
-          clientId: input.clientId,
-          userObjectId: options.userObjectId,
-        });
-      } catch (e: any) {
-        assert.equal(e.statusCode, 400);
-        return;
-      }
 
-      assert.fail("Should have thrown an error");
-    });
+        assert.fail("Should have thrown an error");
+      })
+    );
 
-    given([
+    [
       { userObjectId: "", description: "an empty userObjectId" },
       { userObjectId: "invalid", description: "an invalid userObjectId" },
       { userObjectId: options.clientId, description: "a wrong userObjectId" },
-    ]).it("throws an error when attempting to exchange", async function (input) {
-      try {
-        if (isPlaybackMode()) {
-          input.userObjectId = sanitizedValue;
+    ].forEach((input) =>
+      it(`throws an error when attempting to exchange <${input.description}>`, async function () {
+        try {
+          if (isPlaybackMode()) {
+            input.userObjectId = sanitizedValue;
+          }
+          await client.getTokenForTeamsUser({
+            teamsUserAadToken: options.teamsUserAadToken,
+            clientId: options.clientId,
+            userObjectId: input.userObjectId,
+          });
+        } catch (e: any) {
+          assert.equal(e.statusCode, 400);
+          return;
         }
-        await client.getTokenForTeamsUser({
-          teamsUserAadToken: options.teamsUserAadToken,
-          clientId: options.clientId,
-          userObjectId: input.userObjectId,
-        });
-      } catch (e: any) {
-        assert.equal(e.statusCode, 400);
-        return;
-      }
 
-      assert.fail("Should have thrown an error");
-    });
+        assert.fail("Should have thrown an error");
+      })
+    );
   });
 });

--- a/sdk/communication/communication-identity/test/public/node/tokenCustomExpiration.node.spec.ts
+++ b/sdk/communication/communication-identity/test/public/node/tokenCustomExpiration.node.spec.ts
@@ -12,7 +12,6 @@ import {
   createRecordedCommunicationIdentityClientWithToken,
 } from "../utils/recordedClient";
 import { CreateUserAndTokenOptions, GetTokenOptions } from "../../../src/models";
-import { given } from "mocha-testdata";
 
 matrix([[true, false]], async function (useAad: boolean) {
   describe(`Get Token With Custom Expiration [Playback/Live]${
@@ -53,71 +52,76 @@ matrix([[true, false]], async function (useAad: boolean) {
       };
     }
 
-    given([
+    [
       { tokenExpiresInMinutes: 60, description: "min valid" },
       { tokenExpiresInMinutes: 1440, description: "max valid" },
-    ]).it("successfully gets a valid custom expiration token", async function (input) {
-      const user: CommunicationUserIdentifier = await client.createUser();
-      const tokenOptions: GetTokenOptions = { tokenExpiresInMinutes: input.tokenExpiresInMinutes };
-      const { token, expiresOn } = await client.getToken(user, ["chat"], tokenOptions);
+    ].forEach((input) =>
+      it(`successfully gets a valid custom expiration token <${input.description}>`, async function () {
+        const user: CommunicationUserIdentifier = await client.createUser();
+        const tokenOptions: GetTokenOptions = {
+          tokenExpiresInMinutes: input.tokenExpiresInMinutes,
+        };
+        const { token, expiresOn } = await client.getToken(user, ["chat"], tokenOptions);
 
-      assert.isString(token);
-      assert.instanceOf(expiresOn, Date);
-      if (isLiveMode()) {
-        const { withinAllowedDeviation, tokenExpirationInMinutes } =
-          tokenExpirationWithinAllowedDeviation(
-            input.tokenExpiresInMinutes,
-            expiresOn,
-            TOKEN_EXPIRATION_ALLOWED_DEVIATION
+        assert.isString(token);
+        assert.instanceOf(expiresOn, Date);
+        if (isLiveMode()) {
+          const { withinAllowedDeviation, tokenExpirationInMinutes } =
+            tokenExpirationWithinAllowedDeviation(
+              input.tokenExpiresInMinutes,
+              expiresOn,
+              TOKEN_EXPIRATION_ALLOWED_DEVIATION
+            );
+          assert.isTrue(
+            withinAllowedDeviation,
+            `Token expiration is outside of allowed ${
+              TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100
+            }% deviation. Expected minutes: ${input.tokenExpiresInMinutes}, actual minutes: ${
+              // to round to max 2 decimal places
+              Math.round((tokenExpirationInMinutes + Number.EPSILON) * 100) / 100
+            }.`
           );
-        assert.isTrue(
-          withinAllowedDeviation,
-          `Token expiration is outside of allowed ${
-            TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100
-          }% deviation. Expected minutes: ${input.tokenExpiresInMinutes}, actual minutes: ${
-            // to round to max 2 decimal places
-            Math.round((tokenExpirationInMinutes + Number.EPSILON) * 100) / 100
-          }.`
-        );
-      }
-    });
+        }
+      })
+    );
 
-    given([
+    [
       { tokenExpiresInMinutes: 60, description: "min valid" },
       { tokenExpiresInMinutes: 1440, description: "max valid" },
-    ]).it("successfully gets user and valid custom expiration token", async function (input) {
-      const tokenOptions: CreateUserAndTokenOptions = {
-        tokenExpiresInMinutes: input.tokenExpiresInMinutes,
-      };
-      const { token, expiresOn } = await client.createUserAndToken(["chat"], tokenOptions);
+    ].forEach((input) =>
+      it(`successfully gets user and valid custom expiration token <${input.description}>`, async function () {
+        const tokenOptions: CreateUserAndTokenOptions = {
+          tokenExpiresInMinutes: input.tokenExpiresInMinutes,
+        };
+        const { token, expiresOn } = await client.createUserAndToken(["chat"], tokenOptions);
 
-      assert.isString(token);
-      assert.instanceOf(expiresOn, Date);
-      if (isLiveMode()) {
-        const { withinAllowedDeviation, tokenExpirationInMinutes } =
-          tokenExpirationWithinAllowedDeviation(
-            input.tokenExpiresInMinutes,
-            expiresOn,
-            TOKEN_EXPIRATION_ALLOWED_DEVIATION
+        assert.isString(token);
+        assert.instanceOf(expiresOn, Date);
+        if (isLiveMode()) {
+          const { withinAllowedDeviation, tokenExpirationInMinutes } =
+            tokenExpirationWithinAllowedDeviation(
+              input.tokenExpiresInMinutes,
+              expiresOn,
+              TOKEN_EXPIRATION_ALLOWED_DEVIATION
+            );
+          assert.isTrue(
+            withinAllowedDeviation,
+            `Token expiration is outside of allowed ${
+              TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100
+            }% deviation. Expected minutes: ${input.tokenExpiresInMinutes}, actual minutes: ${
+              // to round to max 2 decimal places
+              Math.round((tokenExpirationInMinutes + Number.EPSILON) * 100) / 100
+            }.`
           );
-        assert.isTrue(
-          withinAllowedDeviation,
-          `Token expiration is outside of allowed ${
-            TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100
-          }% deviation. Expected minutes: ${input.tokenExpiresInMinutes}, actual minutes: ${
-            // to round to max 2 decimal places
-            Math.round((tokenExpirationInMinutes + Number.EPSILON) * 100) / 100
-          }.`
-        );
-      }
-    });
+        }
+      })
+    );
 
-    given([
+    [
       { tokenExpiresInMinutes: 59, description: "lo inval" },
       { tokenExpiresInMinutes: 1441, description: "hi inval" },
-    ]).it(
-      "throws error when attempting to issue an invalid expiration token",
-      async function (input) {
+    ].forEach((input) =>
+      it(`throws error when attempting to issue an invalid expiration token <${input.description}>`, async function () {
         const user: CommunicationUserIdentifier = await client.createUser();
         const tokenOptions: GetTokenOptions = {
           tokenExpiresInMinutes: input.tokenExpiresInMinutes,
@@ -128,15 +132,14 @@ matrix([[true, false]], async function (useAad: boolean) {
         } catch (e: any) {
           assert.equal(e.statusCode, 400);
         }
-      }
+      })
     );
 
-    given([
+    [
       { tokenExpiresInMinutes: 59, description: "lo inval" },
       { tokenExpiresInMinutes: 1441, description: "hi inval" },
-    ]).it(
-      "throws error when attempting to issue user and invalid expiration token",
-      async function (input) {
+    ].forEach((input) =>
+      it(`throws error when attempting to issue user and invalid expiration token <${input.description}>`, async function () {
         const tokenOptions: CreateUserAndTokenOptions = {
           tokenExpiresInMinutes: input.tokenExpiresInMinutes,
         };
@@ -146,7 +149,7 @@ matrix([[true, false]], async function (useAad: boolean) {
         } catch (e: any) {
           assert.equal(e.statusCode, 400);
         }
-      }
+      })
     );
   });
 });

--- a/sdk/schemaregistry/schema-registry-json/package.json
+++ b/sdk/schemaregistry/schema-registry-json/package.json
@@ -84,7 +84,6 @@
     "@microsoft/api-extractor": "^7.31.1",
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-inject": "^5.0.0",
-    "@types/ajv": "^1.0.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^16.0.0",
     "ajv": "^8.12.0",

--- a/sdk/schemaregistry/schema-registry-json/samples/v1-beta/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry-json/samples/v1-beta/typescript/package.json
@@ -35,7 +35,6 @@
     "@azure/event-hubs": "^5.8.0"
   },
   "devDependencies": {
-    "@types/ajv": "^1.0.0",
     "@types/node": "^14.0.0",
     "typescript": "~5.0.0",
     "rimraf": "latest"


### PR DESCRIPTION
Rush warns about

> WARN  deprecated mocha-testdata@1.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 WARN  deprecated @types/ajv@1.0.0: This is a stub types definition for ajv (https://github.com/epoberezkin/ajv). ajv provides its own type definitions, so you don't need @types/ajv installed!

This PR rewrites `given()` with plain `forEach()` calls and remove the two dependencies `mocha-testdata` and `@types/ajv`.


### Packages impacted by this PR
communication-identity
schema-registry-avro

### Issues associated with this PR
#24379 

