### PR TITLE
[Azure Monitor OpenTelemetry] Avoid dependency telemetry for ingestion endpoint calls

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/log.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/log.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { diag } from "@opentelemetry/api";
-import { ExportResult, ExportResultCode } from "@opentelemetry/core";
+import { context, diag } from "@opentelemetry/api";
+import { ExportResult, ExportResultCode, suppressTracing } from "@opentelemetry/core";
 import { AzureMonitorBaseExporter } from "./base";
 import { TelemetryItem as Envelope } from "../generated";
 import { logToEnvelope } from "../utils/logUtils";
@@ -56,7 +56,10 @@ export class AzureMonitorLogExporter extends AzureMonitorBaseExporter implements
         envelopes.push(envelope);
       }
     });
-    resultCallback(await this._sender.exportEnvelopes(envelopes));
+    // Supress tracing until OpenTelemetry Logs SDK support it
+    context.with(suppressTracing(context.active()), async () => {
+      resultCallback(await this._sender.exportEnvelopes(envelopes));
+    });
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
@@ -4,13 +4,19 @@
 import * as http from "http";
 
 export function ignoreOutgoingRequestHook(request: http.RequestOptions): boolean {
-  if (
-    request &&
-    request.headers &&
-    request.headers["user-agent"] &&
-    request.headers["user-agent"].toString().indexOf("azsdk-js-monitor-opentelemetry-exporter") > -1
-  ) {
-    return true;
+  if (request && request.headers) {
+    if (
+      (request.headers["User-Agent"] &&
+        request.headers["User-Agent"]
+          .toString()
+          .indexOf("azsdk-js-monitor-opentelemetry-exporter") > -1) ||
+      (request.headers["user-agent"] &&
+        request.headers["user-agent"]
+          .toString()
+          .indexOf("azsdk-js-monitor-opentelemetry-exporter") > -1)
+    ) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry
@azure/monitor-opentelemetry-exporter