### PR TITLE
[Azure Monitor OpenTelemetry Distro] Remove singleton in handlers

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -13,20 +13,12 @@ import { AzureLogRecordProcessor } from "./logRecordProcessor";
  * Azure Monitor OpenTelemetry Log Handler
  */
 export class LogHandler {
-  private static _instance: LogHandler;
   private _loggerProvider: LoggerProvider;
   private _azureExporter: AzureMonitorLogExporter;
   private _logRecordProcessor: BatchLogRecordProcessor;
   private _config: InternalConfig;
   private _metricHandler?: MetricHandler;
   private _azureLogProccessor: AzureLogRecordProcessor;
-
-  public static getInstance(config: InternalConfig, metricHandler: MetricHandler) {
-    if (!LogHandler._instance) {
-      LogHandler._instance = new LogHandler(config, metricHandler);
-    }
-    return LogHandler._instance;
-  }
 
   /**
    * Initializes a new instance of the TraceHandler class.

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
@@ -19,20 +19,12 @@ import { APPLICATION_INSIGHTS_NO_STANDARD_METRICS } from "./types";
  * Azure Monitor OpenTelemetry Metric Handler
  */
 export class MetricHandler {
-  private static _instance: MetricHandler;
   private _collectionInterval = 60000; // 60 seconds
   private _meterProvider: MeterProvider;
   private _azureExporter: AzureMonitorMetricExporter;
   private _metricReader: PeriodicExportingMetricReader;
   private _standardMetrics?: StandardMetrics;
   private _config: InternalConfig;
-
-  public static getInstance(config: InternalConfig, options?: { collectionInterval: number }) {
-    if (!MetricHandler._instance) {
-      MetricHandler._instance = new MetricHandler(config, options);
-    }
-    return MetricHandler._instance;
-  }
 
   /**
    * Initializes a new instance of the MetricHandler class.

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -39,7 +39,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
   }
 
   /**
-   * Initializes a new instance of the AzureMonitorOpenTelemetryConfig class.
+   * Initializes a new instance of the AzureMonitorOpenTelemetryOptions class.
    */
   constructor(options?: AzureMonitorOpenTelemetryOptions) {
     // Default values

--- a/sdk/monitor/monitor-opentelemetry/src/traces/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/handler.ts
@@ -32,7 +32,6 @@ import { Instrumentation } from "@opentelemetry/instrumentation";
  * Azure Monitor OpenTelemetry Trace Handler
  */
 export class TraceHandler {
-  private static _instance: TraceHandler;
   private _spanProcessor: BatchSpanProcessor;
   private _tracerProvider: NodeTracerProvider;
   private _azureExporter: AzureMonitorTraceExporter;
@@ -40,13 +39,6 @@ export class TraceHandler {
   private _config: InternalConfig;
   private _metricHandler: MetricHandler;
   private _azureFunctionsHook: AzureFunctionsHook;
-
-  public static getInstance(config: InternalConfig, metricHandler: MetricHandler) {
-    if (!TraceHandler._instance) {
-      TraceHandler._instance = new TraceHandler(config, metricHandler);
-    }
-    return TraceHandler._instance;
-  }
 
   /**
    * Initializes a new instance of the TraceHandler class.

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -24,8 +24,8 @@ describe("LogHandler", () => {
 
   before(() => {
     sandbox = sinon.createSandbox();
-    metricHandler = MetricHandler.getInstance(_config);
-    handler = LogHandler.getInstance(_config, metricHandler);
+    metricHandler = new MetricHandler(_config);
+    handler = new LogHandler(_config, metricHandler);
     exportStub = sinon.stub(handler["_azureExporter"], "export").callsFake(
       (logs: any, resultCallback: any) =>
         new Promise((resolve) => {
@@ -68,7 +68,7 @@ describe("LogHandler", () => {
     });
 
     it("tracing", (done) => {
-      TraceHandler.getInstance(_config, metricHandler);
+      new TraceHandler(_config, metricHandler);
       trace.getTracer("testTracer").startActiveSpan("test", () => {
         // Generate Log record
         const logRecord: APILogRecord = {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/metricHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/metricHandler.test.ts
@@ -21,8 +21,6 @@ describe("MetricHandler", () => {
 
   beforeEach(() => {
     originalEnv = process.env;
-    metrics.disable();
-    (MetricHandler["_instance"] as any) = null;
   });
 
   before(() => {
@@ -32,11 +30,12 @@ describe("MetricHandler", () => {
   afterEach(() => {
     process.env = originalEnv;
     handler.shutdown();
+    metrics.disable();
     sandbox.restore();
   });
 
   function createHandler() {
-    handler = MetricHandler.getInstance(_config, {
+    handler = new MetricHandler(_config, {
       collectionInterval: 100,
     });
     exportStub = sinon.stub(handler["_azureExporter"], "export").callsFake(

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -29,14 +29,11 @@ describe("Library/TraceHandler", () => {
     sandbox = sinon.createSandbox();
   });
 
-  beforeEach(() => {
-    trace.disable();
-    metrics.disable();
-    (TraceHandler["_instance"] as any) = null;
-    (MetricHandler["_instance"] as any) = null;
-  });
-
   afterEach(() => {
+    metricHandler.shutdown();
+    handler.shutdown();
+    metrics.disable();
+    trace.disable();
     mockHttpServer.close();
     sandbox.restore();
     exportStub.resetHistory();
@@ -48,8 +45,8 @@ describe("Library/TraceHandler", () => {
 
   function createHandler(httpConfig: HttpInstrumentationConfig) {
     _config.instrumentationOptions.http = httpConfig;
-    metricHandler = MetricHandler.getInstance(_config);
-    handler = TraceHandler.getInstance(_config, metricHandler);
+    metricHandler = new MetricHandler(_config);
+    handler = new TraceHandler(_config, metricHandler);
     exportStub = sinon.stub(handler["_azureExporter"], "export").callsFake(
       (spans: any, resultCallback: any) =>
         new Promise((resolve) => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

Removing singleton will allow customers to create multiple instances and send telemetry to different connection strings if needed