### PR TITLE
Remove duplicate identity test variables

### DIFF
--- a/sdk/identity/identity/test-resources.bicep
+++ b/sdk/identity/identity/test-resources.bicep
@@ -1,0 +1,1 @@
+param baseName string

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -22,12 +22,6 @@ stages:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_IDENTITY_TEST_TENANTID: $(net-identity-tenantid)
-        AZURE_IDENTITY_TEST_USERNAME: $(net-identity-username)
-        AZURE_IDENTITY_TEST_PASSWORD: $(net-identity-password)
-        IDENTITY_SP_CLIENT_ID: $(net-identity-sp-clientid)
-        IDENTITY_SP_TENANT_ID: $(net-identity-sp-tenantid)
-        IDENTITY_SP_CLIENT_SECRET: $(net-identity-sp-clientsecret)
         IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
         IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
         IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx


### PR DESCRIPTION
Parity with https://github.com/Azure/azure-sdk-for-net/pull/38370

These values actually aren't used as they get overridden by the base subscription config (https://github.com/Azure/azure-sdk-for-js/blob/main/eng/pipelines/templates/stages/archetype-sdk-tests.yml#L45). This PR removes them because we've had some issues where these values have been updated, but then got overridden by the older values from the subscription config. Part of an effort to deprecate yaml defined values and one-off keyvault secrets.