### PR TITLE
Add MicrosoftTeamsUserIdentifier to Call Invite

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -11,6 +11,7 @@ import { CommunicationIdentifier } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import * as coreClient from '@azure/core-client';
 import { KeyCredential } from '@azure/core-auth';
+import { MicrosoftTeamsUserIdentifier } from '@azure/communication-common';
 import { OperationOptions } from '@azure/core-client';
 import { PhoneNumberIdentifier } from '@azure/communication-common';
 import { TokenCredential } from '@azure/core-auth';
@@ -137,7 +138,7 @@ export interface CallInvite {
     readonly sourceCallIdNumber?: PhoneNumberIdentifier;
     // (undocumented)
     sourceDisplayName?: string;
-    readonly targetParticipant: PhoneNumberIdentifier | CommunicationUserIdentifier;
+    readonly targetParticipant: PhoneNumberIdentifier | CommunicationUserIdentifier | MicrosoftTeamsUserIdentifier;
 }
 
 // @public

--- a/sdk/communication/communication-call-automation/src/models/models.ts
+++ b/sdk/communication/communication-call-automation/src/models/models.ts
@@ -4,6 +4,7 @@
 import {
   CommunicationIdentifier,
   CommunicationUserIdentifier,
+  MicrosoftTeamsUserIdentifier,
   PhoneNumberIdentifier,
 } from "@azure/communication-common";
 import { CallConnectionStateModel } from "../generated/src";
@@ -232,8 +233,11 @@ export class CustomContext {
 
 /** Call invitee details. */
 export interface CallInvite {
-  /** The Target's PhoneNumberIdentifier or CommunicationUserIdentifier. */
-  readonly targetParticipant: PhoneNumberIdentifier | CommunicationUserIdentifier;
+  /** The Target's PhoneNumberIdentifier, CommunicationUserIdentifier or MicrosoftTeamsUserIdentifier. */
+  readonly targetParticipant:
+    | PhoneNumberIdentifier
+    | CommunicationUserIdentifier
+    | MicrosoftTeamsUserIdentifier;
   /** Caller's phone number identifier. */
   readonly sourceCallIdNumber?: PhoneNumberIdentifier;
   sourceDisplayName?: string;


### PR DESCRIPTION
### Describe the problem that is addressed by this PR
CallInvite was missing MicrosoftTeamsUserIdentifier

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
