### PR TITLE
[core] Add support for SSE content type

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Return a stream when the response's content-type is `text/event-stream`.
+
 ## 1.1.4 (2023-07-06)
 
 ### Features Added

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -66,12 +66,11 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/test-utils": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
-    "@types/chai": "^4.1.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.0",
     "@types/sinon": "^10.0.0",
-    "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "eslint": "^8.0.0",
     "inherits": "^2.0.3",

--- a/sdk/core/core-client-rest/review/core-client.api.md
+++ b/sdk/core/core-client-rest/review/core-client.api.md
@@ -78,7 +78,7 @@ export interface ErrorResponse {
 
 // @public
 export interface FullOperationResponse extends PipelineResponse {
-    parsedBody?: RequestBodyType;
+    parsedBody?: RequestBodyType | Record<string, any>;
     rawHeaders?: RawHttpHeaders;
     request: PipelineRequest;
 }

--- a/sdk/core/core-client-rest/src/common.ts
+++ b/sdk/core/core-client-rest/src/common.ts
@@ -107,7 +107,7 @@ export interface FullOperationResponse extends PipelineResponse {
   /**
    * The response body as parsed JSON.
    */
-  parsedBody?: RequestBodyType;
+  parsedBody?: RequestBodyType | Record<string, any>;
 
   /**
    * The request that generated the response.

--- a/sdk/core/core-client-rest/src/getClient.ts
+++ b/sdk/core/core-client-rest/src/getClient.ts
@@ -12,7 +12,7 @@ import {
   RequestParameters,
   StreamableMethod,
 } from "./common";
-import { sendRequest, sendRequestAsStream } from "./sendRequest";
+import { sendRequest } from "./sendRequest";
 import { buildRequestUrl } from "./urlHelpers";
 
 /**
@@ -59,8 +59,20 @@ export function getClient(
   }
 
   const { allowInsecureConnection, httpClient } = clientOptions;
-  const client = (path: string, ...args: Array<any>) => {
-    const getUrl = (requestOptions: RequestParameters) =>
+  const client = (
+    path: string,
+    ...args: Array<any>
+  ): {
+    get: (requestOptions?: RequestParameters) => StreamableMethod;
+    post: (requestOptions?: RequestParameters) => StreamableMethod;
+    put: (requestOptions?: RequestParameters) => StreamableMethod;
+    patch: (requestOptions?: RequestParameters) => StreamableMethod;
+    delete: (requestOptions?: RequestParameters) => StreamableMethod;
+    head: (requestOptions?: RequestParameters) => StreamableMethod;
+    options: (requestOptions?: RequestParameters) => StreamableMethod;
+    trace: (requestOptions?: RequestParameters) => StreamableMethod;
+  } => {
+    const getUrl = (requestOptions: RequestParameters): string =>
       buildRequestUrl(baseUrl, path, args, { allowInsecureConnection, ...requestOptions });
 
     return {
@@ -174,22 +186,22 @@ function buildOperation(
       ).then(onFulfilled, onrejected);
     },
     async asBrowserStream() {
-      return sendRequestAsStream<HttpBrowserStreamResponse>(
+      return sendRequest(
         method,
         url,
         pipeline,
-        { ...options, allowInsecureConnection },
+        { ...options, allowInsecureConnection, responseAsStream: true },
         httpClient
-      );
+      ) as Promise<HttpBrowserStreamResponse>;
     },
     async asNodeStream() {
-      return sendRequestAsStream<HttpNodeStreamResponse>(
+      return sendRequest(
         method,
         url,
         pipeline,
-        { ...options, allowInsecureConnection },
+        { ...options, allowInsecureConnection, responseAsStream: true },
         httpClient
-      );
+      ) as Promise<HttpNodeStreamResponse>;
     },
   };
 }

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -8,7 +8,6 @@ import {
   Pipeline,
   PipelineRequest,
   PipelineResponse,
-  RawHttpHeaders,
   RequestBodyType,
   RestError,
   createHttpHeaders,
@@ -32,63 +31,27 @@ export async function sendRequest(
   method: HttpMethods,
   url: string,
   pipeline: Pipeline,
-  options: RequestParameters = {},
+  options: InternalRequestParameters = {},
   customHttpClient?: HttpClient
 ): Promise<HttpResponse> {
   const httpClient = customHttpClient ?? getCachedDefaultHttpsClient();
   const request = buildPipelineRequest(method, url, options);
-
   const response = await pipeline.sendRequest(httpClient, request);
-
-  const rawHeaders: RawHttpHeaders = response.headers.toJSON();
-
-  const parsedBody: RequestBodyType | undefined = getResponseBody(response);
+  const headers = response.headers.toJSON();
+  const parsedBody = await getResponseBody(response, {
+    stream: options.responseAsStream,
+  });
 
   if (options?.onResponse) {
-    options.onResponse({ ...response, request, rawHeaders, parsedBody });
+    options.onResponse({ ...response, request, rawHeaders: headers, parsedBody });
   }
 
   return {
     request,
-    headers: rawHeaders,
+    headers,
     status: `${response.status}`,
     body: parsedBody,
   };
-}
-
-/**
- * Helper function to send request used by the client
- * @param method - method to use to send the request
- * @param url - url to send the request to
- * @param pipeline - pipeline with the policies to run when sending the request
- * @param options - request options
- * @param customHttpClient - a custom HttpClient to use when making the request
- * @returns returns and HttpResponse
- */
-export async function sendRequestAsStream<
-  TResponse extends HttpResponse & {
-    body: NodeJS.ReadableStream | ReadableStream<Uint8Array> | undefined;
-  }
->(
-  method: HttpMethods,
-  url: string,
-  pipeline: Pipeline,
-  options: RequestParameters = {},
-  customHttpClient?: HttpClient
-): Promise<TResponse> {
-  const httpClient = customHttpClient ?? getCachedDefaultHttpsClient();
-  const request = buildPipelineRequest(method, url, { ...options, responseAsStream: true });
-  const response = await pipeline.sendRequest(httpClient, request);
-  const rawHeaders: RawHttpHeaders = response.headers.toJSON();
-
-  const parsedBody = response.browserStreamBody ?? response.readableStreamBody;
-
-  return {
-    request,
-    headers: rawHeaders,
-    status: `${response.status}`,
-    body: parsedBody,
-  } as TResponse;
 }
 
 /**
@@ -203,7 +166,7 @@ function isFormData(body: unknown): body is FormDataMap {
  * Checks if binary data is in Uint8Array format, if so decode it to a binary string
  * to send over the wire
  */
-function processFormData(formData?: FormDataMap) {
+function processFormData(formData?: FormDataMap): FormDataMap | undefined {
   if (!formData) {
     return formData;
   }
@@ -224,29 +187,57 @@ function processFormData(formData?: FormDataMap) {
 
 /**
  * Prepares the response body
+ * @param response - The received response
+ * @param coerceAs - The type to coerce the body as
  */
-function getResponseBody(response: PipelineResponse): RequestBodyType | undefined {
+async function getResponseBody(
+  response: PipelineResponse,
+  coerceAs: { stream?: boolean } = {}
+): Promise<RequestBodyType | Record<string, any> | string | undefined> {
   // Set the default response type
   const contentType = response.headers.get("content-type") ?? "";
   const firstType = contentType.split(";")[0];
-  const bodyToParse: string = response.bodyAsText ?? "";
+  const bodyToParse = response.bodyAsText;
+
+  if (
+    /**
+     * If the client is asking for a stream, return it directly.
+     */
+    coerceAs.stream ||
+    /**
+     * If the response is a server-sent event stream, the body stream
+     * is returned directly so that the client code can parse the chunks
+     * into events.
+     */
+    firstType === "text/event-stream"
+  ) {
+    return response.readableStreamBody ?? response.browserStreamBody;
+  }
 
   if (firstType === "text/plain") {
     return String(bodyToParse);
   }
   // Default to "application/json" and fallback to string;
+  return tryParse(bodyToParse, firstType !== "application/json", response);
+}
+
+function tryParse(
+  bodyAsText: PipelineResponse["bodyAsText"],
+  allowUnparsed: boolean,
+  response: PipelineResponse
+): Record<string, any> | string | undefined {
   try {
-    return bodyToParse ? JSON.parse(bodyToParse) : undefined;
-  } catch (error: any) {
+    return bodyAsText ? JSON.parse(bodyAsText) : undefined;
+  } catch (error) {
     // If we were supposed to get a JSON object and failed to
     // parse, throw a parse error
-    if (firstType === "application/json") {
+    if (!allowUnparsed) {
       throw createParseError(response, error);
     }
 
     // We are not sure how to handle the response so we return it as
     // plain text.
-    return String(bodyToParse);
+    return String(bodyAsText);
   }
 }
 
@@ -257,6 +248,6 @@ function createParseError(response: PipelineResponse, err: any): RestError {
     code: errCode,
     statusCode: response.status,
     request: response.request,
-    response: response,
+    response,
   });
 }

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -33,7 +33,7 @@ export function buildRequestUrl(
   );
 }
 
-function appendQueryParams(url: string, options: RequestParameters = {}) {
+function appendQueryParams(url: string, options: RequestParameters = {}): string {
   if (!options.queryParameters) {
     return url;
   }
@@ -57,7 +57,7 @@ function appendQueryParams(url: string, options: RequestParameters = {}) {
   return parsedUrl.toString();
 }
 
-function skipQueryParameterEncoding(url: URL) {
+function skipQueryParameterEncoding(url: URL): URL {
   if (!url) {
     return url;
   }
@@ -96,7 +96,7 @@ function buildRoutePath(
   routePath: string,
   pathParameters: string[],
   options: RequestParameters = {}
-) {
+): string {
   for (const pathParam of pathParameters) {
     let value = pathParam;
     if (!options.skipUrlEncoding) {

--- a/sdk/core/core-client-rest/test/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/clientHelpers.spec.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 import { createDefaultPipeline } from "../src/clientHelpers";
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 import { bearerTokenAuthenticationPolicyName } from "@azure/core-rest-pipeline";
 import { keyCredentialAuthenticationPolicyName } from "../src/keyCredentialAuthenticationPolicy";
 import { TokenCredential } from "@azure/core-auth";
-import { fail } from "assert";
 import { apiVersionPolicyName } from "../src/apiVersionPolicy";
 describe("clientHelpers", () => {
   const mockBaseUrl = "https://example.org";
@@ -42,7 +41,7 @@ describe("clientHelpers", () => {
   it("should throw if key credentials but no Api Header Name", () => {
     try {
       createDefaultPipeline(mockBaseUrl, { key: "mockKey" });
-      fail("Expected to throw an error");
+      assert.fail("Expected to throw an error");
     } catch (error: any) {
       assert.equal((error as Error).message, "Missing API Key Header Name");
     }

--- a/sdk/core/core-client-rest/test/getBinaryBody.spec.ts
+++ b/sdk/core/core-client-rest/test/getBinaryBody.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 import { binaryArrayToString } from "../src/helpers/getBinaryBody";
 
 describe("getBinaryBody", () => {

--- a/sdk/core/core-client-rest/test/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/getClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 import { getCachedDefaultHttpsClient } from "../src/clientHelpers";
 import { getClient } from "../src/getClient";
 import sinon from "sinon";
@@ -175,7 +175,8 @@ describe("getClient", () => {
   });
 
   it("should insert policies in the correct pipeline position", async function () {
-    const sendRequest = (request: PipelineRequest, next: SendRequest) => next(request);
+    const sendRequest = (request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> =>
+      next(request);
     const retryPolicy: PipelinePolicy = {
       name: "retry",
       sendRequest,

--- a/sdk/core/core-client-rest/test/sendRequest.spec.ts
+++ b/sdk/core/core-client-rest/test/sendRequest.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { sendRequest } from "../src/sendRequest";
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 import {
   Pipeline,
   PipelineResponse,

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { buildBaseUrl, buildRequestUrl } from "../src/urlHelpers";
-import { assert } from "chai";
+import { assert } from "@azure/test-utils";
 
 describe("urlHelpers", () => {
   const mockBaseUrl = "https://example.org";


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/core-client

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/26961

### Describe the problem that is addressed by this PR
When the response's content type is [`text/event-stream`](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#sending_events_from_the_server), the response shouldn't be deserialized as JSON.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
