### PR TITLE
[Identity] Disable loading profiles in powershell

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.  ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
+- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile`  and "-NonInteractive" flag to avoid loading user profiles for more consistent behavior.  ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
 ### Other Changes
 
 ## 3.3.0 (2023-08-14)

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-
+- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.  ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
 ### Other Changes
 
 ## 3.3.0 (2023-08-14)

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -146,11 +146,13 @@ export class AzurePowerShellCredential implements TokenCredential {
       const results = await runCommands([
         [
           powerShellCommand,
+          "-NoProfile",
           "-Command",
           "Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru",
         ],
         [
           powerShellCommand,
+          "-NoProfile",
           "-Command",
           `Get-AzAccessToken ${tenantSection} -ResourceUrl "${resource}" | ConvertTo-Json`,
         ],

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -153,6 +153,7 @@ export class AzurePowerShellCredential implements TokenCredential {
         [
           powerShellCommand,
           "-NoProfile",
+          "-NonInteractive",
           "-Command",
           `Get-AzAccessToken ${tenantSection} -ResourceUrl "${resource}" | ConvertTo-Json`,
         ],

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -147,6 +147,7 @@ export class AzurePowerShellCredential implements TokenCredential {
         [
           powerShellCommand,
           "-NoProfile",
+          "-NonInteractive",
           "-Command",
           "Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru",
         ],


### PR DESCRIPTION
Passing -NoProfile is generally recommended to ensure the powershell script is run in the default environment without user profile side effects interfering.