### PR TITLE
[engsys] build test assets only for browser runs

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -107,7 +107,7 @@ jobs:
       - script: |
           node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
-        condition: and(succeededOrFailed(),eq(variables['DependencyVersion'],''))
+        condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['DependencyVersion'],''))
 
       - script: |
           npm install

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -107,7 +107,7 @@ jobs:
       - script: |
           node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
-        condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['DependencyVersion'],''))
+        condition: and(succeededOrFailed(), eq(variables['TestType'], 'browser'), eq(variables['DependencyVersion'],''))
 
       - script: |
           npm install

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -27,7 +27,7 @@ steps:
   - script: |
       node eng/tools/rush-runner.js build:test "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build test assets"
-    condition: and(succeeded(),eq(variables['TestType'], 'browser'))
+    condition: and(succeeded(), eq(variables['TestType'], 'browser'))
 
   - template: ../steps/use-node-test-version.yml
 

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -27,6 +27,7 @@ steps:
   - script: |
       node eng/tools/rush-runner.js build:test "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build test assets"
+    condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
   - template: ../steps/use-node-test-version.yml
 


### PR DESCRIPTION
We no longer run Node tests against bundled tests. The test inputs are from dist-esm/test and running `build` produces the same output as `build:test` as far as Node is concerned.

For browser we still need the bundled tests from `build:test`.

This PR enables "Build test assets" step only if the run is for browser.
