### PR TITLE
change FeedRange interface to abstract class

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -943,10 +943,10 @@ export interface FeedOptions extends SharedOptions {
     useIncrementalFeed?: boolean;
 }
 
-// @public (undocumented)
-export interface FeedRange {
-    maxExclusive: string;
-    minInclusive: string;
+// @public
+export abstract class FeedRange {
+    readonly maxExclusive: string;
+    readonly minInclusive: string;
 }
 
 // @public (undocumented)

--- a/sdk/cosmosdb/cosmos/src/client/ChangeFeed/FeedRange.ts
+++ b/sdk/cosmosdb/cosmos/src/client/ChangeFeed/FeedRange.ts
@@ -1,33 +1,41 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { ErrorResponse } from "../../request";
+
 /**
- * @hidden
  * Specifies a feed range for the changefeed.
  */
-export class FeedRangeInternal implements FeedRange {
+export abstract class FeedRange {
   /**
    * Min value for the feed range.
    */
-  minInclusive: string;
+  readonly minInclusive: string;
   /**
    * Max value for the feed range.
    */
-  maxExclusive: string;
+  readonly maxExclusive: string;
+  /**
+   * @internal
+   */
+  protected constructor(minInclusive: string, maxExclusive: string) {
+    // only way to explictly block users from creating FeedRange directly in JS
+    if (new.target === FeedRange) {
+      throw new ErrorResponse("Cannot instantiate abstract class FeedRange");
+    }
 
-  constructor(minInclusive: string, maxExclusive: string) {
     this.minInclusive = minInclusive;
     this.maxExclusive = maxExclusive;
   }
 }
 
-export interface FeedRange {
-  /**
-   * Min value for the feed range.
-   */
-  minInclusive: string;
-  /**
-   * Max value for the feed range.
-   */
-  maxExclusive: string;
+/**
+ * @hidden
+ * Specifies a feed range for the changefeed.
+ */
+export class FeedRangeInternal extends FeedRange {
+  /* eslint-disable @typescript-eslint/no-useless-constructor */
+  constructor(minInclusive: string, maxExclusive: string) {
+    super(minInclusive, maxExclusive);
+  }
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
`FeedRange` for changefeed is changed from interface to abstract class for avoiding confusion among users. Users cannot create instance of abstract class and can now only pass feed range from the result of `container.getFeedRanges()` call.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
