### PR TITLE
Move identity variable setting into test-resources-pre.ps1

### DIFF
--- a/sdk/identity/identity/test-resources-pre.ps1
+++ b/sdk/identity/identity/test-resources-pre.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+if (!$CI) {
+    # TODO: Remove this once auto-cloud config downloads are supported locally
+    Write-Host "Skipping cert setup in local testing mode"
+    return
+}
+
+if ($EnvironmentVariables -eq $null -or $EnvironmentVariables.Count -eq 0) {
+    throw "EnvironmentVariables must be set in the calling script New-TestResources.ps1"
+}
+
+$tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+$pfxPath = Join-Path $tmp "test.pfx"
+$pemPath = Join-Path $tmp "test.pem"
+$sniPath = Join-Path $tmp "testsni.pfx"
+$sniPemPath = Join-Path $tmp "testsni.pem"
+
+Write-Host "Creating identity test files: $pfxPath $pemPath $sniPath $sniPemPath"
+
+# javascript wants to read \n escaped as \\n which does not match the certificate pattern regex in the identity sdk
+# Convert to real newlines before writing to the file
+$pemContents = $EnvironmentVariables['PEM_CONTENTS'] -replace "\n","`n"
+$sniPemContents = $EnvironmentVariables['SNI_PEM_CONTENTS'] -replace "\n","`n"
+Set-Content -Path $pemPath -Value $pemContents
+Set-Content -Path $sniPemPath -Value $sniPemContents
+[System.Convert]::FromBase64String($EnvironmentVariables['PFX_CONTENTS']) | Set-Content -Path $pfxPath -AsByteStream
+[System.Convert]::FromBase64String($EnvironmentVariables['SNI_CONTENTS']) | Set-Content -Path $sniPath -AsByteStream
+
+# Set for pipeline
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PFX;]$pfxPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_PEM;]$pemPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_SNI;]$sniPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_SP_CERT_SNI_PEM;]$sniPemPath"
+# Set for local
+$env:IDENTITY_SP_CERT_PFX = $pfxPath
+$env:IDENTITY_SP_CERT_PEM = $pemPath
+$env:IDENTITY_SP_CERT_SNI = $sniPath
+$env:IDENTITY_SP_CERT_SNI_PEM = $sniPemPath

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -7,23 +7,14 @@ stages:
       ServiceDirectory: identity
       TimeoutInMinutes: 120
       SupportedClouds: 'Public,UsGov,China,Canary'
-      PreSteps:
-        - pwsh: |
-            [System.Convert]::FromBase64String($env:PFX_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/test.pfx -AsByteStream
-            Set-Content -Path $(Agent.TempDirectory)/test.pem -Value $env:PEM_CONTENTS
-            [System.Convert]::FromBase64String($env:SNI_CONTENTS) | Set-Content -Path $(Agent.TempDirectory)/testsni.pfx -AsByteStream
-            Set-Content -Path $(Agent.TempDirectory)/testsni.pem -Value $env:SNI_PEM_CONTENTS
-          env:
-            PFX_CONTENTS: $(net-identity-spcert-pfx)
-            PEM_CONTENTS: $(net-identity-spcert-pem)
-            SNI_CONTENTS: $(net-identity-spcert-sni)
-            SNI_PEM_CONTENTS: $(net-identity-spcert-sni-pem)
+      CloudConfig:
+        Public:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            # Contains alternate tenant, AAD app and cert info for testing
+            - $(sub-config-identity-test-resources)
+            - $(sub-config-identity-test-resources-js)
       EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        IDENTITY_SP_CERT_PFX: $(Agent.TempDirectory)/test.pfx
-        IDENTITY_SP_CERT_PEM: $(Agent.TempDirectory)/test.pem
-        IDENTITY_SP_CERT_SNI: $(Agent.TempDirectory)/testsni.pfx
-        IDENTITY_SP_CERT_SNI_PEM: $(Agent.TempDirectory)/testsni.pem
-        IDENTITY_PEM_CONTENTS: $(net-identity-spcert-pem)
+        AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)


### PR DESCRIPTION
Updating the identity live tests to remove logic and env setting from yaml in favor of a dedicated keyvault config and powershell script. This will make it possible to improve local and sovereign cloud testing, and make cross-language config updates more easily.

Related: https://github.com/Azure/azure-sdk-for-net/pull/38473
