### PR TITLE
[core-client] allow serializing browser ReadableStream

### DIFF
--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an error when serializing browser ReadableStream [PR #27052](https://github.com/Azure/azure-sdk-for-js/pull/27052)
+
 ### Other Changes
 
 ## 1.7.3 (2023-06-01)

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -431,7 +431,7 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
       if (
         objectType !== "string" &&
         typeof value.pipe !== "function" && // NodeJS.ReadableStream
-        typeof value.tee !== "function" &&  // browser ReadableStream
+        typeof value.tee !== "function" && // browser ReadableStream
         !(value instanceof ArrayBuffer) &&
         !ArrayBuffer.isView(value) &&
         // File objects count as a type of Blob, so we want to use instanceof explicitly

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -439,7 +439,7 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
         objectType !== "function"
       ) {
         throw new Error(
-          `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, NodeJS.ReadableStream, or () => NodeJS.ReadableStream.`
+          `${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, ReadableStream, or () => ReadableStream.`
         );
       }
     }

--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -430,7 +430,8 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
       const objectType = typeof value;
       if (
         objectType !== "string" &&
-        typeof value.pipe !== "function" &&
+        typeof value.pipe !== "function" && // NodeJS.ReadableStream
+        typeof value.tee !== "function" &&  // browser ReadableStream
         !(value instanceof ArrayBuffer) &&
         !ArrayBuffer.isView(value) &&
         // File objects count as a type of Blob, so we want to use instanceof explicitly

--- a/sdk/core/core-client/test/browser/serializer.spec.ts
+++ b/sdk/core/core-client/test/browser/serializer.spec.ts
@@ -24,5 +24,20 @@ describe("Serializer (browser specific)", function () {
       const result = serializer.serialize(mapper, file);
       assert.strictEqual(result, file, "Expect file streams to be left intact");
     });
+
+    it("Should accept ReadableStream", function () {
+      const stream = new ReadableStream();
+
+      const serializer = createSerializer();
+
+      const mapper: Mapper = {
+        type: { name: "Stream" },
+        required: true,
+        serializedName: "Stream",
+      };
+
+      const result = serializer.serialize(mapper, stream);
+      assert.strictEqual(result, stream, "Expect stream to be left intact");
+    });
   });
 });


### PR DESCRIPTION
We have browser stream support in fetchHttpClient but miss to allow it to be serialized so an error is thrown when serializing a browser ReadableStream.

This PR adds the condition for browser ReadableStream when checking whether the type is supported.


### Packages impacted by this PR
`@azure/core-client`
