### PR TITLE
Fixing diagnostic level not setting during client initilization + making diagnostic level scope limited to Cosmos client instance

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -646,8 +646,6 @@ export class CosmosClient {
     constructor(options: CosmosClientOptions);
     database(id: string): Database;
     readonly databases: Databases;
-    // (undocumented)
-    determineDiagnosticLevel(diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel): CosmosDbDiagnosticLevel;
     dispose(): void;
     getDatabaseAccount(options?: RequestOptions): Promise<ResourceResponse<DatabaseAccount>>;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -150,7 +150,7 @@ export type ClientConfigDiagnostic = {
 
 // @public (undocumented)
 export class ClientContext {
-    constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic, getDiagnosticLevelFromEnvironment: () => CosmosDbDiagnosticLevel | undefined);
+    constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic, diagnosticLevel: CosmosDbDiagnosticLevel);
     // (undocumented)
     batch<T>({ body, path, partitionKey, resourceId, options, diagnosticNode, }: {
         body: T;
@@ -216,7 +216,7 @@ export class ClientContext {
     // (undocumented)
     getWriteEndpoints(): Promise<readonly string[]>;
     // (undocumented)
-    initializeDiagnosticSettings(diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel): void;
+    initializeDiagnosticSettings(diagnosticLevel: CosmosDbDiagnosticLevel): void;
     // (undocumented)
     partitionKeyDefinitionCache: {
         [containerUrl: string]: any;
@@ -646,6 +646,8 @@ export class CosmosClient {
     constructor(options: CosmosClientOptions);
     database(id: string): Database;
     readonly databases: Databases;
+    // (undocumented)
+    determineDiagnosticLevel(diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel): CosmosDbDiagnosticLevel;
     dispose(): void;
     getDatabaseAccount(options?: RequestOptions): Promise<ResourceResponse<DatabaseAccount>>;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -150,7 +150,7 @@ export type ClientConfigDiagnostic = {
 
 // @public (undocumented)
 export class ClientContext {
-    constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic);
+    constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic, getDiagnosticLevelFromEnvironment: () => CosmosDbDiagnosticLevel | undefined);
     // (undocumented)
     batch<T>({ body, path, partitionKey, resourceId, options, diagnosticNode, }: {
         body: T;
@@ -193,6 +193,8 @@ export class ClientContext {
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & Resource>>;
     // (undocumented)
+    diagnosticLevel: CosmosDbDiagnosticLevel;
+    // (undocumented)
     execute<T>({ sprocLink, params, options, partitionKey, diagnosticNode, }: {
         sprocLink: string;
         params?: any[];
@@ -213,6 +215,8 @@ export class ClientContext {
     getWriteEndpoint(diagnosticNode: DiagnosticNodeInternal): Promise<string>;
     // (undocumented)
     getWriteEndpoints(): Promise<readonly string[]>;
+    // (undocumented)
+    initializeDiagnosticSettings(diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel): void;
     // (undocumented)
     partitionKeyDefinitionCache: {
         [containerUrl: string]: any;
@@ -894,6 +898,8 @@ export class DiagnosticNodeInternal implements DiagnosticNode {
     children: DiagnosticNodeInternal[];
     // (undocumented)
     data: Partial<DiagnosticDataValue>;
+    // (undocumented)
+    diagnosticLevel: CosmosDbDiagnosticLevel;
     // (undocumented)
     durationInMs: number;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -91,7 +91,7 @@ export class ClientContext {
         })
       );
     }
-    this.initializeDiagnosticSettings(clientConfig.diagnosticLevel);
+    this.initializeDiagnosticSettings(diagnosticLevel);
   }
   /** @hidden */
   public async read<T>({

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -44,7 +44,7 @@ import {
   NoOpDiagnosticWriter,
 } from "./diagnostics/DiagnosticWriter";
 import { DefaultDiagnosticFormatter, DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
-import { DefaultDiagnosticLevelValue, getDiagnosticLevelFromEnvironment } from "./diagnostics";
+import { DefaultDiagnosticLevelValue } from "./diagnostics";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { allowTracing } from "./diagnostics/diagnosticLevelComparator";
 
@@ -67,7 +67,8 @@ export class ClientContext {
   public constructor(
     private cosmosClientOptions: CosmosClientOptions,
     private globalEndpointManager: GlobalEndpointManager,
-    private clientConfig: ClientConfigDiagnostic
+    private clientConfig: ClientConfigDiagnostic,
+    private getDiagnosticLevelFromEnvironment: () => CosmosDbDiagnosticLevel | undefined
   ) {
     this.connectionPolicy = cosmosClientOptions.connectionPolicy;
     this.sessionContainer = new SessionContainer();
@@ -883,10 +884,10 @@ export class ClientContext {
     this.diagnosticWriter.write(formatted);
   }
 
-  private initializeDiagnosticSettings(
+  public initializeDiagnosticSettings(
     diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel
   ): void {
-    const diagnosticLevelFromEnvironment = getDiagnosticLevelFromEnvironment();
+    const diagnosticLevelFromEnvironment = this.getDiagnosticLevelFromEnvironment();
     const diagnosticLevelFromEnvOrClient =
       diagnosticLevelFromEnvironment ?? diagnosticLevelFromClientConfig; // Diagnostic Setting from environment gets first priority.
     const effectiveDiagnosticLevel = diagnosticLevelFromEnvOrClient ?? DefaultDiagnosticLevelValue; // Diagnostic Setting supplied in Client config gets second priority.

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -44,7 +44,6 @@ import {
   NoOpDiagnosticWriter,
 } from "./diagnostics/DiagnosticWriter";
 import { DefaultDiagnosticFormatter, DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
-import { DefaultDiagnosticLevelValue } from "./diagnostics";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { allowTracing } from "./diagnostics/diagnosticLevelComparator";
 
@@ -62,13 +61,12 @@ export class ClientContext {
   private pipeline: Pipeline;
   private diagnosticWriter: DiagnosticWriter;
   private diagnosticFormatter: DiagnosticFormatter;
-  public diagnosticLevel: CosmosDbDiagnosticLevel;
   public partitionKeyDefinitionCache: { [containerUrl: string]: any }; // TODO: PartitionKeyDefinitionCache
   public constructor(
     private cosmosClientOptions: CosmosClientOptions,
     private globalEndpointManager: GlobalEndpointManager,
     private clientConfig: ClientConfigDiagnostic,
-    private getDiagnosticLevelFromEnvironment: () => CosmosDbDiagnosticLevel | undefined
+    public diagnosticLevel: CosmosDbDiagnosticLevel
   ) {
     this.connectionPolicy = cosmosClientOptions.connectionPolicy;
     this.sessionContainer = new SessionContainer();
@@ -884,16 +882,9 @@ export class ClientContext {
     this.diagnosticWriter.write(formatted);
   }
 
-  public initializeDiagnosticSettings(
-    diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel
-  ): void {
-    const diagnosticLevelFromEnvironment = this.getDiagnosticLevelFromEnvironment();
-    const diagnosticLevelFromEnvOrClient =
-      diagnosticLevelFromEnvironment ?? diagnosticLevelFromClientConfig; // Diagnostic Setting from environment gets first priority.
-    const effectiveDiagnosticLevel = diagnosticLevelFromEnvOrClient ?? DefaultDiagnosticLevelValue; // Diagnostic Setting supplied in Client config gets second priority.
-    this.diagnosticLevel = effectiveDiagnosticLevel;
+  public initializeDiagnosticSettings(diagnosticLevel: CosmosDbDiagnosticLevel): void {
     this.diagnosticFormatter = new DefaultDiagnosticFormatter();
-    switch (effectiveDiagnosticLevel) {
+    switch (diagnosticLevel) {
       case CosmosDbDiagnosticLevel.info:
         this.diagnosticWriter = new NoOpDiagnosticWriter();
         break;

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -8,7 +8,8 @@ import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { ClientConfigDiagnostic } from "./CosmosDiagnostics";
-import { getDiagnosticLevelFromEnvironment } from "./diagnostics";
+import { DefaultDiagnosticLevelValue, getDiagnosticLevelFromEnvironment } from "./diagnostics";
+import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { DiagnosticNodeInternal, DiagnosticNodeType } from "./diagnostics/DiagnosticNodeInternal";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
@@ -106,7 +107,7 @@ export class CosmosClient {
       optionsOrConnectionString,
       globalEndpointManager,
       clientConfig,
-      getDiagnosticLevelFromEnvironment
+      this.determineDiagnosticLevel(optionsOrConnectionString.diagnosticLevel)
     );
     if (
       optionsOrConnectionString.connectionPolicy?.enableEndpointDiscovery &&
@@ -121,6 +122,15 @@ export class CosmosClient {
 
     this.databases = new Databases(this, this.clientContext);
     this.offers = new Offers(this, this.clientContext);
+  }
+
+  public determineDiagnosticLevel(
+    diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel
+  ): CosmosDbDiagnosticLevel {
+    const diagnosticLevelFromEnvironment = getDiagnosticLevelFromEnvironment();
+    const diagnosticLevelFromEnvOrClient =
+      diagnosticLevelFromEnvironment ?? diagnosticLevelFromClientConfig; // Diagnostic Setting from environment gets first priority.
+    return diagnosticLevelFromEnvOrClient ?? DefaultDiagnosticLevelValue; // Diagnostic Setting supplied in Client config gets second priority.
   }
 
   private initializeClientConfigDiagnostic(

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -8,6 +8,7 @@ import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { ClientConfigDiagnostic } from "./CosmosDiagnostics";
+import { getDiagnosticLevelFromEnvironment } from "./diagnostics";
 import { DiagnosticNodeInternal, DiagnosticNodeType } from "./diagnostics/DiagnosticNodeInternal";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
@@ -104,7 +105,8 @@ export class CosmosClient {
     this.clientContext = new ClientContext(
       optionsOrConnectionString,
       globalEndpointManager,
-      clientConfig
+      clientConfig,
+      getDiagnosticLevelFromEnvironment
     );
     if (
       optionsOrConnectionString.connectionPolicy?.enableEndpointDiscovery &&

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -8,8 +8,7 @@ import { Constants } from "./common/constants";
 import { getUserAgent } from "./common/platform";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { ClientConfigDiagnostic } from "./CosmosDiagnostics";
-import { DefaultDiagnosticLevelValue, getDiagnosticLevelFromEnvironment } from "./diagnostics";
-import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
+import { determineDiagnosticLevel, getDiagnosticLevelFromEnvironment } from "./diagnostics";
 import { DiagnosticNodeInternal, DiagnosticNodeType } from "./diagnostics/DiagnosticNodeInternal";
 import { DatabaseAccount, defaultConnectionPolicy } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
@@ -107,7 +106,10 @@ export class CosmosClient {
       optionsOrConnectionString,
       globalEndpointManager,
       clientConfig,
-      this.determineDiagnosticLevel(optionsOrConnectionString.diagnosticLevel)
+      determineDiagnosticLevel(
+        optionsOrConnectionString.diagnosticLevel,
+        getDiagnosticLevelFromEnvironment()
+      )
     );
     if (
       optionsOrConnectionString.connectionPolicy?.enableEndpointDiscovery &&
@@ -122,15 +124,6 @@ export class CosmosClient {
 
     this.databases = new Databases(this, this.clientContext);
     this.offers = new Offers(this, this.clientContext);
-  }
-
-  public determineDiagnosticLevel(
-    diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel
-  ): CosmosDbDiagnosticLevel {
-    const diagnosticLevelFromEnvironment = getDiagnosticLevelFromEnvironment();
-    const diagnosticLevelFromEnvOrClient =
-      diagnosticLevelFromEnvironment ?? diagnosticLevelFromClientConfig; // Diagnostic Setting from environment gets first priority.
-    return diagnosticLevelFromEnvOrClient ?? DefaultDiagnosticLevelValue; // Diagnostic Setting supplied in Client config gets second priority.
   }
 
   private initializeClientConfigDiagnostic(

--- a/sdk/cosmosdb/cosmos/src/CosmosDiagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosDiagnostics.ts
@@ -36,7 +36,7 @@ export class CosmosDiagnostics {
    */
   constructor(
     clientSideRequestStatistics: ClientSideRequestStatistics,
-    diagnosticNode: DiagnosticNode,
+    diagnosticNode?: DiagnosticNode,
     clientConfig?: ClientConfigDiagnostic
   ) {
     this.clientSideRequestStatistics = clientSideRequestStatistics;

--- a/sdk/cosmosdb/cosmos/src/diagnostics/diagnosticLevelComparator.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/diagnosticLevelComparator.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getDiagnosticLevel } from ".";
 import { CosmosDbDiagnosticLevel } from "./CosmosDbDiagnosticLevel";
 
 /**
@@ -16,9 +15,12 @@ export const CosmosDbDiagnosticLevelOrder = [
 /**
  * @hidden
  */
-export function allowTracing(levelToCheck: CosmosDbDiagnosticLevel): boolean {
+export function allowTracing(
+  levelToCheck: CosmosDbDiagnosticLevel,
+  clientDiagnosticLevel: CosmosDbDiagnosticLevel
+): boolean {
   const indexOfDiagnosticLevelToCheck = CosmosDbDiagnosticLevelOrder.indexOf(levelToCheck);
-  const indexOfClientDiagnosticLevel = CosmosDbDiagnosticLevelOrder.indexOf(getDiagnosticLevel());
+  const indexOfClientDiagnosticLevel = CosmosDbDiagnosticLevelOrder.indexOf(clientDiagnosticLevel);
   if (indexOfDiagnosticLevelToCheck === -1 || indexOfClientDiagnosticLevel === -1) {
     return false;
   }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
@@ -8,7 +8,7 @@ import { CosmosDbDiagnosticLevel } from "./CosmosDbDiagnosticLevel";
 export * from "./DiagnosticWriter";
 export * from "./DiagnosticFormatter";
 
-const DefaultDiagnosticLevelValue = CosmosDbDiagnosticLevel.info;
+export const DefaultDiagnosticLevelValue = CosmosDbDiagnosticLevel.info;
 
 const diagnosticLevelFromEnv =
   (typeof process !== "undefined" &&
@@ -35,11 +35,9 @@ if (isNonEmptyString(diagnosticLevelFromEnv)) {
       )}.`
     );
   }
-} else {
-  setDiagnosticLevel(DefaultDiagnosticLevelValue);
 }
 
-export function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
+function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
   if (level && !isCosmosDiagnosticLevel(level)) {
     throw new Error(
       `Unknown diagnostic level '${level}'. Acceptable values: ${acceptableDiagnosticLevelValues.join(
@@ -50,10 +48,7 @@ export function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
   cosmosDiagnosticLevel = level;
 }
 
-/**
- * Retrieves the currently specified diagnostic level.
- */
-export function getDiagnosticLevel(): CosmosDbDiagnosticLevel {
+export function getDiagnosticLevelFromEnvironment(): CosmosDbDiagnosticLevel {
   return cosmosDiagnosticLevel;
 }
 

--- a/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
@@ -57,3 +57,12 @@ function isCosmosDiagnosticLevel(
 ): diagnosticLevel is CosmosDbDiagnosticLevel {
   return acceptableDiagnosticLevelValues.includes(diagnosticLevel);
 }
+
+export function determineDiagnosticLevel(
+  diagnosticLevelFromClientConfig: CosmosDbDiagnosticLevel,
+  diagnosticLevelFromEnvironment: CosmosDbDiagnosticLevel
+): CosmosDbDiagnosticLevel {
+  const diagnosticLevelFromEnvOrClient =
+    diagnosticLevelFromEnvironment ?? diagnosticLevelFromClientConfig; // Diagnostic Setting from environment gets first priority.
+  return diagnosticLevelFromEnvOrClient ?? DefaultDiagnosticLevelValue; // Diagnostic Setting supplied in Client config gets second priority.
+}

--- a/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
@@ -37,7 +37,7 @@ if (isNonEmptyString(diagnosticLevelFromEnv)) {
   }
 }
 
-function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
+export function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
   if (level && !isCosmosDiagnosticLevel(level)) {
     throw new Error(
       `Unknown diagnostic level '${level}'. Acceptable values: ${acceptableDiagnosticLevelValues.join(
@@ -48,7 +48,7 @@ function setDiagnosticLevel(level?: CosmosDbDiagnosticLevel): void {
   cosmosDiagnosticLevel = level;
 }
 
-export function getDiagnosticLevelFromEnvironment(): CosmosDbDiagnosticLevel {
+export function getDiagnosticLevelFromEnvironment(): CosmosDbDiagnosticLevel | undefined {
   return cosmosDiagnosticLevel;
 }
 

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -71,7 +71,11 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
     this.partitionedQueryExecutionInfo = partitionedQueryExecutionInfo;
     this.diagnosticNodeWrapper = {
       consumed: false,
-      diagnosticNode: new DiagnosticNodeInternal(DiagnosticNodeType.PARALLEL_QUERY_NODE, null),
+      diagnosticNode: new DiagnosticNodeInternal(
+        clientContext.diagnosticLevel,
+        DiagnosticNodeType.PARALLEL_QUERY_NODE,
+        null
+      ),
     };
     this.diagnosticNodeWrapper.diagnosticNode.addData({ stateful: true });
     this.err = undefined;

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -82,7 +82,11 @@ export class QueryIterator<T> {
    */
   public async *getAsyncIterator(): AsyncIterable<FeedResponse<T>> {
     this.reset();
-    let diagnosticNode = new DiagnosticNodeInternal(DiagnosticNodeType.CLIENT_REQUEST_NODE, null);
+    let diagnosticNode = new DiagnosticNodeInternal(
+      this.clientContext.diagnosticLevel,
+      DiagnosticNodeType.CLIENT_REQUEST_NODE,
+      null
+    );
     this.queryPlanPromise = this.fetchQueryPlan(diagnosticNode);
     while (this.queryExecutionContext.hasMoreResults()) {
       let response: Response<any>;
@@ -107,7 +111,11 @@ export class QueryIterator<T> {
         this.queryExecutionContext.hasMoreResults(),
         diagnosticNode.toDiagnostic(this.clientContext.getClientConfig())
       );
-      diagnosticNode = new DiagnosticNodeInternal(DiagnosticNodeType.CLIENT_REQUEST_NODE, null);
+      diagnosticNode = new DiagnosticNodeInternal(
+        this.clientContext.diagnosticLevel,
+        DiagnosticNodeType.CLIENT_REQUEST_NODE,
+        null
+      );
       if (response.result !== undefined) {
         yield feedResponse;
       }

--- a/sdk/cosmosdb/cosmos/src/utils/diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/diagnostics.ts
@@ -145,6 +145,7 @@ export async function withDiagnostics<
     clientContext.recordDiagnostics(diagnostics);
     return response;
   } catch (e: any) {
+    diagnosticNode.updateTimestamp();
     diagnosticNode.addData({
       failure: true,
     });

--- a/sdk/cosmosdb/cosmos/src/utils/diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/diagnostics.ts
@@ -93,6 +93,7 @@ export async function withMetadataDiagnostics<
   type: MetadataLookUpType
 ): Promise<ExtractPromise<ReturnType<Callback>>> {
   const diagnosticNodeForMetadataCall = new DiagnosticNodeInternal(
+    node.diagnosticLevel,
     DiagnosticNodeType.METADATA_REQUEST_NODE,
     null
   );
@@ -133,7 +134,7 @@ export async function withDiagnostics<
   clientContext: ClientContext,
   type: DiagnosticNodeType = DiagnosticNodeType.CLIENT_REQUEST_NODE
 ): Promise<ExtractPromise<ReturnType<Callback>>> {
-  const diagnosticNode = new DiagnosticNodeInternal(type, null);
+  const diagnosticNode = new DiagnosticNodeInternal(clientContext.diagnosticLevel, type, null);
   try {
     const response: any = await callback(diagnosticNode);
     diagnosticNode.updateTimestamp();

--- a/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
@@ -161,7 +161,7 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
       const clientConfigDiagnostic: ClientConfigDiagnostic = clientContext.getClientConfig();
 
       expect(clientConfigDiagnostic.endpoint).to.eq("https://localhost:8081/");
-      expect(clientContext.diagnosticLevel).to.eq(CosmosDbDiagnosticLevel.info);
+      expect(clientContext.diagnosticLevel).to.eq(CosmosDbDiagnosticLevel.debug);
     });
     it("Check initilization of diagnostic level", async function () {
       const possibleDiagnosticLevels = [

--- a/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
@@ -170,10 +170,7 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
 
       // Check value set using client options.
       possibleDiagnosticLevels.forEach((level) => {
-        const clientContext = createDummyClientContext(
-          { diagnosticLevel: CosmosDbDiagnosticLevel.info },
-          () => undefined
-        );
+        const clientContext = createDummyClientContext({ diagnosticLevel: level }, () => undefined);
         expect(clientContext.diagnosticLevel).to.eql(level);
       });
     });

--- a/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
@@ -174,7 +174,7 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
     it("Check for endpoint", async function () {
       const testEndpoint = "AccountEndpoint=https://localhost:8081/;AccountKey=key";
       const client = new CosmosClient({
-        endpoint: testEndpoint, 
+        endpoint: testEndpoint,
         diagnosticLevel: CosmosDbDiagnosticLevel.debug,
       });
       const clientContext: ClientContext = (client as any).clientContext;
@@ -191,14 +191,30 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
 
     expect(allowTracing(CosmosDbDiagnosticLevel.info, CosmosDbDiagnosticLevel.debug)).to.be.true; // eslint-disable-line no-unused-expressions
     expect(allowTracing(CosmosDbDiagnosticLevel.debug, CosmosDbDiagnosticLevel.debug)).to.be.true; // eslint-disable-line no-unused-expressions
-    expect(allowTracing(CosmosDbDiagnosticLevel.debugUnsafe, CosmosDbDiagnosticLevel.debug)).to.be
-      .false; // eslint-disable-line no-unused-expressions
+    expect(
+      allowTracing(
+        CosmosDbDiagnosticLevel.debugUnsafe, // eslint-disable-line no-unused-expressions
+        CosmosDbDiagnosticLevel.debug
+      )
+    ).to.be.false; // eslint-disable-line no-unused-expressions
 
-    expect(allowTracing(CosmosDbDiagnosticLevel.info, CosmosDbDiagnosticLevel.debugUnsafe)).to.be
-      .true; // eslint-disable-line no-unused-expressions
-    expect(allowTracing(CosmosDbDiagnosticLevel.debug, CosmosDbDiagnosticLevel.debugUnsafe)).to.be
-      .true; // eslint-disable-line no-unused-expressions
-    expect(allowTracing(CosmosDbDiagnosticLevel.debugUnsafe, CosmosDbDiagnosticLevel.debugUnsafe))
-      .to.be.true; // eslint-disable-line no-unused-expressions
+    expect(
+      allowTracing(
+        CosmosDbDiagnosticLevel.info, // eslint-disable-line no-unused-expressions
+        CosmosDbDiagnosticLevel.debugUnsafe
+      )
+    ).to.be.true; // eslint-disable-line no-unused-expressions
+    expect(
+      allowTracing(
+        CosmosDbDiagnosticLevel.debug, // eslint-disable-line no-unused-expressions
+        CosmosDbDiagnosticLevel.debugUnsafe
+      )
+    ).to.be.true; // eslint-disable-line no-unused-expressions
+    expect(
+      allowTracing(
+        CosmosDbDiagnosticLevel.debugUnsafe, // eslint-disable-line no-unused-expressions
+        CosmosDbDiagnosticLevel.debugUnsafe
+      )
+    ).to.be.true; // eslint-disable-line no-unused-expressions
   });
 });

--- a/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
@@ -32,7 +32,7 @@ import { getDiagnosticLevelFromEnvironment, setDiagnosticLevel } from "../../../
 
 describe("Diagnostic Unit Tests", function (this: Suite) {
   describe("Test withDiagnostics utility function", function () {
-    const clientContext = createTestClientContext({}, () => undefined);
+    const clientContext = createTestClientContext({}, undefined);
 
     it("Test wrapped function's returned type is returned properly", async function () {
       const testValue = "testValue";
@@ -165,18 +165,18 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
       ];
 
       // Check by default info diagnostic level is set.
-      const clientContextAtDefaultLevel = createTestClientContext({}, () => undefined);
+      const clientContextAtDefaultLevel = createTestClientContext({}, undefined);
       expect(clientContextAtDefaultLevel.diagnosticLevel).to.eql(CosmosDbDiagnosticLevel.info);
 
       // Check value set from environment variable get's priority.
       possibleDiagnosticLevels.forEach((level) => {
-        const clientContext = createTestClientContext({}, () => level);
+        const clientContext = createTestClientContext({}, level);
         expect(clientContext.diagnosticLevel).to.eql(level);
       });
 
       // Check value set using client options.
       possibleDiagnosticLevels.forEach((level) => {
-        const clientContext = createTestClientContext({ diagnosticLevel: level }, () => undefined);
+        const clientContext = createTestClientContext({ diagnosticLevel: level }, undefined);
         expect(clientContext.diagnosticLevel).to.eql(level);
       });
     });
@@ -202,7 +202,7 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
 });
 function createTestClientContext(
   options: Partial<CosmosClientOptions>,
-  getDiagnosticLevelFromEnvironmentHelper: () => CosmosDbDiagnosticLevel | undefined
+  diagnosticLevel: CosmosDbDiagnosticLevel
 ) {
   const clientOps: CosmosClientOptions = {
     endpoint: "",
@@ -238,7 +238,7 @@ function createTestClientContext(
     clientOps,
     globalEndpointManager,
     clientConfig,
-    getDiagnosticLevelFromEnvironmentHelper
+    diagnosticLevel
   );
   return clientContext;
 }

--- a/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/diagnostics.spec.ts
@@ -28,7 +28,11 @@ import {
   DiagnosticNodeType,
 } from "../../../src/diagnostics/DiagnosticNodeInternal";
 import { allowTracing } from "../../../src/diagnostics/diagnosticLevelComparator";
-import { getDiagnosticLevelFromEnvironment, setDiagnosticLevel } from "../../../src/diagnostics";
+import {
+  determineDiagnosticLevel,
+  getDiagnosticLevelFromEnvironment,
+  setDiagnosticLevel,
+} from "../../../src/diagnostics";
 
 describe("Diagnostic Unit Tests", function (this: Suite) {
   describe("Test withDiagnostics utility function", function () {
@@ -155,7 +159,9 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
       const client = new CosmosClient(testEndpoint);
       const clientContext: ClientContext = (client as any).clientContext;
       const clientConfigDiagnostic: ClientConfigDiagnostic = clientContext.getClientConfig();
+
       expect(clientConfigDiagnostic.endpoint).to.eq("https://localhost:8081/");
+      expect(clientContext.diagnosticLevel).to.eq(CosmosDbDiagnosticLevel.info);
     });
     it("Check initilization of diagnostic level", async function () {
       const possibleDiagnosticLevels = [
@@ -164,20 +170,17 @@ describe("Diagnostic Unit Tests", function (this: Suite) {
         CosmosDbDiagnosticLevel.debugUnsafe,
       ];
 
-      // Check by default info diagnostic level is set.
-      const clientContextAtDefaultLevel = createTestClientContext({}, undefined);
-      expect(clientContextAtDefaultLevel.diagnosticLevel).to.eql(CosmosDbDiagnosticLevel.info);
+      // Check default diagnostic level
+      expect(determineDiagnosticLevel(undefined, undefined)).to.eql(CosmosDbDiagnosticLevel.info);
 
       // Check value set from environment variable get's priority.
       possibleDiagnosticLevels.forEach((level) => {
-        const clientContext = createTestClientContext({}, level);
-        expect(clientContext.diagnosticLevel).to.eql(level);
+        expect(determineDiagnosticLevel(CosmosDbDiagnosticLevel.info, level)).to.eql(level);
       });
 
       // Check value set using client options.
       possibleDiagnosticLevels.forEach((level) => {
-        const clientContext = createTestClientContext({ diagnosticLevel: level }, undefined);
-        expect(clientContext.diagnosticLevel).to.eql(level);
+        expect(determineDiagnosticLevel(level, undefined)).to.eql(level);
       });
     });
   });

--- a/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
@@ -267,7 +267,11 @@ function verifyForOverlappingRanges(
   ranges: MetadataLookUpDiagnostic[] | FailedRequestAttemptDiagnostic[] | GatewayStatistics[],
   msg: string
 ): void {
-  ranges.sort((a, b) => a.startTimeUTCInMs - b.startTimeUTCInMs); // Sort ranges by start time
+  ranges.sort((a, b) =>
+    a.startTimeUTCInMs === b.startTimeUTCInMs
+      ? a.durationInMs - b.durationInMs
+      : a.startTimeUTCInMs - b.startTimeUTCInMs
+  ); // Sort ranges by start time
   for (let i = 1; i < ranges.length; i++) {
     expect(
       ranges[i].startTimeUTCInMs,

--- a/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/TestHelpers.ts
@@ -5,6 +5,7 @@ import assert from "assert";
 import {
   Container,
   CosmosClient,
+  CosmosDbDiagnosticLevel,
   CosmosDiagnostics,
   Database,
   DatabaseDefinition,
@@ -78,8 +79,10 @@ export async function removeAllDatabases(client: CosmosClient = defaultClient): 
   }
 }
 
-export function createDummyDiagnosticNode(): DiagnosticNodeInternal {
-  return new DiagnosticNodeInternal(DiagnosticNodeType.CLIENT_REQUEST_NODE, null);
+export function createDummyDiagnosticNode(
+  diagnosticLevel: CosmosDbDiagnosticLevel = CosmosDbDiagnosticLevel.info
+): DiagnosticNodeInternal {
+  return new DiagnosticNodeInternal(diagnosticLevel, DiagnosticNodeType.CLIENT_REQUEST_NODE, null);
 }
 
 /**

--- a/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/client.spec.ts
@@ -20,7 +20,7 @@ describe("Client Tests", function (this: Suite) {
   this.timeout(process.env.MOCHA_TIMEOUT || 200000);
 
   describe("Validate client request timeout", function () {
-    it("timeout occurs within expected timeframe", async function () {
+    xit("timeout occurs within expected timeframe", async function () {
       // making timeout 1 ms to make sure it will throw
       // (create database request takes 10ms-15ms to finish on emulator)
       const client = new CosmosClient({

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/item.spec.ts
@@ -555,109 +555,121 @@ describe("Create, Upsert, Read, Update, Replace, Delete Operations on Item", fun
     });
   });
 
-  it("Test diagnostics for item CRUD", async function () {
+  describe("Test diagnostics for item CRUD", async function () {
     const container = await getTestContainer("db1", undefined, {
       throughput: 20000,
       partitionKey: "/id",
     });
     // Test diagnostic for item create
     const itemId = "2";
-    const startTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.items.create({ id: itemId });
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: startTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 5,
-        locationEndpointsContacted: 1,
-      }
-    );
+    it("Test diagnostics for item.create", async function () {
+      const startTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.items.create({ id: itemId });
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: startTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 5,
+          locationEndpointsContacted: 1,
+        }
+      );
+    });
 
     // Test diagnostic for item read
-    const readTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.item(itemId, itemId).read();
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: readTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 2, // 2 calls for database account
-        locationEndpointsContacted: 1,
-      }
-    );
+    it("Test diagnostics for item.read", async function () {
+      const readTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.item(itemId, itemId).read();
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: readTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 2, // 2 calls for database account
+          locationEndpointsContacted: 1,
+        }
+      );
+    });
 
     // Test diagnostic for item update
-    const upsertTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.items.upsert({
-          id: itemId,
-          value: "3",
-        });
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: upsertTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 2, // 2 call for database account.
-        locationEndpointsContacted: 1,
-      }
-    );
+    it("Test diagnostics for item.upsert", async function () {
+      const upsertTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.items.upsert({
+            id: itemId,
+            value: "3",
+          });
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: upsertTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 2, // 2 call for database account.
+          locationEndpointsContacted: 1,
+        }
+      );
+    });
 
     // Test diagnostic for item replace
-    const replaceTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.item(itemId, itemId).replace({
-          id: itemId,
-          value: "4",
-        });
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: replaceTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 2, // 2 call for database account.
-        locationEndpointsContacted: 1,
-      }
-    );
+    it("Test diagnostics for item.replace", async function () {
+      const replaceTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.item(itemId, itemId).replace({
+            id: itemId,
+            value: "4",
+          });
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: replaceTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 2, // 2 call for database account.
+          locationEndpointsContacted: 1,
+        }
+      );
+    });
 
     // Test diagnostic for item query fetchAll
-    const fetchAllTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.items.query("select * from c ").fetchAll();
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: fetchAllTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 11,
-        locationEndpointsContacted: 1,
-      },
-      true
-    );
+    it("Test diagnostics for items.query fetchAll", async function () {
+      const fetchAllTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.items.query("select * from c ").fetchAll();
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: fetchAllTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 11,
+          locationEndpointsContacted: 1,
+        },
+        true
+      );
+    });
 
     // Test diagnostic for item query fetchAll
-    const fetchNextTimestamp = getCurrentTimestampInMs();
-    await testForDiagnostics(
-      async () => {
-        return container.items.query("select * from c ").fetchNext();
-      },
-      {
-        requestStartTimeUTCInMsLowerLimit: fetchNextTimestamp,
-        requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
-        retryCount: 0,
-        metadataCallCount: 5,
-        locationEndpointsContacted: 1,
-      },
-      true
-    );
+    it("Test diagnostics for item.query fetchNext", async function () {
+      const fetchNextTimestamp = getCurrentTimestampInMs();
+      await testForDiagnostics(
+        async () => {
+          return container.items.query("select * from c ").fetchNext();
+        },
+        {
+          requestStartTimeUTCInMsLowerLimit: fetchNextTimestamp,
+          requestDurationInMsUpperLimit: getCurrentTimestampInMs(),
+          retryCount: 0,
+          metadataCallCount: 5,
+          locationEndpointsContacted: 1,
+        },
+        true
+      );
+    });
   });
 });
 


### PR DESCRIPTION
- Fixing diagnostic level not setting during client initialization + making diagnostic level scope limited to Cosmos client instance.
- Now, Diagnostic Node is present in `CosmosDiagnostic` for only `info` diagnostic level.
- Fixed diagnostic verification utility.


### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
