### PR TITLE
[data-tables] Avoid mutating client options parameter

### DIFF
--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -32,6 +32,7 @@ import {
   InternalClientPipelineOptions,
   OperationOptions,
   ServiceClient,
+  ServiceClientOptions,
 } from "@azure/core-client";
 import { GeneratedClient, TableDeleteEntityOptionalParams } from "./generated";
 import {
@@ -232,10 +233,10 @@ export class TableClient {
     this.clientOptions = (!isCredential(credentialOrOptions) ? credentialOrOptions : options) || {};
 
     this.allowInsecureConnection = this.clientOptions.allowInsecureConnection ?? false;
-    this.clientOptions.endpoint = this.clientOptions.endpoint || this.url;
 
-    const internalPipelineOptions: InternalClientPipelineOptions = {
+    const internalPipelineOptions: ServiceClientOptions & InternalClientPipelineOptions = {
       ...this.clientOptions,
+      endpoint: this.clientOptions.endpoint || this.url,
       loggingOptions: {
         logger: logger.info,
         additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames],

--- a/sdk/tables/data-tables/src/TableServiceClient.ts
+++ b/sdk/tables/data-tables/src/TableServiceClient.ts
@@ -10,7 +10,11 @@ import {
   SetPropertiesOptions,
   SetPropertiesResponse,
 } from "./generatedModels";
-import { InternalClientPipelineOptions, OperationOptions } from "@azure/core-client";
+import {
+  InternalClientPipelineOptions,
+  OperationOptions,
+  ServiceClientOptions,
+} from "@azure/core-client";
 import {
   ListTableItemsOptions,
   TableItem,
@@ -161,21 +165,18 @@ export class TableServiceClient {
     const clientOptions =
       (!isCredential(credentialOrOptions) ? credentialOrOptions : options) || {};
 
-    clientOptions.endpoint = clientOptions.endpoint || this.url;
-
-    const internalPipelineOptions: InternalClientPipelineOptions = {
+    const internalPipelineOptions: ServiceClientOptions & InternalClientPipelineOptions = {
       ...clientOptions,
-      ...{
-        loggingOptions: {
-          logger: logger.info,
-          additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames],
-        },
-        deserializationOptions: {
-          parseXML,
-        },
-        serializationOptions: {
-          stringifyXML,
-        },
+      endpoint: clientOptions.endpoint || this.url,
+      loggingOptions: {
+        logger: logger.info,
+        additionalAllowedHeaderNames: [...TablesLoggingAllowedHeaderNames],
+      },
+      deserializationOptions: {
+        parseXML,
+      },
+      serializationOptions: {
+        stringifyXML,
       },
     };
     const client = new GeneratedClient(this.url, internalPipelineOptions);


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/data-tables`

### Describe the problem that is addressed by this PR

If a consumer re-uses a single options argument when configuring multiple clients, they may run into issues because both the TableClient and TableServiceClient mutate the options bag directly instead of creating a copy.

### Provide a list of related PRs _(if any)_

This issue was originally raised in the following community PR, but it was never merged:

https://github.com/Azure/azure-sdk-for-js/pull/26211
