### PR TITLE
Revert "[engsys] build test assets only for browser runs (#27035)"

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -107,7 +107,7 @@ jobs:
       - script: |
           node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
-        condition: and(succeededOrFailed(), eq(variables['TestType'], 'browser'), eq(variables['DependencyVersion'],''))
+        condition: and(succeededOrFailed(),eq(variables['DependencyVersion'],''))
 
       - script: |
           npm install

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -27,7 +27,6 @@ steps:
   - script: |
       node eng/tools/rush-runner.js build:test "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build test assets"
-    condition: and(succeeded(), eq(variables['TestType'], 'browser'))
 
   - template: ../steps/use-node-test-version.yml
 


### PR DESCRIPTION
This reverts commit e453c2d5f7a65c4cbb1e9cf1ba8904bfc6d830b6.

PR #27035 keeps `build;test` only for browser runs. It turns out that a couple of packages have custom `build:test` scripts that are different from `build`.  While we can explore more on enabling `build:test` for these few packages, this PR reverts the changes to unblock automation builds.