### PR TITLE
fix Deno detected as a browser in core-rest-pipeline

### DIFF
--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -11,7 +11,7 @@ import { ProxySettings } from ".";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
 import { defaultRetryPolicy } from "./policies/defaultRetryPolicy";
 import { formDataPolicy } from "./policies/formDataPolicy";
-import { isNode } from "@azure/core-util";
+import { isNode, isDeno } from "@azure/core-util";
 import { proxyPolicy } from "./policies/proxyPolicy";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
 import { tlsPolicy } from "./policies/tlsPolicy";
@@ -79,10 +79,11 @@ export interface InternalPipelineOptions extends PipelineOptions {
 export function createPipelineFromOptions(options: InternalPipelineOptions): Pipeline {
   const pipeline = createEmptyPipeline();
 
-  if (isNode) {
-    if (options.tlsOptions) {
-      pipeline.addPolicy(tlsPolicy(options.tlsOptions));
-    }
+  if (isNode && options.tlsOptions) {
+    pipeline.addPolicy(tlsPolicy(options.tlsOptions));
+  }
+
+  if (isNode || isDeno) {
     pipeline.addPolicy(proxyPolicy(options.proxyOptions));
     pipeline.addPolicy(decompressResponsePolicy());
   }


### PR DESCRIPTION
### Packages impacted by this PR
core-rest-pipeline

### Issues associated with this PR 
https://github.com/Azure/azure-sdk-for-js/issues/27077

### Describe the problem that is addressed by this PR
Using Azure SDK in a Deno environment causes the following issue:
```
Error: proxyPolicy is not supported in browser environment
    at https://esm.sh/v132/@azure/core-rest-pipeline@1.12.0/deno/core-rest-pipeline.mjs:2:11023
```
After investigating a little bit, The following PR might be the thing that triggered it: https://github.com/Azure/azure-sdk-for-js/pull/26897 - however, it just revealed the underlying issue of - not adding the right policies to isDeno environments


### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [] Added a changelog (if necessary)
