### PR TITLE
[Identity] update mapping for browser for azd

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 - Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile`  and "-NonInteractive" flag to avoid loading user profiles for more consistent behavior.  ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
+- Fixed browser bundling for Azure Developer CLI credential 
 ### Other Changes
 
 ## 3.3.0 (2023-08-14)

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -10,6 +10,7 @@
     "os": false,
     "process": false,
     "./dist-esm/src/credentials/azureCliCredential.js": "./dist-esm/src/credentials/azureCliCredential.browser.js",
+    "./dist-esm/src/credentials/azureDeveloperCliCredential.js": "./dist-esm/src/credentials/azureDeveloperCliCredential.browser.js",
     "./dist-esm/src/credentials/environmentCredential.js": "./dist-esm/src/credentials/environmentCredential.browser.js",
     "./dist-esm/src/credentials/managedIdentityCredential/index.js": "./dist-esm/src/credentials/managedIdentityCredential/index.browser.js",
     "./dist-esm/src/credentials/clientCertificateCredential.js": "./dist-esm/src/credentials/clientCertificateCredential.browser.js",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Bug fixes

### Describe the problem that is addressed by this PR
Fixes bug for browser bundling for Azure Developer CLI Credential which otherwise includes `child_process`.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
