### PR TITLE
additional deploy config - tenant ID & redirect URI

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- added options to specify tenant ID and redirect URI for InteractiveBrowserCredential of Azure Identity
 
 ### Other Changes
+
+- updated "tools" package version
 
 ## 1.0.0-beta.2 (2022-08-26)
 

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/_shared/deploy.js.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/_shared/deploy.js.mustache
@@ -3,5 +3,6 @@ const {deployNodeJS} = require("@azure/api-management-custom-widgets-tools")
 const serviceInformation = {{&configDeploy}}
 const name = "{{name}}"
 const fallbackConfigPath = "./static/config.msapim.json"
+const config = {{&configAdditional}}
 
-deployNodeJS(serviceInformation, name, fallbackConfigPath)
+deployNodeJS(serviceInformation, name, fallbackConfigPath, config)

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/react/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/react/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1",
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/react/src/providers.tsx
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/react/src/providers.tsx
@@ -20,6 +20,16 @@ export const SecretsContext = React.createContext<Secrets>({
   userId: "",
   apiVersion: "",
   managementApiUrl: "",
+  parentLocation: {
+    host: "",
+    hostname: "",
+    href: "",
+    origin: "",
+    pathname: "",
+    port: "",
+    protocol: "",
+    search: "",
+  },
 })
 export const SecretsProvider: React.FC<{children?: React.ReactNode; targetModule: TargetModule}> = (
   {children, targetModule},

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/typescript/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/typescript/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1"
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "prettier": "^2.7.1",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/vue/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/templates/vue/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1",
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2",
     "vue": "^3.2.37"
   },
   "devDependencies": {

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/review/api-management-custom-widgets-scaffolder.api.md
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/review/api-management-custom-widgets-scaffolder.api.md
@@ -26,6 +26,8 @@ export function generateProject(widgetConfig: CustomWidgetCommonConfig, deployme
 
 // @public
 export interface Options {
+    configAdvancedRedirectUri?: string;
+    configAdvancedTenantId?: string;
     openUrl?: string;
 }
 

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute-configs.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute-configs.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Configs, DeploymentConfig, Options, TECHNOLOGIES, WidgetConfig } from "../scaffolding";
+import { Configs, ServiceInformation, Options, TECHNOLOGIES, WidgetConfig } from "../scaffolding";
 
 import inquirer from "inquirer";
 
 export const fieldIdToName: Record<
-  keyof (WidgetConfig & DeploymentConfig & Options) | string,
+  keyof (WidgetConfig & ServiceInformation & Options) | string,
   string
 > = {
   displayName: "Widget display name",
@@ -19,6 +19,8 @@ export const fieldIdToName: Record<
   apiVersion: "Management API version",
 
   openUrl: "Developer portal URL",
+  configAdvancedTenantId: "Tenant ID",
+  configAdvancedRedirectUri: "Redirect URI",
 };
 
 export const prefixUrlProtocol = (value: string): string =>
@@ -70,7 +72,7 @@ export const validateWidgetConfig: Validate<WidgetConfig> = {
   },
 };
 
-export const validateDeployConfig: Validate<DeploymentConfig> = {
+export const validateDeployConfig: Validate<ServiceInformation> = {
   resourceId: (input) => {
     const required = validateRequired(fieldIdToName.resourceId)(input);
     if (required !== true) return required;
@@ -86,6 +88,13 @@ export const validateDeployConfig: Validate<DeploymentConfig> = {
 
 export const validateMiscConfig: Validate<Options> = {
   openUrl: (input) => {
+    if (!input) return true;
+    return validateUrl(fieldIdToName.openUrl)(input);
+  },
+  configAdvancedTenantId: () => {
+    return true;
+  },
+  configAdvancedRedirectUri: (input) => {
     if (!input) return true;
     return validateUrl(fieldIdToName.openUrl)(input);
   },
@@ -114,7 +123,9 @@ export const promptWidgetConfig = (partial: Partial<WidgetConfig>): Promise<Widg
     partial
   );
 
-export const promptDeployConfig = (partial: Partial<DeploymentConfig>): Promise<DeploymentConfig> =>
+export const promptServiceInformation = (
+  partial: Partial<ServiceInformation>
+): Promise<ServiceInformation> =>
   inquirer.prompt(
     [
       {
@@ -157,6 +168,22 @@ export const promptMiscConfig = (partial: Partial<Options>): Promise<Options> =>
           fieldIdToName.openUrl +
           " for widget development and testing (optional; e.g., https://contoso.developer.azure-api.net/ or http://localhost:8080)",
         transformer: prefixUrlProtocol,
+        validate: validateMiscConfig.openUrl,
+      },
+      {
+        name: "configAdvancedTenantId",
+        type: "input",
+        message:
+          fieldIdToName.configAdvancedTenantId +
+          " to be used in Azure Identity InteractiveBrowserCredential class (optional)",
+        validate: validateMiscConfig.openUrl,
+      },
+      {
+        name: "configAdvancedRedirectUri",
+        type: "input",
+        message:
+          fieldIdToName.configAdvancedRedirectUri +
+          " to be used in Azure Identity InteractiveBrowserCredential class (optional; default is http://localhost:1337)",
         validate: validateMiscConfig.openUrl,
       },
     ],

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute.ts
@@ -6,7 +6,7 @@
 import { Log, buildGetConfig } from "./execute-helpers";
 import {
   prefixUrlProtocol,
-  promptDeployConfig,
+  promptServiceInformation,
   promptMiscConfig,
   promptWidgetConfig,
   validateDeployConfig,
@@ -33,27 +33,29 @@ async function main(): Promise<void> {
   white("Specify the custom widget configuration.");
   const widgetConfig = await getConfig(promptWidgetConfig, validateWidgetConfig);
   white("Specify the Azure API Management service configuration.");
-  const deployConfig = await getConfig(promptDeployConfig, validateDeployConfig);
+  const serviceInformation = await getConfig(promptServiceInformation, validateDeployConfig);
   white("Specify other options");
   const miscConfig = await getConfig(promptMiscConfig, validateMiscConfig);
 
-  if (deployConfig.resourceId[0] === "/") {
-    deployConfig.resourceId = deployConfig.resourceId.slice(1);
+  if (serviceInformation.resourceId[0] === "/") {
+    serviceInformation.resourceId = serviceInformation.resourceId.slice(1);
   }
-  if (deployConfig.resourceId.slice(-1) === "/") {
-    deployConfig.resourceId = deployConfig.resourceId.slice(0, -1);
+  if (serviceInformation.resourceId.slice(-1) === "/") {
+    serviceInformation.resourceId = serviceInformation.resourceId.slice(0, -1);
   }
-  if (deployConfig.apiVersion === "") {
-    delete deployConfig.apiVersion;
+  if (serviceInformation.apiVersion === "") {
+    delete serviceInformation.apiVersion;
   }
 
-  deployConfig.managementApiEndpoint = prefixUrlProtocol(deployConfig.managementApiEndpoint);
+  serviceInformation.managementApiEndpoint = prefixUrlProtocol(
+    serviceInformation.managementApiEndpoint
+  );
 
   miscConfig.openUrl = miscConfig.openUrl
     ? prefixUrlProtocol(miscConfig.openUrl)
     : miscConfig.openUrl;
 
-  return generateProject(widgetConfig, deployConfig, miscConfig)
+  return generateProject(widgetConfig, serviceInformation, miscConfig)
     .then(() => green("\nThe custom widget’s code scaffold has been successfully generated.\n"))
     .catch(console.error);
 }

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/generateProject.browser.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/generateProject.browser.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DeploymentConfig, Options, WidgetConfig } from "./scaffolding";
+import { ServiceInformation, Options, WidgetConfig } from "./scaffolding";
 
 export async function generateProject(
   _widgetConfig: WidgetConfig,
-  _deployConfig: DeploymentConfig,
+  _deployConfig: ServiceInformation,
   _miscConfig: Options = {}
 ): Promise<void> {
   throw new Error("Only for Node.js");

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/generateProject.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/generateProject.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import {
-  DeploymentConfig,
+  ServiceInformation,
   OVERRIDE_DEFAULT_PORT,
   OVERRIDE_PORT_KEY,
   Options,
@@ -26,10 +26,10 @@ const templateSuffix = ".mustache";
  */
 export async function generateProject(
   widgetConfig: WidgetConfig,
-  deploymentConfig: DeploymentConfig,
+  deploymentConfig: ServiceInformation,
   options: Options = {}
 ): Promise<void> {
-  const { openUrl } = options;
+  const { openUrl, configAdvancedTenantId, configAdvancedRedirectUri } = options;
   const openUrlParsed = openUrl ? new URL(openUrl) : null;
   if (openUrlParsed) {
     openUrlParsed.searchParams.append(OVERRIDE_PORT_KEY, String(OVERRIDE_DEFAULT_PORT));
@@ -41,6 +41,17 @@ export async function generateProject(
     open: openUrlParsed ? openUrlParsed.toString() : true,
   };
 
+  const configAdditional = {
+    interactiveBrowserCredentialOptions: { redirectUri: "http://localhost:1337" } as {
+      redirectUri: string;
+      tenantId?: string;
+    },
+  };
+  if (configAdvancedTenantId)
+    configAdditional.interactiveBrowserCredentialOptions.tenantId = configAdvancedTenantId;
+  if (configAdvancedRedirectUri)
+    configAdditional.interactiveBrowserCredentialOptions.redirectUri = configAdvancedRedirectUri;
+
   const renderTemplate = async (file: string): Promise<void> => {
     const isTemplate = file.endsWith(templateSuffix);
     const encoding = file.endsWith(".ttf") ? "binary" : "utf8";
@@ -51,6 +62,7 @@ export async function generateProject(
         displayName: widgetConfig.displayName,
         config: JSON.stringify({ ...widgetConfig, name }, null, "\t"),
         configDeploy: JSON.stringify(deploymentConfig, null, "\t"),
+        configAdditional: JSON.stringify(configAdditional, null, "\t"),
         serverSettings: JSON.stringify(serverSettings, null, "\t"),
       });
     }

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/index.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/index.ts
@@ -15,7 +15,7 @@ export {
 export { generateProject } from "./generateProject";
 export type {
   WidgetConfig as CustomWidgetCommonConfig,
-  DeploymentConfig,
+  ServiceInformation as DeploymentConfig,
   Options,
   ScaffoldTech,
 } from "./scaffolding";

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/scaffolding.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/scaffolding.ts
@@ -27,7 +27,7 @@ export interface WidgetConfig {
 }
 
 /** Data needed for deployment. */
-export interface DeploymentConfig {
+export interface ServiceInformation {
   /** Management API endpoint to use (e.g. management.azure.com). */
   managementApiEndpoint: string;
   /** resourceId of your APIM service, must be in this format: subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.ApiManagement/service/<service-name> */
@@ -40,9 +40,13 @@ export interface DeploymentConfig {
 export interface Options {
   /** The URL to open after development server of the widget is started (URL of your Developer Portal). If you don't want to use this feature, set it to `false`. If you want to open just the widget page, set it to `true`. */
   openUrl?: string;
+  /** advance configuration option for the deploy function - tenant ID for InteractiveBrowserCredentialNodeOptions */
+  configAdvancedTenantId?: string;
+  /** advance configuration option for the deploy function - redirect URI for InteractiveBrowserCredentialNodeOptions */
+  configAdvancedRedirectUri?: string;
 }
 
-export type Configs = WidgetConfig | DeploymentConfig | Options;
+export type Configs = WidgetConfig | ServiceInformation | Options;
 
 /**
  * Converts user defined name of a custom widget to a unique ID, which is in context of Dev Portal known as "name".

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/_shared/deploy.js.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/_shared/deploy.js.mustache
@@ -3,5 +3,6 @@ const {deployNodeJS} = require("@azure/api-management-custom-widgets-tools")
 const serviceInformation = {{&configDeploy}}
 const name = "{{name}}"
 const fallbackConfigPath = "./static/config.msapim.json"
+const config = {{&configAdditional}}
 
-deployNodeJS(serviceInformation, name, fallbackConfigPath)
+deployNodeJS(serviceInformation, name, fallbackConfigPath, config)

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/react/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/react/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1",
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/react/src/providers.tsx
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/react/src/providers.tsx
@@ -20,6 +20,16 @@ export const SecretsContext = React.createContext<Secrets>({
   userId: "",
   apiVersion: "",
   managementApiUrl: "",
+  parentLocation: {
+    host: "",
+    hostname: "",
+    href: "",
+    origin: "",
+    pathname: "",
+    port: "",
+    protocol: "",
+    search: "",
+  },
 })
 export const SecretsProvider: React.FC<{children?: React.ReactNode; targetModule: TargetModule}> = (
   {children, targetModule},

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/typescript/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/typescript/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1"
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "prettier": "^2.7.1",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/vue/package.json.mustache
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/templates/vue/package.json.mustache
@@ -10,7 +10,7 @@
     "deploy": "npm run build && node deploy.js"
   },
   "dependencies": {
-    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.1",
+    "@azure/api-management-custom-widgets-tools": "^1.0.0-beta.2",
     "vue": "^3.2.37"
   },
   "devDependencies": {


### PR DESCRIPTION
### Packages impacted by this PR

api-management-custom-widgets-scaffolder

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/26593

### Describe the problem that is addressed by this PR
This PR adds options to specify during scaffolding process tenant ID and redirect URI for InteractiveBrowserCredential of Azure Identity, which were added to the tools package in the related PR.
Also it updates tools package in templates to the latest version.

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
