### PR TITLE
[dev-tool] Create a symbolic link to recordings when running the proxy tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ code-model-*
 *.cpuprofile
 # Temp typespec files
 TempTypeSpecFiles/
+
+# Symbolic link from project directory to recordings
+_recordings


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/dev-tool`

### Description

This is a quality-of-life change which makes inspecting recordings easier. With the new asset sync flow, recordings are no longer stored in the repo with each package. If you want to look at your recordings for some reason (e.g. after re-recording to make sure you aren't leaking any secrets), it takes a few extra steps to find them: navigate to the repo root, look at the `.breadcrumb` file in the `.assets` folder, and then use that to find the location of the recordings corresponding to your package.

This PR improves that process by creating a symbolic link to the recordings from each package, restoring the original flow.