### PR TITLE
[Azure Monitor OpenTelemetry Exporter] Update Statsbeat Metric names

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -56,12 +56,12 @@ export const StatsbeatResourceProvider = {
 };
 
 export enum StatsbeatCounter {
-  SUCCESS_COUNT = "Request Success Count",
-  FAILURE_COUNT = "Request Failure Count",
-  RETRY_COUNT = "Retry Count",
-  THROTTLE_COUNT = "Throttle Count",
-  EXCEPTION_COUNT = "Exception Count",
-  AVERAGE_DURATION = "Request Duration",
+  SUCCESS_COUNT = "Request_Success_Count",
+  FAILURE_COUNT = "Request_Failure_Count",
+  RETRY_COUNT = "Retry_Count",
+  THROTTLE_COUNT = "Throttle_Count",
+  EXCEPTION_COUNT = "Exception_Count",
+  AVERAGE_DURATION = "Request_Duration",
   ATTACH = "Attach",
   FEATURE = "Feature",
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

Warnings are displayed when using exporter because  OTel recently added validation for the metric name and these should not have spaces https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument