### PR TITLE
[recorder] Fix env var issue where one variable a substring of another

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where environment variables were not being sanitized correctly when one's original value is a substring of another. [#27187](https://github.com/Azure/azure-sdk-for-js/pull/27187)
+
 ### Other Changes
 
 - Improved some error messages: [#26094](https://github.com/Azure/azure-sdk-for-js/pull/26094)

--- a/sdk/test-utils/recorder/src/sanitizer.ts
+++ b/sdk/test-utils/recorder/src/sanitizer.ts
@@ -34,9 +34,9 @@ type AddSanitizer<T> = (
 const pluralize =
   <T>(singular: AddSanitizer<T>): AddSanitizer<T[]> =>
   async (httpClient, url, recordingId, sanitizers) => {
-    await Promise.all(
-      sanitizers.map((sanitizer) => singular(httpClient, url, recordingId, sanitizer))
-    );
+    for (const sanitizer of sanitizers) {
+      await singular(httpClient, url, recordingId, sanitizer);
+    }
   };
 
 /**

--- a/sdk/test-utils/recorder/src/utils/envSetupForPlayback.ts
+++ b/sdk/test-utils/recorder/src/utils/envSetupForPlayback.ts
@@ -39,14 +39,18 @@ export async function handleEnvSetup(
       );
 
       // If the env variables are present in the recordings as plain strings, they will be replaced with the provided values in record mode
+      const valueToReplacementPairs = Object.entries(envSetupForPlayback)
+        // Map the values from the environment to their replacements
+        .map(([key, value]) => [env[key], value])
+        // Don't perform a replacement if the environment variable to replace is not actually defined
+        .filter(([key]) => key !== undefined) as [string, string][];
 
-      const generalSanitizers: FindReplaceSanitizer[] = [];
-      for (const [key, value] of Object.entries(envSetupForPlayback)) {
-        const envKey = env[key];
-        if (envKey) {
-          generalSanitizers.push({ target: envKey, value });
-        }
-      }
+      // Sort so that we add the sanitizers from longest replacement value to shortest to ensure if one value is a substring of another,
+      // the replacement of the shorter value doesn't interfere with the replacement of the longer value.
+      const generalSanitizers: FindReplaceSanitizer[] = valueToReplacementPairs
+        .sort(([aKey], [bKey]) => bKey.length - aKey.length)
+        .map(([envKey, value]) => ({ target: envKey, value }));
+
       await addSanitizers(httpClient, url, recordingId, {
         generalSanitizers,
       });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/test-recorder`

### Issues associated with this PR

- Fixes #11379 (an issue from 2020!)

### Describe the problem that is addressed by this PR

Fixes a long-running issue recently rediscovered by @minhanh-phan. If we have 2 environment variables in our `.env`, where one is a substring of another, e.g.:

```sh
VAR_1=TestTestTest
VAR_2=Test
```

we can run into an issue where the shorter environment variable gets replaced first in the recordng, causing the first variable to not be sanitized properly. This causes issues in playback.

This PR fixes the issue by:
- Ordering the sanitizers applied by `envSetupForPlayback` by the length of the environment variable value, in descending order, and
- Adding the sanitizers in a deterministic order instead of applying them in parallel and using `Promise.all`.