### PR TITLE
[ai-content-safety-rest] Update dependency @azure/core-util version to ^1.4.0

### DIFF
--- a/sdk/contentsafety/ai-content-safety-rest/package.json
+++ b/sdk/contentsafety/ai-content-safety-rest/package.json
@@ -101,7 +101,7 @@
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
     "nyc": "^15.0.0",
-    "@azure/core-util": "1.4.1"
+    "@azure/core-util": "^1.4.0"
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/contentsafety/ai-content-safety-rest/README.md",
   "//metadata": {


### PR DESCRIPTION
Since 1.4.1 core-util has not been released, and https://github.com/Azure/azure-sdk-for-js/pull/26748 jumps from 1.4.0 to 1.5.0 core-util directly.. leads to CI failure at #26748.

Instead of depending on the unreleased/fixed `1.4.1` version of `core-util`... 
Depending on `^1.4.0` is better and won't have other dependencies on releases.