### PR TITLE
[core-xml] Fix build failure

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14,7 +14,7 @@ dependencies:
   '@rush-temp/ai-anomaly-detector':
     specifier: file:./projects/ai-anomaly-detector.tgz
     version: file:projects/ai-anomaly-detector.tgz
-  '@rush-temp/ai-content-safety': 
+  '@rush-temp/ai-content-safety':
     specifier: file:./projects/ai-content-safety.tgz
     version: file:projects/ai-content-safety.tgz
   '@rush-temp/ai-document-translator':
@@ -1118,7 +1118,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-util': 1.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -1131,7 +1131,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.4.0
       tslib: 2.6.2
@@ -1155,7 +1155,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-http-compat': 1.3.0
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.4.0
       '@azure/logger': 1.0.4
@@ -1174,7 +1174,7 @@ packages:
       '@azure/core-http-compat': 2.0.1
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.4.0
       '@azure/logger': 1.0.4
@@ -1192,7 +1192,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1207,7 +1207,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1222,7 +1222,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1237,7 +1237,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1252,7 +1252,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1267,23 +1267,7 @@ packages:
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@azure/communication-common@2.2.1:
-    resolution: {integrity: sha512-5Ls1zfy56tOghPxS7gAetSybQNxR22lF76q4Uk2QbP4TIHs7sj3lL+Y6npAAE1nkbcNqBTYPziolJBP+xHX2FA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
-      '@azure/core-tracing': 1.0.1
-      '@azure/core-util': 1.4.0
-      events: 3.3.0
-      jwt-decode: 3.1.2
+      '@azure/core-rest-pipeline': 1.12.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -1337,7 +1321,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.4.0
       '@azure/logger': 1.0.4
@@ -1352,7 +1336,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1363,7 +1347,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1377,7 +1361,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.4.0
       '@azure/logger': 1.0.4
-      '@types/node-fetch': 2.6.4
+      '@types/node-fetch': 2.6.5
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
       node-fetch: 2.7.0
@@ -1408,8 +1392,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@azure/core-rest-pipeline@1.12.0:
-    resolution: {integrity: sha512-+MnSB0vGZjszSzr5AW8z93/9fkDu2RLtWmAN8gskURq7EW2sSwqy8jZa0V26rjuBVkwhdA3Hw8z3VWoeBUOw+A==}
+  /@azure/core-rest-pipeline@1.12.1:
+    resolution: {integrity: sha512-SsyWQ+T5MFQRX+M8H/66AlaI6HyCbQStGfFngx2fuiW+vKI2DkhtOvbYodPyf9fOe/ARLWWc3ohX54lQ5Kmaog==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -1463,13 +1447,13 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.4.0
       '@azure/logger': 1.0.4
       '@azure/msal-browser': 2.38.2
       '@azure/msal-common': 7.6.0
-      '@azure/msal-node': 1.18.2
+      '@azure/msal-node': 1.18.3
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.2
@@ -1501,7 +1485,7 @@ packages:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
       '@azure/core-lro': 2.5.4
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1512,7 +1496,7 @@ packages:
     dependencies:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.4
       pako: 2.1.0
@@ -1528,7 +1512,7 @@ packages:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.4
       tslib: 2.6.2
@@ -1563,12 +1547,12 @@ packages:
       node-addon-api: 5.0.0
     dev: false
 
-  /@azure/msal-node@1.18.2:
-    resolution: {integrity: sha512-bLbuhF9Q5cgwj9tt8R7EV9MbCwGuFgZiv6Gw0VvHx5AcWHhh2m8hYginGagB4EucxKueFDwZP6aZVAxfuD/lUQ==}
+  /@azure/msal-node@1.18.3:
+    resolution: {integrity: sha512-lI1OsxNbS/gxRD4548Wyj22Dk8kS7eGMwD9GlBZvQmFV8FJUXoXySL1BiNzDsHUE96/DS/DHmA+F73p1Dkcktg==}
     engines: {node: 10 || 12 || 14 || 16 || 18}
     dependencies:
       '@azure/msal-common': 13.3.0
-      jsonwebtoken: 9.0.1
+      jsonwebtoken: 9.0.2
       uuid: 8.3.2
     dev: false
 
@@ -1578,7 +1562,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.1.4
       '@azure/core-auth': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/logger': 1.0.4
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -1591,7 +1575,7 @@ packages:
     dependencies:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.4
       tslib: 2.6.2
@@ -1605,7 +1589,7 @@ packages:
     dependencies:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.4
       tslib: 2.6.2
@@ -1620,7 +1604,7 @@ packages:
       '@azure/core-auth': 1.5.0
       '@azure/core-client': 1.7.3
       '@azure/core-paging': 1.5.0
-      '@azure/core-rest-pipeline': 1.12.0
+      '@azure/core-rest-pipeline': 1.12.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.4
       events: 3.3.0
@@ -1644,33 +1628,33 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@babel/code-frame@7.22.10:
-    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
+  /@babel/code-frame@7.22.13:
+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.10
+      '@babel/highlight': 7.22.20
       chalk: 2.4.2
     dev: false
 
-  /@babel/compat-data@7.22.9:
-    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
+  /@babel/compat-data@7.22.20:
+    resolution: {integrity: sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/core@7.22.11:
-    resolution: {integrity: sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==}
+  /@babel/core@7.22.20:
+    resolution: {integrity: sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.10
-      '@babel/generator': 7.22.10
-      '@babel/helper-compilation-targets': 7.22.10
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.11)
-      '@babel/helpers': 7.22.11
-      '@babel/parser': 7.22.11
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
-      '@babel/types': 7.22.11
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.22.15
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-module-transforms': 7.22.20(@babel/core@7.22.20)
+      '@babel/helpers': 7.22.15
+      '@babel/parser': 7.22.16
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.20
+      '@babel/types': 7.22.19
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -1680,29 +1664,29 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/generator@7.22.10:
-    resolution: {integrity: sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==}
+  /@babel/generator@7.22.15:
+    resolution: {integrity: sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.22.19
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
     dev: false
 
-  /@babel/helper-compilation-targets@7.22.10:
-    resolution: {integrity: sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==}
+  /@babel/helper-compilation-targets@7.22.15:
+    resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/helper-validator-option': 7.22.5
+      '@babel/compat-data': 7.22.20
+      '@babel/helper-validator-option': 7.22.15
       browserslist: 4.21.10
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: false
 
-  /@babel/helper-environment-visitor@7.22.5:
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+  /@babel/helper-environment-visitor@7.22.20:
+    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
     engines: {node: '>=6.9.0'}
     dev: false
 
@@ -1710,50 +1694,50 @@ packages:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.11
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.19
     dev: false
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.22.19
     dev: false
 
-  /@babel/helper-module-imports@7.22.5:
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+  /@babel/helper-module-imports@7.22.15:
+    resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.22.19
     dev: false
 
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.11):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+  /@babel/helper-module-transforms@7.22.20(@babel/core@7.22.20):
+    resolution: {integrity: sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.11
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
+      '@babel/core': 7.22.20
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
     dev: false
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.22.19
     dev: false
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.22.19
     dev: false
 
   /@babel/helper-string-parser@7.22.5:
@@ -1761,82 +1745,82 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-validator-identifier@7.22.5:
-    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-validator-option@7.22.5:
-    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
+  /@babel/helper-validator-option@7.22.15:
+    resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helpers@7.22.11:
-    resolution: {integrity: sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==}
+  /@babel/helpers@7.22.15:
+    resolution: {integrity: sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
-      '@babel/types': 7.22.11
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.22.20
+      '@babel/types': 7.22.19
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/highlight@7.22.10:
-    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
+  /@babel/highlight@7.22.20:
+    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser@7.22.11:
-    resolution: {integrity: sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==}
+  /@babel/parser@7.22.16:
+    resolution: {integrity: sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: false
 
-  /@babel/runtime@7.22.11:
-    resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
+  /@babel/runtime@7.22.15:
+    resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
     dev: false
 
-  /@babel/template@7.22.5:
-    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+  /@babel/template@7.22.15:
+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.10
-      '@babel/parser': 7.22.11
-      '@babel/types': 7.22.11
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.19
     dev: false
 
-  /@babel/traverse@7.22.11:
-    resolution: {integrity: sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==}
+  /@babel/traverse@7.22.20:
+    resolution: {integrity: sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.10
-      '@babel/generator': 7.22.10
-      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.22.15
+      '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.11
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.19
       debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/types@7.22.11:
-    resolution: {integrity: sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==}
+  /@babel/types@7.22.19:
+    resolution: {integrity: sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: false
 
@@ -1852,18 +1836,18 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: false
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.49.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.49.0
       eslint-visitor-keys: 3.4.3
     dev: false
 
-  /@eslint-community/regexpp@4.8.0:
-    resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
+  /@eslint-community/regexpp@4.8.1:
+    resolution: {integrity: sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: false
 
@@ -1874,7 +1858,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
-      globals: 13.21.0
+      globals: 13.22.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -1884,13 +1868,13 @@ packages:
       - supports-color
     dev: false
 
-  /@eslint/js@8.48.0:
-    resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
+  /@eslint/js@8.49.0:
+    resolution: {integrity: sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@humanwhocodes/config-array@0.11.10:
-    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
+  /@humanwhocodes/config-array@0.11.11:
+    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -1981,39 +1965,39 @@ packages:
       lodash: 4.17.21
     dev: false
 
-  /@microsoft/api-extractor-model@7.27.6(@types/node@14.18.56):
-    resolution: {integrity: sha512-eiCnlayyum1f7fS2nA9pfIod5VCNR1G+Tq84V/ijDrKrOFVa598BLw145nCsGDMoFenV6ajNi2PR5WCwpAxW6Q==}
+  /@microsoft/api-extractor-model@7.28.0(@types/node@14.18.62):
+    resolution: {integrity: sha512-QIMtUVm1tqiKG+M6ciFgRShcDoovyltaeg+CbyOnyr7SMrp6gg0ojK5/nToMqR9kAvsTS4QVgW4Twl50EoAjcw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@14.18.56)
+      '@rushstack/node-core-library': 3.60.0(@types/node@14.18.62)
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  /@microsoft/api-extractor-model@7.27.6(@types/node@16.18.46):
-    resolution: {integrity: sha512-eiCnlayyum1f7fS2nA9pfIod5VCNR1G+Tq84V/ijDrKrOFVa598BLw145nCsGDMoFenV6ajNi2PR5WCwpAxW6Q==}
+  /@microsoft/api-extractor-model@7.28.0(@types/node@16.18.53):
+    resolution: {integrity: sha512-QIMtUVm1tqiKG+M6ciFgRShcDoovyltaeg+CbyOnyr7SMrp6gg0ojK5/nToMqR9kAvsTS4QVgW4Twl50EoAjcw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@16.18.46)
+      '@rushstack/node-core-library': 3.60.0(@types/node@16.18.53)
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  /@microsoft/api-extractor@7.36.4(@types/node@14.18.56):
-    resolution: {integrity: sha512-21UECq8C/8CpHT23yiqTBQ10egKUacIpxkPyYR7hdswo/M5yTWdBvbq+77YC9uPKQJOUfOD1FImBQ1DzpsdeQQ==}
+  /@microsoft/api-extractor@7.37.0(@types/node@14.18.62):
+    resolution: {integrity: sha512-df/wffWpDhYRw7kzdxeHGsCpim+dC8aFiZlsJb4uFvVPWhBZpDzOhQxSUTFx3Df1ORY+/JjuPR3fDE9Hq+PHzQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.27.6(@types/node@14.18.56)
+      '@microsoft/api-extractor-model': 7.28.0(@types/node@14.18.62)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@14.18.56)
-      '@rushstack/rig-package': 0.4.1
-      '@rushstack/ts-command-line': 4.15.2
+      '@rushstack/node-core-library': 3.60.0(@types/node@14.18.62)
+      '@rushstack/rig-package': 0.5.0
+      '@rushstack/ts-command-line': 4.16.0
       colors: 1.2.5
       lodash: 4.17.21
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.0.4
@@ -2021,19 +2005,19 @@ packages:
       - '@types/node'
     dev: false
 
-  /@microsoft/api-extractor@7.36.4(@types/node@16.18.46):
-    resolution: {integrity: sha512-21UECq8C/8CpHT23yiqTBQ10egKUacIpxkPyYR7hdswo/M5yTWdBvbq+77YC9uPKQJOUfOD1FImBQ1DzpsdeQQ==}
+  /@microsoft/api-extractor@7.37.0(@types/node@16.18.53):
+    resolution: {integrity: sha512-df/wffWpDhYRw7kzdxeHGsCpim+dC8aFiZlsJb4uFvVPWhBZpDzOhQxSUTFx3Df1ORY+/JjuPR3fDE9Hq+PHzQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.27.6(@types/node@16.18.46)
+      '@microsoft/api-extractor-model': 7.28.0(@types/node@16.18.53)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@16.18.46)
-      '@rushstack/rig-package': 0.4.1
-      '@rushstack/ts-command-line': 4.15.2
+      '@rushstack/node-core-library': 3.60.0(@types/node@16.18.53)
+      '@rushstack/rig-package': 0.5.0
+      '@rushstack/ts-command-line': 4.16.0
       colors: 1.2.5
       lodash: 4.17.21
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.0.4
@@ -2436,7 +2420,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-commonjs@25.0.4(rollup@3.28.1):
+  /@rollup/plugin-commonjs@25.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-L92Vz9WUZXDnlQQl3EwbypJR4+DM2EbsO+/KOcEkP4Mc6Ct453EeDB2uH9lgRwj4w5yflgNpq9pHOiY8aoUXBQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2445,13 +2429,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
   /@rollup/plugin-inject@5.0.3(rollup@2.79.1):
@@ -2469,7 +2453,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-inject@5.0.3(rollup@3.28.1):
+  /@rollup/plugin-inject@5.0.3(rollup@3.29.2):
     resolution: {integrity: sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2478,10 +2462,10 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       estree-walker: 2.0.2
       magic-string: 0.27.0
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
   /@rollup/plugin-json@6.0.0(rollup@2.79.1):
@@ -2497,7 +2481,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-json@6.0.0(rollup@3.28.1):
+  /@rollup/plugin-json@6.0.0(rollup@3.29.2):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2506,8 +2490,8 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
-      rollup: 3.28.1
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
+      rollup: 3.29.2
     dev: false
 
   /@rollup/plugin-multi-entry@6.0.0(rollup@2.79.1):
@@ -2524,7 +2508,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-multi-entry@6.0.0(rollup@3.28.1):
+  /@rollup/plugin-multi-entry@6.0.0(rollup@3.29.2):
     resolution: {integrity: sha512-msBgVncGQwh/ahxeP/rc8MXVZNBOjoVCsBuDk6uqyFzDv/SZN7jksfAsu6DJ2w4r5PaBX3/OXOjVPeCxya2waA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2533,9 +2517,9 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/plugin-virtual': 3.0.1(rollup@3.28.1)
+      '@rollup/plugin-virtual': 3.0.1(rollup@3.29.2)
       matched: 5.0.1
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
   /@rollup/plugin-node-resolve@13.3.0(rollup@2.79.1):
@@ -2549,11 +2533,11 @@ packages:
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
-      resolve: 1.22.4
+      resolve: 1.22.6
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-node-resolve@15.2.1(rollup@3.28.1):
+  /@rollup/plugin-node-resolve@15.2.1(rollup@3.29.2):
     resolution: {integrity: sha512-nsbUg588+GDSu8/NS8T4UAshO6xeaOfINNuXeVHcKV02LJtoRaM1SiOacClw4kws1SFiNhdLGxlbMY9ga/zs/w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2562,13 +2546,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
-      resolve: 1.22.4
-      rollup: 3.28.1
+      resolve: 1.22.6
+      rollup: 3.29.2
     dev: false
 
   /@rollup/plugin-replace@5.0.2(rollup@2.79.1):
@@ -2585,7 +2569,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.28.1):
+  /@rollup/plugin-replace@5.0.2(rollup@3.29.2):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2594,12 +2578,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       magic-string: 0.27.0
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.28.1)(tslib@2.6.2)(typescript@5.0.4):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.0.4):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2612,9 +2596,9 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
-      resolve: 1.22.4
-      rollup: 3.28.1
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
+      resolve: 1.22.6
+      rollup: 3.29.2
       tslib: 2.6.2
       typescript: 5.0.4
     dev: false
@@ -2631,7 +2615,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-virtual@3.0.1(rollup@3.28.1):
+  /@rollup/plugin-virtual@3.0.1(rollup@3.29.2):
     resolution: {integrity: sha512-fK8O0IL5+q+GrsMLuACVNk2x21g3yaw+sG2qn16SnUd3IlBsQyvWxLMGHmCmXRMecPjGRSZ/1LmZB4rjQm68og==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2640,7 +2624,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
   /@rollup/pluginutils@3.1.0(rollup@2.79.1):
@@ -2670,7 +2654,7 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/pluginutils@5.0.4(rollup@3.28.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2682,54 +2666,54 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.28.1
+      rollup: 3.29.2
     dev: false
 
-  /@rushstack/node-core-library@3.59.7(@types/node@14.18.56):
-    resolution: {integrity: sha512-ln1Drq0h+Hwa1JVA65x5mlSgUrBa1uHL+V89FqVWQgXd1vVIMhrtqtWGQrhTnFHxru5ppX+FY39VWELF/FjQCw==}
+  /@rushstack/node-core-library@3.60.0(@types/node@14.18.62):
+    resolution: {integrity: sha512-PcyrqhILvzU+65wMFybQ2VeGNnU5JzhDq2OvUi3j6jPUxyllM7b2hrRUwCuVaYboewYzIbpzXFzgxe2K7ii1nw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 7.5.4
       z-schema: 5.0.5
     dev: false
 
-  /@rushstack/node-core-library@3.59.7(@types/node@16.18.46):
-    resolution: {integrity: sha512-ln1Drq0h+Hwa1JVA65x5mlSgUrBa1uHL+V89FqVWQgXd1vVIMhrtqtWGQrhTnFHxru5ppX+FY39VWELF/FjQCw==}
+  /@rushstack/node-core-library@3.60.0(@types/node@16.18.53):
+    resolution: {integrity: sha512-PcyrqhILvzU+65wMFybQ2VeGNnU5JzhDq2OvUi3j6jPUxyllM7b2hrRUwCuVaYboewYzIbpzXFzgxe2K7ii1nw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 16.18.53
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 7.5.4
       z-schema: 5.0.5
     dev: false
 
-  /@rushstack/rig-package@0.4.1:
-    resolution: {integrity: sha512-AGRwpqlXNSp9LhUSz4HKI9xCluqQDt/obsQFdv/NYIekF3pTTPzc+HbQsIsjVjYnJ3DcmxOREVMhvrMEjpiq6g==}
+  /@rushstack/rig-package@0.5.0:
+    resolution: {integrity: sha512-bGnOW4DWHOePDiABKy6qyqYJl9i7fKn4bRucExRVt5QzyPxuVHMl8CMmCabtoNSpXzgG3qymWOrMoa/W2PpJrw==}
     dependencies:
-      resolve: 1.22.4
+      resolve: 1.22.6
       strip-json-comments: 3.1.1
     dev: false
 
-  /@rushstack/ts-command-line@4.15.2:
-    resolution: {integrity: sha512-5+C2uoJY8b+odcZD6coEe2XNC4ZjGB4vCMESbqW/8DHRWC/qIHfANdmN9F1wz/lAgxz72i7xRoVtPY2j7e4gpQ==}
+  /@rushstack/ts-command-line@4.16.0:
+    resolution: {integrity: sha512-WJKhdR9ThK9Iy7t78O3at7I3X4Ssp5RRZay/IQa8NywqkFy/DQbT3iLouodMMdUwLZD9n8n++xLubVd3dkmpkg==}
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10
@@ -2807,13 +2791,6 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: false
 
-  /@types/ajv@1.0.0:
-    resolution: {integrity: sha512-yGSqw9/QKd5FXbTNrSANcJ6IHWeNhA+gokXqmlPquJgLDC87d4g2FGPs+AlCeGG0GuZXmPq42hOFA2hnPymCLw==}
-    deprecated: This is a stub types definition for ajv (https://github.com/epoberezkin/ajv). ajv provides its own type definitions, so you don't need @types/ajv installed!
-    dependencies:
-      ajv: 8.12.0
-    dev: false
-
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: false
@@ -2822,21 +2799,21 @@ packages:
     resolution: {integrity: sha512-2+rYSaWrpdbQG3SA0LmMT6YxWLrI81AqpMlSkw3QtFc2HGDufkweQSn30Eiev7x9LL0oyFrBqk1PXOnB9IEgKg==}
     dev: false
 
-  /@types/body-parser@1.19.2:
-    resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
+  /@types/body-parser@1.19.3:
+    resolution: {integrity: sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==}
     dependencies:
-      '@types/connect': 3.4.35
-      '@types/node': 16.18.46
+      '@types/connect': 3.4.36
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/chai-as-promised@7.1.5:
-    resolution: {integrity: sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==}
+  /@types/chai-as-promised@7.1.6:
+    resolution: {integrity: sha512-cQLhk8fFarRVZAXUQV1xEnZgMoPxqKojBvRkqPCKPQCzEhpbbSKl1Uu75kDng7k5Ln6LQLUmNBjLlFthCgm1NA==}
     dependencies:
       '@types/chai': 4.3.6
     dev: false
 
-  /@types/chai-string@1.4.2:
-    resolution: {integrity: sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==}
+  /@types/chai-string@1.4.3:
+    resolution: {integrity: sha512-bLp5xMQ7Ml0fWa05IPpLjIznTkNbuBE3GtRTzKrp0d10IavlBFcu9vXP2liWaXta79unO693q3kuRxD7g2YYGw==}
     dependencies:
       '@types/chai': 4.3.6
     dev: false
@@ -2845,20 +2822,20 @@ packages:
     resolution: {integrity: sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==}
     dev: false
 
-  /@types/connect@3.4.35:
-    resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
+  /@types/connect@3.4.36:
+    resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: false
 
-  /@types/cors@2.8.13:
-    resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
+  /@types/cors@2.8.14:
+    resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/debug@4.1.8:
@@ -2870,14 +2847,14 @@ packages:
   /@types/decompress@4.2.4:
     resolution: {integrity: sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/eslint@8.4.10:
     resolution: {integrity: sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==}
     dependencies:
       '@types/estree': 1.0.1
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.13
     dev: false
 
   /@types/estree@0.0.39:
@@ -2891,8 +2868,8 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 16.18.46
-      '@types/qs': 6.9.7
+      '@types/node': 14.18.62
+      '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
     dev: false
@@ -2900,76 +2877,76 @@ packages:
   /@types/express@4.17.17:
     resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
     dependencies:
-      '@types/body-parser': 1.19.2
+      '@types/body-parser': 1.19.3
       '@types/express-serve-static-core': 4.17.36
-      '@types/qs': 6.9.7
+      '@types/qs': 6.9.8
       '@types/serve-static': 1.15.2
     dev: false
 
-  /@types/fs-extra@8.1.2:
-    resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
+  /@types/fs-extra@8.1.3:
+    resolution: {integrity: sha512-7IdV01N0u/CaVO0fuY1YmEg14HQN3+EW8mpNgg6NEfxEl/lzCa5OxlBu3iFsCAdamnYOcTQ7oEi43Xc/67Rgzw==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/http-errors@2.0.1:
-    resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
+  /@types/http-errors@2.0.2:
+    resolution: {integrity: sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==}
     dev: false
 
   /@types/inquirer@8.2.6:
     resolution: {integrity: sha512-3uT88kxg8lNzY8ay2ZjP44DKcRaTGztqeIvN2zHvhzIBH/uAPaL75aBtdNRKbA7xXoMbBt5kX0M00VKAnfOYlA==}
     dependencies:
-      '@types/through': 0.0.30
+      '@types/through': 0.0.31
       rxjs: 7.8.1
     dev: false
 
   /@types/is-buffer@2.0.0:
     resolution: {integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/json-schema@7.0.12:
-    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
+  /@types/json-schema@7.0.13:
+    resolution: {integrity: sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==}
     dev: false
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
 
-  /@types/jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
+  /@types/jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-b0jGiOgHtZ2jqdPgPnP6WLCXZk1T8p06A/vPGzUvxpFGgKMbjXJDjC5m52ErqBnIuWZFgGoIJyRdeG5AyreJjA==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/jws@3.2.5:
-    resolution: {integrity: sha512-xGTxZH34xOryaTN8CMsvhh9lfNqFuHiMoRvsLYWQdBJHqiECyfInXVl2eK8Jz2emxZWMIn5RBlmr3oDVPeWujw==}
+  /@types/jws@3.2.6:
+    resolution: {integrity: sha512-SVbs88FPvGVMj19JYVOV+NpWu3HO5LUjz0+z6ks/rdRbrWlxs6fBz6Qxb/PKalZaweJisPyfikeoPu8VlpljQQ==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/linkify-it@3.0.2:
-    resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
+  /@types/linkify-it@3.0.3:
+    resolution: {integrity: sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g==}
     dev: false
 
   /@types/markdown-it@12.2.3:
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
     dependencies:
-      '@types/linkify-it': 3.0.2
+      '@types/linkify-it': 3.0.3
       '@types/mdurl': 1.0.2
     dev: false
 
   /@types/mdast@3.0.12:
     resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: false
 
   /@types/mdurl@1.0.2:
@@ -3003,22 +2980,22 @@ packages:
   /@types/mysql@2.15.21:
     resolution: {integrity: sha512-NPotx5CVful7yB+qZbWtXL2fA4e7aEHkihHLjklc6ID8aq7bhguHgeIoC1EmSNTAuCgI6ZXrjt2ZSaXnYX0EUg==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/node-fetch@2.6.4:
-    resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
+  /@types/node-fetch@2.6.5:
+    resolution: {integrity: sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==}
     dependencies:
-      '@types/node': 16.18.46
-      form-data: 3.0.1
+      '@types/node': 14.18.62
+      form-data: 4.0.0
     dev: false
 
-  /@types/node@14.18.56:
-    resolution: {integrity: sha512-+k+57NVS9opgrEn5l9c0gvD1r6C+PtyhVE4BTnMMRwiEA8ZO8uFcs6Yy2sXIy0eC95ZurBtRSvhZiHXBysbl6w==}
+  /@types/node@14.18.62:
+    resolution: {integrity: sha512-53Fhb08qfKwSNCIUtysIqw0ye+v1d5QCdL2kl8liKQFlOZTAo+nEYr/FztzMaHBFwB5H0ugF0PF0gmtojaNNiQ==}
     dev: false
 
-  /@types/node@16.18.46:
-    resolution: {integrity: sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==}
+  /@types/node@16.18.53:
+    resolution: {integrity: sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==}
     dev: false
 
   /@types/pako@2.0.0:
@@ -3034,7 +3011,7 @@ packages:
   /@types/pg@8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
       pg-protocol: 1.6.0
       pg-types: 2.2.0
     dev: false
@@ -3051,8 +3028,8 @@ packages:
     resolution: {integrity: sha512-rt2GvuoXcYb+R4X8SF4jlTSXDWoUmkZf7OB8iTRRfE5dmqHn47rY8CRIEPDD5lY28cU86+xXYQ5RsXq/9nydvQ==}
     dev: false
 
-  /@types/qs@6.9.7:
-    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
+  /@types/qs@6.9.8:
+    resolution: {integrity: sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==}
     dev: false
 
   /@types/range-parser@1.2.4:
@@ -3062,7 +3039,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/resolve@1.20.2:
@@ -3077,23 +3054,23 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: false
 
-  /@types/semver@7.5.0:
-    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+  /@types/semver@7.5.2:
+    resolution: {integrity: sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==}
     dev: false
 
   /@types/send@0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/serve-static@1.15.2:
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
     dependencies:
-      '@types/http-errors': 2.0.1
+      '@types/http-errors': 2.0.2
       '@types/mime': 3.0.1
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/shimmer@1.0.2:
@@ -3113,35 +3090,35 @@ packages:
   /@types/stoppable@1.1.1:
     resolution: {integrity: sha512-b8N+fCADRIYYrGZOcmOR8ZNBOqhktWTB/bMUl5LvGtT201QKJZOOH5UsFyI3qtteM6ZAJbJqZoBcLqqxKIwjhw==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/through@0.0.30:
-    resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
+  /@types/through@0.0.31:
+    resolution: {integrity: sha512-LpKpmb7FGevYgXnBXYs6HWnmiFyVG07Pt1cnbgM1IhEacITTiUaBXXvOR3Y50ksaJWGSfhbEvQFivQEFGCC55w==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/tough-cookie@4.0.2:
-    resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
+  /@types/tough-cookie@4.0.3:
+    resolution: {integrity: sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==}
     dev: false
 
-  /@types/trusted-types@2.0.3:
-    resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
+  /@types/trusted-types@2.0.4:
+    resolution: {integrity: sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==}
     dev: false
 
   /@types/tunnel@0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/underscore@1.11.8:
-    resolution: {integrity: sha512-p6xsoGDciPWrMc5EgyYwPdluONx1dXiXAZ+CqfGMJfsGcm+VkSLS8fP7I1DWGa3uRo9o2E6mAgBAXpWQAhk8jg==}
+  /@types/underscore@1.11.9:
+    resolution: {integrity: sha512-M63wKUdsjDFUfyFt1TCUZHGFk9KDAa5JP0adNUErbm0U45Lr06HtANdYRP+GyleEopEoZ4UyBcdAC5TnW4Uz2w==}
     dev: false
 
-  /@types/unist@2.0.7:
-    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
+  /@types/unist@2.0.8:
+    resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
     dev: false
 
   /@types/uuid@8.3.4:
@@ -3151,19 +3128,19 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
-  /@types/xml2js@0.4.11:
-    resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
+  /@types/xml2js@0.4.12:
+    resolution: {integrity: sha512-CZPpQKBZ8db66EP5hCjwvYrLThgZvnyZrPXK2W+UI1oOaWezGt34iOaUCX4Jah2X8+rQqjvl9VKEIT8TR1I0rA==}
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
 
   /@types/yargs-parser@21.0.0:
@@ -3180,11 +3157,11 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.48.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.49.0)(typescript@5.0.4):
     resolution: {integrity: sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3195,13 +3172,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.8.0
-      '@typescript-eslint/parser': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
+      '@eslint-community/regexpp': 4.8.1
+      '@typescript-eslint/parser': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.57.1
-      '@typescript-eslint/type-utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.48.0
+      eslint: 8.49.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -3212,20 +3189,20 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils@5.57.1(eslint@8.48.0)(typescript@5.0.4):
+  /@typescript-eslint/experimental-utils@5.57.1(eslint@8.49.0)(typescript@5.0.4):
     resolution: {integrity: sha512-5F5s8mpM1Y0RQ5iWzKQPQm5cmhARgcMfUwyHX1ZZFL8Tm0PyzyQ+9jgYSMaW74XXvpDg9/KdmMICLlwNwKtO7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      eslint: 8.48.0
+      '@typescript-eslint/utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
+      eslint: 8.49.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser@5.57.1(eslint@8.48.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.57.1(eslint@8.49.0)(typescript@5.0.4):
     resolution: {integrity: sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3239,7 +3216,7 @@ packages:
       '@typescript-eslint/types': 5.57.1
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.48.0
+      eslint: 8.49.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -3253,7 +3230,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.57.1
     dev: false
 
-  /@typescript-eslint/type-utils@5.57.1(eslint@8.48.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.57.1(eslint@8.49.0)(typescript@5.0.4):
     resolution: {integrity: sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3264,9 +3241,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.48.0
+      eslint: 8.49.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -3299,19 +3276,19 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.57.1(eslint@8.48.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.57.1(eslint@8.49.0)(typescript@5.0.4):
     resolution: {integrity: sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
+      '@types/json-schema': 7.0.13
+      '@types/semver': 7.5.2
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
-      eslint: 8.48.0
+      eslint: 8.49.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3497,13 +3474,13 @@ packages:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: false
 
-  /array-includes@3.1.6:
-    resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==}
+  /array-includes@3.1.7:
+    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       get-intrinsic: 1.2.1
       is-string: 1.0.7
     dev: false
@@ -3513,55 +3490,56 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /array.prototype.findlastindex@1.2.2:
-    resolution: {integrity: sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==}
+  /array.prototype.findlastindex@1.2.3:
+    resolution: {integrity: sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.1
     dev: false
 
-  /array.prototype.flat@1.3.1:
-    resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
+  /array.prototype.flat@1.3.2:
+    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
     dev: false
 
-  /array.prototype.flatmap@1.3.1:
-    resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
+  /array.prototype.flatmap@1.3.2:
+    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
     dev: false
 
-  /array.prototype.reduce@1.0.5:
-    resolution: {integrity: sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==}
+  /array.prototype.reduce@1.0.6:
+    resolution: {integrity: sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       es-array-method-boxes-properly: 1.0.0
       is-string: 1.0.7
     dev: false
 
-  /arraybuffer.prototype.slice@1.0.1:
-    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
+  /arraybuffer.prototype.slice@1.0.2:
+    resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       get-intrinsic: 1.2.1
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
@@ -3605,7 +3583,7 @@ packages:
   /axios@1.5.0:
     resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.3(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -3714,10 +3692,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001524
-      electron-to-chromium: 1.4.503
+      caniuse-lite: 1.0.30001538
+      electron-to-chromium: 1.4.526
       node-releases: 2.0.13
-      update-browserslist-db: 1.0.11(browserslist@4.21.10)
+      update-browserslist-db: 1.0.12(browserslist@4.21.10)
     dev: false
 
   /buffer-alloc-unsafe@1.1.0:
@@ -3810,8 +3788,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /caniuse-lite@1.0.30001524:
-    resolution: {integrity: sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==}
+  /caniuse-lite@1.0.30001538:
+    resolution: {integrity: sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==}
     dev: false
 
   /catharsis@0.9.0:
@@ -3960,8 +3938,8 @@ packages:
       restore-cursor: 3.1.0
     dev: false
 
-  /cli-spinners@2.9.0:
-    resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
+  /cli-spinners@2.9.1:
+    resolution: {integrity: sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==}
     engines: {node: '>=6'}
     dev: false
 
@@ -4133,8 +4111,8 @@ packages:
       yargs: 16.2.0
     dev: false
 
-  /core-js@3.32.1:
-    resolution: {integrity: sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==}
+  /core-js@3.32.2:
+    resolution: {integrity: sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==}
     requiresBuild: true
     dev: false
 
@@ -4216,7 +4194,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.22.15
     dev: false
 
   /date-format@4.0.14:
@@ -4224,8 +4202,8 @@ packages:
     engines: {node: '>=4.0'}
     dev: false
 
-  /dayjs@1.11.9:
-    resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
+  /dayjs@1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
     dev: false
 
   /debug@2.6.9:
@@ -4238,7 +4216,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.1
     dev: false
 
   /debug@3.2.7:
@@ -4369,15 +4347,25 @@ packages:
       clone: 1.0.4
     dev: false
 
+  /define-data-property@1.1.0:
+    resolution: {integrity: sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.1
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.0
+    dev: false
+
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
     dev: false
 
-  /define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
+  /define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
+      define-data-property: 1.1.0
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: false
@@ -4487,10 +4475,6 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: false
 
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: false
-
   /ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
@@ -4505,8 +4489,8 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
-  /electron-to-chromium@1.4.503:
-    resolution: {integrity: sha512-LF2IQit4B0VrUHFeQkWhZm97KuJSGF2WJqq1InpY+ECpFRkXd8yTIaTtJxsO0OKDmiBYwWqcrNaXOurn2T2wiA==}
+  /electron-to-chromium@1.4.526:
+    resolution: {integrity: sha512-tjjTMjmZAx1g6COrintLTa2/jcafYKxKoiEkdQOrVdbLaHh2wCt2nsAF8ZHweezkrP+dl/VG9T5nabcYoo0U5Q==}
     dev: false
 
   /emoji-regex@7.0.3:
@@ -4542,8 +4526,8 @@ packages:
     engines: {node: '>=10.2.0'}
     dependencies:
       '@types/cookie': 0.4.1
-      '@types/cors': 2.8.13
-      '@types/node': 16.18.46
+      '@types/cors': 2.8.14
+      '@types/node': 14.18.62
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -4576,17 +4560,17 @@ packages:
       is-arrayish: 0.2.1
     dev: false
 
-  /es-abstract@1.22.1:
-    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
+  /es-abstract@1.22.2:
+    resolution: {integrity: sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      arraybuffer.prototype.slice: 1.0.1
+      arraybuffer.prototype.slice: 1.0.2
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.5
+      function.prototype.name: 1.1.6
       get-intrinsic: 1.2.1
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
@@ -4607,12 +4591,12 @@ packages:
       object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.0
-      safe-array-concat: 1.0.0
+      regexp.prototype.flags: 1.5.1
+      safe-array-concat: 1.0.1
       safe-regex-test: 1.0.0
-      string.prototype.trim: 1.2.7
-      string.prototype.trimend: 1.0.6
-      string.prototype.trimstart: 1.0.6
+      string.prototype.trim: 1.2.8
+      string.prototype.trimend: 1.0.7
+      string.prototype.trimstart: 1.0.7
       typed-array-buffer: 1.0.0
       typed-array-byte-length: 1.0.0
       typed-array-byte-offset: 1.0.0
@@ -4694,13 +4678,13 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@9.0.0(eslint@8.48.0):
+  /eslint-config-prettier@9.0.0(eslint@8.49.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.49.0
     dev: false
 
   /eslint-import-resolver-node@0.3.9:
@@ -4708,10 +4692,10 @@ packages:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.13.0
-      resolve: 1.22.4
+      resolve: 1.22.6
     dev: false
 
-  /eslint-module-utils@2.8.0(eslint@8.48.0):
+  /eslint-module-utils@2.8.0(eslint@8.49.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4721,53 +4705,53 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.48.0
+      eslint: 8.49.0
     dev: false
 
-  /eslint-plugin-es@3.0.1(eslint@8.48.0):
+  /eslint-plugin-es@3.0.1(eslint@8.49.0):
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.49.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import@2.28.1(eslint@8.48.0):
+  /eslint-plugin-import@2.28.1(eslint@8.49.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
     dependencies:
-      array-includes: 3.1.6
-      array.prototype.findlastindex: 1.2.2
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
+      array-includes: 3.1.7
+      array.prototype.findlastindex: 1.2.3
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.48.0
+      eslint: 8.49.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(eslint@8.48.0)
+      eslint-module-utils: 2.8.0(eslint@8.49.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
       minimatch: 3.1.2
-      object.fromentries: 2.0.6
-      object.groupby: 1.0.0
+      object.fromentries: 2.0.7
+      object.groupby: 1.0.1
       object.values: 1.1.7
       semver: 6.3.1
       tsconfig-paths: 3.14.2
     dev: false
 
-  /eslint-plugin-markdown@3.0.1(eslint@8.48.0):
+  /eslint-plugin-markdown@3.0.1(eslint@8.49.0):
     resolution: {integrity: sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.49.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
@@ -4778,28 +4762,28 @@ packages:
     engines: {node: '>=5.0.0'}
     dev: false
 
-  /eslint-plugin-node@11.1.0(eslint@8.48.0):
+  /eslint-plugin-node@11.1.0(eslint@8.49.0):
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.48.0
-      eslint-plugin-es: 3.0.1(eslint@8.48.0)
+      eslint: 8.49.0
+      eslint-plugin-es: 3.0.1(eslint@8.49.0)
       eslint-utils: 2.1.0
       ignore: 5.2.4
       minimatch: 3.1.2
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 6.3.1
     dev: false
 
-  /eslint-plugin-promise@6.1.1(eslint@8.48.0):
+  /eslint-plugin-promise@6.1.1(eslint@8.49.0):
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.49.0
     dev: false
 
   /eslint-plugin-tsdoc@0.2.17:
@@ -4842,16 +4826,16 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /eslint@8.48.0:
-    resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
+  /eslint@8.49.0:
+    resolution: {integrity: sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
-      '@eslint-community/regexpp': 4.8.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
+      '@eslint-community/regexpp': 4.8.1
       '@eslint/eslintrc': 2.1.2
-      '@eslint/js': 8.48.0
-      '@humanwhocodes/config-array': 0.11.10
+      '@eslint/js': 8.49.0
+      '@humanwhocodes/config-array': 0.11.11
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -4869,7 +4853,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.21.0
+      globals: 13.22.0
       graphemer: 1.4.0
       ignore: 5.2.4
       imurmurhash: 0.1.4
@@ -5081,8 +5065,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: false
 
-  /fast-xml-parser@4.2.7:
-    resolution: {integrity: sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==}
+  /fast-xml-parser@4.3.0:
+    resolution: {integrity: sha512-5Wln/SBrtlN37aboiNNFHfSALwLzpUx1vJhDgDVPKKG3JrNe8BWTUoNKqkeKk/HqNbKxC8nEAJaBydq30yHoLA==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -5113,9 +5097,9 @@ packages:
       node-fetch:
         optional: true
     dependencies:
-      '@babel/core': 7.22.11
-      '@babel/runtime': 7.22.11
-      core-js: 3.32.1
+      '@babel/core': 7.22.20
+      '@babel/runtime': 7.22.15
+      core-js: 3.32.2
       debug: 4.3.4(supports-color@8.1.1)
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
@@ -5226,7 +5210,7 @@ packages:
     resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      flatted: 3.2.7
+      flatted: 3.2.9
       keyv: 4.5.3
       rimraf: 3.0.2
     dev: false
@@ -5243,12 +5227,12 @@ packages:
     hasBin: true
     dev: false
 
-  /flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+  /flatted@3.2.9:
+    resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: false
 
-  /follow-redirects@1.15.2(debug@4.3.4):
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+  /follow-redirects@1.15.3(debug@4.3.4):
+    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5283,15 +5267,6 @@ packages:
 
   /form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-    dev: false
-
-  /form-data@3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
     dev: false
 
   /form-data@4.0.0:
@@ -5390,13 +5365,13 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: false
 
-  /function.prototype.name@1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+  /function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       functions-have-names: 1.2.3
     dev: false
 
@@ -5482,8 +5457,8 @@ packages:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: false
 
-  /glob@10.3.4:
-    resolution: {integrity: sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==}
+  /glob@10.3.5:
+    resolution: {integrity: sha512-bYUpUD7XDEHI4Q2O5a7PXGvyw4deKR70kHiDxzQbe925wbZknhOzUt2xBgTkYL6RBcVeXYuD9iNYeqoWbBZQnA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
     dependencies:
@@ -5500,7 +5475,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -5560,8 +5535,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /globals@13.21.0:
-    resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
+  /globals@13.22.0:
+    resolution: {integrity: sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -5571,7 +5546,7 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
     dev: false
 
   /globby@11.1.0:
@@ -5705,7 +5680,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.3(debug@4.3.4)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -6134,7 +6109,7 @@ packages:
     resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.22.11
+      '@babel/core': 7.22.20
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -6146,8 +6121,8 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.22.11
-      '@babel/parser': 7.22.11
+      '@babel/core': 7.22.20
+      '@babel/parser': 7.22.16
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -6250,7 +6225,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.16
       '@jsdoc/salty': 0.2.5
       '@types/markdown-it': 12.2.3
       bluebird: 3.7.2
@@ -6332,12 +6307,18 @@ packages:
       graceful-fs: 4.2.11
     dev: false
 
-  /jsonwebtoken@9.0.1:
-    resolution: {integrity: sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==}
+  /jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
     dependencies:
       jws: 3.2.2
-      lodash: 4.17.21
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.5.4
     dev: false
@@ -6535,7 +6516,7 @@ packages:
       socket.io: 4.7.2
       source-map: 0.6.1
       tmp: 0.2.1
-      ua-parser-js: 0.7.35
+      ua-parser-js: 0.7.36
       yargs: 16.2.0
     transitivePeerDependencies:
       - bufferutil
@@ -6630,12 +6611,40 @@ packages:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: false
 
+  /lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+    dev: false
+
+  /lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+    dev: false
+
   /lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     dev: false
 
+  /lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+    dev: false
+
+  /lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+    dev: false
+
+  /lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+    dev: false
+
+  /lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: false
+
+  /lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
     dev: false
 
   /lodash.sortby@4.7.0:
@@ -6674,7 +6683,7 @@ packages:
     dependencies:
       date-format: 4.0.14
       debug: 4.3.4(supports-color@8.1.1)
-      flatted: 3.2.7
+      flatted: 3.2.9
       rfdc: 1.3.0
       streamroller: 3.1.5
     transitivePeerDependencies:
@@ -7053,11 +7062,6 @@ packages:
       - supports-color
     dev: false
 
-  /mocha-testdata@1.2.0:
-    resolution: {integrity: sha512-mBxVCUbfyhWRT/QFgEfBtmeQ2I7LYKnBWuTVYKAUoZois8wYUm6EUTUhPxAYa4LOh/SaK0neRSdevH62Ov6N8w==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dev: false
-
   /mocha@10.2.0:
     resolution: {integrity: sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==}
     engines: {node: '>= 14.0.0'}
@@ -7117,8 +7121,8 @@ packages:
       yargs-unparser: 1.6.0
     dev: false
 
-  /mock-socket@9.2.1:
-    resolution: {integrity: sha512-aw9F9T9G2zpGipLLhSNh6ZpgUyUl4frcVmRN08uE1NWPWg43Wx6+sGPDbQ7E5iFZZDJW5b5bypMeAEHqTbIFag==}
+  /mock-socket@9.3.1:
+    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
     engines: {node: '>= 8'}
     dev: false
 
@@ -7235,7 +7239,7 @@ packages:
   /node-environment-flags@1.0.6:
     resolution: {integrity: sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==}
     dependencies:
-      object.getownpropertydescriptors: 2.1.6
+      object.getownpropertydescriptors: 2.1.7
       semver: 5.7.2
     dev: false
 
@@ -7285,7 +7289,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.4
+      resolve: 1.22.6
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: false
@@ -7308,7 +7312,7 @@ packages:
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.1
-      string.prototype.padend: 3.1.4
+      string.prototype.padend: 3.1.5
     dev: false
 
   /npm-run-path@4.0.1:
@@ -7379,7 +7383,7 @@ packages:
     resolution: {integrity: sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       function-bind: 1.1.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
@@ -7390,37 +7394,37 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: false
 
-  /object.fromentries@2.0.6:
-    resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
+  /object.fromentries@2.0.7:
+    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
-  /object.getownpropertydescriptors@2.1.6:
-    resolution: {integrity: sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==}
+  /object.getownpropertydescriptors@2.1.7:
+    resolution: {integrity: sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==}
     engines: {node: '>= 0.8'}
     dependencies:
-      array.prototype.reduce: 1.0.5
+      array.prototype.reduce: 1.0.6
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      safe-array-concat: 1.0.0
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
+      safe-array-concat: 1.0.1
     dev: false
 
-  /object.groupby@1.0.0:
-    resolution: {integrity: sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==}
+  /object.groupby@1.0.1:
+    resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
       get-intrinsic: 1.2.1
     dev: false
 
@@ -7429,8 +7433,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
   /on-finished@2.3.0:
@@ -7507,7 +7511,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.9.0
+      cli-spinners: 2.9.1
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -7611,7 +7615,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.10
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -7902,7 +7906,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 16.18.46
+      '@types/node': 14.18.62
       long: 5.2.3
     dev: false
 
@@ -8115,7 +8119,7 @@ packages:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
     dependencies:
-      resolve: 1.22.4
+      resolve: 1.22.6
     dev: false
 
   /regenerator-runtime@0.13.11:
@@ -8126,13 +8130,13 @@ packages:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: false
 
-  /regexp.prototype.flags@1.5.0:
-    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
+  /regexp.prototype.flags@1.5.1:
+    resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      functions-have-names: 1.2.3
+      define-properties: 1.2.1
+      set-function-name: 2.0.1
     dev: false
 
   /regexpp@3.2.0:
@@ -8163,7 +8167,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       module-details-from-path: 1.0.3
-      resolve: 1.22.4
+      resolve: 1.22.6
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8205,8 +8209,8 @@ packages:
       path-parse: 1.0.7
     dev: false
 
-  /resolve@1.22.4:
-    resolution: {integrity: sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==}
+  /resolve@1.22.6:
+    resolution: {integrity: sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==}
     hasBin: true
     dependencies:
       is-core-module: 2.13.0
@@ -8261,7 +8265,7 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      glob: 10.3.4
+      glob: 10.3.5
     dev: false
 
   /rollup-plugin-polyfill-node@0.12.0(rollup@2.79.1):
@@ -8277,7 +8281,7 @@ packages:
     resolution: {integrity: sha512-rZqFD43y4U9nSqVq3iyWBiDwmBQJY8Txi04yI9jTKD3xcl7CbFjh1qRpQshUB3sONLubDzm7vJiwB+1MEGv67w==}
     dev: false
 
-  /rollup-plugin-sourcemaps@0.6.3(@types/node@14.18.56)(rollup@2.79.1):
+  /rollup-plugin-sourcemaps@0.6.3(@types/node@14.18.62)(rollup@2.79.1):
     resolution: {integrity: sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -8288,7 +8292,7 @@ packages:
         optional: true
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       rollup: 2.79.1
       source-map-resolve: 0.6.0
     dev: false
@@ -8318,8 +8322,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /rollup@3.28.1:
-    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8343,8 +8347,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /safe-array-concat@1.0.0:
-    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
+  /safe-array-concat@1.0.1:
+    resolution: {integrity: sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==}
     engines: {node: '>=0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -8444,6 +8448,15 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: false
+
+  /set-function-name@2.0.1:
+    resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.0
     dev: false
 
   /setprototypeof@1.2.0:
@@ -8627,7 +8640,7 @@ packages:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.15
     dev: false
 
   /spdx-exceptions@2.3.0:
@@ -8638,11 +8651,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.15
     dev: false
 
-  /spdx-license-ids@3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+  /spdx-license-ids@3.0.15:
+    resolution: {integrity: sha512-lpT8hSQp9jAKp9mhtBU4Xjon8LPGBvLIuBiSVhMEtmLecTh2mO0tlqrAMp47tBXzMr13NJMQ2lf7RpQGLJ3HsQ==}
     dev: false
 
   /sprintf-js@1.0.3:
@@ -8720,38 +8733,38 @@ packages:
       strip-ansi: 7.1.0
     dev: false
 
-  /string.prototype.padend@3.1.4:
-    resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
+  /string.prototype.padend@3.1.5:
+    resolution: {integrity: sha512-DOB27b/2UTTD+4myKUFh+/fXWcu/UDyASIXfg+7VzoCNNGOfWvoyU/x5pvVHr++ztyt/oSYI1BcWBBG/hmlNjA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
-  /string.prototype.trim@1.2.7:
-    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
+  /string.prototype.trim@1.2.8:
+    resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
-  /string.prototype.trimend@1.0.6:
-    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
+  /string.prototype.trimend@1.0.7:
+    resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
-  /string.prototype.trimstart@1.0.6:
-    resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
+  /string.prototype.trimstart@1.0.7:
+    resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.2.1
+      es-abstract: 1.22.2
     dev: false
 
   /string_decoder@0.10.31:
@@ -9000,7 +9013,7 @@ packages:
       code-block-writer: 12.0.0
     dev: false
 
-  /ts-node@10.9.1(@types/node@14.18.56)(typescript@5.0.4):
+  /ts-node@10.9.1(@types/node@14.18.62)(typescript@5.0.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -9019,7 +9032,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -9031,7 +9044,7 @@ packages:
       yn: 3.1.1
     dev: false
 
-  /ts-node@10.9.1(@types/node@16.18.46)(typescript@5.0.4):
+  /ts-node@10.9.1(@types/node@16.18.53)(typescript@5.0.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -9050,7 +9063,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 16.18.46
+      '@types/node': 16.18.53
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -9210,8 +9223,8 @@ packages:
     hasBin: true
     dev: false
 
-  /ua-parser-js@0.7.35:
-    resolution: {integrity: sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==}
+  /ua-parser-js@0.7.36:
+    resolution: {integrity: sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==}
     dev: false
 
   /uc.micro@1.0.6:
@@ -9244,8 +9257,8 @@ packages:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
     dev: false
 
-  /undici@5.23.0:
-    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
+  /undici@5.25.1:
+    resolution: {integrity: sha512-nTw6b2G2OqP6btYPyghCgV4hSwjJlL/78FMJatVLCa3otj6PCOQSt6dVtYt82OtNqFz8XsnJ+vsXLADPXjPhqw==}
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
@@ -9254,7 +9267,7 @@ packages:
   /unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: false
 
   /universal-user-agent@6.0.0:
@@ -9286,8 +9299,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /update-browserslist-db@1.0.11(browserslist@4.21.10):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+  /update-browserslist-db@1.0.12(browserslist@4.21.10):
+    resolution: {integrity: sha512-tE1smlR58jxbFMtrMpFNRmsrOXlpNXss965T1CrpwuZUzUAg/TBQc94SpyhDLSzrqrJS9xTRBthnZAGcE1oaxg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -9310,8 +9323,8 @@ packages:
       requires-port: 1.0.0
     dev: false
 
-  /url@0.11.1:
-    resolution: {integrity: sha512-rWS3H04/+mzzJkv0eZ7vEDGiQbgquI1fGfOad6zKvgYQi1SzMmhl7c/DdRGxhaWrVH6z0qWITo8rpnxK/RfEhA==}
+  /url@0.11.3:
+    resolution: {integrity: sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==}
     dependencies:
       punycode: 1.4.1
       qs: 6.11.2
@@ -9341,8 +9354,8 @@ packages:
     hasBin: true
     dev: false
 
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 
@@ -9549,11 +9562,24 @@ packages:
         optional: true
     dev: false
 
+  /ws@8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /xhr-mock@2.5.1:
     resolution: {integrity: sha512-UKOjItqjFgPUwQGPmRAzNBn8eTfIhcGjBVGvKYAWxUQPQsXNGD6KEckGTiHwyaAUp9C9igQlnN1Mp79KWCg7CQ==}
     dependencies:
       global: 4.4.0
-      url: 0.11.1
+      url: 0.11.3
     dev: false
 
   /xml2js@0.5.0:
@@ -9604,8 +9630,8 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
 
-  /yaml@2.3.1:
-    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+  /yaml@2.3.2:
+    resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}
     engines: {node: '>= 14'}
     dev: false
 
@@ -9763,14 +9789,14 @@ packages:
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -9785,7 +9811,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -9803,14 +9829,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -9830,7 +9856,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -9848,16 +9874,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       csv-parse: 5.5.0
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -9875,7 +9901,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -9888,38 +9914,38 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-ghhD0hitSl1yehkXY8937HiI0GIesBzqf10RHxOM3KYXo60elnspeGRfCd/ODPfDFrYwSROqNrKbSssvQ+ioPQ==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-HtRgWb64AgSkfZlAE07H76mxQwpf+B4dq61gzAdDFcy+Mw7wbTWZfMmni0q20NpQOmLW6FaBJ49ghON1fo24Eg==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.2_@types+node@14.18.53
-      '@types/chai': 4.3.5
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.53
+      '@types/node': 14.18.62
       autorest: 3.6.3
-      chai: 4.3.7
+      chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.45.0
-      karma: 6.4.2
+      eslint: 8.49.0
+      karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-junit-reporter: 2.0.1_karma@6.4.2
+      karma-junit-reporter: 2.0.1(karma@6.4.2)
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@6.4.2
+      karma-mocha-reporter: 2.2.5(karma@6.4.2)
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
       mkdirp: 2.1.6
       mocha: 7.2.0
-      mocha-junit-reporter: 1.23.3_mocha@7.2.0
+      mocha-junit-reporter: 1.23.3(mocha@7.2.0)
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.6.0
+      tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
       - bufferutil
@@ -9934,14 +9960,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -9960,7 +9986,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -9978,18 +10004,18 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/prettier': 2.6.4
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -10009,7 +10035,7 @@ packages:
       rollup: 2.79.1
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10027,17 +10053,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10056,7 +10082,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10075,19 +10101,19 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/decompress': 4.2.4
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       decompress: 4.2.1
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10105,7 +10131,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10122,18 +10148,18 @@ packages:
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/node': 14.18.56
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/node': 14.18.62
       autorest: 3.6.3
       dotenv: 8.6.0
-      eslint: 8.48.0
+      eslint: 8.49.0
       mkdirp: 1.0.4
       mocha: 7.2.0
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10149,16 +10175,16 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10175,7 +10201,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10193,14 +10219,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10218,7 +10244,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10236,17 +10262,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10264,7 +10290,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10282,15 +10308,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10308,7 +10334,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10325,13 +10351,13 @@ packages:
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
       '@types/inquirer': 8.2.6
       '@types/mocha': 7.0.2
       '@types/mustache': 4.2.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/yargs': 17.0.24
       '@types/yargs-parser': 21.0.0
@@ -10339,7 +10365,7 @@ packages:
       chalk: 4.1.2
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       glob: 9.3.5
       inquirer: 8.2.6
       magic-string: 0.27.0
@@ -10351,7 +10377,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -10369,20 +10395,20 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
       '@types/mime': 3.0.1
       '@types/mocha': 7.0.2
       '@types/mustache': 4.2.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/yargs': 17.0.24
       '@types/yargs-parser': 21.0.0
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10402,7 +10428,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -10421,16 +10447,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -10448,7 +10474,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10468,13 +10494,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10482,8 +10508,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10499,21 +10525,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10529,21 +10555,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10559,13 +10585,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10573,7 +10599,7 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10587,13 +10613,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10601,8 +10627,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10618,21 +10644,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10648,13 +10674,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10662,8 +10688,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10679,13 +10705,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10693,8 +10719,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10710,21 +10736,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10740,13 +10766,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10754,8 +10780,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10771,13 +10797,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10785,8 +10811,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10802,13 +10828,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10816,8 +10842,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10833,14 +10859,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -10858,7 +10884,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10876,21 +10902,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10906,13 +10932,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10920,8 +10946,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10937,13 +10963,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -10951,8 +10977,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10968,13 +10994,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -10982,8 +11008,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -10999,13 +11025,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -11013,8 +11039,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11030,13 +11056,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11044,8 +11070,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11061,21 +11087,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11091,21 +11117,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11121,21 +11147,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11151,13 +11177,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11165,8 +11191,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11183,13 +11209,13 @@ packages:
     dependencies:
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11197,8 +11223,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11214,21 +11240,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11244,21 +11270,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11274,13 +11300,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11288,8 +11314,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11305,21 +11331,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11335,21 +11361,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11365,21 +11391,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11396,13 +11422,13 @@ packages:
     dependencies:
       '@azure/arm-cosmosdb': 15.5.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11410,8 +11436,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11427,13 +11453,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11441,8 +11467,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11458,13 +11484,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11472,8 +11498,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11489,21 +11515,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11519,21 +11545,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11549,13 +11575,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11563,8 +11589,8 @@ packages:
       mocha: 7.2.0
       rimraf: 5.0.1
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11581,13 +11607,13 @@ packages:
     dependencies:
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11595,8 +11621,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11612,13 +11638,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11626,8 +11652,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11645,14 +11671,14 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -11670,7 +11696,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -11688,13 +11714,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11702,8 +11728,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11719,21 +11745,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11749,13 +11775,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11763,8 +11789,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11780,13 +11806,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11794,8 +11820,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11811,13 +11837,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11825,8 +11851,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11842,13 +11868,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11856,8 +11882,8 @@ packages:
       mocha: 7.2.0
       rimraf: 5.0.1
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11873,13 +11899,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11887,8 +11913,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11905,14 +11931,14 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -11930,7 +11956,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -11948,13 +11974,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11962,8 +11988,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -11979,13 +12005,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -11993,8 +12019,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12005,18 +12031,18 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-aTZZunMkiPA6kuNjfLPPJm7Uhk47BQ+fpMra7raCedYUrnRfPVw1ehndznjELIbuaPaybiBzB9Ti09MSDysHbQ==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-GhkzcQ7p1/1B503z9URCbi60a95oDT+sJpK98TgsCpeoTBJ4WUN24EAfpdLhMTAwyhs3P7BpxS2Iqo53vo+s0A==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12024,8 +12050,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12041,13 +12067,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12055,8 +12081,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12072,21 +12098,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12102,13 +12128,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12116,8 +12142,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12133,13 +12159,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12147,8 +12173,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12164,13 +12190,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12178,8 +12204,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12195,21 +12221,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12225,21 +12251,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12255,21 +12281,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12285,21 +12311,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12315,13 +12341,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12329,8 +12355,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12346,21 +12372,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12376,21 +12402,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12406,13 +12432,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12420,8 +12446,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12437,13 +12463,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12451,8 +12477,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12468,21 +12494,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12498,13 +12524,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12512,8 +12538,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12529,13 +12555,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12543,8 +12569,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12560,13 +12586,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12574,8 +12600,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12591,13 +12617,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12605,8 +12631,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12622,13 +12648,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12636,8 +12662,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12653,21 +12679,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12683,21 +12709,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12713,13 +12739,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12727,8 +12753,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12744,13 +12770,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12758,8 +12784,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12775,21 +12801,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12805,13 +12831,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12819,8 +12845,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12836,21 +12862,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12866,13 +12892,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12880,8 +12906,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12897,13 +12923,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -12911,8 +12937,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12928,13 +12954,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12942,8 +12968,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12959,13 +12985,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -12973,8 +12999,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -12990,13 +13016,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13004,8 +13030,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13021,13 +13047,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13035,8 +13061,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13054,13 +13080,13 @@ packages:
       '@azure/arm-network': 26.0.0
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13068,8 +13094,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13085,13 +13111,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13099,8 +13125,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13116,21 +13142,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13146,13 +13172,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13160,8 +13186,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13177,13 +13203,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13191,8 +13217,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13208,13 +13234,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13222,8 +13248,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13239,21 +13265,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13269,21 +13295,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13299,13 +13325,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13313,8 +13339,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13330,13 +13356,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13344,8 +13370,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13361,21 +13387,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13391,21 +13417,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13421,21 +13447,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13451,13 +13477,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13465,8 +13491,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13482,13 +13508,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13496,8 +13522,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13513,21 +13539,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13544,13 +13570,13 @@ packages:
     dependencies:
       '@azure/arm-compute': 17.3.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13558,8 +13584,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13575,21 +13601,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13605,13 +13631,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13619,8 +13645,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13636,13 +13662,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13650,8 +13676,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13667,13 +13693,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13681,8 +13707,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13698,13 +13724,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13712,8 +13738,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13729,13 +13755,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13743,8 +13769,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13760,13 +13786,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13774,8 +13800,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13791,13 +13817,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13805,8 +13831,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13822,13 +13848,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -13836,8 +13862,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13853,21 +13879,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13883,13 +13909,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -13897,8 +13923,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13914,13 +13940,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -13928,8 +13954,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13945,21 +13971,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -13975,13 +14001,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -13989,8 +14015,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14006,21 +14032,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14036,21 +14062,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14066,13 +14092,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14080,8 +14106,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14097,13 +14123,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14111,7 +14137,7 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14125,21 +14151,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14155,13 +14181,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14169,8 +14195,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14186,21 +14212,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14216,13 +14242,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14230,8 +14256,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14247,13 +14273,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14261,8 +14287,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14278,21 +14304,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14308,13 +14334,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14322,8 +14348,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14340,13 +14366,13 @@ packages:
     dependencies:
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14354,8 +14380,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14371,13 +14397,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14385,8 +14411,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14402,21 +14428,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14432,13 +14458,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14446,8 +14472,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14463,13 +14489,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14477,8 +14503,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14497,13 +14523,13 @@ packages:
       '@azure/arm-operationalinsights': 8.0.1
       '@azure/arm-storage': 17.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14511,8 +14537,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14528,13 +14554,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14542,8 +14568,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14559,13 +14585,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14573,8 +14599,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14590,21 +14616,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14620,13 +14646,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14634,8 +14660,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14651,13 +14677,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14665,8 +14691,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14682,13 +14708,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14696,8 +14722,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14714,14 +14740,14 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -14739,7 +14765,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -14757,13 +14783,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14771,8 +14797,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14788,21 +14814,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14818,13 +14844,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -14832,8 +14858,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14849,13 +14875,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14863,8 +14889,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14880,21 +14906,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14910,21 +14936,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14940,13 +14966,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -14954,8 +14980,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -14971,21 +14997,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15001,13 +15027,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15015,8 +15041,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15032,13 +15058,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15046,8 +15072,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15063,21 +15089,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15093,13 +15119,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15107,8 +15133,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15124,13 +15150,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15138,8 +15164,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15155,13 +15181,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -15169,8 +15195,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15186,13 +15212,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -15200,8 +15226,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15217,13 +15243,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15231,8 +15257,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15248,21 +15274,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15278,13 +15304,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -15292,8 +15318,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15309,21 +15335,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15339,13 +15365,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15353,8 +15379,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15370,21 +15396,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15400,13 +15426,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15414,8 +15440,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15431,13 +15457,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15445,8 +15471,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15462,21 +15488,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15492,13 +15518,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15506,8 +15532,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15523,13 +15549,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15537,8 +15563,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15554,13 +15580,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15568,8 +15594,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15580,19 +15606,19 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-JDTsZOuYhef+ouTE3gpTZ6HfGpWoq4Q9NoKyE0OYCHoY6CeiGUqYivKUwEYzmiKIjAyDW9LBLQjjexvhG/xNEg==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-yRoTaH0f5+DBBUidse7sz5UDIn1TTltX///zwO0gjQUvCnte4Mu6zA14Cdg36oRZ60iljQsEIR4tsFx4zhcGBw==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
       '@azure/arm-network': 26.0.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15600,8 +15626,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15617,13 +15643,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15631,8 +15657,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15648,13 +15674,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -15662,8 +15688,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15679,13 +15705,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15693,8 +15719,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15710,13 +15736,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15724,8 +15750,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15741,21 +15767,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15771,13 +15797,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15785,8 +15811,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15802,21 +15828,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15832,13 +15858,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15846,8 +15872,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15863,13 +15889,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15877,8 +15903,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15894,13 +15920,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15908,8 +15934,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15925,13 +15951,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -15939,8 +15965,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15956,13 +15982,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -15970,8 +15996,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -15987,21 +16013,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16017,13 +16043,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16031,8 +16057,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16048,13 +16074,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16062,8 +16088,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16079,13 +16105,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16093,8 +16119,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16110,13 +16136,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16124,8 +16150,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16141,21 +16167,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16171,13 +16197,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16185,8 +16211,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16202,21 +16228,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16233,14 +16259,14 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -16258,7 +16284,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -16276,13 +16302,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16290,8 +16316,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16307,13 +16333,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16321,8 +16347,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16338,13 +16364,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16352,8 +16378,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16369,13 +16395,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16383,8 +16409,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16400,13 +16426,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16414,8 +16440,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16431,13 +16457,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16445,8 +16471,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16462,13 +16488,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16476,8 +16502,8 @@ packages:
       mocha: 7.2.0
       rimraf: 5.0.1
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16493,13 +16519,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16507,8 +16533,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16524,13 +16550,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16538,8 +16564,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16555,13 +16581,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16569,8 +16595,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16586,13 +16612,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16600,8 +16626,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16617,13 +16643,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16631,8 +16657,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16648,13 +16674,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16662,8 +16688,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16679,21 +16705,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16709,21 +16735,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16739,21 +16765,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16769,21 +16795,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16799,13 +16825,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16813,8 +16839,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16830,21 +16856,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16860,13 +16886,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16874,8 +16900,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16891,13 +16917,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -16905,8 +16931,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16922,21 +16948,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16952,13 +16978,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16966,8 +16992,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -16983,13 +17009,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -16997,8 +17023,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17014,21 +17040,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17044,13 +17070,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 8.6.0
@@ -17058,8 +17084,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17075,13 +17101,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -17089,8 +17115,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17106,13 +17132,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -17120,8 +17146,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17137,21 +17163,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17167,13 +17193,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
@@ -17181,8 +17207,8 @@ packages:
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17198,21 +17224,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       mkdirp: 1.0.4
       mocha: 7.2.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -17228,18 +17254,18 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       buffer: 6.0.3
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       jsrsasign: 10.8.6
@@ -17262,7 +17288,7 @@ packages:
       rimraf: 3.0.2
       safe-buffer: 5.2.1
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17276,21 +17302,20 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-T+0Vz2bQ6lOhzAVSeERChaJQTc7I1Va7iMGrI+9dXRwe18vjOWKDJA844KrhJtW1IOJZJPKa5P19S9Gsl99kJA==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-Ar4gZmdIoE81kqpPnkjSrJWRXsv4vhrQykjEkYixd7MRmcFINfKv99B4cScmTCzuSebNTBsyyVnZls2DLVIoRA==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -17307,7 +17332,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -17320,21 +17345,20 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-I95R4LweEY6DulekdZyHFBDc5gYAZ7Dq8xDpF8nMZh6twr85oOWFiOgFBB3L13A+3O2YE1xcCUUaen/4YR1zgg==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-Lr9F5MxDq9pYPblmhTKJR7vTWluHaZ1RDeZnYRn8AHXcJoqSzXvGjHLlkvrwbCUMTRUFgiTuxSy46KumKRsEQA==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -17354,7 +17378,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17369,22 +17393,21 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-2lbV09MTvQOFhBj4wbaTLnBdu8R29yfzrZBFdGdk+DPG5SMG/nu3fl2CC3+rQp7sy+s8tGpjsPpcsAhnb1gRqw==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-BZQ8JcRQ6AYZIh3x0TZF4ofzkzvj8yeokPWwzLUoJoGdS/Bd2Vd5rAfVZwH6OL/AvqmI7GVNY6KK8K/vfghmmw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/communication-signaling': 1.0.0-beta.20
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17404,7 +17427,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17424,16 +17447,16 @@ packages:
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       jwt-decode: 3.1.2
@@ -17453,7 +17476,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17467,20 +17490,19 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-GOyJNqPuvzmz77q4iSanoi9igNxVqVyvTUi+xh5XRcbfLPKQJSbvjpV3DZuZeL9WHxW35Z0hZeFthhEEhzScgA==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-afDSmfDusmfsXok4Ws6htYLFJFqzaQQJdv5cGIbO+II8FV/3fWGCXd566PKT/lt7qDTGZzVDObWFPg5wJTqfpQ==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -17497,7 +17519,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 1.14.1
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17511,22 +17533,21 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-JG9T9VS1aWHfOQeT0jkuqWA8FaoOoFWn2T87HVTCl5Ryo+c+TId7mKGFFdLS20mPlam1lmBkF/t56dbZHmJ1Ww==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-txAjUJm6MTseZ/+YZP0NGBS26dkQyWv33TGllxjjLu0uSS3OWZmZQU3rpQlcCLdxVWe27VHxgVNciM+KwONTxg==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@azure/msal-node': 1.18.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@azure/msal-node': 1.18.3
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17540,7 +17561,6 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
-      mocha-testdata: 1.2.0
       nyc: 15.1.0
       prettier: 2.8.8
       process: 0.11.10
@@ -17548,7 +17568,7 @@ packages:
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -17561,21 +17581,20 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-qypc/gsoj0jLDj+V3UVqyZ+ajM0AL3mZR44NSqyCY5MZmU+BQ10o2n3jW2oGShmhVjeb//cvUNkTvJZzluKUsA==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-7W7ojlceOXwLiKrJgyUDy0Hi15zVsWYz7YxKufsgU+xbDrysQaoydBkpdnM+FX0sshMIZ258o3DUywLE68ysQA==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17595,7 +17614,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17610,21 +17629,20 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-BXacXKJAkKRQZ7UsCbRZbS2izmaiKVK7w7iNDJWmJ5oSbwThzyaWNpjpKyLyszzxvWBUupXrzKOeoiAWRTPucA==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-S8Nt5zhyRiBCVY2dof2f7oyTthSatuS9IZZdDvg8lFlcti7XqBu4WwS2GdhxoKUbsZcpQyW3JYQG632pWSsg0Q==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17644,7 +17662,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -17657,22 +17675,21 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-pOCQO9HL24abJ9gVn3hTaGfeK5xyI6+Z0WvJJJMENZFe5edUeK7TrKhqE7AkC2AgOuXr6mT60QgnIPlBXIbS1Q==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-qjBy6YQQnGMH9FvYgoy1owQcXY/i8IV6Q1WBxd687yKmQ+LgjH6sPcIOYWmAVOwIBgdvMRCymhJMxdCU6BHm3Q==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17690,7 +17707,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17704,22 +17721,21 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-EUHxa+KcpREhYTxft9Z74xzVamJrF91CRee+uRKJ5PX0KEP4by3SbXWWMN18PFn0e4Dq8od3kOy5C+F10nf96Q==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-XnvfVkkbxr/Zlng73VcTQ7y69UtgtFJsO2uY6uLkTLNZtCGGBAIoi5OOT1lkGZqIrCZNASKwhPVwBQFAkEwGiw==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17737,7 +17753,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17751,21 +17767,20 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-Ediq03xRYY5TTg2YJcwm+4bDaNoyHF1iN5Hz7i6AbfY4a7Wn9XrapjXYlhRHNDSnDqWhT6/8C45EcDeRcqHEgw==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-VOaYHR5r7unCyiKROE7O9hACRQa05pRXh/6scZzJEGHNIBbQCeWRfZE74usf0lGDPioU6vt8t81/i+Rv7t1NhA==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-env-preprocessor: 0.1.1
       mkdirp: 1.0.4
@@ -17774,7 +17789,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 1.14.1
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17788,22 +17803,21 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-ZVSS7zUEO+jzNK9j3puY5elfldkHPwfiZXkrJnwSlAeckEgF5IVtbxFUiEnvYdKYovqvApoKF28LrkPhFQyThg==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-6ojiKk0CZStYwojQTvccaRKwgZMenNQHJ5Qr59clzMYNlBviW66D0qrL3QeenP6ZTsET8/2H9aqTVBCzd3mihw==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17821,7 +17835,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17835,22 +17849,21 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-NZmHYycCztveawVX5v3SeQEFexWIGahxtmQz+mM9V31YbZKtvCIoxt0D0SzQqdlU4/TyK11TVlpjQ9yR1eU/qA==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-rhpQi+HoB1XGHOAHPoV8M8jvsQhjL8Aoe2EayIBrYXUyWfanYLd24Z0xWIn6UjF2COVRHAD5xADJ1m2D/784EQ==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17868,7 +17881,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -17883,22 +17896,21 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-KNOwdeTgbB90YxXyrUOfwKyv0yjL4tT1E7o5hIpPLmtBxT6EoP2pe3kI0Mjrv4wNpGntTZxLYx7uo29jRK0Ogg==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-LeoaA4BZzguvQCFmqrAqvIuGKsKGoDpzeZEdFuqYc0ZxuoENpw/bgW9aTHko8lYf7G4Q7useh6G4cCNjH+ebsQ==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -17916,7 +17928,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17930,22 +17942,21 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-EKP8pP5kbaw0LW3OABeUBM4h/4Wnd2glSRop0C9yjaJoEn2Z8dJbNfu0wQpmVOlxM8kaP5ZbgJ627gJbjBvpcw==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-+Q2QeSp/lvXt0TZorV6YiNHg32cUtCGQOdgIf+QWZbMbcRM2lSWUscAk7ZUElLzslKrSrRHLuEqs50juBvIHuA==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
-      '@azure/communication-common': 2.2.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -17962,7 +17973,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -17981,21 +17992,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18010,16 +18021,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18035,7 +18046,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18053,7 +18064,7 @@ packages:
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-inject': 5.0.3(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
@@ -18063,7 +18074,7 @@ packages:
       '@types/chai': 4.3.6
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/ws': 7.4.7
       buffer: 6.0.3
@@ -18071,7 +18082,7 @@ packages:
       cross-env: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18087,13 +18098,13 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
-      ws: 8.13.0
+      ws: 8.14.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -18108,20 +18119,20 @@ packages:
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18136,15 +18147,15 @@ packages:
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18160,7 +18171,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18178,14 +18189,14 @@ packages:
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18201,7 +18212,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18218,16 +18229,16 @@ packages:
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/node': 14.18.56
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/node': 14.18.62
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -18242,23 +18253,23 @@ packages:
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger-js': 1.3.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@types/chai': 4.3.6
       '@types/express': 4.17.17
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@types/node-fetch': 2.6.4
+      '@types/node': 14.18.62
+      '@types/node-fetch': 2.6.5
       '@types/sinon': 10.0.16
-      '@types/tough-cookie': 4.0.2
-      '@types/trusted-types': 2.0.3
+      '@types/tough-cookie': 4.0.3
+      '@types/trusted-types': 2.0.4
       '@types/tunnel': 0.0.3
       '@types/uuid': 8.3.4
-      '@types/xml2js': 0.4.11
+      '@types/xml2js': 0.4.12
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       express: 4.18.2
       fetch-mock: 9.11.0(node-fetch@2.7.0)
       form-data: 4.0.0
@@ -18281,7 +18292,7 @@ packages:
       shx: 0.3.4
       sinon: 15.2.0
       tough-cookie: 4.1.3
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       tunnel: 0.0.6
       typescript: 5.0.4
@@ -18304,11 +18315,11 @@ packages:
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -18323,7 +18334,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18340,14 +18351,14 @@ packages:
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -18361,7 +18372,7 @@ packages:
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18378,18 +18389,18 @@ packages:
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
@@ -18411,7 +18422,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18430,12 +18441,12 @@ packages:
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18455,7 +18466,7 @@ packages:
       prettier: 2.8.8
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18473,14 +18484,14 @@ packages:
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18496,7 +18507,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18514,17 +18525,17 @@ packages:
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18540,7 +18551,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18558,16 +18569,16 @@ packages:
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@types/trusted-types': 2.0.3
+      '@types/node': 14.18.62
+      '@types/trusted-types': 2.0.4
       chai: 4.3.8
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
-      fast-xml-parser: 4.2.7
+      eslint: 8.49.0
+      fast-xml-parser: 4.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18582,7 +18593,7 @@ packages:
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18601,24 +18612,24 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@sinonjs/fake-timers': 11.1.0
       '@types/chai': 4.3.6
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.1
       '@types/sinon': 10.0.16
       '@types/sinonjs__fake-timers': 8.1.2
-      '@types/underscore': 1.11.8
+      '@types/underscore': 1.11.9
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       execa: 5.1.1
       fast-json-stable-stringify: 2.1.0
@@ -18634,7 +18645,7 @@ packages:
       semaphore: 1.1.0
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       universal-user-agent: 6.0.0
@@ -18651,17 +18662,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18678,7 +18689,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18699,18 +18710,18 @@ packages:
     dependencies:
       '@_ts/max': /typescript@5.2.2
       '@_ts/min': /typescript@4.2.4
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-multi-entry': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/decompress': 4.2.4
       '@types/fs-extra': 9.0.13
       '@types/minimist': 1.2.2
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/prettier': 2.7.3
       '@types/semver': 7.3.13
       autorest: 3.6.3
@@ -18725,7 +18736,7 @@ packages:
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       env-paths: 2.2.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       fs-extra: 11.1.1
       karma: 6.4.2(debug@4.3.4)
       minimist: 1.2.8
@@ -18736,15 +18747,15 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-polyfill-node: 0.12.0(rollup@2.79.1)
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       rollup-plugin-visualizer: 5.9.2(rollup@2.79.1)
       semver: 7.5.4
       strip-json-comments: 5.0.1
       ts-morph: 19.0.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
-      yaml: 2.3.1
+      yaml: 2.3.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -18761,14 +18772,14 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -18786,7 +18797,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18804,16 +18815,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -18830,7 +18841,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -18849,14 +18860,14 @@ packages:
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      eslint: 8.48.0
-      eslint-plugin-import: 2.28.1(eslint@8.48.0)
-      eslint-plugin-markdown: 3.0.1(eslint@8.48.0)
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.49.0)(typescript@5.0.4)
+      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
+      eslint: 8.49.0
+      eslint-plugin-import: 2.28.1(eslint@8.49.0)
+      eslint-plugin-markdown: 3.0.1(eslint@8.49.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-promise: 6.1.1(eslint@8.48.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.49.0)
       eslint-plugin-tsdoc: 0.2.17
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18871,20 +18882,20 @@ packages:
       '@types/chai': 4.3.6
       '@types/eslint': 8.4.10
       '@types/estree': 1.0.1
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.13
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
+      '@types/node': 14.18.62
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.49.0)(typescript@5.0.4)
+      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.49.0)(typescript@5.0.4)
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
       chai: 4.3.8
-      eslint: 8.48.0
-      eslint-config-prettier: 9.0.0(eslint@8.48.0)
-      eslint-plugin-import: 2.28.1(eslint@8.48.0)
-      eslint-plugin-markdown: 3.0.1(eslint@8.48.0)
+      eslint: 8.49.0
+      eslint-config-prettier: 9.0.0(eslint@8.49.0)
+      eslint-plugin-import: 2.28.1(eslint@8.49.0)
+      eslint-plugin-markdown: 3.0.1(eslint@8.49.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-promise: 6.1.1(eslint@8.48.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.49.0)
       eslint-plugin-tsdoc: 0.2.17
       glob: 9.3.5
       json-schema: 0.4.0
@@ -18893,7 +18904,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -18909,7 +18920,7 @@ packages:
     dependencies:
       '@azure/core-amqp': 3.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-inject': 5.0.3(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
@@ -18918,11 +18929,11 @@ packages:
       '@rollup/plugin-replace': 5.0.2(rollup@2.79.1)
       '@types/async-lock': 1.4.0
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
-      '@types/chai-string': 1.4.2
+      '@types/chai-as-promised': 7.1.6
+      '@types/chai-string': 1.4.3
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/ws': 7.4.7
       buffer: 6.0.3
@@ -18935,7 +18946,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       https-proxy-agent: 5.0.1
       is-buffer: 2.0.5
@@ -18960,12 +18971,12 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
-      ws: 8.13.0
+      ws: 8.14.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -18980,18 +18991,18 @@ packages:
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19008,7 +19019,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -19026,20 +19037,20 @@ packages:
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
-      '@types/chai-string': 1.4.2
+      '@types/chai-as-promised': 7.1.6
+      '@types/chai-string': 1.4.3
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       chai-string: 1.5.0(chai@4.3.8)
       cross-env: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       guid-typescript: 1.0.9
@@ -19058,7 +19069,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19075,20 +19086,20 @@ packages:
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
-      '@types/chai-string': 1.4.2
+      '@types/chai-as-promised': 7.1.6
+      '@types/chai-string': 1.4.3
       '@types/debug': 4.1.8
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       chai-string: 1.5.0(chai@4.3.8)
       cross-env: 7.0.3
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       guid-typescript: 1.0.9
       inherits: 2.0.4
@@ -19106,7 +19117,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19125,15 +19136,15 @@ packages:
     dependencies:
       '@azure/functions': 3.5.1
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -19152,7 +19163,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19171,15 +19182,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19197,7 +19208,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19215,15 +19226,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19241,7 +19252,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19258,17 +19269,17 @@ packages:
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
-      '@azure/msal-node': 1.18.2
+      '@azure/msal-node': 1.18.3
       '@azure/msal-node-extensions': 1.0.0-alpha.25
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/jws': 3.2.5
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/jws': 3.2.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@types/qs': 6.9.7
+      '@types/node': 14.18.62
+      '@types/qs': 6.9.8
       '@types/sinon': 10.0.16
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 7.2.0
@@ -19277,7 +19288,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19296,16 +19307,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/jws': 3.2.5
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/jws': 3.2.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@types/qs': 6.9.7
+      '@types/node': 14.18.62
+      '@types/qs': 6.9.8
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 7.2.0
@@ -19314,7 +19325,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19334,24 +19345,24 @@ packages:
     dependencies:
       '@azure/msal-browser': 2.38.2
       '@azure/msal-common': 13.3.0
-      '@azure/msal-node': 1.18.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@azure/msal-node': 1.18.3
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/jsonwebtoken': 9.0.2
-      '@types/jws': 3.2.5
+      '@types/jsonwebtoken': 9.0.3
+      '@types/jws': 3.2.6
       '@types/mocha': 7.0.2
       '@types/ms': 0.7.31
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/stoppable': 1.1.1
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
-      jsonwebtoken: 9.0.1
+      jsonwebtoken: 9.0.2
       jws: 4.0.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -19371,7 +19382,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       stoppable: 1.1.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19392,15 +19403,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19419,7 +19430,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -19437,14 +19448,14 @@ packages:
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -19464,7 +19475,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -19483,14 +19494,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
@@ -19499,7 +19510,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -19516,13 +19527,13 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -19543,7 +19554,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19561,10 +19572,10 @@ packages:
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/node': 14.18.56
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/node': 14.18.62
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
@@ -19574,7 +19585,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19593,14 +19604,14 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       cross-env: 7.0.3
-      dayjs: 1.11.9
+      dayjs: 1.11.10
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -19621,7 +19632,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19641,13 +19652,13 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -19666,7 +19677,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19685,16 +19696,16 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19712,10 +19723,10 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -19730,15 +19741,15 @@ packages:
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19755,7 +19766,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19773,13 +19784,13 @@ packages:
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/node': 14.18.56
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/node': 14.18.62
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -19795,15 +19806,15 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19821,7 +19832,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19841,15 +19852,15 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19867,7 +19878,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19887,15 +19898,15 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19913,7 +19924,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19933,15 +19944,15 @@ packages:
       '@azure-rest/core-client': 1.0.0-beta.10
       '@azure/identity': 2.1.0
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -19959,7 +19970,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -19976,16 +19987,16 @@ packages:
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -20001,7 +20012,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -20020,17 +20031,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -20047,7 +20058,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -20066,13 +20077,13 @@ packages:
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rhea: 3.0.2
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20088,17 +20099,17 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/monitor-query': 1.1.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/pako': 2.0.0
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -20119,7 +20130,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -20137,7 +20148,7 @@ packages:
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@opentelemetry/api-logs': 0.43.0
       '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
@@ -20150,17 +20161,17 @@ packages:
       '@opentelemetry/sdk-trace-node': 1.17.0(@opentelemetry/api@1.6.0)
       '@opentelemetry/semantic-conventions': 1.17.0
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
-      eslint-plugin-node: 11.1.0(eslint@8.48.0)
+      eslint: 8.49.0
+      eslint-plugin-node: 11.1.0(eslint@8.49.0)
       mocha: 7.2.0
       nock: 12.0.3
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20175,7 +20186,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/functions': 3.5.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@opentelemetry/api-logs': 0.43.0
       '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
@@ -20193,18 +20204,18 @@ packages:
       '@opentelemetry/sdk-trace-node': 1.17.0(@opentelemetry/api@1.6.0)
       '@opentelemetry/semantic-conventions': 1.17.0
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       dotenv: 16.3.1
-      eslint: 8.48.0
-      eslint-plugin-node: 11.1.0(eslint@8.48.0)
+      eslint: 8.49.0
+      eslint-plugin-node: 11.1.0(eslint@8.49.0)
       mocha: 7.2.0
       nock: 12.0.3
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20219,20 +20230,20 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@opentelemetry/sdk-trace-base': 1.17.0(@opentelemetry/api@1.6.0)
       '@opentelemetry/sdk-trace-node': 1.17.0(@opentelemetry/api@1.6.0)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -20249,7 +20260,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20266,21 +20277,21 @@ packages:
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@rollup/plugin-commonjs': 25.0.4(rollup@3.28.1)
-      '@rollup/plugin-inject': 5.0.3(rollup@3.28.1)
-      '@rollup/plugin-json': 6.0.0(rollup@3.28.1)
-      '@rollup/plugin-multi-entry': 6.0.0(rollup@3.28.1)
-      '@rollup/plugin-node-resolve': 15.2.1(rollup@3.28.1)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.28.1)
-      '@rollup/plugin-typescript': 11.1.3(rollup@3.28.1)(tslib@2.6.2)(typescript@5.0.4)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@rollup/plugin-commonjs': 25.0.4(rollup@3.29.2)
+      '@rollup/plugin-inject': 5.0.3(rollup@3.29.2)
+      '@rollup/plugin-json': 6.0.0(rollup@3.29.2)
+      '@rollup/plugin-multi-entry': 6.0.0(rollup@3.29.2)
+      '@rollup/plugin-node-resolve': 15.2.1(rollup@3.29.2)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.29.2)
+      '@rollup/plugin-typescript': 11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.0.4)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -20299,9 +20310,9 @@ packages:
       prettier: 2.8.8
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
-      rollup: 3.28.1
+      rollup: 3.29.2
       rollup-plugin-shim: 1.0.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -20320,12 +20331,12 @@ packages:
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
@@ -20347,7 +20358,7 @@ packages:
       prettier: 2.8.8
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20365,7 +20376,7 @@ packages:
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
       '@opentelemetry/instrumentation': 0.42.0(@opentelemetry/api@1.6.0)
@@ -20373,13 +20384,13 @@ packages:
       '@opentelemetry/sdk-trace-node': 1.17.0(@opentelemetry/api@1.6.0)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -20397,7 +20408,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -20416,12 +20427,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20436,12 +20447,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20455,12 +20466,12 @@ packages:
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20475,12 +20486,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20495,13 +20506,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/app-configuration': 1.5.0-beta.1
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20516,12 +20527,12 @@ packages:
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20536,18 +20547,18 @@ packages:
     version: 0.0.0
     dependencies:
       '@types/express': 4.17.17
-      '@types/node': 16.18.46
+      '@types/node': 16.18.53
       concurrently: 8.2.1
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       express: 4.18.2
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@16.18.46)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@16.18.53)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
-      undici: 5.23.0
+      undici: 5.25.1
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -20559,13 +20570,13 @@ packages:
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20581,14 +20592,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-amqp': 3.3.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       moment: 2.29.4
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20603,12 +20614,12 @@ packages:
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20623,13 +20634,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20644,13 +20655,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20666,13 +20677,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20688,13 +20699,13 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20711,12 +20722,12 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/monitor-ingestion': 1.0.0-beta.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20733,13 +20744,13 @@ packages:
       '@opentelemetry/api': 1.6.0
       '@opentelemetry/api-logs': 0.43.0
       '@opentelemetry/sdk-logs': 0.43.0(@opentelemetry/api-logs@0.43.0)(@opentelemetry/api@1.6.0)
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20756,12 +20767,12 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/monitor-query': 1.1.1
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20777,12 +20788,12 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/schema-registry': 1.2.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20798,12 +20809,12 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/search-documents': 11.3.0-beta.7
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20817,13 +20828,13 @@ packages:
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20838,15 +20849,15 @@ packages:
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
-      '@types/node-fetch': 2.6.4
+      '@types/node': 14.18.62
+      '@types/node-fetch': 2.6.5
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       node-fetch: 2.7.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20862,13 +20873,13 @@ packages:
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20883,13 +20894,13 @@ packages:
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20906,13 +20917,13 @@ packages:
     dependencies:
       '@azure/app-configuration': 1.4.1
       '@azure/identity': 2.1.0
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -20928,14 +20939,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -20953,7 +20964,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -20971,14 +20982,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -20996,7 +21007,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21014,14 +21025,14 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21039,7 +21050,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21057,15 +21068,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21083,7 +21094,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21101,15 +21112,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       autorest: 3.6.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21127,7 +21138,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21145,15 +21156,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -21171,7 +21182,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21191,13 +21202,13 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/schema-registry': 1.2.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@16.18.46)
+      '@microsoft/api-extractor': 7.37.0(@types/node@16.18.53)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-inject': 5.0.3(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 16.18.46
+      '@types/node': 16.18.53
       '@types/uuid': 8.3.4
       avsc: 5.7.7
       buffer: 6.0.3
@@ -21205,7 +21216,7 @@ packages:
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21228,7 +21239,7 @@ packages:
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@16.18.46)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@16.18.53)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -21248,16 +21259,15 @@ packages:
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/schema-registry': 1.3.0-beta.1
-      '@microsoft/api-extractor': 7.36.4(@types/node@16.18.46)
+      '@microsoft/api-extractor': 7.37.0(@types/node@16.18.53)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-inject': 5.0.3(rollup@2.79.1)
-      '@types/ajv': 1.0.0
       '@types/mocha': 7.0.2
-      '@types/node': 16.18.46
+      '@types/node': 16.18.53
       ajv: 8.12.0
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21278,7 +21288,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@16.18.46)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@16.18.53)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21296,12 +21306,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21319,7 +21329,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -21338,15 +21348,15 @@ packages:
     dependencies:
       '@azure/core-http-compat': 1.3.0
       '@azure/openai': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       events: 3.3.0
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -21366,7 +21376,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21386,7 +21396,7 @@ packages:
     dependencies:
       '@azure/core-amqp': 3.3.0
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-inject': 5.0.3(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
@@ -21394,11 +21404,11 @@ packages:
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
       '@rollup/plugin-replace': 5.0.2(rollup@2.79.1)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/debug': 4.1.8
       '@types/is-buffer': 2.0.0
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       '@types/ws': 7.4.7
@@ -21410,7 +21420,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       https-proxy-agent: 5.0.1
@@ -21438,13 +21448,13 @@ packages:
       rimraf: 3.0.2
       rollup: 2.79.1
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
-      ws: 8.13.0
+      ws: 8.14.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -21459,17 +21469,17 @@ packages:
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -21492,7 +21502,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21512,18 +21522,18 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
-      '@types/node-fetch': 2.6.4
+      '@types/node': 14.18.62
+      '@types/node-fetch': 2.6.5
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -21543,7 +21553,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21564,17 +21574,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       execa: 6.1.0
@@ -21597,7 +21607,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21616,10 +21626,10 @@ packages:
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
@@ -21627,7 +21637,7 @@ packages:
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
@@ -21648,7 +21658,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21668,16 +21678,16 @@ packages:
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -21696,7 +21706,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21716,17 +21726,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
       es6-promise: 4.2.8
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -21745,7 +21755,7 @@ packages:
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -21765,17 +21775,17 @@ packages:
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21793,7 +21803,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -21812,18 +21822,18 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/uuid': 8.3.4
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21842,7 +21852,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -21862,17 +21872,17 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21892,7 +21902,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -21910,16 +21920,16 @@ packages:
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -21935,7 +21945,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -21953,16 +21963,16 @@ packages:
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@rollup/plugin-commonjs': 24.1.0(rollup@2.79.1)
       '@rollup/plugin-json': 6.0.0(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 13.3.0(rollup@2.79.1)
-      '@types/node': 14.18.56
-      eslint: 8.48.0
+      '@types/node': 14.18.62
+      eslint: 8.49.0
       rimraf: 3.0.2
       rollup: 2.79.1
-      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.56)(rollup@2.79.1)
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      rollup-plugin-sourcemaps: 0.6.3(@types/node@14.18.62)(rollup@2.79.1)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -21977,16 +21987,16 @@ packages:
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -22002,7 +22012,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uglify-js: 3.17.4
@@ -22020,14 +22030,14 @@ packages:
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -22045,7 +22055,7 @@ packages:
       prettier: 2.8.8
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -22065,15 +22075,15 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
       downlevel-dts: 0.10.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
@@ -22092,7 +22102,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -22111,12 +22121,12 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
-      '@types/node': 14.18.56
-      eslint: 8.48.0
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
+      '@types/node': 14.18.62
+      eslint: 8.49.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -22131,15 +22141,15 @@ packages:
     dependencies:
       '@types/chai': 4.3.6
       '@types/express': 4.17.17
-      '@types/fs-extra': 8.1.2
+      '@types/fs-extra': 8.1.3
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/uuid': 8.3.4
       chai: 4.3.8
       concurrently: 8.2.1
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       express: 4.18.2
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -22155,7 +22165,7 @@ packages:
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       uuid: 8.3.2
@@ -22175,9 +22185,9 @@ packages:
     dependencies:
       '@types/fs-extra': 9.0.13
       '@types/minimist': 1.2.2
-      '@types/node': 14.18.56
-      '@types/node-fetch': 2.6.4
-      eslint: 8.48.0
+      '@types/node': 14.18.62
+      '@types/node-fetch': 2.6.5
+      eslint: 8.49.0
       fs-extra: 10.1.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
@@ -22187,7 +22197,7 @@ packages:
       node-fetch: 2.7.0
       prettier: 2.8.8
       rimraf: 3.0.2
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -22205,18 +22215,18 @@ packages:
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@opentelemetry/api': 1.6.0
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       chai-as-promised: 7.1.1(chai@4.3.8)
       chai-exclude: 2.1.0(chai@4.3.8)
       cross-env: 7.0.3
-      eslint: 8.48.0
+      eslint: 8.49.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -22225,7 +22235,7 @@ packages:
       prettier: 2.8.8
       rimraf: 3.0.2
       sinon: 15.2.0
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -22243,21 +22253,21 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/web-pubsub-client': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/express': 4.17.17
       '@types/express-serve-static-core': 4.17.36
-      '@types/jsonwebtoken': 9.0.2
+      '@types/jsonwebtoken': 9.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/ws': 7.4.7
       chai: 4.3.8
       copyfiles: 2.4.1
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       express: 4.18.2
       karma: 6.4.2(debug@4.3.4)
@@ -22276,7 +22286,7 @@ packages:
       long: 5.2.3
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
-      mock-socket: 9.2.1
+      mock-socket: 9.3.1
       nyc: 15.1.0
       prettier: 2.8.8
       protobufjs: 7.2.5
@@ -22285,7 +22295,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -22304,21 +22314,21 @@ packages:
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/chai-as-promised': 7.1.5
+      '@types/chai-as-promised': 7.1.6
       '@types/express': 4.17.17
       '@types/express-serve-static-core': 4.17.36
-      '@types/jsonwebtoken': 9.0.2
+      '@types/jsonwebtoken': 9.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/ws': 7.4.7
       buffer: 6.0.3
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       express: 4.18.2
       karma: 6.4.2(debug@4.3.4)
@@ -22334,14 +22344,14 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 7.2.0
       mocha-junit-reporter: 2.2.1(mocha@7.2.0)
-      mock-socket: 9.2.1
+      mock-socket: 9.3.1
       nyc: 15.1.0
       prettier: 2.8.8
       puppeteer: 19.11.1(typescript@5.0.4)
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
       util: 0.12.5
@@ -22361,18 +22371,18 @@ packages:
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
       '@types/express': 4.17.17
       '@types/express-serve-static-core': 4.17.36
-      '@types/jsonwebtoken': 9.0.2
+      '@types/jsonwebtoken': 9.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
       express: 4.18.2
       mocha: 7.2.0
@@ -22383,7 +22393,7 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -22400,19 +22410,19 @@ packages:
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@microsoft/api-extractor': 7.37.0(@types/node@14.18.62)
       '@types/chai': 4.3.6
-      '@types/jsonwebtoken': 9.0.2
+      '@types/jsonwebtoken': 9.0.3
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.56
+      '@types/node': 14.18.62
       '@types/sinon': 10.0.16
       '@types/ws': 8.5.5
       chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.48.0
+      eslint: 8.49.0
       esm: 3.2.25
-      jsonwebtoken: 9.0.1
+      jsonwebtoken: 9.0.2
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -22430,10 +22440,10 @@ packages:
       rimraf: 3.0.2
       sinon: 15.2.0
       source-map-support: 0.5.21
-      ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@14.18.62)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4
-      ws: 8.13.0
+      ws: 8.14.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -70,7 +70,8 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "tslib": "^2.2.0",
-    "fast-xml-parser": "^4.2.4"
+    "fast-xml-parser": "^4.2.4",
+    "@azure/core-util": "^1.4.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/core/core-xml/src/xml.ts
+++ b/sdk/core/core-xml/src/xml.ts
@@ -3,6 +3,7 @@
 
 import { XMLBuilder, XMLParser, XMLValidator } from "fast-xml-parser";
 import { XML_ATTRKEY, XML_CHARKEY, XmlOptions } from "./xml.common";
+import { isObject, objectHasProperty } from "@azure/core-util";
 
 function getCommonOptions(options: XmlOptions): {
   attributesGroupName: string;
@@ -99,14 +100,17 @@ export async function parseXML(str: string, opts: XmlOptions = {}): Promise<any>
 
   // Remove the <?xml version="..." ?> node.
   // This is a change in behavior on fxp v4. Issue #424
-  if (parsedXml["?xml"]) {
+  if (objectHasProperty(parsedXml, "?xml")) {
     delete parsedXml["?xml"];
   }
 
   if (!opts.includeRoot) {
-    for (const key of Object.keys(parsedXml)) {
-      const value = parsedXml[key];
-      return typeof value === "object" ? { ...value } : value;
+    if (isObject(parsedXml)) {
+      // So that TS knows that parsedXml is an object
+      for (const key of Object.keys(parsedXml)) {
+        const value = parsedXml[key];
+        return typeof value === "object" ? { ...value } : value;
+      }
     }
   }
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/core-xml`

### Issues associated with this PR
#27195 
```

==[ BLOCKED: 4 operations ]====================================================

These operations were blocked by dependencies that failed:
  @azure/event-hubs
  @azure/test-utils
  @azure-tools/test-recorder
  @azure/core-client

==[ FAILURE: 1 operation ]=====================================================

--[ FAILURE: @azure/core-xml ]-------------------------------[ 2.09 seconds ]--

Invoking: npm run clean && tsc -p . && dev-tool run bundle && api-extractor run --local && npm run build:types 

> @azure/core-xml@1.3.5 clean
> rimraf dist dist-* temp types *.tgz *.log

src/xml.ts(102,7): error TS7053: Element implicitly has an 'any' type because expression of type '"?xml"' can't be used to index type 'GenericObjectOrArray<unknown>'.
  Property '?xml' does not exist on type 'GenericObjectOrArray<unknown>'.
src/xml.ts(103,12): error TS7053: Element implicitly has an 'any' type because expression of type '"?xml"' can't be used to index type 'GenericObjectOrArray<unknown>'.
  Property '?xml' does not exist on type 'GenericObjectOrArray<unknown>'.
src/xml.ts(108,21): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'GenericObjectOrArray<unknown>'.
  No index signature with a parameter of type 'string' was found on type 'GenericObjectOrArray<unknown>'.


Operations failed.

rush build (2.46 seconds)
```
Spotted while working on #26748
### Describe the problem that is addressed by this PR
Uses type guards to narrow down the type of `parsedXml` 
