### PR TITLE
[engsys] fix pnpm-lock.yaml

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14,7 +14,7 @@ dependencies:
   '@rush-temp/ai-anomaly-detector':
     specifier: file:./projects/ai-anomaly-detector.tgz
     version: file:projects/ai-anomaly-detector.tgz
-  '@rush-temp/ai-content-safety': 
+  '@rush-temp/ai-content-safety':
     specifier: file:./projects/ai-content-safety.tgz
     version: file:projects/ai-content-safety.tgz
   '@rush-temp/ai-document-translator':
@@ -4480,11 +4480,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230920
-    dev: false
-
-  /eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+      typescript: 5.3.0-dev.20230921
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -9204,8 +9200,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.3.0-dev.20230920:
-    resolution: {integrity: sha512-XaiYm7T6bGo+5mbRsmFqujMbNz0BLRCTKXiG7Nuodxz/aB5XJhJ01s/9GOJ/BS2XcxBqMoTbrGf61OdqzYhpxg==}
+  /typescript@5.3.0-dev.20230921:
+    resolution: {integrity: sha512-TZnDMkY/mgooSXJv72Zxr71MvXYUKiH05lekDOB9FaScoHLGNDvqw6IrT6qXx/kD6eJFpW2gadIz1eJQeA/URw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -9888,38 +9884,38 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-ghhD0hitSl1yehkXY8937HiI0GIesBzqf10RHxOM3KYXo60elnspeGRfCd/ODPfDFrYwSROqNrKbSssvQ+ioPQ==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-HtRgWb64AgSkfZlAE07H76mxQwpf+B4dq61gzAdDFcy+Mw7wbTWZfMmni0q20NpQOmLW6FaBJ49ghON1fo24Eg==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.36.2_@types+node@14.18.53
-      '@types/chai': 4.3.5
+      '@microsoft/api-extractor': 7.36.4(@types/node@14.18.56)
+      '@types/chai': 4.3.6
       '@types/mocha': 7.0.2
-      '@types/node': 14.18.53
+      '@types/node': 14.18.56
       autorest: 3.6.3
-      chai: 4.3.7
+      chai: 4.3.8
       cross-env: 7.0.3
       dotenv: 16.3.1
-      eslint: 8.45.0
-      karma: 6.4.2
+      eslint: 8.48.0
+      karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.3.0
-      karma-junit-reporter: 2.0.1_karma@6.4.2
+      karma-junit-reporter: 2.0.1(karma@6.4.2)
       karma-mocha: 2.0.1
-      karma-mocha-reporter: 2.2.5_karma@6.4.2
+      karma-mocha-reporter: 2.2.5(karma@6.4.2)
       karma-source-map-support: 1.4.0
       karma-sourcemap-loader: 0.3.8
       mkdirp: 2.1.6
       mocha: 7.2.0
-      mocha-junit-reporter: 1.23.3_mocha@7.2.0
+      mocha-junit-reporter: 1.23.3(mocha@7.2.0)
       nyc: 15.1.0
       prettier: 2.8.8
       rimraf: 3.0.2
       source-map-support: 0.5.21
-      tslib: 2.6.0
+      tslib: 2.6.2
       typescript: 5.0.4
     transitivePeerDependencies:
       - bufferutil
@@ -12005,7 +12001,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-aTZZunMkiPA6kuNjfLPPJm7Uhk47BQ+fpMra7raCedYUrnRfPVw1ehndznjELIbuaPaybiBzB9Ti09MSDysHbQ==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-GhkzcQ7p1/1B503z9URCbi60a95oDT+sJpK98TgsCpeoTBJ4WUN24EAfpdLhMTAwyhs3P7BpxS2Iqo53vo+s0A==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -15580,7 +15576,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-JDTsZOuYhef+ouTE3gpTZ6HfGpWoq4Q9NoKyE0OYCHoY6CeiGUqYivKUwEYzmiKIjAyDW9LBLQjjexvhG/xNEg==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-yRoTaH0f5+DBBUidse7sz5UDIn1TTltX///zwO0gjQUvCnte4Mu6zA14Cdg36oRZ60iljQsEIR4tsFx4zhcGBw==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -17276,7 +17272,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-T+0Vz2bQ6lOhzAVSeERChaJQTc7I1Va7iMGrI+9dXRwe18vjOWKDJA844KrhJtW1IOJZJPKa5P19S9Gsl99kJA==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-Ar4gZmdIoE81kqpPnkjSrJWRXsv4vhrQykjEkYixd7MRmcFINfKv99B4cScmTCzuSebNTBsyyVnZls2DLVIoRA==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -17320,7 +17316,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-I95R4LweEY6DulekdZyHFBDc5gYAZ7Dq8xDpF8nMZh6twr85oOWFiOgFBB3L13A+3O2YE1xcCUUaen/4YR1zgg==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-Lr9F5MxDq9pYPblmhTKJR7vTWluHaZ1RDeZnYRn8AHXcJoqSzXvGjHLlkvrwbCUMTRUFgiTuxSy46KumKRsEQA==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -17369,7 +17365,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-2lbV09MTvQOFhBj4wbaTLnBdu8R29yfzrZBFdGdk+DPG5SMG/nu3fl2CC3+rQp7sy+s8tGpjsPpcsAhnb1gRqw==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-BZQ8JcRQ6AYZIh3x0TZF4ofzkzvj8yeokPWwzLUoJoGdS/Bd2Vd5rAfVZwH6OL/AvqmI7GVNY6KK8K/vfghmmw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -17467,7 +17463,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-GOyJNqPuvzmz77q4iSanoi9igNxVqVyvTUi+xh5XRcbfLPKQJSbvjpV3DZuZeL9WHxW35Z0hZeFthhEEhzScgA==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-afDSmfDusmfsXok4Ws6htYLFJFqzaQQJdv5cGIbO+II8FV/3fWGCXd566PKT/lt7qDTGZzVDObWFPg5wJTqfpQ==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -17511,7 +17507,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-JG9T9VS1aWHfOQeT0jkuqWA8FaoOoFWn2T87HVTCl5Ryo+c+TId7mKGFFdLS20mPlam1lmBkF/t56dbZHmJ1Ww==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-txAjUJm6MTseZ/+YZP0NGBS26dkQyWv33TGllxjjLu0uSS3OWZmZQU3rpQlcCLdxVWe27VHxgVNciM+KwONTxg==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -17561,7 +17557,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-qypc/gsoj0jLDj+V3UVqyZ+ajM0AL3mZR44NSqyCY5MZmU+BQ10o2n3jW2oGShmhVjeb//cvUNkTvJZzluKUsA==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-7W7ojlceOXwLiKrJgyUDy0Hi15zVsWYz7YxKufsgU+xbDrysQaoydBkpdnM+FX0sshMIZ258o3DUywLE68ysQA==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -17610,7 +17606,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-BXacXKJAkKRQZ7UsCbRZbS2izmaiKVK7w7iNDJWmJ5oSbwThzyaWNpjpKyLyszzxvWBUupXrzKOeoiAWRTPucA==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-S8Nt5zhyRiBCVY2dof2f7oyTthSatuS9IZZdDvg8lFlcti7XqBu4WwS2GdhxoKUbsZcpQyW3JYQG632pWSsg0Q==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -17657,7 +17653,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-pOCQO9HL24abJ9gVn3hTaGfeK5xyI6+Z0WvJJJMENZFe5edUeK7TrKhqE7AkC2AgOuXr6mT60QgnIPlBXIbS1Q==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-qjBy6YQQnGMH9FvYgoy1owQcXY/i8IV6Q1WBxd687yKmQ+LgjH6sPcIOYWmAVOwIBgdvMRCymhJMxdCU6BHm3Q==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -17704,7 +17700,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-EUHxa+KcpREhYTxft9Z74xzVamJrF91CRee+uRKJ5PX0KEP4by3SbXWWMN18PFn0e4Dq8od3kOy5C+F10nf96Q==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-XnvfVkkbxr/Zlng73VcTQ7y69UtgtFJsO2uY6uLkTLNZtCGGBAIoi5OOT1lkGZqIrCZNASKwhPVwBQFAkEwGiw==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -17751,7 +17747,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-Ediq03xRYY5TTg2YJcwm+4bDaNoyHF1iN5Hz7i6AbfY4a7Wn9XrapjXYlhRHNDSnDqWhT6/8C45EcDeRcqHEgw==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-VOaYHR5r7unCyiKROE7O9hACRQa05pRXh/6scZzJEGHNIBbQCeWRfZE74usf0lGDPioU6vt8t81/i+Rv7t1NhA==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -17788,7 +17784,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-ZVSS7zUEO+jzNK9j3puY5elfldkHPwfiZXkrJnwSlAeckEgF5IVtbxFUiEnvYdKYovqvApoKF28LrkPhFQyThg==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-6ojiKk0CZStYwojQTvccaRKwgZMenNQHJ5Qr59clzMYNlBviW66D0qrL3QeenP6ZTsET8/2H9aqTVBCzd3mihw==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -17835,7 +17831,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-NZmHYycCztveawVX5v3SeQEFexWIGahxtmQz+mM9V31YbZKtvCIoxt0D0SzQqdlU4/TyK11TVlpjQ9yR1eU/qA==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-rhpQi+HoB1XGHOAHPoV8M8jvsQhjL8Aoe2EayIBrYXUyWfanYLd24Z0xWIn6UjF2COVRHAD5xADJ1m2D/784EQ==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -17883,7 +17879,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-KNOwdeTgbB90YxXyrUOfwKyv0yjL4tT1E7o5hIpPLmtBxT6EoP2pe3kI0Mjrv4wNpGntTZxLYx7uo29jRK0Ogg==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-LeoaA4BZzguvQCFmqrAqvIuGKsKGoDpzeZEdFuqYc0ZxuoENpw/bgW9aTHko8lYf7G4Q7useh6G4cCNjH+ebsQ==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -17930,7 +17926,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-EKP8pP5kbaw0LW3OABeUBM4h/4Wnd2glSRop0C9yjaJoEn2Z8dJbNfu0wQpmVOlxM8kaP5ZbgJ627gJbjBvpcw==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-+Q2QeSp/lvXt0TZorV6YiNHg32cUtCGQOdgIf+QWZbMbcRM2lSWUscAk7ZUElLzslKrSrRHLuEqs50juBvIHuA==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
There's an error from previous commit which caused `rush update` to bump dependency versions. Normally only `rush update --full` does that.

This PR fixes pnpm-lock.yaml by checking out to a good and old version then run `rush update`

