### PR TITLE
[test] fix recorder dependency version

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -88,7 +88,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure-tools/test-recorder": "^3.0.1",
+    "@azure-tools/test-recorder": "^3.0.0",
     "@azure-tools/test-credential": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",


### PR DESCRIPTION
The minor version of test-recorder was bumped thus 3.0.1 is no longer valid. This PR changes the version to ^3.0.0
