### PR TITLE
[Event Hubs] [core-util] Mark next week for release in changelog

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.5.0 (Unreleased)
+## 1.5.0 (2023-09-25)
 
 ### Features Added
 

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.5.0 (2023-09-21)
+## 1.5.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.11.2 (2023-09-21)
+## 5.11.2 (Unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.11.2 (Unreleased)
+## 5.11.2 (2023-09-25)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
Packages have not been released yet.
Followup of #26748