### PR TITLE
[eslint-plugin] update eslint version and fix deprecation warnings

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1881,6 +1881,16 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.50.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.50.0
+      eslint-visitor-keys: 3.4.3
+    dev: false
+
   /@eslint-community/regexpp@4.8.0:
     resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1908,8 +1918,24 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
+  /@eslint/js@8.50.0:
+    resolution: {integrity: sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.4(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@humanwhocodes/config-array@0.11.11:
+    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -2876,8 +2902,8 @@ packages:
       '@types/node': 16.18.46
     dev: false
 
-  /@types/eslint@8.4.10:
-    resolution: {integrity: sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==}
+  /@types/eslint@8.44.3:
+    resolution: {integrity: sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
@@ -3219,6 +3245,34 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.50.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.8.0
+      '@typescript-eslint/parser': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 5.57.1
+      '@typescript-eslint/type-utils': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.50.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/experimental-utils@5.57.1(eslint@8.48.0)(typescript@5.0.4):
     resolution: {integrity: sha512-5F5s8mpM1Y0RQ5iWzKQPQm5cmhARgcMfUwyHX1ZZFL8Tm0PyzyQ+9jgYSMaW74XXvpDg9/KdmMICLlwNwKtO7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3227,6 +3281,19 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
       eslint: 8.48.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  /@typescript-eslint/experimental-utils@5.57.1(eslint@8.50.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-5F5s8mpM1Y0RQ5iWzKQPQm5cmhARgcMfUwyHX1ZZFL8Tm0PyzyQ+9jgYSMaW74XXvpDg9/KdmMICLlwNwKtO7w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      eslint: 8.50.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3247,6 +3314,26 @@ packages:
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.48.0
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/parser@5.57.1(eslint@8.50.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.57.1
+      '@typescript-eslint/types': 5.57.1
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.50.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -3274,6 +3361,26 @@ packages:
       '@typescript-eslint/utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.48.0
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/type-utils@5.57.1(eslint@8.50.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.50.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -3319,6 +3426,26 @@ packages:
       '@typescript-eslint/types': 5.57.1
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
       eslint: 8.48.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  /@typescript-eslint/utils@5.57.1(eslint@8.50.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.50.0)
+      '@types/json-schema': 7.0.12
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.57.1
+      '@typescript-eslint/types': 5.57.1
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
+      eslint: 8.50.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -4487,7 +4614,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230922
+      typescript: 5.3.0-dev.20230925
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -4697,13 +4824,13 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@9.0.0(eslint@8.48.0):
+  /eslint-config-prettier@9.0.0(eslint@8.50.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.48.0
+      eslint: 8.50.0
     dev: false
 
   /eslint-import-resolver-node@0.3.9:
@@ -4725,6 +4852,19 @@ packages:
     dependencies:
       debug: 3.2.7
       eslint: 8.48.0
+    dev: false
+
+  /eslint-module-utils@2.8.0(eslint@8.50.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: '*'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+    dependencies:
+      debug: 3.2.7
+      eslint: 8.50.0
     dev: false
 
   /eslint-plugin-es@3.0.1(eslint@8.48.0):
@@ -4764,6 +4904,32 @@ packages:
       tsconfig-paths: 3.14.2
     dev: false
 
+  /eslint-plugin-import@2.28.1(eslint@8.50.0):
+    resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    dependencies:
+      array-includes: 3.1.6
+      array.prototype.findlastindex: 1.2.2
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.50.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.0(eslint@8.50.0)
+      has: 1.0.3
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.6
+      object.groupby: 1.0.0
+      object.values: 1.1.7
+      semver: 6.3.1
+      tsconfig-paths: 3.14.2
+    dev: false
+
   /eslint-plugin-markdown@3.0.1(eslint@8.48.0):
     resolution: {integrity: sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4771,6 +4937,18 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       eslint: 8.48.0
+      mdast-util-from-markdown: 0.8.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-plugin-markdown@3.0.1(eslint@8.50.0):
+    resolution: {integrity: sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.50.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
@@ -4803,6 +4981,15 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
       eslint: 8.48.0
+    dev: false
+
+  /eslint-plugin-promise@6.1.1(eslint@8.50.0):
+    resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.50.0
     dev: false
 
   /eslint-plugin-tsdoc@0.2.17:
@@ -4855,6 +5042,52 @@ packages:
       '@eslint/eslintrc': 2.1.2
       '@eslint/js': 8.48.0
       '@humanwhocodes/config-array': 0.11.10
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4(supports-color@8.1.1)
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.21.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint@8.50.0:
+    resolution: {integrity: sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.50.0)
+      '@eslint-community/regexpp': 4.8.0
+      '@eslint/eslintrc': 2.1.2
+      '@eslint/js': 8.50.0
+      '@humanwhocodes/config-array': 0.11.11
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -9207,8 +9440,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.3.0-dev.20230922:
-    resolution: {integrity: sha512-QmuWGuk9Uk3blOaDo5P9wVLAOw7CfhrHmWoQAD+5UAQeR52S0/W0BjuYgCMGwmxVJJgYK1WCeBdbTi2jLxvoog==}
+  /typescript@5.3.0-dev.20230925:
+    resolution: {integrity: sha512-Q8U1zNAGD0BSaVuaHmjhYB8sM5VyTcp0y6IM4Q3v40uLX3MysM5yLl6qSxzA3PTzXmQmahLy+08aM3cZA0hR5A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -18655,27 +18888,27 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-T3wphYpquczXfzzVd7sVSZiqP/NLeUJKwOqwG1pN5IOKsZABe3DnTDuA1Ta5b8iuqTRlvjc/LRczLFK+VZDKkA==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-7AEsp+dPkhVgShQclZCFnp+Ws/TxvOwjxsYlD6SHk5wD2mKVV6AryX5lMz7KlTWmwpZuTaxz73lXduKltkfcIg==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
       '@types/chai': 4.3.6
-      '@types/eslint': 8.4.10
+      '@types/eslint': 8.44.3
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
       '@types/mocha': 7.0.2
       '@types/node': 14.18.56
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.48.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.50.0)(typescript@5.0.4)
+      '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.50.0)(typescript@5.0.4)
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.4)
       chai: 4.3.8
-      eslint: 8.48.0
-      eslint-config-prettier: 9.0.0(eslint@8.48.0)
-      eslint-plugin-import: 2.28.1(eslint@8.48.0)
-      eslint-plugin-markdown: 3.0.1(eslint@8.48.0)
+      eslint: 8.50.0
+      eslint-config-prettier: 9.0.0(eslint@8.50.0)
+      eslint-plugin-import: 2.28.1(eslint@8.50.0)
+      eslint-plugin-markdown: 3.0.1(eslint@8.50.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-promise: 6.1.1(eslint@8.48.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.50.0)
       eslint-plugin-tsdoc: 0.2.17
       glob: 9.3.5
       json-schema: 0.4.0

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "~5.57.0",
     "@typescript-eslint/parser": "~5.57.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.50.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-promise": "^6.0.0",
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@typescript-eslint/typescript-estree": "~5.57.0",
-    "@types/eslint": "~8.4.0",
+    "@types/eslint": "~8.44.0",
     "@types/estree": "~1.0.0",
     "eslint-config-prettier": "^9.0.0",
     "glob": "^9.0.0",
@@ -86,7 +86,7 @@
     "@typescript-eslint/experimental-utils": "~5.57.0",
     "@typescript-eslint/parser": "~5.57.0",
     "chai": "^4.2.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.50.0",
     "mocha": "^10.0.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.0",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -31,7 +31,7 @@ export = {
     "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
-    /\.ts$/.test(context.getFilename())
+    /\.ts$/.test(context.filename)
       ? {
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
@@ -27,7 +27,7 @@ export = {
       inner: "publicTrimmedFilePath",
       expected: false,
     });
-    const fileName = context.getFilename();
+    const fileName = context.filename;
     return stripPath(fileName) === "api-extractor.json"
       ? ({
           // callback functions

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
@@ -104,7 +104,7 @@ export = {
     "require async client methods to accept an AbortSignalLike parameter"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const parserServices = context.parserServices as ParserServices;
+    const parserServices = context.sourceCode.parserServices as ParserServices;
     if (
       parserServices.program === undefined ||
       parserServices.esTreeNodeToTSNodeMap === undefined

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
@@ -24,7 +24,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "include",
     });
-    return stripPath(context.getFilename()) === "tsconfig.json"
+    return stripPath(context.filename) === "tsconfig.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal-private-member.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal-private-member.ts
@@ -63,7 +63,7 @@ export = {
     "requires TSDoc comments to not include an '@internal' tag if the object is private"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const parserServices = context.parserServices as ParserServices;
+    const parserServices = context.sourceCode.parserServices as ParserServices;
     if (
       parserServices.program === undefined ||
       parserServices.esTreeNodeToTSNodeMap === undefined

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -98,7 +98,7 @@ export = {
     "require TSDoc comments to include an '@internal' or '@hidden' tag if the object is not public-facing"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const fileName = context.getFilename();
+    const fileName = context.filename;
 
     // on the first run, if on a .ts file (program.getSourceFile is file-type dependent)
     if (context.settings.exported === undefined && /\.ts$/.test(fileName)) {
@@ -111,7 +111,7 @@ export = {
       }
     }
 
-    const parserServices = context.parserServices as ParserServices;
+    const parserServices = context.sourceCode.parserServices as ParserServices;
     if (
       parserServices.program === undefined ||
       parserServices.esTreeNodeToTSNodeMap === undefined
@@ -134,8 +134,8 @@ export = {
           // standalone functions
           ":function": (node: Node): void => {
             if (
-              context
-                .getAncestors()
+              context.sourceCode
+                .getAncestors(node)
                 .every(
                   (ancestor: Node): boolean =>
                     !["ClassBody", "TSInterfaceBody", "TSModuleBlock"].includes(ancestor.type)

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
@@ -21,7 +21,7 @@ export = {
     "limit thrown errors to ECMAScript built-in error types (TypeError, RangeError, Error)"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
-    /src/.test(context.getFilename())
+    /src/.test(context.filename)
       ? ({
           // callback functions
 
@@ -36,7 +36,7 @@ export = {
           // if throwing an identifier
           "ThrowStatement[argument.type='Identifier']": (node: ThrowStatement): void => {
             const thrown = node.argument as Identifier;
-            const parserServices = context.parserServices as ParserServices;
+            const parserServices = context.sourceCode.parserServices as ParserServices;
             if (
               parserServices.program === undefined ||
               parserServices.esTreeNodeToTSNodeMap === undefined

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
@@ -21,7 +21,7 @@ export = {
     "force there to be only named exports at the top level"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
-    relative(normalize(context.getFilename()), normalize(context.settings.main)) === ""
+    relative(normalize(context.filename), normalize(context.settings.main)) === ""
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
@@ -21,7 +21,7 @@ export = {
     "require client method option parameter type names to be suffixed with Options and prefixed with the method name"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const parserServices = context.parserServices as ParserServices;
+    const parserServices = context.sourceCode.parserServices as ParserServices;
     if (parserServices.program === undefined) {
       return {};
     }

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
@@ -24,7 +24,7 @@ export = {
       outer: "author",
       expected: "Microsoft Corporation",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
@@ -25,7 +25,7 @@ export = {
       inner: "url",
       expected: "https://github.com/Azure/azure-sdk-for-js/issues",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
@@ -45,7 +45,7 @@ export = {
       inner: "node",
       expected: options.nodeVersionOverride || LTS,
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -63,7 +63,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "files",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
@@ -23,7 +23,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "homepage",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
@@ -24,7 +24,7 @@ export = {
       outer: "keywords",
       expected: ["azure", "cloud"],
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
@@ -24,7 +24,7 @@ export = {
       outer: "license",
       expected: "MIT",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -24,7 +24,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "main",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -24,7 +24,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "module",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
@@ -24,7 +24,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "name",
     });
-    const fileName = context.getFilename();
+    const fileName = context.filename;
     return stripPath(fileName) === "package.json"
       ? ({
           // callback functions

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -24,7 +24,7 @@ export = {
       outer: "repository",
       expected: "github:Azure/azure-sdk-for-js",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
@@ -28,7 +28,7 @@ export = {
       outer: "scripts",
       inner: "test",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
@@ -25,7 +25,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "sdk-type",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
@@ -24,7 +24,7 @@ export = {
       outer: "sideEffects",
       expected: false,
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
@@ -25,7 +25,7 @@ export = {
       outer: "types",
       expected: false,
     });
-    const fileName = context.getFilename();
+    const fileName = context.filename;
     return stripPath(fileName) === "package.json"
       ? ({
           // callback functions

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -244,7 +244,7 @@ export = {
   ),
 
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const parserServices = context.parserServices as ParserServices;
+    const parserServices = context.sourceCode.parserServices as ParserServices;
     if (
       parserServices.program === undefined ||
       parserServices.esTreeNodeToTSNodeMap === undefined ||
@@ -259,10 +259,10 @@ export = {
     const verifiedMethods: string[] = [];
     const verifiedDeclarations: string[] = [];
 
-    return /src/.test(context.getFilename())
+    return /src/.test(context.filename)
       ? ({
           "MethodDefinition > FunctionExpression": (node: FunctionExpression): void => {
-            const parent = context.getAncestors().reverse()[0] as MethodDefinition;
+            const parent = context.sourceCode.getAncestors(node).reverse()[0] as MethodDefinition;
             const key = parent.key as Identifier;
             const name = key.name;
 

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
@@ -18,7 +18,7 @@ import { isExternalModule } from "typescript";
 export = {
   meta: getRuleMetaData("ts-use-promises", "force usage of built-in promises over external ones"),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    const parserServices: ParserServices = context.parserServices;
+    const parserServices: ParserServices = context.sourceCode.parserServices;
     if (
       parserServices.program === undefined ||
       parserServices.esTreeNodeToTSNodeMap === undefined

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -20,7 +20,7 @@ export = {
     const verifiers = getVerifiers(context, {
       outer: "version",
     });
-    return stripPath(context.getFilename()) === "package.json"
+    return stripPath(context.filename) === "package.json"
       ? ({
           // callback functions
 

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/exports.ts
@@ -17,7 +17,7 @@ import { Rule } from "eslint";
  * @returns a list of Symbols containing type information for all top-level exports, or undefined if improperly configured
  */
 const getExports = (context: Rule.RuleContext): TSSymbol[] | undefined => {
-  const parserServices = context.parserServices as ParserServices;
+  const parserServices = context.sourceCode.parserServices as ParserServices;
   if (parserServices.program === undefined) {
     return undefined;
   }


### PR DESCRIPTION
- update eslint to ^8.50.0, @types/eslint to ~8.44.0
- fix deprecation warnings by using recommended new api
