### PR TITLE
[dev-tool] update dependency ts-morph version to ^20.0.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2785,8 +2785,8 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /@ts-morph/common@0.20.0:
-    resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
+  /@ts-morph/common@0.21.0:
+    resolution: {integrity: sha512-ES110Mmne5Vi4ypUKrtVQfXFDtCsDXiUiGxF6ILVlE90dDD4fdpC1LSjydl/ml7xJWKSDZwUYD2zkOePMSrPBA==}
     dependencies:
       fast-glob: 3.3.1
       minimatch: 7.4.6
@@ -4487,7 +4487,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230922
+      typescript: 5.3.0-dev.20230925
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -8996,10 +8996,10 @@ packages:
     hasBin: true
     dev: false
 
-  /ts-morph@19.0.0:
-    resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
+  /ts-morph@20.0.0:
+    resolution: {integrity: sha512-JVmEJy2Wow5n/84I3igthL9sudQ8qzjh/6i4tmYCm6IqYyKFlNbJZi7oBdjyqcWSWYRu3CtL0xbT6fS03ESZIg==}
     dependencies:
-      '@ts-morph/common': 0.20.0
+      '@ts-morph/common': 0.21.0
       code-block-writer: 12.0.0
     dev: false
 
@@ -9207,8 +9207,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.3.0-dev.20230922:
-    resolution: {integrity: sha512-QmuWGuk9Uk3blOaDo5P9wVLAOw7CfhrHmWoQAD+5UAQeR52S0/W0BjuYgCMGwmxVJJgYK1WCeBdbTi2jLxvoog==}
+  /typescript@5.3.0-dev.20230925:
+    resolution: {integrity: sha512-Q8U1zNAGD0BSaVuaHmjhYB8sM5VyTcp0y6IM4Q3v40uLX3MysM5yLl6qSxzA3PTzXmQmahLy+08aM3cZA0hR5A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -18484,7 +18484,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-j9fmM/MAWFeDiCNgOl8fTqyQxvWQg/DNPlm7UWIZtnJRNU3F3V2qxC91FhNGhEw3zuCshfvcWFo+Rdqo7at6rw==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-w0TETD51ln0GmU0KWEWge94WsVhurCR2AxBnwl3DNQjcRQ0jgaPBstcr//K4TWJ/RJ2iBvaXsd3Z0ycHPu1mpQ==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -18531,7 +18531,7 @@ packages:
       rollup-plugin-visualizer: 5.9.2(rollup@2.79.1)
       semver: 7.5.4
       strip-json-comments: 5.0.1
-      ts-morph: 19.0.0
+      ts-morph: 20.0.0
       ts-node: 10.9.1(@types/node@14.18.56)(typescript@5.0.4)
       tslib: 2.6.2
       typescript: 5.0.4

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -58,7 +58,7 @@
     "tslib": "^2.2.0",
     "typescript": "~5.0.0",
     "yaml": "^2.3.0",
-    "ts-morph": "^19.0.0"
+    "ts-morph": "^20.0.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",


### PR DESCRIPTION
There are some breaking changes when they upgrade to TS 5.2 but we don't use the affected Api.

https://github.com/dsherret/ts-morph/compare/19.0.0...20.0.0
