### PR TITLE
[keyvault] Fix keyvault-keys build warnings

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -39,7 +39,9 @@
     "./dist-esm/keyvault-keys/src/cryptography/crypto.js": "./dist-esm/keyvault-keys/src/cryptography/crypto.browser.js",
     "./dist-esm/keyvault-keys/src/cryptography/rsaCryptographyProvider.js": "./dist-esm/keyvault-keys/src/cryptography/rsaCryptographyProvider.browser.js",
     "./dist-esm/keyvault-keys/src/cryptography/aesCryptographyProvider.js": "./dist-esm/keyvault-keys/src/cryptography/aesCryptographyProvider.browser.js",
-    "./dist-esm/keyvault-keys/test/utils/base64url.js": "./dist-esm/keyvault-keys/test/utils/base64url.browser.js"
+    "./dist-esm/keyvault-keys/test/utils/base64url.js": "./dist-esm/keyvault-keys/test/utils/base64url.browser.js",
+    "./dist-esm/keyvault-keys/test/public/crypto.spec.js": "./dist-esm/keyvault-keys/test/public/crypto.spec.browser.js",
+    "./dist-esm/keyvault-keys/test/public/localCryptography.spec.js": "./dist-esm/keyvault-keys/test/public/localCryptography.spec.browser.js"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
@@ -50,7 +52,7 @@
     "build:nodebrowser": "npm run bundle",
     "build:test": "tsc -p . && npm run bundle",
     "build": "npm run clean && tsc -p . && npm run build:nodebrowser && api-extractor run --local",
-    "bundle": "dev-tool run bundle --polyfill-node=false",
+    "bundle": "dev-tool run bundle",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-* types *.tgz *.log dist-browser statistics.html coverage && rimraf src/**/*.js && rimraf test/**/*.js",
     "execute:samples": "dev-tool samples run samples-dev",

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.browser.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// These tests should not run in the browser -- local cryptography is only supported in Node

--- a/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/crypto.spec.ts
@@ -13,7 +13,6 @@ import TestClient from "./utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "./utils/crypto";
 import { RsaCryptographyProvider } from "../../src/cryptography/rsaCryptographyProvider";
 import { getServiceVersion } from "./utils/common";
-import { isNode } from "@azure/core-util";
 
 describe("CryptographyClient (all decrypts happen remotely)", () => {
   const keyPrefix = `crypto${env.KEY_NAME || "KeyName"}`;
@@ -25,11 +24,6 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   let keyName: string;
   let keyVaultKey: KeyVaultKey;
   let keySuffix: string;
-
-  if (!isNode) {
-    // Local cryptography is only supported in NodeJS
-    return;
-  }
 
   describe("RSA keys", () => {
     beforeEach(async function (this: Context) {

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.browser.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// These tests should not run in the browser -- local cryptography is only supported in Node

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -3,7 +3,6 @@
 
 import { Context } from "mocha";
 import { CryptographyClient, KeyClient, KeyVaultKey, SignatureAlgorithm } from "../../src";
-import { isNode } from "@azure/core-util";
 import { createHash } from "crypto";
 import { authenticate, envSetupForPlayback } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -20,11 +19,6 @@ describe("Local cryptography public tests", () => {
   let recorder: Recorder;
   let credential: ClientSecretCredential;
   let keySuffix: string;
-
-  if (!isNode) {
-    // Local cryptography is only supported in NodeJS
-    return;
-  }
 
   beforeEach(async function (this: Context) {
     recorder = new Recorder(this.currentTest);

--- a/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/localCryptography.spec.ts
@@ -200,13 +200,6 @@ describe("Local cryptography public tests", () => {
 
     for (const localAlgorithmName of localSupportedAlgorithmNames) {
       it(localAlgorithmName, async function (this: Context): Promise<void> {
-        if (!isNode) {
-          console.log(
-            `Skipping test, Local sign of algorithm ${localAlgorithmName} is only supported in NodeJS`
-          );
-          this.skip();
-        }
-
         const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
         const keyVaultKey = await client.createKey(keyName, "RSA");
         const cryptoClient = new CryptographyClient(


### PR DESCRIPTION
### Issues associated with this PR

- Fixes #27106

### Describe the problem that is addressed by this PR
Fix browser bundling warnings by:

- Create browser mappings for Node-only tests which use `crypto.createHash`, which does not have a polyfill
- Re-enabling Node polyfill for browser bundle

### Packages impacted by this PR

- `@azure/keyvault-keys`