### PR TITLE
[OpenAI] Package relevant type files only

### DIFF
--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -68,7 +68,8 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types",
+    "types/openai.d.ts",
+    "types/src",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Otherwise, irrelevant types for `sources` and `test` get packaged