### PR TITLE
[Azure Monitor OpenTelemetry Exporter] Fix issue with credentialScopes setup

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
@@ -37,9 +37,9 @@ export class HttpSender extends BaseSender {
       ...options,
     };
 
-    if (options?.credential) {
+    if (this._appInsightsClientOptions.credential) {
       // Add credentialScopes
-      options.credentialScopes = [applicationInsightsResource];
+      this._appInsightsClientOptions.credentialScopes = [applicationInsightsResource];
     }
     this._appInsightsClient = new ApplicationInsightsClient(this._appInsightsClientOptions);
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
#27268 

Issue is causing first time this code is executed credentialScopes are not passed to core-client adding incorrect default one.