### PR TITLE
[schema registry avro] Add Logical Type for DateType

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/avroSerializer.ts
@@ -13,6 +13,7 @@ import LRUCache from "lru-cache";
 import LRUCacheOptions = LRUCache.Options;
 import { isMessageContent } from "./utility";
 import { logger } from "./logger";
+import { DateType } from "./logicalTypes";
 
 type AVSCSerializer = avro.Type;
 
@@ -96,7 +97,7 @@ export class AvroSerializer<MessageT = MessageContent> {
          */
         ({
           data,
-          contentType: contentType,
+          contentType,
         } as MessageContent as unknown as MessageT);
   }
 
@@ -242,7 +243,11 @@ function convertMessage<MessageT>(
 
 function getSerializerForSchema(schema: string): AVSCSerializer {
   return wrapError(
-    () => avro.Type.forSchema(JSON.parse(schema), { omitRecordMethods: true }),
+    () =>
+      avro.Type.forSchema(JSON.parse(schema), {
+        omitRecordMethods: true,
+        logicalTypes: { "timestamp-millis": DateType },
+      }),
     `Parsing Avro schema failed:\n\n\t${schema}\n\nSee 'cause' for more details.`
   );
 }

--- a/sdk/schemaregistry/schema-registry-avro/src/logicalTypes.ts
+++ b/sdk/schemaregistry/schema-registry-avro/src/logicalTypes.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as avro from "avsc";
+
+/**
+ * Custom logical type used to encode native Date objects as longs.
+ *
+ * It also supports reading dates serialized as strings (by creating an
+ * appropriate resolver).
+ *
+ */
+export class DateType extends avro.types.LogicalType {
+  _fromValue(val: string): Date {
+    return new Date(val);
+  }
+  _toValue(date: unknown): number | undefined {
+    return date instanceof Date ? +date : undefined;
+  }
+  _resolve(type: unknown): ((val: string) => Date) | undefined {
+    return avro.Type.isType(type, "long", "string", "logical:timestamp-millis")
+      ? this._fromValue
+      : undefined;
+  }
+}

--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/dummies.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/dummies.ts
@@ -3,6 +3,7 @@
 
 import * as avro from "avsc/";
 import { env } from "@azure-tools/test-recorder";
+import { DateType } from "../../../src/logicalTypes";
 
 export const testSchemaObject: avro.schema.RecordType = {
   type: "record",
@@ -30,3 +31,21 @@ export const testSchemaIds = [
 export const testSchema = JSON.stringify(testSchemaObject);
 export const testValue = { name: "Nick", favoriteNumber: 42 };
 export const testAvroType = avro.Type.forSchema(testSchemaObject, { omitRecordMethods: true });
+export const testDateSchemaObject: avro.schema.RecordType = {
+  type: "record",
+  name: "AvroUser",
+  namespace: "com.azure.schemaregistry.samples",
+  fields: [
+    { name: "amount", type: "int" },
+    { name: "time", type: { type: "long", logicalType: "timestamp-millis" } },
+  ],
+};
+export const testDateSchema = JSON.stringify(testDateSchemaObject);
+export const testTransaction = {
+  amount: 32,
+  time: new Date("Thu Nov 05 2015 11:38:05 GMT-0800 (PST)"),
+};
+export const testAvroDateType = avro.Type.forSchema(testDateSchemaObject, {
+  omitRecordMethods: true,
+  logicalTypes: { "timestamp-millis": DateType },
+});

--- a/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedSerializer.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/public/utils/mockedSerializer.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT license.
 
 import { AvroSerializer, AvroSerializerOptions } from "../../../src";
-import { testGroup, testSchema, testSchemaObject } from "./dummies";
+import {
+  testGroup,
+  testSchema,
+  testSchemaObject,
+  testDateSchema,
+  testDateSchemaObject,
+} from "./dummies";
 import { SchemaRegistry } from "@azure/schema-registry";
 import { createTestRegistry } from "./mockedRegistryClient";
 import { Recorder } from "@azure-tools/test-recorder";
@@ -31,6 +37,16 @@ export async function registerTestSchema(registry: SchemaRegistry): Promise<stri
     name: `${testSchemaObject.namespace}.${testSchemaObject.name}`,
     groupName: testGroup,
     definition: testSchema,
+    format: "avro",
+  });
+  return schema.id;
+}
+
+export async function registerLogicalTypesTestSchema(registry: SchemaRegistry): Promise<string> {
+  const schema = await registry.registerSchema({
+    name: `${testDateSchemaObject.namespace}.${testDateSchemaObject.name}`,
+    groupName: testGroup,
+    definition: testDateSchema,
     format: "avro",
   });
   return schema.id;


### PR DESCRIPTION
### Packages impacted by this PR
schema-registry-avro

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Add support for `timestampt-millis` logical types for serialization/ deserialization

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
