### PR TITLE
[dev-tool] ignore more rollup warnings from opentelemetry

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -62,10 +62,17 @@ function ignoreRheaPromiseCircularDependency(warning: RollupWarning): boolean {
   );
 }
 
+function ignoreOpenTelemetryCircularDependency(warning: RollupWarning): boolean {
+  return (
+    warning.code === "CIRCULAR_DEPENDENCY" &&
+    matchesPathSegments(warning.ids?.[0], ["node_modules", "@opentelemetry"])
+  );
+}
+
 function ignoreOpenTelemetryThisIsUndefined(warning: RollupWarning): boolean {
   return (
     warning.code === "THIS_IS_UNDEFINED" &&
-    matchesPathSegments(warning.id, ["node_modules", "@opentelemetry", "api"])
+    matchesPathSegments(warning.id, ["node_modules", "@opentelemetry"])
   );
 }
 
@@ -85,6 +92,7 @@ const warningInhibitors: Array<(warning: RollupWarning) => boolean> = [
   ignoreChaiCircularDependency,
   ignoreRheaPromiseCircularDependency,
   ignoreNiseSinonEval,
+  ignoreOpenTelemetryCircularDependency,
   ignoreOpenTelemetryThisIsUndefined,
   ignoreMissingExportsFromEmpty,
 ];


### PR DESCRIPTION
Ignore warnings like

>../../../common/temp/node_modules/.pnpm/@opentelemetry+resources@1.17.0_@opentelemetry+api@1.6.0/node_modules/@opentelemetry/resources/build/esm/detect-resources.js (16:17) The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten

and

>Circular dependency: ../../../common/temp/node_modules/.pnpm/@opentelemetry+sdk-trace-base@1.17.0_@opentelemetry+api@1.6.0/node_modules/@opentelemetry/sdk-trace-base/build/esm/index.js -> ../../../common/temp/node_modules/.pnpm/@opentelemetry+sdk-trace-base@1.17.0_@opentelemetry+api@1.6.0/node_modules/@opentelemetry/sdk-trace-base/build/esm/BasicTracerProvider.js -> ../../../common/temp/node_modules/.pnpm/@opentelemetry+sdk-trace-base@1.17.0_@opentelemetry+api@1.6.0/node_modules/@opentelemetry/sdk-trace-base/build/esm/index.js


