### PR TITLE
[web-pubsub-client] ParseMessages can return array of messages

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client.api.md
+++ b/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client.api.md
@@ -270,7 +270,7 @@ export interface WebPubSubClientOptions {
 export interface WebPubSubClientProtocol {
     readonly isReliableSubProtocol: boolean;
     readonly name: string;
-    parseMessages(input: string | ArrayBuffer | Buffer): WebPubSubMessage | null;
+    parseMessages(input: string | ArrayBuffer | Buffer): WebPubSubMessage[] | WebPubSubMessage | null;
     writeMessage(message: WebPubSubMessage): string | ArrayBuffer;
 }
 

--- a/sdk/web-pubsub/web-pubsub-client/src/protocols/index.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/protocols/index.ts
@@ -23,7 +23,7 @@ export interface WebPubSubClientProtocol {
    * Creates WebPubSubMessage objects from the specified serialized representation.
    * @param input - The serialized representation
    */
-  parseMessages(input: string | ArrayBuffer | Buffer): WebPubSubMessage | null;
+  parseMessages(input: string | ArrayBuffer | Buffer): WebPubSubMessage[] | WebPubSubMessage | null;
 
   /**
    * Write WebPubSubMessage to string or ArrayBuffer

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -667,7 +667,7 @@ export class WebPubSubClient {
           this._safeEmitServerMessage(message);
         };
 
-        let message: WebPubSubMessage | null;
+        let messages: WebPubSubMessage[] | WebPubSubMessage | null;
         try {
           let convertedData: Buffer | ArrayBuffer | string;
           if (Array.isArray(data)) {
@@ -676,8 +676,8 @@ export class WebPubSubClient {
             convertedData = data;
           }
 
-          message = this._protocol.parseMessages(convertedData);
-          if (message === null) {
+          messages = this._protocol.parseMessages(convertedData);
+          if (messages === null) {
             // null means the message is not recognized.
             return;
           }
@@ -686,35 +686,41 @@ export class WebPubSubClient {
           throw err;
         }
 
-        try {
-          switch (message.kind) {
-            case "ack": {
-              handleAckMessage(message as AckMessage);
-              break;
-            }
-            case "connected": {
-              handleConnectedMessage(message as ConnectedMessage);
-              break;
-            }
-            case "disconnected": {
-              handleDisconnectedMessage(message as DisconnectedMessage);
-              break;
-            }
-            case "groupData": {
-              handleGroupDataMessage(message as GroupDataMessage);
-              break;
-            }
-            case "serverData": {
-              handleServerDataMessage(message as ServerDataMessage);
-              break;
-            }
-          }
-        } catch (err) {
-          logger.warning(
-            `An error occurred while handling the message with kind: ${message.kind} from service`,
-            err
-          );
+        if (!Array.isArray(messages)) {
+          messages = [messages];
         }
+
+        messages.forEach(message => {
+          try {
+            switch (message.kind) {
+              case "ack": {
+                handleAckMessage(message as AckMessage);
+                break;
+              }
+              case "connected": {
+                handleConnectedMessage(message as ConnectedMessage);
+                break;
+              }
+              case "disconnected": {
+                handleDisconnectedMessage(message as DisconnectedMessage);
+                break;
+              }
+              case "groupData": {
+                handleGroupDataMessage(message as GroupDataMessage);
+                break;
+              }
+              case "serverData": {
+                handleServerDataMessage(message as ServerDataMessage);
+                break;
+              }
+            }
+          } catch (err) {
+            logger.warning(
+              `An error occurred while handling the message with kind: ${message.kind} from service`,
+              err
+            );
+          }
+        });
       });
     });
   }

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -690,7 +690,7 @@ export class WebPubSubClient {
           messages = [messages];
         }
 
-        messages.forEach(message => {
+        messages.forEach((message) => {
           try {
             switch (message.kind) {
               case "ack": {

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -391,16 +391,18 @@ describe("WebPubSubClient", function () {
   });
 
   describe("WebPubSubClient handle messages", () => {
-    it("Handle a list of messages", async() => {
+    it("Handle a list of messages", async () => {
       const client = new WebPubSubClient("wss://service.com");
       const testWs = new TestWebSocketClient(client);
       makeStartable(testWs);
 
-      const mock = sinon.mock(client["_protocol"]); 
-      mock.expects("parseMessages").returns([
-        {kind: "serverData", data: "a", dataType: "text" } as ServerDataMessage,
-        {kind: "serverData", data: "b", dataType: "text" } as ServerDataMessage,
-      ]);
+      const mock = sinon.mock(client["_protocol"]);
+      mock
+        .expects("parseMessages")
+        .returns([
+          { kind: "serverData", data: "a", dataType: "text" } as ServerDataMessage,
+          { kind: "serverData", data: "b", dataType: "text" } as ServerDataMessage,
+        ]);
 
       const callback = sinon.spy();
       client.on("server-message", callback);

--- a/sdk/web-pubsub/web-pubsub-client/test/jsonProtocol.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/jsonProtocol.spec.ts
@@ -382,7 +382,11 @@ describe("JsonProtocol", function () {
     tests.forEach(({ testName, message, assertFunc }) => {
       it(`parse message test ${testName}`, () => {
         const parsedMsg = protocol.parseMessages(JSON.stringify(message));
-        assertFunc(parsedMsg!);
+        if (!Array.isArray(parsedMsg)) {
+          assertFunc(parsedMsg!);
+        } else {
+          throw new Error("should not be an array");
+        }
       });
     });
   });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-client

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Change the interface of `parseMessages` and allow protocol implementor to return a list of messages. It's designed for further possible new protocols that contains multiple messages in one websocket frame.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
