### PR TITLE
[Azure Monitor OpenTelemetry] Change JSON config values precedence

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -55,10 +55,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
       redis4: { enabled: false },
     };
     this._resource = this._getDefaultResource();
-    // Merge JSON configuration file if available
-    this._mergeConfig();
-    // Check for explicitly passed options when instantiating client
-    // This will take precedence over other settings
+
     if (options) {
       // Merge default with provided options
       this.azureMonitorExporterOptions = Object.assign(
@@ -72,6 +69,8 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
       this.resource = Object.assign(this.resource, options.resource);
       this.samplingRatio = options.samplingRatio || this.samplingRatio;
     }
+    // JSON configuration will take precedence over other settings
+    this._mergeConfig();
   }
 
   private _mergeConfig() {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/jsonConfig.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/jsonConfig.test.ts
@@ -116,5 +116,45 @@ describe("Json Config", () => {
         "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333;IngestionEndpoint=https://centralus-0.in.applicationinsights.azure.com/"
       );
     });
+
+    it("JSON config through env variable", () => {
+      const env = <{ [id: string]: string }>{};
+
+      let inputJson = {
+        azureMonitorExporterOptions: {
+          connectionString: "testConnString",
+          storageDirectory: "teststorageDirectory",
+          disableOfflineStorage: true,
+        },
+        samplingRatio: 1,
+        instrumentationOptions: {
+          http: { enabled: true },
+          azureSdk: { enabled: false },
+          mongoDb: { enabled: false },
+          mySql: { enabled: false },
+          postgreSql: { enabled: false },
+          redis: { enabled: false },
+          redis4: { enabled: false },
+        },
+      };
+      env["APPLICATIONINSIGHTS_CONFIGURATION_CONTENT"] = JSON.stringify(inputJson);
+      process.env = env;
+      const config = JsonConfig.getInstance();
+
+      assert.strictEqual(config.samplingRatio, 1);
+      assert.strictEqual(config.instrumentationOptions?.http?.enabled, true);
+      assert.strictEqual(config.instrumentationOptions?.azureSdk?.enabled, false);
+      assert.strictEqual(config.instrumentationOptions?.mongoDb?.enabled, false);
+      assert.strictEqual(config.instrumentationOptions?.mySql?.enabled, false);
+      assert.strictEqual(config.instrumentationOptions?.postgreSql?.enabled, false);
+      assert.strictEqual(config.instrumentationOptions?.redis?.enabled, false);
+      assert.strictEqual(config.instrumentationOptions?.redis4?.enabled, false);
+      assert.strictEqual(config.azureMonitorExporterOptions?.connectionString, "testConnString");
+      assert.strictEqual(
+        config.azureMonitorExporterOptions?.storageDirectory,
+        "teststorageDirectory"
+      );
+      assert.strictEqual(config.azureMonitorExporterOptions?.disableOfflineStorage, true);
+    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

JSON config values are ignored if options are provided, this is causing issue with auto attach scenarios, where JSON should have precedence over default and options provided by code.