### PR TITLE
[ServiceBus] throw error for invalid `scheduledEnqueueTimeUtc`

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add check to ensure argument to `scheduledEnqueueTimeUtc` of `scheduleMessages()` method is an instance of `Date` [PR #27396](https://github.com/Azure/azure-sdk-for-js/pull/27396)
+
 ## 7.9.2 (2023-10-10)
 
 ### Bugs Fixed

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -10,6 +10,7 @@ import {
   getSenderClosedErrorMsg,
   throwErrorIfConnectionClosed,
   throwIfNotValidServiceBusMessage,
+  throwTypeErrorIfNotInstanceOfParameterType,
   throwTypeErrorIfParameterMissing,
   throwTypeErrorIfParameterNotLong,
 } from "./util/errors";
@@ -293,12 +294,18 @@ export class ServiceBusSenderImpl implements ServiceBusSender {
     options: OperationOptionsBase = {}
   ): Promise<Long[]> {
     this._throwIfSenderOrConnectionClosed();
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "messages", messages);
     throwTypeErrorIfParameterMissing(
       this._context.connectionId,
       "scheduledEnqueueTimeUtc",
       scheduledEnqueueTimeUtc
     );
-    throwTypeErrorIfParameterMissing(this._context.connectionId, "messages", messages);
+    throwTypeErrorIfNotInstanceOfParameterType(
+      this._context.connectionId,
+      "scheduledEnqueueTimeUtc",
+      scheduledEnqueueTimeUtc,
+      Date
+    );
     const messagesToSchedule = Array.isArray(messages) ? messages : [messages];
 
     for (const message of messagesToSchedule) {

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -111,6 +111,30 @@ export function throwTypeErrorIfParameterMissing(
  * @param connectionId - Id of the underlying AMQP connection used for logging
  * @param parameterName - Name of the parameter to type check
  * @param parameterValue - Value of the parameter to type check
+ * @param constructor - Expected type of the parameter
+ */
+
+export function throwTypeErrorIfNotInstanceOfParameterType(
+  connectionId: string,
+  parameterName: string,
+  parameterValue: unknown,
+  constructor: Function,
+): void {
+  if (!(parameterValue instanceof constructor)) {
+    const error = new TypeError(
+      `The parameter "${parameterName}" should be an instance of "${constructor.name}"`
+    );
+    logger.warning(`[${connectionId}] %O`, error);
+    throw error;
+  }
+}
+
+/**
+ * @internal
+ * Logs and Throws TypeError if given parameter is not of expected type
+ * @param connectionId - Id of the underlying AMQP connection used for logging
+ * @param parameterName - Name of the parameter to type check
+ * @param parameterValue - Value of the parameter to type check
  * @param expectedType - Expected type of the parameter
  */
 

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -117,7 +117,7 @@ export function throwTypeErrorIfNotInstanceOfParameterType(
   connectionId: string,
   parameterName: string,
   parameterValue: unknown,
-  constructor: Function,
+  constructor: Function // eslint-disable @typescript-eslint/ban-types
 ): void {
   if (!(parameterValue instanceof constructor)) {
     const error = new TypeError(

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -117,7 +117,8 @@ export function throwTypeErrorIfNotInstanceOfParameterType(
   connectionId: string,
   parameterName: string,
   parameterValue: unknown,
-  constructor: Function // eslint-disable @typescript-eslint/ban-types
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  constructor: Function
 ): void {
   if (!(parameterValue instanceof constructor)) {
     const error = new TypeError(

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -107,13 +107,12 @@ export function throwTypeErrorIfParameterMissing(
 
 /**
  * @internal
- * Logs and Throws TypeError if given parameter is not of expected type
+ * Logs and Throws TypeError if given parameter is not an instance of expected type
  * @param connectionId - Id of the underlying AMQP connection used for logging
  * @param parameterName - Name of the parameter to type check
  * @param parameterValue - Value of the parameter to type check
- * @param constructor - Expected type of the parameter
+ * @param constructor - Constructor function of the expected parameter type
  */
-
 export function throwTypeErrorIfNotInstanceOfParameterType(
   connectionId: string,
   parameterName: string,
@@ -137,7 +136,6 @@ export function throwTypeErrorIfNotInstanceOfParameterType(
  * @param parameterValue - Value of the parameter to type check
  * @param expectedType - Expected type of the parameter
  */
-
 export function throwTypeErrorIfParameterTypeMismatch(
   connectionId: string,
   parameterName: string,

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -120,6 +120,20 @@ describe("sender unit tests", () => {
     });
   });
 
+  it("doesn't allow invalid enqueue time", async function() {
+    try {
+      await sender.scheduleMessages(
+        { body: "message" },
+        // @ts-expect-error We are trying invalid types on purpose to test the error thrown
+        "invalid date"
+      );
+      assert.fail("You should not be seeing this.");
+    } catch (err: any) {
+      assert.equal(err.name, "TypeError");
+      assert.equal(err.message, `The parameter "scheduledEnqueueTimeUtc" should be an instance of "Date"`);
+    }
+  });
+
   it("should set source in created sender options", () => {
     const options = sender["_sender"]["_createSenderOptions"]();
     assert.equal(options.source, "serviceBusClientId");

--- a/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/sender.spec.ts
@@ -120,7 +120,7 @@ describe("sender unit tests", () => {
     });
   });
 
-  it("doesn't allow invalid enqueue time", async function() {
+  it("doesn't allow invalid enqueue time", async function () {
     try {
       await sender.scheduleMessages(
         { body: "message" },
@@ -130,7 +130,10 @@ describe("sender unit tests", () => {
       assert.fail("You should not be seeing this.");
     } catch (err: any) {
       assert.equal(err.name, "TypeError");
-      assert.equal(err.message, `The parameter "scheduledEnqueueTimeUtc" should be an instance of "Date"`);
+      assert.equal(
+        err.message,
+        `The parameter "scheduledEnqueueTimeUtc" should be an instance of "Date"`
+      );
     }
   });
 


### PR DESCRIPTION
to `scheduleMessages()`.

The service ignores the value when it is not valid. This may surprise JavaScript developers who pass in a datetime string and expect it to work.  This adds an `instanceof` check to only accept `Date` instances

