### PR TITLE
Fix bad paths and remove missing paths from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -192,9 +192,6 @@
 # PRLabel: %Remote Rendering
 /sdk/remoterendering/ @FlorianBorn71
 
-# PRLabel: %VideoAnalyzer
-/sdk/videoanalyzer/video-analyzer-edge/ @hivyas @bterlson
-
 # PRLabel: %Maps
 /sdk/maps/ @dubiety @andykao1213
 
@@ -244,21 +241,12 @@
 /sdk/appservice/ci.mgmt.yml          @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/attestation/arm-attestation/ @qiaozha @MaryGao
 /sdk/attestation/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/authorization/arm-authorization/ @qiaozha @MaryGao
 /sdk/authorization/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
@@ -281,9 +269,6 @@
 # PRLabel: %Mgmt
 /sdk/batch/arm-batch/ @qiaozha @MaryGao
 /sdk/batch/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/batchai/arm-batchai/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/billing/arm-billing/ @qiaozha @MaryGao
@@ -323,9 +308,6 @@
 /sdk/compute/ci.mgmt.yml       @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/compute/arm-compute-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/compute/arm-compute-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
@@ -355,8 +337,8 @@
 /sdk/cosmosdb/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/cosmosdbforpostgresql/arm-cosmosdbforpostgresql/ @qiaozha @MaryGao
-/sdk/cosmosdbforpostgresql/ci.mgmt.yml @qiaozha @MaryGao
+/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/ @qiaozha @MaryGao
+/sdk/cosmosforpostgresql/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/customer-insights/arm-customerinsights/ @qiaozha @MaryGao
@@ -422,18 +404,11 @@
 /sdk/dns/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/dns/arm-dns-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/dns/arm-dns-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/domainservices/arm-domainservices/ @qiaozha @MaryGao
 /sdk/domainservices/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/edgegateway/arm-edgegateway/ @qiaozha @MaryGao
-/sdk/edgegateway/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/eventgrid/arm-eventgrid/ @qiaozha @MaryGao
@@ -499,15 +474,8 @@
 /sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/iotspaces/arm-iotspaces/ @qiaozha @MaryGao
-/sdk/iotspaces/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/keyvault/arm-keyvault/ @qiaozha @MaryGao
 /sdk/keyvault/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
@@ -536,9 +504,6 @@
 /sdk/locks/arm-locks-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/locks/arm-locks-profile-hybrid-2019-03-01/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/logic/arm-logic/ @qiaozha @MaryGao
 /sdk/logic/ci.mgmt.yml @qiaozha @MaryGao
 
@@ -559,10 +524,6 @@
 # PRLabel: %Mgmt
 /sdk/machinelearningexperimentation/arm-machinelearningexperimentation/ @qiaozha @MaryGao
 /sdk/machinelearningexperimentation/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/machinelearningservices/arm-machinelearningservices/ @qiaozha @MaryGao
-/sdk/machinelearningservices/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/managedapplications/arm-managedapplications/ @qiaozha @MaryGao
@@ -586,7 +547,7 @@
 
 # PRLabel: %Mgmt
 /sdk/mariadb/arm-mariadb/ @qiaozha @MaryGao
-/sdk/mmariadbaps/ci.mgmt.yml @qiaozha @MaryGao
+/sdk/mariadb/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/marketplaceordering/arm-marketplaceordering/ @qiaozha @MaryGao
@@ -609,9 +570,6 @@
 /sdk/monitor/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
@@ -620,7 +578,6 @@
 
 # PRLabel: %Mgmt
 /sdk/mysql/arm-mysql/      @qiaozha @MaryGao
-/sdk/mysql/arm-mysql-rest/ @qiaozha @MaryGao
 /sdk/mysql/ci.mgmt.yml     @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
@@ -635,9 +592,6 @@
 # PRLabel: %Mgmt
 /sdk/networkcloud/arm-networkcloud/      @qiaozha @MaryGao
 /sdk/networkcloud/ci.mgmt.yml       @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/network/arm-network-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/network/arm-network-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
@@ -672,9 +626,6 @@
 
 # PRLabel: %Mgmt
 /sdk/policy/arm-policy-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
-/sdk/policy/arm-policy-profile-hybrid-2019-03-01/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/policyinsights/arm-policyinsights/ @qiaozha @MaryGao
@@ -755,9 +706,6 @@
 /sdk/resources/arm-resources-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/resources/arm-resources-profile-hybrid-2019-03-01/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/search/arm-search/ @qiaozha @MaryGao
 /sdk/search/ci.mgmt.yml @qiaozha @MaryGao
 
@@ -803,9 +751,6 @@
 /sdk/storage/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/storage/arm-storage-profile-2019-03-01-hybrid/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/storage/arm-storage-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
@@ -840,9 +785,6 @@
 /sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/ @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/subscription/arm-subscriptions-profile-hybrid-2019-03-01/ @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/support/arm-support/ @qiaozha @MaryGao
 /sdk/support/ci.mgmt.yml  @qiaozha @MaryGao
 
@@ -871,10 +813,6 @@
 /sdk/resources-subscriptions/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/videoanalyzer/arm-videoanalyzer/ @qiaozha @MaryGao
-/sdk/videoanalyzer/ci.mgmt.yml @qiaozha @MaryGao
-
-# PRLabel: %Mgmt
 /sdk/templatespecs/arm-templatespecs/ @qiaozha @MaryGao
 /sdk/templatespecs/ci.mgmt.yml @qiaozha @MaryGao
 
@@ -895,7 +833,7 @@
 /sdk/portal/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/loadtesting/arm-loadtestservice/ @qiaozha @MaryGao
+/sdk/loadtesting/arm-loadtesting/ @qiaozha @MaryGao
 /sdk/loadtesting/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
@@ -907,8 +845,8 @@
 /sdk/imagebuilder/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
-/sdk/securityinsights/arm-securityinsights/ @qiaozha @MaryGao
-/sdk/securityinsights/ci.mgmt.yml @qiaozha @MaryGao
+/sdk/securityinsight/arm-securityinsight/ @qiaozha @MaryGao
+/sdk/securityinsight/ci.mgmt.yml @qiaozha @MaryGao
 
 # PRLabel: %Mgmt
 /sdk/oep/arm-oep/ @qiaozha @MaryGao


### PR DESCRIPTION
I have to say, of all the azure-sdk-for-&lt;lang&gt; repositories that I've been fixing up for bad/missing paths, this one is the worst, by far. 

/CC @qiaozha and @MaryGao 
When releasing a hybrid library with the date in its name, the old one was removed but when the new path entries were added, the old ones were left. There are also a number entries that will not work correctly. For example,
`# PRLabel: %Mgmt`
`/sdk/analysisservices/arm-analysisservices/ @qiaozha @MaryGao`
`/sdk/analysisservices/ci.mgmt.yml @qiaozha @MaryGao`

This will add the Mgmt label to a PR that changes anything in /sdk/analysisservices/arm-analysisservices/ but, the PRLabel only applies to the entry immediately below it. The /sdk/analysisservices/ci.mgmt.yml will not have this label applied. Each source line needs its own label, preferably with a blank line in between. I'm mentioning this here because there are roughly 100 entries like this. Further, if the subdirectory entry is the only thing in the sdk/serviceDirectory along with the ci.mgmt.yml file, then you only need the /sdk/serviceDirectory/ tagged with your names.

`# PRLabel: %Mgmt`
`/sdk/analysisservices/arm-analysisservices/ @qiaozha @MaryGao`

`# PRLabel: %Mgmt`
`/sdk/analysisservices/ci.mgmt.yml @qiaozha @MaryGao`

