### PR TITLE
[core] Add cloudflare support

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Support Cloudflare workers by only setting the available fields in the `Request` class for the Fetch API.
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
@@ -80,8 +80,13 @@ async function makeRequest(request: PipelineRequest): Promise<PipelineResponse> 
       method: request.method,
       headers: headers,
       signal: abortController.signal,
-      credentials: request.withCredentials ? "include" : "same-origin",
-      cache: "no-store",
+      // Cloudflare doesn't implement the full Fetch API spec
+      // because of some of it doesn't make sense in the edge.
+      // See https://github.com/cloudflare/workerd/issues/902
+      ...("credentials" in Request.prototype
+        ? { credentials: request.withCredentials ? "include" : "same-origin" }
+        : {}),
+      ...("cache" in Request.prototype ? { cache: "no-store" } : {}),
     };
 
     // According to https://fetch.spec.whatwg.org/#fetch-method,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-rest-pipeline and all libraries that depend on it

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/27412

### Describe the problem that is addressed by this PR
Cloudflare workers implement the Fetch API spec but not all of it since some of it doesn't make sense on the edge. However, CF shows this unsupport by throwing instead of silently ignoring the provided fields. This PR enables Azure libraries to work with Cloudflare workers by fixing this by setting those fields only if they're available in the `Request` class prototype.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Alternatively, I thought about introducing an explicit CF worker check but AFAIK, it is hard because it looks very similar to the browser.

### Are there test cases added in this PR? _(If not, why?)_
No but tested locally.

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
