### PR TITLE
[core-util] Fix issue with Deno showing up as isNode at runtime.

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Improved `isNode` to be false when `isDeno` is true due to Deno implementing `process.version.node`
+
 ### Other Changes
 
 ## 1.5.0 (2023-09-25)

--- a/sdk/core/core-util/src/checkEnvironment.ts
+++ b/sdk/core/core-util/src/checkEnvironment.ts
@@ -53,18 +53,22 @@ export const isWebWorker =
     self.constructor?.name === "SharedWorkerGlobalScope");
 
 /**
- * A constant that indicates whether the environment the code is running is Node.JS.
- */
-export const isNode =
-  typeof process !== "undefined" && Boolean(process.version) && Boolean(process.versions?.node);
-
-/**
  * A constant that indicates whether the environment the code is running is Deno.
  */
 export const isDeno =
   typeof Deno !== "undefined" &&
   typeof Deno.version !== "undefined" &&
   typeof Deno.version.deno !== "undefined";
+
+/**
+ * A constant that indicates whether the environment the code is running is Node.JS.
+ */
+export const isNode =
+  typeof process !== "undefined" &&
+  Boolean(process.version) &&
+  Boolean(process.versions?.node) &&
+  // Deno thought it was a good idea to spoof process.versions.node, see https://deno.land/std@0.177.0/node/process.ts?s=versions
+  !isDeno;
 
 /**
  * A constant that indicates whether the environment the code is running is Bun.sh.


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-util`

### Issues associated with this PR

Fixes #27077

### Describe the problem that is addressed by this PR

Deno implemented `process.versions.node`, which is how we detect that we are running inside a Node environment. Since Deno actually is much closer to a browser environment, this is *not* what was expected at runtime and resulted in things like loading the browser version of pipeline policies that throw due to not being implemented/relevant in browsers.

I kept this really simple by making `isNode` check that `isDeno` is false. Since `isNode` was previously false inside Deno environments, I don't think this will break anything.

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-js/pull/27090

