### PR TITLE
[test] use friendlier name in identity unit test titles

### DIFF
--- a/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
@@ -257,7 +257,8 @@ az login --scope https://test.windows.net/.default`;
   ]) {
     const tenantIdErrorMessage =
       "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names.";
-    it(`rejects invalid tenant id "${tenantId}" in getToken`, async function () {
+    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzureCliCredential();
       await assert.isRejected(
         credential.getToken("https://service/.default", {
@@ -267,7 +268,7 @@ az login --scope https://test.windows.net/.default`;
       );
     });
 
-    it(`rejects invalid tenant id "${tenantId}" in constructor`, function () {
+    it(`rejects invalid tenant id of ${testCase} in constructor`, function () {
       assert.throws(() => {
         new AzureCliCredential({ tenantId: tenantId });
       }, tenantIdErrorMessage);
@@ -275,7 +276,8 @@ az login --scope https://test.windows.net/.default`;
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    it(`rejects invalid scope "${inputScope}"`, async function () {
+    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzureCliCredential();
       await assert.isRejected(
         credential.getToken(inputScope),

--- a/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureCliCredential.spec.ts
@@ -257,7 +257,8 @@ az login --scope https://test.windows.net/.default`;
   ]) {
     const tenantIdErrorMessage =
       "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names.";
-    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    const testCase =
+      tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
     it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzureCliCredential();
       await assert.isRejected(
@@ -276,7 +277,12 @@ az login --scope https://test.windows.net/.default`;
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    const testCase =
+      inputScope === ""
+        ? "empty string"
+        : inputScope === "\0"
+        ? "null character"
+        : `"${inputScope}"`;
     it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzureCliCredential();
       await assert.isRejected(

--- a/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
@@ -179,7 +179,8 @@ describe("AzureDeveloperCliCredential (internal)", function () {
   ]) {
     const tenantIdErrorMessage =
       "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names.";
-    it(`rejects invalid tenant id "${tenantId}" in getToken`, async function () {
+    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzureDeveloperCliCredential();
       await assert.isRejected(
         credential.getToken("https://service/.default", {
@@ -188,7 +189,7 @@ describe("AzureDeveloperCliCredential (internal)", function () {
         tenantIdErrorMessage
       );
     });
-    it(`rejects invalid tenant id "${tenantId}" in constructor`, function () {
+    it(`rejects invalid tenant id of ${testCase} in constructor`, function () {
       assert.throws(() => {
         new AzureDeveloperCliCredential({ tenantId: tenantId });
       }, tenantIdErrorMessage);
@@ -196,7 +197,8 @@ describe("AzureDeveloperCliCredential (internal)", function () {
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    it(`rejects invalid scope "${inputScope}"`, async function () {
+    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzureDeveloperCliCredential();
       await assert.isRejected(
         credential.getToken(inputScope),

--- a/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
@@ -179,7 +179,8 @@ describe("AzureDeveloperCliCredential (internal)", function () {
   ]) {
     const tenantIdErrorMessage =
       "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names.";
-    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    const testCase =
+      tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
     it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzureDeveloperCliCredential();
       await assert.isRejected(
@@ -197,7 +198,12 @@ describe("AzureDeveloperCliCredential (internal)", function () {
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    const testCase =
+      inputScope === ""
+        ? "empty string"
+        : inputScope === "\0"
+        ? "null character"
+        : `"${inputScope}"`;
     it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzureDeveloperCliCredential();
       await assert.isRejected(

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -245,7 +245,8 @@ describe("AzurePowerShellCredential", function () {
     "12345678-1234-1234-1234-123456789012;",
     "12345678-1234-1234-1234-123456789012,",
   ]) {
-    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    const testCase =
+      tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
     it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzurePowerShellCredential();
       await assert.isRejected(
@@ -263,7 +264,12 @@ describe("AzurePowerShellCredential", function () {
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    const testCase =
+      inputScope === ""
+        ? "empty string"
+        : inputScope === "\0"
+        ? "null character"
+        : `"${inputScope}"`;
     it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzurePowerShellCredential();
       await assert.isRejected(

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -245,7 +245,8 @@ describe("AzurePowerShellCredential", function () {
     "12345678-1234-1234-1234-123456789012;",
     "12345678-1234-1234-1234-123456789012,",
   ]) {
-    it(`rejects invalid tenant id "${tenantId}" in getToken`, async function () {
+    const testCase = tenantId === " " ? "whitespace" : tenantId === "\0" ? "null character" : `"${tenantId}"`;
+    it(`rejects invalid tenant id of ${testCase} in getToken`, async function () {
       const credential = new AzurePowerShellCredential();
       await assert.isRejected(
         credential.getToken("https://service/.default", {
@@ -254,7 +255,7 @@ describe("AzurePowerShellCredential", function () {
         tenantIdErrorMessage
       );
     });
-    it(`rejects invalid tenant id "${tenantId}" in constructor`, function () {
+    it(`rejects invalid tenant id of ${testCase} in constructor`, function () {
       assert.throws(() => {
         new AzurePowerShellCredential({ tenantId: tenantId });
       }, tenantIdErrorMessage);
@@ -262,7 +263,8 @@ describe("AzurePowerShellCredential", function () {
   }
 
   for (const inputScope of ["scope |", "", "\0", "scope;", "scope,", "scope'", "scope&"]) {
-    it(`rejects invalid scope "${inputScope}"`, async function () {
+    const testCase = inputScope === "" ? "empty string" : inputScope === "\0" ? "null character" : `"${inputScope}"`;
+    it(`rejects invalid scope of ${testCase}`, async function () {
       const credential = new AzurePowerShellCredential();
       await assert.isRejected(
         credential.getToken(inputScope),


### PR DESCRIPTION
This fixes issue in build pipeline test result publish step where the test result publisher failed to read the result xml due to the 0x00 character in the file.

