### PR TITLE
Fixing issues with dev-tool customize.

### DIFF
--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -295,11 +295,11 @@ function isSelfImport(module: string, file: SourceFile): boolean {
     projectPath = projectPath.getParent() as Directory;
   }
   // e.g: ./sources/generated/src
-  let relativeOriginal = originalDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
+  const relativeOriginal = originalDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
   // e.g: ./sources/customizations
-  let relativeCustom = customDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
+  const relativeCustom = customDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
   // e.g: ./sources/
-  let prefix = commonPrefix(relativeOriginal, relativeCustom);
+  const prefix = commonPrefix(relativeOriginal, relativeCustom);
   // e.g generated/src
   let originalSuffix = relativeOriginal.substring(prefix.length);
   // e.g generated/src/
@@ -309,9 +309,9 @@ function isSelfImport(module: string, file: SourceFile): boolean {
   if (index < 0) {
     return false;
   }
-  let moduleRelative = module.substring(index + originalSuffix.length);
-  let a = file.getFilePath().replace(/\\/g, '/').replace(/\.ts$/, ".js");
-  if (a.endsWith(moduleRelative)) {
+  const moduleRelative = module.substring(index + originalSuffix.length);
+  const sanitizedPath = file.getFilePath().replace(/\\/g, '/').replace(/\.ts$/, ".js");
+  if (sanitizedPath.endsWith(moduleRelative)) {
     return true;
   }
   return false;

--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -12,6 +12,7 @@ import {
   TypeAliasDeclaration,
   SourceFile,
   ImportDeclaration,
+  Directory,
 } from "ts-morph";
 import { augmentFunctions } from "./functions";
 import { augmentClasses } from "./classes";
@@ -20,7 +21,7 @@ import { sortSourceFileContents } from "./helpers/preformat";
 import { addHeaderToFiles } from "./helpers/addFileHeaders";
 import { resolveProject } from "../resolveProject";
 import { augmentTypeAliases } from "./aliases";
-import { setCustomizationState, resetCustomizationState } from "./state";
+import { setCustomizationState, resetCustomizationState, getCustomizationState } from "./state";
 import { getNewCustomFiles } from "./helpers/files";
 import { augmentImports } from "./imports";
 
@@ -39,7 +40,7 @@ export async function customize(originalDir: string, customDir: string, outDir: 
     return;
   }
 
-  _originalFolderName = customDir.split("/").pop() ?? _originalFolderName;
+  _originalFolderName = originalDir.replace(commonPrefix(originalDir, customDir), "").replace(/\\/g, "/") ?? _originalFolderName;
 
   // Bring files only present in custom into the output
   copyFilesInCustom(originalDir, customDir, outDir);
@@ -247,14 +248,13 @@ function transformGeneratedImport(moduleSpecifier: string) {
 
 function copyCustomImports(customFile: SourceFile, originalFile: SourceFile) {
   for (const customImport of customFile.getImportDeclarations()) {
+    if (isSelfImport(customImport.getModuleSpecifierValue(), originalFile)) {
+      continue;
+    }
     if (isGeneratedImport(customImport)) {
       const newModuleSpecifier = transformGeneratedImport(customImport.getModuleSpecifierValue());
       customImport.setModuleSpecifier(newModuleSpecifier);
       originalFile.addImportDeclaration(customImport.getStructure());
-    }
-
-    if (customImport.isModuleSpecifierRelative()) {
-      continue;
     }
 
     const originalImport = originalFile.getImportDeclaration(
@@ -273,11 +273,46 @@ function copyCustomImports(customFile: SourceFile, originalFile: SourceFile) {
 
     const allImports = new Set<string>(originalNamedImports);
     for (const customNamedImport of customImport.getNamedImports()) {
-      allImports.add(customNamedImport.getName());
+      allImports.add(customNamedImport.getText());
     }
 
     originalImport?.removeNamedImports();
     originalImport?.addNamedImports(Array.from(allImports));
   }
   originalFile.organizeImports();
+}
+
+function commonPrefix(a: string, b: string) {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return a.slice(0, i);
+}
+
+function isSelfImport(module: string, file: SourceFile): boolean {
+  const { customDir, originalDir } = getCustomizationState();
+  let projectPath = file.getDirectory();
+  while (projectPath.getRelativePathTo(customDir).startsWith("..")) {
+    projectPath = projectPath.getParent() as Directory;
+  }
+  // e.g: ./sources/generated/src
+  let relativeOriginal = originalDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
+  // e.g: ./sources/customizations
+  let relativeCustom = customDir.replace(/\\/g, '/').replace(projectPath.getPath(), ".");
+  // e.g: ./sources/
+  let prefix = commonPrefix(relativeOriginal, relativeCustom);
+  // e.g generated/src
+  let originalSuffix = relativeOriginal.substring(prefix.length);
+  // e.g generated/src/
+  originalSuffix = originalSuffix.endsWith("/") ? originalSuffix : originalSuffix + "/";
+  // e.g folder/file.js (with the original module being ../../generated/src/folder/file.js)
+  const index = module.search(originalSuffix);
+  if (index < 0) {
+    return false;
+  }
+  let moduleRelative = module.substring(index + originalSuffix.length);
+  let a = file.getFilePath().replace(/\\/g, '/').replace(/\.ts$/, ".js");
+  if (a.endsWith(moduleRelative)) {
+    return true;
+  }
+  return false;
 }

--- a/common/tools/dev-tool/src/util/customization/functions.ts
+++ b/common/tools/dev-tool/src/util/customization/functions.ts
@@ -43,8 +43,8 @@ export function augmentFunction(
 
 function isAugmentingFunction(fn: FunctionDeclaration): boolean {
   const customFunctionContent = fn.getBody()?.getFullText();
-
-  if (customFunctionContent?.includes(`_${fn.getName()}`)) {
+  const fnRegex = new RegExp(`_${fn.getName()}\\s*\\(`);
+  if (customFunctionContent?.match(fnRegex)) {
     return true;
   }
 


### PR DESCRIPTION
### Packages impacted by this PR

dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

This PR addresses a couple of problems with the `customize` tool.

- If when replacing a function, you called a function that had the same names as prefix it would make the old function private instead of removing it (e.g replacing `foo` and having another a function call to `_foobar` would trigger this issue)
- If customized code was importing from the same file but the generated version, the reference to the generated file would show up in the end result.
- In some conditions, importing from generated code would result in the import not being translated into importing the end result file.
- Under certain circumstances, importing a custom-only file would not be reflected in the end result.
- Named imports of generated code were not being reflected.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
