### PR TITLE
[storage] update code coverage config files

### DIFF
--- a/sdk/storage/storage-file-datalake/.nycrc
+++ b/sdk/storage/storage-file-datalake/.nycrc
@@ -1,12 +1,10 @@
 {
     "include": [
-      "dist-esm/**/src/**/*.js"
+      "dist-esm/storage-common/src/**/*.js",
+      "dist-esm/storage-file-datalake/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "dist-esm/storage-file-datalake/src/StorageBrowserPolicyFactory.js",
-      "dist-esm/storage-file-datalake/src/policies/StorageBrowserPolicy.js",
-      "dist-esm/storage-file-datalake/src/credentials/StorageSharedKeyCredential.browser.js",
       "dist-esm/storage-file-datalake/src/models.js",
       "dist-esm/storage-file-datalake/src/index.browser.js",
       "dist-esm/storage-file-datalake/src/utils/utils.browser.js",

--- a/sdk/storage/storage-file-share/.nycrc
+++ b/sdk/storage/storage-file-share/.nycrc
@@ -4,14 +4,14 @@
     ],
     "exclude": [
       "**/*.d.ts",
-      "dist-esm/src/StorageBrowserPolicyFactory.js",
-      "dist-esm/src/policies/StorageBrowserPolicy.js",
-      "dist-esm/src/FileDownloadResponse.browser.js",
-      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
-      "dist-esm/src/models.js",
-      "dist-esm/src/index.browser.js",
-      "dist-esm/src/utils/utils.browser.js",
-      "dist-esm/src/generated/src/storageClient.js"
+      "dist-esm/storage-file-share/src/StorageBrowserPolicyFactory.js",
+      "dist-esm/storage-file-share/src/policies/StorageBrowserPolicy.js",
+      "dist-esm/storage-file-share/src/FileDownloadResponse.browser.js",
+      "dist-esm/storage-file-share/src/credentials/StorageSharedKeyCredential.browser.js",
+      "dist-esm/storage-file-share/src/models.js",
+      "dist-esm/storage-file-share/src/index.browser.js",
+      "dist-esm/storage-file-share/src/utils/utils.browser.js",
+      "dist-esm/storage-file-share/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",

--- a/sdk/storage/storage-queue/.nycrc
+++ b/sdk/storage/storage-queue/.nycrc
@@ -1,15 +1,13 @@
 {
     "include": [
-      "dist-esm/src/**/*.js"
+      "dist-esm/storage-common/src/**/*.js",
+      "dist-esm/storage-queue/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "dist-esm/src/StorageBrowserPolicyFactory.js",
-      "dist-esm/src/policies/StorageBrowserPolicy.js",
-      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
-      "dist-esm/src/models.js",
-      "dist-esm/src/index.browser.js",
-      "dist-esm/src/generated/src/storageClient.js"
+      "dist-esm/storage-queue/src/models.js",
+      "dist-esm/storage-queue/src/index.browser.js",
+      "dist-esm/storage-queue/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",


### PR DESCRIPTION
Some build output file paths in code coverage config are now out-dated:

- shared policies are now from storage-blob so they are no longer needed in `exclude` list.
- output files for queue are now under dist-esm/storage-queue

This PR updates these config files to have correct paths.