### PR TITLE
[dev-tool] Inline dynamic imports in browser bundle

### DIFF
--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -180,6 +180,7 @@ export default leafCommand(commandInfo, async (options) => {
         file: `dist-test/index.browser.js`,
         format: "umd",
         sourcemap: true,
+        inlineDynamicImports: true,
       });
     } catch (error: any) {
       log.error(error);

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:samples": "echo Obsolete.",
-    "build:test": "tsc -p . && dev-tool run bundle",
+    "build:test": "tsc -p . && dev-tool run bundle --inline-dynamic-imports-for-browser-test=true",
     "build": "npm run clean && npm run extract-api && tsc -p . && dev-tool run bundle",
     "clean": "rimraf dist dist-* types *.tgz *.log",
     "execute:samples": "dev-tool samples run samples-dev",


### PR DESCRIPTION
Because `umd` doesn't support dynamic imports and rollup will give errors like:

>RollupError: Invalid value "umd" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds.

This error showed up in rush automation runs where we upgraded to msal-browser 3.3.0 which started using `await import`.

This PR uses `inlineDynamicImports: true` for browser test bundle.
