### PR TITLE
[keyvault] Add `x509ThumbprintString` property to `CertificateProperties`

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added property `x509ThumbprintString` to `CertificateProperties`. This property is a hex string representation of the existing `x509Thumbprint` property added for convenience.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -111,7 +111,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-util": "^1.0.0",
+    "@azure/core-util": "^1.6.1",
     "@azure/core-tracing": "^1.0.0",
     "@azure/keyvault-common": "^1.0.0",
     "@azure/logger": "^1.0.0",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -198,6 +198,7 @@ export interface CertificateProperties {
     readonly vaultUrl?: string;
     readonly version?: string;
     readonly x509Thumbprint?: Uint8Array;
+    readonly x509ThumbprintString?: string;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -456,6 +456,10 @@ export interface CertificateProperties {
    */
   readonly x509Thumbprint?: Uint8Array;
   /**
+   * Thumbprint of the certifiate encoded as a hex string.
+   */
+  readonly x509ThumbprintString?: string;
+  /**
    * The retention dates of the softDelete data.
    * The value should be `>=7` and `<=90` when softDelete enabled.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**

--- a/sdk/keyvault/keyvault-certificates/src/transformations.ts
+++ b/sdk/keyvault/keyvault-certificates/src/transformations.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { uint8ArrayToString } from "@azure/core-util";
 import {
   ArrayOneOrMore,
   CertificateContentType,
@@ -211,6 +212,9 @@ export function getCertificateFromCertificateBundle(
     version: parsedId.version,
     tags: certificateBundle.tags,
     x509Thumbprint: certificateBundle.x509Thumbprint,
+    x509ThumbprintString:
+      certificateBundle.x509Thumbprint &&
+      uint8ArrayToString(certificateBundle.x509Thumbprint, "hex"),
     recoverableDays: attributes.recoverableDays,
   };
 
@@ -244,6 +248,9 @@ export function getCertificateWithPolicyFromCertificateBundle(
     version: parsedId.version,
     tags: certificateBundle.tags,
     x509Thumbprint: certificateBundle.x509Thumbprint,
+    x509ThumbprintString:
+      certificateBundle.x509Thumbprint &&
+      uint8ArrayToString(certificateBundle.x509Thumbprint, "hex"),
     recoverableDays: attributes.recoverableDays,
   };
 
@@ -294,6 +301,7 @@ export function getDeletedCertificateFromItem(item: DeletedCertificateItem): Del
     id: item.id,
     tags: item.tags,
     x509Thumbprint: item.x509Thumbprint,
+    x509ThumbprintString: item.x509Thumbprint && uint8ArrayToString(item.x509Thumbprint, "hex"),
 
     recoverableDays: item.attributes?.recoverableDays,
     recoveryLevel: item.attributes?.recoveryLevel,
@@ -374,6 +382,9 @@ export function getPropertiesFromCertificateBundle(
     version: parsedId.version,
     tags: certificateBundle.tags,
     x509Thumbprint: certificateBundle.x509Thumbprint,
+    x509ThumbprintString:
+      certificateBundle.x509Thumbprint &&
+      uint8ArrayToString(certificateBundle.x509Thumbprint, "hex"),
     recoverableDays: attributes.recoverableDays,
   };
 

--- a/sdk/keyvault/keyvault-certificates/test/internal/transformations.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/internal/transformations.spec.ts
@@ -2,8 +2,18 @@
 // Licensed under the MIT license.
 
 import { assert } from "@azure/test-utils";
-import { CertificateOperation as CoreCertificateOperation } from "../../src/generated/models";
-import { getCertificateOperationFromCoreOperation } from "../../src/transformations";
+import {
+  CertificateBundle,
+  CertificateOperation as CoreCertificateOperation,
+  DeletedCertificateItem,
+} from "../../src/generated/models";
+import {
+  getCertificateFromCertificateBundle,
+  getCertificateOperationFromCoreOperation,
+  getCertificateWithPolicyFromCertificateBundle,
+  getDeletedCertificateFromItem,
+  getPropertiesFromCertificateBundle,
+} from "../../src/transformations";
 
 describe("transformations", function () {
   describe("getCertificateOperationFromCoreOperation", function () {
@@ -42,6 +52,45 @@ describe("transformations", function () {
 
       const output = getCertificateOperationFromCoreOperation("", "", input);
       assert.deepNestedInclude(output, input);
+    });
+  });
+
+  describe("x509ThumbprintString", function () {
+    it("is populated by getCertificateFromCertificateBundle", function () {
+      const bundle: CertificateBundle = {
+        id: "https://myvault.vault.azure.net/certificates/certificateName/version",
+        x509Thumbprint: new Uint8Array([0xab, 0xcd, 0xef]),
+      };
+      const result = getCertificateFromCertificateBundle(bundle);
+      assert.equal(result.properties.x509ThumbprintString, "abcdef");
+    });
+
+    it("is populated by getCertificateWithPolicyFromCertifiateBundle", function () {
+      const bundle: CertificateBundle = {
+        id: "https://myvault.vault.azure.net/certificates/certificateName/version",
+        x509Thumbprint: new Uint8Array([0xab, 0xcd, 0xef]),
+      };
+
+      const result = getCertificateWithPolicyFromCertificateBundle(bundle);
+      assert.equal(result.properties.x509ThumbprintString, "abcdef");
+    });
+
+    it("is populated by getDeletedCertificateFromItem", function () {
+      const item: DeletedCertificateItem = {
+        id: "https://myvault.vault.azure.net/certificates/certificateName/version",
+        x509Thumbprint: new Uint8Array([0xab, 0xcd, 0xef]),
+      };
+      const result = getDeletedCertificateFromItem(item);
+      assert.equal(result.properties.x509ThumbprintString, "abcdef");
+    });
+
+    it("is populated by getPropertiesFromCertificateBundle", function () {
+      const bundle: CertificateBundle = {
+        id: "https://myvault.vault.azure.net/certificates/certificateName/version",
+        x509Thumbprint: new Uint8Array([0xab, 0xcd, 0xef]),
+      };
+      const result = getPropertiesFromCertificateBundle(bundle);
+      assert.equal(result.x509ThumbprintString, "abcdef");
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`

### Issues associated with this PR

- Fixes https://github.com/Azure/azure-sdk-for-js/issues/25716

### Describe the problem that is addressed by this PR

Add convenience property `x509ThumbprintString` which is a hex-encoded representation of the existing `x509Thumbprint` property.