### PR TITLE
[Doc] fix broken links to Node.js releases

### DIFF
--- a/sdk/cognitivelanguage/ai-language-conversations/samples/v1-beta/javascript/README.md
+++ b/sdk/cognitivelanguage/ai-language-conversations/samples/v1-beta/javascript/README.md
@@ -26,7 +26,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
 
 You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
 

--- a/sdk/cognitivelanguage/ai-language-conversations/samples/v1-beta/typescript/README.md
+++ b/sdk/cognitivelanguage/ai-language-conversations/samples/v1-beta/typescript/README.md
@@ -26,7 +26,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample programs are compatible with [LTS versions of Node.js](https://nodejs.org/about/releases/).
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
 
 Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
 

--- a/sdk/maps/maps-geolocation-rest/README.md
+++ b/sdk/maps/maps-geolocation-rest/README.md
@@ -16,7 +16,7 @@ Key links:
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 ### Prerequisites

--- a/sdk/maps/maps-render-rest/README.md
+++ b/sdk/maps/maps-render-rest/README.md
@@ -212,7 +212,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 [api_ref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-render?view=azure-node-preview
 [samples]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-render-rest/samples
 [product_info]: https://docs.microsoft.com/rest/api/maps/render-v2
-[nodejs_release]: https://nodejs.org/about/releases/
+[nodejs_release]: https://github.com/nodejs/release#release-schedule
 [az_subscription]: https://azure.microsoft.com/free/
 [az_maps_account_management]: https://docs.microsoft.com/azure/azure-maps/how-to-manage-account-keys
 [azure_portal]: https://portal.azure.com

--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -15,7 +15,7 @@ Key links:
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 ### Prerequisites

--- a/sdk/maps/maps-search-rest/README.md
+++ b/sdk/maps/maps-search-rest/README.md
@@ -16,7 +16,7 @@ Key links:
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 ### Prerequisites

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
@@ -9,7 +9,7 @@ You can use this library to add protobuf subprotocols including `protobuf.reliab
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 
 ### Prerequisites
 

--- a/sdk/web-pubsub/web-pubsub-client/README.md
+++ b/sdk/web-pubsub/web-pubsub-client/README.md
@@ -22,7 +22,7 @@ _This library is hosted on [NPM][npm]._
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 
 ### Prerequisites
 


### PR DESCRIPTION
A couple of README files have different link than most packages' in this repo, likely due to in-flight PRs when we update the link to point to github one. These are now broken. This PR replaces them with the one used in other packages.
