### PR TITLE
update broken link in web-pubsub-client and web-pubsub-client-protobuf

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
@@ -9,7 +9,7 @@ You can use this library to add protobuf subprotocols including `protobuf.reliab
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 
 ### Prerequisites
 

--- a/sdk/web-pubsub/web-pubsub-client/README.md
+++ b/sdk/web-pubsub/web-pubsub-client/README.md
@@ -22,7 +22,7 @@ _This library is hosted on [NPM][npm]._
 
 ### Currently supported environments
 
-- [LTS versions of Node.js](https://nodejs.org/about/releases/)
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 
 ### Prerequisites
 


### PR DESCRIPTION
```
##[error][404] broken link https://nodejs.org/about/releases/
Checking 1 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/review/web-pubsub-client-protobuf.api.md
Checking 4 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/samples/v1-beta/javascript/README.md
Checking 5 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/samples/v1-beta/typescript/README.md
Checking 0 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/CHANGELOG.md
Checking 11 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
##[warning]broken link https://nodejs.org/about/releases/
Checking 1 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-express/review/web-pubsub-express.api.md
Checking 5 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-express/samples/v1/javascript/README.md
Checking 6 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-express/samples/v1/typescript/README.md
Checking 2 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
Checking 15 links found on page file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-express/README.md
Summary of broken links:
'file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client/README.md' has 1 broken link(s):
  https://nodejs.org/about/releases/
'file:///mnt/vss/_work/1/s/sdk/web-pubsub/web-pubsub-client-protobuf/README.md' has 1 broken link(s):
  https://nodejs.org/about/releases/
Checked 138 links with 2 broken link(s) found.
```

ci link: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3197805&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=aea0e0e1-1e00-5c1b-bba8-b2b238976da3