### PR TITLE
[dev-tool] Drop NodeJS v14 & 16

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -13,7 +13,7 @@ import { S_IRWXO } from "constants";
 import { resolveProject } from "../../util/resolveProject";
 import { findSamplesRelativeDir } from "../../util/findSamplesDir";
 
-const defaultVersions = [14, 16, 18, 19];
+const defaultVersions = [18, 20, 21];
 
 const log = createPrinter("check-node-versions-samples");
 


### PR DESCRIPTION
### Packages impacted by this PR
dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Remove node 14 & 16 in dev-tool checkNodeVersions command

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
