### PR TITLE
[engsys] Update CI to use node 18 as a minimum runtime version

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -17,11 +17,7 @@
         "Pool": "Azure Pipelines"
       }
     },
-    "NodeTestVersion": [
-      "16.x",
-      "18.x",
-      "20.x"
-    ],
+    "NodeTestVersion": ["18.x", "20.x"],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },
@@ -59,10 +55,7 @@
       },
       "TestType": "node",
       "NodeTestVersion": "18.x",
-      "DependencyVersion": [
-        "max",
-        "min"
-      ],
+      "DependencyVersion": ["max", "min"],
       "TestResultsFiles": "**/test-results.xml"
     }
   ]

--- a/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
@@ -21,7 +21,7 @@
         "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
       }
     },
-    "NodeTestVersion": ["16.x", "18.x", "20.x"],
+    "NodeTestVersion": ["18.x", "20.x"],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -9,12 +9,12 @@
         }
       },
       "Versions": {
-        "16.x_service_version_7_2": {
-          "NodeTestVersion": "16.x",
+        "18.x_service_version_7_2": {
+          "NodeTestVersion": "18.x",
           "ServiceVersion": "7.2"
         },
-        "18.x": {
-          "NodeTestVersion": "18.x"
+        "20.x": {
+          "NodeTestVersion": "20.x"
         }
       },
       "TestType": "node"

--- a/sdk/keyvault/keyvault-certificates/platform-matrix.json
+++ b/sdk/keyvault/keyvault-certificates/platform-matrix.json
@@ -8,7 +8,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "16.x",
+      "NodeTestVersion": "18.x",
       "ServiceVersion": ["7.0", "7.1", "7.2"]
     }
   ],

--- a/sdk/keyvault/keyvault-secrets/platform-matrix.json
+++ b/sdk/keyvault/keyvault-secrets/platform-matrix.json
@@ -8,7 +8,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "16.x",
+      "NodeTestVersion": "18.x",
       "ServiceVersion": ["7.0", "7.1", "7.2"]
     }
   ],


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

This PR migrates our CI away from testing Node16. 

Due to Node16 [depending on an insecure version of OpenSSL](https://nodejs.org/en/blog/announcements/nodejs16-eol) we believe that customers should migrate without delay to a supported LTS version of the Node runtime. As such we do not intend to fix bugs that only reproduce in Node 16 runtimes, obviating the need to proactively run in this environment.