### PR TITLE
[EngSys] Replace NodeJS version of 16.x in pipelines with 18.x or 20.x

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -23,7 +23,7 @@ stages:
         steps:
           - template: /eng/pipelines/templates/steps/use-node-version.yml
             parameters:
-              NodeVersion: 16.x
+              NodeVersion: 18.x
 
           - task: PowerShell@2
             inputs:

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -61,24 +61,24 @@ jobs:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "18.x"
-        Windows Node16 (AzureCloud):
+        Windows Node20 (AzureCloud):
           Pool: "azsdk-pool-mms-win-2022-general"
           OSVmImage: "MMS2022"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "16.x"
+          NodeTestVersion: "20.x"
         Linux Node18 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "18.x"
-        Linux Node16 (AzureCloud):
+        Linux Node20 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "16.x"
+          NodeTestVersion: "20.x"
 #        Linux Node12 (AzureUSGovernment):
 #          Pool: Azure Pipelines
 #          OSVmImage: "ubuntu-18.04"

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,6 @@
 variables:
   DocWardenVersion: '0.5.0'
-  NodeVersion: "16.x"
+  NodeVersion: "18.x"
   OSVmImage: "ubuntu-20.04"
   skipComponentGovernanceDetection: true
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]


### PR DESCRIPTION
- with 18.x by default
- with 20.x to avoid dupe/have better coverage
