### PR TITLE
[dev-tool][customization] fix duplicate file header

### DIFF
--- a/common/tools/dev-tool/src/util/customization/helpers/addFileHeaders.ts
+++ b/common/tools/dev-tool/src/util/customization/helpers/addFileHeaders.ts
@@ -8,9 +8,9 @@ const licenseHeader = `// Copyright (c) Microsoft Corporation.
 const generatedCodeNotice = `
 /**
  * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- * 
+ *
  * Any changes you make here may be lost.
- * 
+ *
  * If you need to make changes, please do so in the original source file, \\{project-root\\}/sources/custom
  */`;
 

--- a/sdk/template/template-dpg/src/WidgetServiceClient.ts
+++ b/sdk/template/template-dpg/src/WidgetServiceClient.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import {
   AnalyzeResult,

--- a/sdk/template/template-dpg/src/WidgetServiceClient.ts
+++ b/sdk/template/template-dpg/src/WidgetServiceClient.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import {
   AnalyzeResult,

--- a/sdk/template/template-dpg/src/api/WidgetServiceContext.ts
+++ b/sdk/template/template-dpg/src/api/WidgetServiceContext.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { ClientOptions } from "@azure-rest/core-client";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import getClient, { WidgetServiceContext } from "../rest/index.js";

--- a/sdk/template/template-dpg/src/api/WidgetServiceContext.ts
+++ b/sdk/template/template-dpg/src/api/WidgetServiceContext.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { ClientOptions } from "@azure-rest/core-client";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import getClient, { WidgetServiceContext } from "../rest/index.js";

--- a/sdk/template/template-dpg/src/api/foo.ts
+++ b/sdk/template/template-dpg/src/api/foo.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 export function foo(): void {
   console.log("foo");
 }

--- a/sdk/template/template-dpg/src/api/foo.ts
+++ b/sdk/template/template-dpg/src/api/foo.ts
@@ -1,29 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
 export function foo(): void {
   console.log("foo");
 }

--- a/sdk/template/template-dpg/src/api/index.ts
+++ b/sdk/template/template-dpg/src/api/index.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 export { Widget, ColorType, AnalyzeResult } from "./models.js";
 export {
   listWidgets,

--- a/sdk/template/template-dpg/src/api/index.ts
+++ b/sdk/template/template-dpg/src/api/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 export { Widget, ColorType, AnalyzeResult } from "./models.js";
 export {
   listWidgets,

--- a/sdk/template/template-dpg/src/api/models.ts
+++ b/sdk/template/template-dpg/src/api/models.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 /** */
 export interface Widget {
   /** The UUID of this widget. This is generated automatically by the service. */

--- a/sdk/template/template-dpg/src/api/models.ts
+++ b/sdk/template/template-dpg/src/api/models.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 /** */
 export interface Widget {
   /** The UUID of this widget. This is generated automatically by the service. */

--- a/sdk/template/template-dpg/src/api/operations.ts
+++ b/sdk/template/template-dpg/src/api/operations.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { StreamableMethod } from "@azure-rest/core-client";
 import { RestError } from "@azure/core-rest-pipeline";
 import { RequestOptions } from "../common/interfaces.js";

--- a/sdk/template/template-dpg/src/api/operations.ts
+++ b/sdk/template/template-dpg/src/api/operations.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { StreamableMethod } from "@azure-rest/core-client";
 import { RestError } from "@azure/core-rest-pipeline";
 import { RequestOptions } from "../common/interfaces.js";

--- a/sdk/template/template-dpg/src/common/interfaces.ts
+++ b/sdk/template/template-dpg/src/common/interfaces.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { RawHttpHeadersInput } from "@azure/core-rest-pipeline";
 
 export interface RequestOptions {

--- a/sdk/template/template-dpg/src/common/interfaces.ts
+++ b/sdk/template/template-dpg/src/common/interfaces.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { RawHttpHeadersInput } from "@azure/core-rest-pipeline";
 
 export interface RequestOptions {

--- a/sdk/template/template-dpg/src/index.ts
+++ b/sdk/template/template-dpg/src/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 export { Widget, ColorType, AnalyzeResult } from "./api/models.js";
 export {
   ListWidgetsOptions,

--- a/sdk/template/template-dpg/src/index.ts
+++ b/sdk/template/template-dpg/src/index.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 export { Widget, ColorType, AnalyzeResult } from "./api/models.js";
 export {
   ListWidgetsOptions,

--- a/sdk/template/template-dpg/src/logger.ts
+++ b/sdk/template/template-dpg/src/logger.ts
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { createClientLogger } from "@azure/logger";
 export const logger = createClientLogger("widget");

--- a/sdk/template/template-dpg/src/logger.ts
+++ b/sdk/template/template-dpg/src/logger.ts
@@ -1,29 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { createClientLogger } from "@azure/logger";
 export const logger = createClientLogger("widget");

--- a/sdk/template/template-dpg/src/rest/clientDefinitions.ts
+++ b/sdk/template/template-dpg/src/rest/clientDefinitions.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import {
   ListWidgetsParameters,
   CreateWidgetParameters,

--- a/sdk/template/template-dpg/src/rest/clientDefinitions.ts
+++ b/sdk/template/template-dpg/src/rest/clientDefinitions.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import {
   ListWidgetsParameters,
   CreateWidgetParameters,

--- a/sdk/template/template-dpg/src/rest/index.ts
+++ b/sdk/template/template-dpg/src/rest/index.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import WidgetServiceClient from "./widgetServiceClient.js";
 
 export * from "./widgetServiceClient.js";

--- a/sdk/template/template-dpg/src/rest/index.ts
+++ b/sdk/template/template-dpg/src/rest/index.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import WidgetServiceClient from "./widgetServiceClient.js";
 
 export * from "./widgetServiceClient.js";

--- a/sdk/template/template-dpg/src/rest/isUnexpected.ts
+++ b/sdk/template/template-dpg/src/rest/isUnexpected.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import {
   ListWidgets200Response,
   ListWidgetsDefaultResponse,

--- a/sdk/template/template-dpg/src/rest/isUnexpected.ts
+++ b/sdk/template/template-dpg/src/rest/isUnexpected.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import {
   ListWidgets200Response,
   ListWidgetsDefaultResponse,

--- a/sdk/template/template-dpg/src/rest/models.ts
+++ b/sdk/template/template-dpg/src/rest/models.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 export interface CreateWidget {
   /** The weight of the widget. This is an int32, but must be greater than zero. */
   weight: number;

--- a/sdk/template/template-dpg/src/rest/models.ts
+++ b/sdk/template/template-dpg/src/rest/models.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 export interface CreateWidget {
   /** The weight of the widget. This is an int32, but must be greater than zero. */
   weight: number;

--- a/sdk/template/template-dpg/src/rest/outputModels.ts
+++ b/sdk/template/template-dpg/src/rest/outputModels.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 export interface WidgetOutput {
   /** The UUID of this widget. This is generated automatically by the service. */
   id: string;

--- a/sdk/template/template-dpg/src/rest/outputModels.ts
+++ b/sdk/template/template-dpg/src/rest/outputModels.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 export interface WidgetOutput {
   /** The UUID of this widget. This is generated automatically by the service. */
   id: string;

--- a/sdk/template/template-dpg/src/rest/parameters.ts
+++ b/sdk/template/template-dpg/src/rest/parameters.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { RequestParameters } from "@azure-rest/core-client";
 import { CreateWidget, UpdateWidget } from "./models.js";
 

--- a/sdk/template/template-dpg/src/rest/parameters.ts
+++ b/sdk/template/template-dpg/src/rest/parameters.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { RequestParameters } from "@azure-rest/core-client";
 import { CreateWidget, UpdateWidget } from "./models.js";
 

--- a/sdk/template/template-dpg/src/rest/responses.ts
+++ b/sdk/template/template-dpg/src/rest/responses.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { HttpResponse } from "@azure-rest/core-client";
 import { WidgetOutput, WidgetErrorOutput, AnalyzeResultOutput } from "./outputModels.js";
 

--- a/sdk/template/template-dpg/src/rest/responses.ts
+++ b/sdk/template/template-dpg/src/rest/responses.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { HttpResponse } from "@azure-rest/core-client";
 import { WidgetOutput, WidgetErrorOutput, AnalyzeResultOutput } from "./outputModels.js";
 

--- a/sdk/template/template-dpg/src/rest/widgetServiceClient.ts
+++ b/sdk/template/template-dpg/src/rest/widgetServiceClient.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
+ *
+ * Any changes you make here may be lost.
+ *
+ * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
+ */
+
 import { ClientOptions, addCredentialPipelinePolicy, getClient } from "@azure-rest/core-client";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { logger } from "../logger.js";

--- a/sdk/template/template-dpg/src/rest/widgetServiceClient.ts
+++ b/sdk/template/template-dpg/src/rest/widgetServiceClient.ts
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
-/**
- * THIS IS AN AUTO-GENERATED FILE - DO NOT EDIT!
- *
- * Any changes you make here may be lost.
- *
- * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
- */
-
 import { ClientOptions, addCredentialPipelinePolicy, getClient } from "@azure-rest/core-client";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { logger } from "../logger.js";


### PR DESCRIPTION
There are two trailing whitespaces in the header template. However after we customize, we run format so the whitespaces are removed.  That would fail the check of whether the header already exists.  This PR removes the trailing whitespaces thus after formatting the header still matches the template.

Issue #26741 