### PR TITLE
[Azure Monitor-Opentelemetry] Fix Statsbeat Feature Enum to Match Spec

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
-## 1.0.0-beta.18 (unreleased)
+## 1.0.0-beta.18 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
 
 ### Bugs Fixed
 
 - Fix Feature and Instrumentation Statsbeat type value.
+
+### Other Changes
 
 ## 1.0.0-beta.17 (2023-10-09)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.18 (Unreleased)
+## 1.0.0-beta.18 ()
 
 ### Features Added
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.18 (Unreleased)
+## 1.0.0-beta.18 (unreleased)
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.18 (Unreleased)
+
+### Bugs Fixed
+
+- Fix Feature and Instrumentation Statsbeat type value.
+
 ## 1.0.0-beta.17 (2023-10-09)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -125,6 +125,6 @@ export interface VirtualMachineInfo {
 }
 
 export enum StatsbeatFeatureType {
-  FEATURE = "Feature",
-  INSTRUMENTATION = "Instrumentation",
+  FEATURE = 0,
+  INSTRUMENTATION = 1,
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -368,6 +368,10 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         assert.strictEqual(metrics.length, 2, "Metrics count");
         assert.strictEqual(metrics[0].descriptor.name, StatsbeatCounter.FEATURE);
         assert.strictEqual(metrics[1].descriptor.name, StatsbeatCounter.ATTACH);
+        // Instrumentation statsbeat
+        assert.strictEqual(metrics[0].dataPoints[0].attributes.type, 1);
+        // Feature statsbeat
+        assert.strictEqual(metrics[0].dataPoints[1].attributes.type, 0);
 
         // Clean up env variables
         delete process.env.STATSBEAT_INSTRUMENTATIONS;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
Statsbeat feature enum should use 0 to indicate feature statsbeat and 1 to indicate instrumentation. They were erroneously set to strings.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
