### PR TITLE
Correct the azd credential ordering in README

### DIFF
--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -133,9 +133,9 @@ If used from Node.js, the `DefaultAzureCredential` will attempt to authenticate 
 1. **Environment** - The `DefaultAzureCredential` will read account information specified via [environment variables](#environment-variables) and use it to authenticate.
 1. **Workload Identity** - If the application is deployed to Azure Kubernetes Service with Managed Identity enabled, `DefaultAzureCredential` will authenticate with it.
 1. **Managed Identity** - If the application is deployed to an Azure host with Managed Identity enabled, the `DefaultAzureCredential` will authenticate with that account.
-1. **Azure Developer CLI** - If the developer has authenticated an account via the Azure Developer CLI `azd auth login` command, the `DefaultAzureCredential` will authenticate with that account.
 1. **Azure CLI** - If the developer has authenticated an account via the Azure CLI `az login` command, the `DefaultAzureCredential` will authenticate with that account.
 1. **Azure PowerShell** - If the developer has authenticated using the Azure PowerShell module `Connect-AzAccount` command, the `DefaultAzureCredential` will authenticate with that account.
+1. **Azure Developer CLI** - If the developer has authenticated an account via the Azure Developer CLI `azd auth login` command, the `DefaultAzureCredential` will authenticate with that account.
 
 #### Continuation policy
 


### PR DESCRIPTION
Update the list to reflect reality, per this code: https://github.com/Azure/azure-sdk-for-js/blob/722ce97e25b2492737a75711d35322929dab277d/sdk/identity/identity/src/credentials/defaultAzureCredential.ts#L149-L156