### PR TITLE
[dev-tool][bundle] set esModule to true for cjs output

### DIFF
--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -110,6 +110,7 @@ export default leafCommand(commandInfo, async (options) => {
         format: "cjs",
         sourcemap: true,
         exports: "named",
+        esModule: true,
       });
     } catch (error: any) {
       log.error(error);


### PR DESCRIPTION
to maintain back compatibility.

Related issue https://github.com/Azure/azure-sdk-for-js/issues/27618

Previously `import * as serviceBus from @azure/service-bus` is working but broken after upgrading to rollup v3.

The rollup migration guide suggested `esModule: true`

More details:
- https://rollupjs.org/migration/#changed-defaults
- https://rollupjs.org/configuration-options/#output-esmodule