### PR TITLE
Cherry pick from main PR #27302 from main branch

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -55,24 +55,24 @@ jobs:
       condition: and(succeeded(), eq(dependencies.smoke_test_eligibility.outputs['check_smoke_tests.RunSmokeTests'], true))
     strategy:
       matrix:
-        Mac Node14 (AzureCloud):
+        Mac Node18 (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "macos-11"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "14.x"
+          NodeTestVersion: "18.x"
         Windows Node16 (AzureCloud):
           Pool: "azsdk-pool-mms-win-2022-general"
           OSVmImage: "MMS2022"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "16.x"
-        Linux Node14 (AzureCloud):
+        Linux Node18 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
-          NodeTestVersion: "14.x"
+          NodeTestVersion: "18.x"
         Linux Node16 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -35,8 +35,8 @@ stages:
       MatrixFilters:
         - TestType=node
         - DependencyVersion=^$
-        - NodeTestVersion=14.x
-        - Pool=.*mms-win-2019.*
+        - NodeTestVersion=18.x
+        - Pool=.*mms-win-2022.*
       PreSteps:
         - template: /eng/pipelines/templates/steps/cosmos-integration-public.yml
       PostSteps:

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -18,7 +18,6 @@
       }
     },
     "NodeTestVersion": [
-      "14.x",
       "16.x",
       "18.x"
     ],
@@ -48,7 +47,7 @@
           "TestResultsFiles": "**/test-results.browser.xml"
         }
       },
-      "NodeTestVersion": "14.x"
+      "NodeTestVersion": "18.x"
     },
     {
       "Agent": {
@@ -58,7 +57,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "14.x",
+      "NodeTestVersion": "18.x",
       "DependencyVersion": [
         "max",
         "min"

--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -6,14 +6,6 @@ steps:
     parameters:
       NodeVersion: $(NodeTestVersion)
 
-  # Node 14.x uses package node-gyp@5.1.0 which is not compatible with win2022. 
-  # Following the readme to upgrade to the latest one. Readme: https://github.com/nodejs/node-gyp/blob/main/docs/Force-npm-to-use-global-node-gyp.md
-  - pwsh: | 
-      npm install --global node-gyp@latest
-      npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-    displayName: Upgrade node-gyp version in Node 14x
-    condition: and(eq(variables['Pool'], 'azsdk-pool-mms-win-2022-general'), eq(variables['NodeTestVersion'], '14.x'))
-
   # Packages with native dependencies must be reinstalled after changing Node versions
   - pwsh: |
       $nativeDependencySymlinkPaths = "common/temp/node_modules/.pnpm/node_modules/keytar,common/temp/node_modules/.pnpm/node_modules/@azure/msal-node-extensions"

--- a/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/communication-phone-numbers/phone-numbers-livetest-matrix.json
@@ -21,7 +21,7 @@
         "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"
       }
     },
-    "NodeTestVersion": ["14.x", "16.x", "18.x"],
+    "NodeTestVersion": ["16.x", "18.x", "20.x"],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },
@@ -53,7 +53,7 @@
           "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "false"
         }
       },
-      "NodeTestVersion": "14.x"
+      "NodeTestVersion": "18.x"
     },
     {
       "Agent": {
@@ -63,7 +63,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "14.x",
+      "NodeTestVersion": "18.x",
       "DependencyVersion": ["max", "min"],
       "TestResultsFiles": "**/test-results.xml",
       "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "true"

--- a/sdk/keyvault/keyvault-admin/platform-matrix.json
+++ b/sdk/keyvault/keyvault-admin/platform-matrix.json
@@ -9,12 +9,12 @@
         }
       },
       "Versions": {
-        "14.x": {
-          "NodeTestVersion": "14.x"
-        },
         "16.x_service_version_7_2": {
           "NodeTestVersion": "16.x",
           "ServiceVersion": "7.2"
+        },
+        "18.x": {
+          "NodeTestVersion": "18.x"
         }
       },
       "TestType": "node"

--- a/sdk/keyvault/keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/keyvault-keys/platform-matrix.json
@@ -9,7 +9,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "14.x"
+      "NodeTestVersion": "18.x"
     },
     {
       "Agent": {
@@ -19,7 +19,7 @@
         }
       },
       "TestType": "node",
-      "NodeTestVersion": "16.x",
+      "NodeTestVersion": "18.x",
       "ServiceVersion": ["7.0", "7.1", "7.2"]
     }
   ],


### PR DESCRIPTION
[engsys] update platform matrix for node 14 deprecation (#27302)

Update the CI matrix so we are no longer testing on Node 14 as it has reached the end of our EOL + 6 months policy.

For coverage and browser legs I bumped it to use the current LTS (18) rather than 16 which is EOL, since most customers are not expected to be using an out of support runtime.
