### PR TITLE
Add AKS resource provider in Statsbeat, add missing resource identifiers

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -29,12 +29,23 @@ export class StatsbeatMetrics {
   protected async getResourceProvider(): Promise<void> {
     // Check resource provider
     this.resourceProvider = StatsbeatResourceProvider.unknown;
-    if (process.env.WEBSITE_SITE_NAME) {
+    if (process.env.AKS_ARM_NAMESPACE_ID) {
+      // AKS
+      this.resourceProvider = StatsbeatResourceProvider.aks;
+      this.resourceIdentifier = process.env.AKS_ARM_NAMESPACE_ID;
+    } else if (process.env.WEBSITE_SITE_NAME) {
       // Web apps
       this.resourceProvider = StatsbeatResourceProvider.appsvc;
+      this.resourceIdentifier = process.env.WEBSITE_SITE_NAME;
+      if (process.env.WEBSITE_HOME_STAMPNAME) {
+        this.resourceIdentifier += "/" + process.env.WEBSITE_HOME_STAMPNAME;
+      }
     } else if (process.env.FUNCTIONS_WORKER_RUNTIME) {
       // Function apps
       this.resourceProvider = StatsbeatResourceProvider.functions;
+      if (process.env.WEBSITE_HOSTNAME) {
+        this.resourceIdentifier = process.env.WEBSITE_HOSTNAME;
+      }
     } else if (await this.getAzureComputeMetadata()) {
       this.resourceProvider = StatsbeatResourceProvider.vm;
       this.resourceIdentifier = this.vmInfo.id + "/" + this.vmInfo.subscriptionId;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -53,6 +53,7 @@ export const MAX_STATSBEAT_FAILURES = 3;
 
 export const StatsbeatResourceProvider = {
   appsvc: "appsvc",
+  aks: "aks",
   functions: "functions",
   vm: "vm",
   unknown: "unknown",

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -174,6 +174,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
+            assert.strictEqual(statsbeat["resourceIdentifier"], "Test Website/testhome");
             done();
           })
           .catch((error: Error) => {
@@ -191,6 +192,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "functions");
+            assert.strictEqual(statsbeat["resourceIdentifier"], "testhost");
             done();
           })
           .catch((error: Error) => {
@@ -210,6 +212,25 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "vm");
+            assert.strictEqual(statsbeat["resourceIdentifier"], "undefined/undefined");
+            done();
+          })
+          .catch((error: Error) => {
+            done(error);
+          });
+      });
+
+      it("should determine if the rp is AKS", (done) => {
+        const newEnv = <{ [id: string]: string }>{};
+        newEnv["AKS_ARM_NAMESPACE_ID"] = "testaks";
+        const originalEnv = process.env;
+        process.env = newEnv;
+
+        statsbeat["getResourceProvider"]()
+          .then(() => {
+            process.env = originalEnv;
+            assert.strictEqual(statsbeat["resourceProvider"], "aks");
+            assert.strictEqual(statsbeat["resourceIdentifier"], "testaks");
             done();
           })
           .catch((error: Error) => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter