### PR TITLE
[ServiceBus] await error handler in session receiver

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Wait for user error handler to finish when possible in session receivers. [PR #27716](https://github.com/Azure/azure-sdk-for-js/pull/27716)
+
 ### Other Changes
 
 ## 7.9.3 (2023-11-07)

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -90,7 +90,7 @@ export interface OnError {
    * NOTE: if this signature changes make sure you reflect those same changes in the
    * `OnErrorNoContext` definition below.
    */
-  (args: ProcessErrorArgs): void;
+  (args: ProcessErrorArgs): Promise<void>;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -730,7 +730,7 @@ export class MessageSession extends LinkEntity<Receiver> {
                 bMessage.messageId,
                 translatedError
               );
-              this._notifyError({
+              await this._notifyError({
                 error: translatedError,
                 errorSource: "abandon",
                 entityPath: this.entityPath,
@@ -772,7 +772,7 @@ export class MessageSession extends LinkEntity<Receiver> {
               this.logPrefix,
               bMessage.messageId
             );
-            this._notifyError({
+            await this._notifyError({
               error: translatedError,
               errorSource: "complete",
               entityPath: this.entityPath,
@@ -878,7 +878,7 @@ export class MessageSession extends LinkEntity<Receiver> {
     );
     try {
       // Notifying so that the streaming receiver knows about the error
-      this._notifyError({
+      await this._notifyError({
         entityPath: this.entityPath,
         fullyQualifiedNamespace: this._context.config.host,
         error: translateServiceBusError(connectionError),

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -444,7 +444,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       onMessageSettled(this.logPrefix, delivery, this._deliveryDispositionMap);
     };
 
-    this._notifyError = (args: ProcessErrorArgs) => {
+    this._notifyError = async (args: ProcessErrorArgs) => {
       if (this._onError) {
         this._onError(args);
         logger.verbose(

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -691,7 +691,7 @@ export class MessageSession extends LinkEntity<Receiver> {
             this.logPrefix,
             bMessage.messageId
           );
-          this._onError!({
+          await this._onError!({
             error: err,
             errorSource: "processMessageCallback",
             entityPath: this.entityPath,
@@ -816,7 +816,7 @@ export class MessageSession extends LinkEntity<Receiver> {
     }
   }
 
-  private processCreditError(err: any): void {
+  private async processCreditError(err: any): Promise<void> {
     if (err.name === "AbortError") {
       // if we fail to add credits because the user has asked us to stop
       // then this isn't an error - it's normal.
@@ -830,7 +830,7 @@ export class MessageSession extends LinkEntity<Receiver> {
 
     // from the user's perspective this is a fatal link error and they should retry
     // opening the link.
-    this._onError!({
+    await this._onError!({
       error,
       errorSource: "processMessageCallback",
       entityPath: this.entityPath,

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSession.spec.ts
@@ -509,7 +509,7 @@ describe("Message session unit tests", () => {
         async (_message) => {
           /* empty body */
         },
-        (errorArgs) => {
+        async (errorArgs) => {
           errors.push({
             message: errorArgs.error.message,
             code: (errorArgs.error as ServiceBusError).code,
@@ -530,7 +530,7 @@ describe("Message session unit tests", () => {
 
     it("processCreditError doesn't log or forward AbortError's", () => {
       let onErrorCalled = false;
-      messageSession["_onError"] = (_err) => {
+      messageSession["_onError"] = async (_err) => {
         onErrorCalled = true;
       };
 
@@ -542,7 +542,7 @@ describe("Message session unit tests", () => {
 
     it("processCreditError forwards non-retryable errors", () => {
       let err: ServiceBusError | Error | undefined;
-      messageSession["_onError"] = (errArgs) => {
+      messageSession["_onError"] = async (errArgs) => {
         err = errArgs.error;
       };
 


### PR DESCRIPTION
Currently in session receiver, we fire-and-forget user's error handler instead of awaiting it. This is causing problems when customer want to modify state in message handler, and want to roll back in case of error as currently we would carry on to abandon the message when error happens, then add credit. The same message could arrive and processed, while the error handling is still going on.

This PR changes it to wait for user error handler before proceeding. This behavior of awaiting user error handler is in line with our streaming receiver and other languages.
