### PR TITLE
Bump nvmrc version to Node 18

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen


### PR DESCRIPTION
Configures nvm to use node 18 in dev environments by default.