### PR TITLE
[monitor] Add pako for React-Native

### DIFF
--- a/sdk/monitor/monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/monitor-ingestion/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- React-Native support for `zlib` via the `pako` package.
+
 ### Other Changes
 
 ## 1.0.0 (2023-02-15)

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -9,6 +9,9 @@
     "./dist-esm/src/gZippingPolicy.js": "./dist-esm/src/gZippingPolicy.browser.js",
     "./dist-esm/src/utils/getBinarySize.js": "./dist-esm/src/utils/getBinarySize.browser.js"
   },
+  "react-native": {
+    "./dist-esm/src/gZippingPolicy.js": "./dist-esm/src/gZippingPolicy.browser.js"
+  },
   "//metadata": {
     "constantPaths": [
       {
@@ -94,8 +97,8 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.0.0",
     "@azure/logger": "^1.0.0",
-    "tslib": "^2.2.0",
-    "pako": "^2.0.4"
+    "pako": "^2.1.0",
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "~1.0.0",

--- a/sdk/monitor/monitor-ingestion/src/gZippingPolicy.browser.ts
+++ b/sdk/monitor/monitor-ingestion/src/gZippingPolicy.browser.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { PipelinePolicy } from "@azure/core-rest-pipeline";
-import * as pako from "pako";
+import pako from "pako";
 /**
  * Name of the {@link gZippingPolicy}
  */


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/monitor-ingestion

### Issues associated with this PR

- #27718

### Describe the problem that is addressed by this PR

React-Native does not support the `zlib` module from React-Native, so we can support this through a pure JavaScript implementation using `pako`.  This PR adds a mapping for using `pako` for React-Native bundler builds.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This uses `pako` instead of a native implementation such as those for React-Native as those are old implementations and not well tested.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
