### PR TITLE
[keyvault] Update Swagger commit hash for 7.5-preview.1

### DIFF
--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -11,9 +11,9 @@ generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file:
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/rbac.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/backuprestore.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/settings.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/rbac.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/backuprestore.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/settings.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 package-version: 4.5.0-beta.1

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -16,7 +16,7 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/certificates.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/certificates.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -10,7 +10,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-core-v2: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -16,7 +16,7 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/5dd1107d5f2be8d600325d795450e1d854fbe7e8/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/secrets.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/a2f6f742d088dcc712e67cb2745d8271eaa370ff/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/secrets.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-admin`
- `@azure/keyvault-certificates`
- `@azure/keyvault-keys`
- `@azure/keyvault-secrets`

### Describe the problem that is addressed by this PR

Updating Autorest config to reference most recent Swagger. Regenerating caused no change in generated code.
