### PR TITLE
[communication] Update jwt-decore to 4.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4488,7 +4488,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20231108
+      typescript: 5.4.0-dev.20231109
     dev: false
 
   /downlevel-dts@0.11.0:
@@ -4497,7 +4497,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20231108
+      typescript: 5.4.0-dev.20231109
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -6389,8 +6389,9 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+  /jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
     dev: false
 
   /karma-chai@0.1.0(chai@4.3.10)(karma@6.4.2):
@@ -9218,8 +9219,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.4.0-dev.20231108:
-    resolution: {integrity: sha512-/DNtrqpbir9XaRxE6qwjhB94pCZzw/9R/PhB8309frJBEBGZ5qSDqstl7YYbhWbqs+zWpCCbwBjWDGlz8wn8GA==}
+  /typescript@5.4.0-dev.20231109:
+    resolution: {integrity: sha512-wX5CSyZbJ0xsgAe0Fyefs8eqEe7o7mp7Nv5EHydBYFpJI/FWZFc4rSF2mGNNZ/1D7JMQgwjCAkZd/2TTF3m/Uw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -16196,7 +16197,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-VXzADwLk1lm6zd66WdVYrPbg1kFCfcnc7Vfro1ZBc8b8zdjvsbMSHNweQL9MUIHGf69RtfK3+HKayNspE8Q9IA==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-+NWUfgZtWMNMXUBQZl8j/sxOgAlIta5f3+lDBF6yhIaIMwCPF6rbvwe72CSQJ7X6xqnmjSwHDVVMLBe7NuYpEQ==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -16214,7 +16215,7 @@ packages:
       esm: 3.2.25
       events: 3.3.0
       inherits: 2.0.4
-      jwt-decode: 3.1.2
+      jwt-decode: 4.0.0
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0
       karma-coverage: 2.2.1
@@ -18971,7 +18972,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-513+6RursrvacSXikoRLb7FRq3qUgWG+KyTQF8LS1AxQKxX2nBQFy1W7tEMe6XIx+nCJttfMhTUNidaSepwxJw==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-YHrn9xBJI6FyBRiFI+/HlrnoWznqBkfsmVcBTU+ATAMC2ysorLiESAoSclT47N/0PyhkopgQWCSYNvzSqvmeqg==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19021,7 +19022,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-FGszKi9uEyS9W6kUbw3iCPcNsHCHSG8IrfzRnQGm+JiNntU/E2VMaMhDyj8kX6kAmyyYsvFkFPQ0coM4zPJQAg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-SdqvvFMi3xwm7UBoehJfdJ6bnnsQs6H6iBeFctfANjHCdModedU9yAt9BcC1jDf3uV5t/8AfUR7C3IydJRXCMw==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -19060,7 +19061,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-eR6zAW7Gyaz+lOpGnVvq5uLy+mw0yyXE66VraoE/mHoNYOdeLS0KeZpXy7KoQ7xXw3gzYh0/VqtlR7ybbpcZxg==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-L6m3YZDJNNzBAmhwxSPAjxCS46TmAJLlRUHNcRIGDlOAymRieaDgjQ7XPXW/++SYhR2SQ/FUmECik+QC+1Ap4w==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -19106,7 +19107,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-Sz0V1tkVZy3TLQqt1o4GttKE0unXoRq60Vf7kFaUmZj7/dWeitoilYWW8rt8aM1dyScbYLLRqzhzsu5ANMsIIA==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-10qgCv4wOYoyBFnGLTJ6yNWylL/3S4PjNeHeTVzF+O4Sy576RBOQIT+hsks9ypVzUCWhHX/r2ZHlJiQMJxEX+A==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -19246,7 +19247,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-s28MA3JOdaXxw8cSJh1ODS4Z9F/pojmw68YXc1q0agZRyB5i6MQinepnXKsSCLc3QV75uwokrBNP8WBgzNyqVQ==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-0J52WP0yVi6MN2r2IqnyUNWj9GLClFwvEGmDxEDOFaoswzmCPkCXtqg0r6gvOu1/2dAdACGsjikSOBcWLrrWiA==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -68,7 +68,7 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.0.0",
     "events": "^3.0.0",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "^4.0.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/sdk/communication/communication-common/src/tokenParser.ts
+++ b/sdk/communication/communication-common/src/tokenParser.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AccessToken } from "@azure/core-auth";
-import jwtDecode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 
 interface JwtToken {
   exp: number;


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/communication-common

### Issues associated with this PR

- #27594

### Describe the problem that is addressed by this PR

Upgrades from 3.x to 4.x for [`jwt-decode`](https://www.npmjs.com/package/jwt-decode).  This includes a breaking change of the default exports versus single exports.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
