### PR TITLE
[core] trim leading and trailing whitespace from header values

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other Changes
 
 - `formDataPolicy` now uses `multipartPolicy` when content type is `multipart/form-data`.
+- Trim leading and trailing whitespace from header values.
 
 ## 1.12.2 (2023-10-23)
 

--- a/sdk/core/core-rest-pipeline/src/httpHeaders.ts
+++ b/sdk/core/core-rest-pipeline/src/httpHeaders.ts
@@ -37,7 +37,7 @@ class HttpHeadersImpl implements HttpHeaders {
    * @param value - The value of the header to set.
    */
   public set(name: string, value: string | number | boolean): void {
-    this._headersMap.set(normalizeName(name), { name, value: String(value) });
+    this._headersMap.set(normalizeName(name), { name, value: String(value).trim() });
   }
 
   /**

--- a/sdk/core/core-rest-pipeline/test/httpHeaders.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/httpHeaders.spec.ts
@@ -44,4 +44,22 @@ describe("HttpHeaders", () => {
       assert.include(rawHeaders, { [name]: value });
     }
   });
+
+  it("should remove leading and trailing whitespace in values", () => {
+    const rawHeaders = {
+      withLeadingWhitespace: "  value1",
+      withTrailingWhitespace: "value2   ",
+      withLeadingAndTrialingWhitespace: " value3 ",
+    };
+    const headers = createHttpHeaders(rawHeaders);
+
+    const expected = {
+      withLeadingWhitespace: "value1",
+      withTrailingWhitespace: "value2",
+      withLeadingAndTrialingWhitespace: "value3",
+    };
+    for (const [name, value] of headers) {
+      assert.include(expected, { [name]: value });
+    }
+  });
 });

--- a/sdk/core/ts-http-runtime/src/httpHeaders.ts
+++ b/sdk/core/ts-http-runtime/src/httpHeaders.ts
@@ -37,7 +37,7 @@ class HttpHeadersImpl implements HttpHeaders {
    * @param value - The value of the header to set.
    */
   public set(name: string, value: string | number | boolean): void {
-    this._headersMap.set(normalizeName(name), { name, value: String(value) });
+    this._headersMap.set(normalizeName(name), { name, value: String(value).trim() });
   }
 
   /**

--- a/sdk/core/ts-http-runtime/test/httpHeaders.spec.ts
+++ b/sdk/core/ts-http-runtime/test/httpHeaders.spec.ts
@@ -44,4 +44,22 @@ describe("HttpHeaders", () => {
       assert.include(rawHeaders, { [name]: value });
     }
   });
+
+  it("should remove leading and trailing whitespace in values", () => {
+    const rawHeaders = {
+      withLeadingWhitespace: "  value1",
+      withTrailingWhitespace: "value2   ",
+      withLeadingAndTrialingWhitespace: " value3 ",
+    };
+    const headers = createHttpHeaders(rawHeaders);
+
+    const expected = {
+      withLeadingWhitespace: "value1",
+      withTrailingWhitespace: "value2",
+      withLeadingAndTrialingWhitespace: "value3",
+    };
+    for (const [name, value] of headers) {
+      assert.include(expected, { [name]: value });
+    }
+  });
 });


### PR DESCRIPTION
as the spec doesn't allow them:

https://www.rfc-editor.org/rfc/rfc9110#name-field-values
