### PR TITLE
Remove PPE and enable Int livetest runs with SMS specific configuration

### DIFF
--- a/sdk/communication/communication-sms/tests.yml
+++ b/sdk/communication/communication-sms/tests.yml
@@ -11,16 +11,13 @@ stages:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
         Int:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-js)
+            - $(sub-config-communication-sms-int-test-resources)
           MatrixFilters:
             - TestType=^(?!(browser|sample)).*
-      Clouds: Public
+      Clouds: Public,Int
       TestResourceDirectories:
         - communication/test-resources/


### PR DESCRIPTION
Done as part of [Task 3499226](https://skype.visualstudio.com/SPOOL/_workitems/edit/3499226): [Reliability] Fix Int pipeline configuration for all SDKs.

Int pipeline yaml definition updated with the new configuration for int environment ([sample execution](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3252150&view=results))

<img width="214" alt="image" src="https://github.com/Azure/azure-sdk-for-js/assets/112948415/6b4a4079-e7fd-4e9c-a4cb-671c982f3905">
