### PR TITLE
[Recorder] Update min dep of core-rest-pipeline

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/test-utils/recorder/",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-rest-pipeline": "^1.1.0",
+    "@azure/core-rest-pipeline": "^1.13.0",
     "@azure/core-auth": "^1.3.2",
     "@azure/core-util": "^1.0.0",
     "@azure/logger": "^1.0.0"


### PR DESCRIPTION
Because the recorder accesses stuff only available in that version.