### PR TITLE
[core-http] trim leading and trailing whitespace from header values

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Trim leading and trailing whitespace from header values.
+
 ## 3.0.3 (2023-08-31)
 
 ### Other Changes

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -139,7 +139,7 @@ export class HttpHeaders implements HttpHeadersLike {
   public set(headerName: string, headerValue: string | number): void {
     this._headersMap[getHeaderKey(headerName)] = {
       name: headerName,
-      value: headerValue.toString(),
+      value: headerValue.toString().trim(),
     };
   }
 

--- a/sdk/core/core-http/test/httpHeadersTests.ts
+++ b/sdk/core/core-http/test/httpHeadersTests.ts
@@ -66,4 +66,22 @@ describe("HttpHeaders", () => {
       assert.include(rawHeaders, { [pair.name]: pair.value });
     });
   });
+
+  it("should remove leading and trailing whitespace in values", () => {
+    const rawHeaders = {
+      withLeadingWhitespace: "  value1",
+      withTrailingWhitespace: "value2   ",
+      withLeadingAndTrialingWhitespace: " value3 ",
+    };
+    const headers = new HttpHeaders(rawHeaders);
+
+    const expected = {
+      withLeadingWhitespace: "value1",
+      withTrailingWhitespace: "value2",
+      withLeadingAndTrialingWhitespace: "value3",
+    };
+    for (const {name, value} of headers.headersArray()) {
+      assert.include(expected, { [name]: value });
+    }
+  });
 });


### PR DESCRIPTION
as the spec doesn't allow them:

https://www.rfc-editor.org/rfc/rfc9110#name-field-values
