### PR TITLE
[EngSys] fix `rush update --full` error

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2045,13 +2045,6 @@ packages:
       fastq: 1.15.0
     dev: false
 
-  /@opentelemetry/api-logs@0.43.0:
-    resolution: {integrity: sha512-0CXMOYPXgAdLM2OzVkiUfAL6QQwWVhnMfUXCqLsITY42FZ9TxAhZIHkoc4mfVxvPuXsBnRYGR8UQZX86p87z4A==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@opentelemetry/api': 1.7.0
-    dev: false
-
   /@opentelemetry/api-logs@0.45.0:
     resolution: {integrity: sha512-swhLdhH/nftC/bNhc3bQ7cn4XJvVO1n8aidDJ7fSw+5ostDLSurDdHS2bY8dxVmb+oHndgBlYOvrx7Jx4OPO6A==}
     engines: {node: '>=14'}
@@ -2078,14 +2071,14 @@ packages:
       '@opentelemetry/api': 1.7.0
     dev: false
 
-  /@opentelemetry/core@1.17.0(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-tfnl3h+UefCgx1aeN2xtrmr6BmdWGKXypk0pflQR0urFS40aE88trnkOMc2HTJZbMrqEEl4HsaBeFhwLVXsrJg==}
+  /@opentelemetry/core@1.18.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-PCW0UCIazJRw4Q8m3Z1A20kJqKTCB4Ob02bFjov3sHozspHGnY21O7T8Q20XKe168N4Px+n7Mt4dkcay3fy92Q==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+      '@opentelemetry/api': '>=1.0.0 <1.8.0'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/semantic-conventions': 1.17.0
+      '@opentelemetry/semantic-conventions': 1.18.0
     dev: false
 
   /@opentelemetry/core@1.18.0(@opentelemetry/api@1.7.0):
@@ -2350,15 +2343,15 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@opentelemetry/resources@1.17.0(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-+u0ciVnj8lhuL/qGRBPeVYvk7fL+H/vOddfvmOeJaA1KC+5/3UED1c9KoZQlRsNT5Kw1FaK8LkY2NVLYfOVZQw==}
+  /@opentelemetry/resources@1.18.0(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-QXdqtTQRl3fVAMu5PSxIev73iaukww/7fW4656pF607ZMAXueRHfdxOBIpGrTvfnv9mcKC3ZwGsIb366JZ2LSQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.7.0'
+      '@opentelemetry/api': '>=1.0.0 <1.8.0'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
-      '@opentelemetry/semantic-conventions': 1.17.0
+      '@opentelemetry/core': 1.18.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/semantic-conventions': 1.18.0
     dev: false
 
   /@opentelemetry/resources@1.18.0(@opentelemetry/api@1.7.0):
@@ -2372,17 +2365,17 @@ packages:
       '@opentelemetry/semantic-conventions': 1.18.0
     dev: false
 
-  /@opentelemetry/sdk-logs@0.43.0(@opentelemetry/api-logs@0.43.0)(@opentelemetry/api@1.6.0):
-    resolution: {integrity: sha512-JyJ2BBRKm37Mc4cSEhFmsMl5ASQn1dkGhEWzAAMSlhPtLRTv5PfvJwhR+Mboaic/eDLAlciwsgijq8IFlf6IgQ==}
+  /@opentelemetry/sdk-logs@0.45.0(@opentelemetry/api-logs@0.45.0)(@opentelemetry/api@1.6.0):
+    resolution: {integrity: sha512-t9RA1hEa4NxYrL2VWL+f3EU8Gvdkv1aqPNmk27/vVHVfVFt2ym8hu4lqTf2hynWbzxmV1+bSMDq8Ar3LTrt0pA==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.7.0'
+      '@opentelemetry/api': '>=1.4.0 <1.8.0'
       '@opentelemetry/api-logs': '>=0.39.1'
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/api-logs': 0.43.0
-      '@opentelemetry/core': 1.17.0(@opentelemetry/api@1.6.0)
-      '@opentelemetry/resources': 1.17.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/api-logs': 0.45.0
+      '@opentelemetry/core': 1.18.0(@opentelemetry/api@1.6.0)
+      '@opentelemetry/resources': 1.18.0(@opentelemetry/api@1.6.0)
     dev: false
 
   /@opentelemetry/sdk-logs@0.45.0(@opentelemetry/api-logs@0.45.0)(@opentelemetry/api@1.7.0):
@@ -2459,11 +2452,6 @@ packages:
       '@opentelemetry/propagator-jaeger': 1.18.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base': 1.18.0(@opentelemetry/api@1.7.0)
       semver: 7.5.4
-    dev: false
-
-  /@opentelemetry/semantic-conventions@1.17.0:
-    resolution: {integrity: sha512-+fguCd2d8d2qruk0H0DsCEy2CTK3t0Tugg7MhZ/UQMvmewbZLNnJ6heSYyzIZWG5IPfAXzoj4f4F/qpM7l4VBA==}
-    engines: {node: '>=14'}
     dev: false
 
   /@opentelemetry/semantic-conventions@1.18.0:
@@ -4488,7 +4476,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20231109
+      typescript: 5.4.0-dev.20231113
     dev: false
 
   /downlevel-dts@0.11.0:
@@ -4497,7 +4485,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20231109
+      typescript: 5.4.0-dev.20231113
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -9219,8 +9207,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.4.0-dev.20231109:
-    resolution: {integrity: sha512-wX5CSyZbJ0xsgAe0Fyefs8eqEe7o7mp7Nv5EHydBYFpJI/FWZFc4rSF2mGNNZ/1D7JMQgwjCAkZd/2TTF3m/Uw==}
+  /typescript@5.4.0-dev.20231113:
+    resolution: {integrity: sha512-5K165L/tImARYZDKwwT2ER9qKt0n56E8jxldXfAVpq8qNqX5o2SvpoPrzCi+eddkHJHl1gPf26xiE+7R6//1Gg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -9754,7 +9742,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-eY0ANDvF7Z5wu5uxSuIRnu/BnH+fj9pHIwFv5rVCYonP+N8tgNriyavIx9GEwxS7M4qrWOzGRs/lsd3zsmmn6w==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-OLqTtjWvicZS8EipiNw0w+OZxeyLYO9o6i4yNCU8HKcxfRtJDg9+MS8xDVTKbG7sVn05d4gmOpBMVrqAlYbpyQ==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -9793,7 +9781,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-a6lGPH/+deAbreOMHvKro3MuLWKw4qvlI/HjFU3ku3EhBS36ht9EOAGtTHW2FQx6jUFcG6fjZohsEKpg0ctWkg==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-aaVzFTQsc+kkxTC3GetTxDcDKDKfhPNkM+RPpXnc9SDsi6zu2qJfbA4hSFaQmzqXwFJqL0Me6DB8+ePWIZ25zw==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -9839,7 +9827,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-Gh6xTsSoCRrtNVsKQf2JCtsUHGyhEblge7xteVj+pvssbpoZzB1XiJWZ8jTORddEGWhVibXXR/WgeHoQR76K/g==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-3QhJ+oA42jRAVpSMHDx7cCY/RdVrrhvpgBmo5/HHkFgRiQX3ls7jX019icrvPjBz/jEIDInzTJ5vuWpykJXgDQ==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -9885,7 +9873,7 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-ve9YOixbfL01GXoFPDForrljSCFd6meD0MBSFU9asoLMHj5HTTXuTigXjFrdSQ4xC6cw3UbfE5pwM7ryJXojRg==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-Afa6TPjGd44mADJeu36v5fLRWjT/8NXZKYeLJfFk5M94kTPA4eoqkjuCNuGv2ra1aHrsH9FlJVdTvcf38zXfYw==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
@@ -9927,7 +9915,7 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-NbwhF30mlK7vwKNF1vC/DePhTGGMExoZTnH9J64mWN6CpswjTPuhC87HPWLWK651eRKQgC3uD94V5yYRJpuGFA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-cRdyJLKq2E9Ru/00Gg40qro4VudDSN7oGJ6fziGwRA55Ho/lTH1Dq0KNBMQYuflA5mSJEUtThiNZaOZ1Qv7lOg==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
@@ -9972,7 +9960,7 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-Mdl1VxqGFOawQh/5SoRX3WvTrAtQJKPtsCkYC/XwlndvX/OveCIGC682YvKWpvhvGl3YTlpq8sXH3jNihozaCA==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-b85Bd/2xI14oNfWy/sbUoUpB0UZH7ckUB2iV4OYTha8lo+t1wH5qKS+JobTOEh+H4ctPjb4jvjFKxL6O3q59eg==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -10020,7 +10008,7 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-OIPyOnJSQZg/wptIAeKNScCZkVtTf/taz5VJQaq7FbXQLyX2gEcK6zmPEy8dwCQ8L7PCa0svT/yYRDrHAU9tmg==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-5jjIousnrkQ5tcrpN2vioNy6LgbgaMqsLi+yKxgCENQOzVClBM2Cv1fe6UPrPXDzWakK1RdX8xpUNGEDJkbwwQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -10069,7 +10057,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-y/Z8gOhpZPwtsPpINet0FASV0QSScOMy47DbkDl6uw8JjfulyQPBSGW7ctHzIF2y6Ktt2T/bNMZY+n7QFm+z5g==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-gInAZNw1Dak/VgQE98HJf0HUGw6FSONq05BR4reVe7tCWbbsT/yOQx4l7QMvImEQSPVswIrWQyTISezlWVOWGA==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -10118,7 +10106,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-wmR2P7LwMR8EeKM1vFVx3phMipNnF+5VriLmluJPmqjs8SZ7jZ16zd8wM+P09vcn/bCqpwMgdyA06NtzykclCQ==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-229rm3bUc6yfaecBRyW5Ylqdp6d3+udh6XDJcEP/fLITXkjGytWUIyWb0z1S/voLdVAet90Y88gBFfouJcUYGw==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -10143,7 +10131,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-fBhBuMnQxanLbBxa6M7oPcrXoUjyuSffdUfH0mddnMgljT80lIJFYSLo3Ts+3OCJsKLlR3JpMvCxl4+ryBhJ+w==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-eHY6+iJL6cgJWF+lH7tV9gjouLsfZZtWmV7rqUDpJugdMfJtod2plOs/mhhdp/HEnHYrUY0hERDGoik6ThkDRw==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -10188,7 +10176,7 @@ packages:
     dev: false
 
   file:projects/ai-personalizer.tgz:
-    resolution: {integrity: sha512-0spWl1wNEzWU96JXAQ0eY2y1fIIjXB3Tn7RG7JpV45nmid0MCU7K1/F0DoWbrW+vo5xFgt4XQZYv/G0sw+gxTQ==, tarball: file:projects/ai-personalizer.tgz}
+    resolution: {integrity: sha512-UizrYTAypADGmA92YLXUx4kbSgZamuf30LaYUY7qTy1yiLs6e1e6DSBKpCOZhtuin+UcFffiJDbnBpLVDgVBcA==, tarball: file:projects/ai-personalizer.tgz}
     name: '@rush-temp/ai-personalizer'
     version: 0.0.0
     dependencies:
@@ -10232,7 +10220,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-sgNKOEYHbTG4Aml6Jiv8sLd1gXnfY2nz2w6QbSv5XWpeNHdZPIa2jP+lEqRfxFfekuJrU5z4BdGouHTEdhzK2Q==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-wWxbPrU4xtgKb5NZb2tgc/RMvpDJVI7HU5+2Qq1BFtSGwi0GQWz8GqDSZBsw7xxhsapyWhM5X5hQNh20LeyUIg==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -10279,7 +10267,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-gVagqnCbjJpBWtovHkMEav3BbGTcyaKJ3sMTR2iaXk0rGU81sV/D1JuCUIxMIX0WfTe0DJ43ANQQKz4OM2pabQ==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-9rg3z/jobQmchF1LtOkcxeOr+r0oiQx75poXNtdRJwGenTd9Xlv9YjeNpjJMA1c3VRxrinle9XGWi0forJHAbA==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
@@ -10324,7 +10312,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-dBhCY0a/dTIxnRfPUupnJ08lcreeAD2pIVifvbWCaHPbLVxPkk2uWXxcYhYA6/XMYEPMY8YyT0iHz9QpSRZuZw==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-swXf8ytyOyRqISaPkgwa/6mdqw8PLCBPkjaGEAQ4DP5rThwPvA582bqw6WO01NWWwQJ74yOBpjBC/a4XPG12Jw==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -10367,7 +10355,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-zLMu7tjV9+ZQZQPLKrZxKpXFu+K4RM4tdDfadyi1/y4pnYdZEVO8W64+RTTR+Iqqimx4fw9IYGdGsKbX7GBrPw==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-+P6ekMfbWE/KoRJOYcUyBhc77stSYB0fh94GjKQnv/25qSTVNEjn75Tz/ATTBJb9iANL/1swTfFCYf9c9uwNdg==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -10419,7 +10407,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-YraVuwbvY1frH5xysbmmmPcXw5LOrHioEVLhxEVtfBFH50PUZe0y1mRCryMh97uhZ218qD2YXFR3oHdDQ3Ve2g==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-r2xcLdk31/abJNGXQh7hqpomUFnIiL/2KNMeXsnv1nBpyfJklXmacRQ2fDghN6625WNfN47TSNQhUtc1+Pq2ug==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -10467,7 +10455,7 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-jTXTZ9QddKjTVOEIr24F2tiUfvixYuEeAxkq/QnyNroAvSxqLO6PiLtj4CGzB2dP2wSoBxXotbENKljzxs74Bg==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-oECkAlHkzO+Bm+U1zykhRhSFcZSM/oeKVu2A3eV+SDtwbe6HDanVLjQAfSV4enj6K+K6NC3aFbPgyscFUGWm1w==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -10492,7 +10480,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-siqI7KGmKdOwARS0+VO8LURs98Hbf+Ie8QHxpuu1dyS6dpPYMCDqgZL5tdLMD4hb2/PxI/J+Kngu1xJwUbN9GQ==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-dNqkb9gBfFflz+qZp5bYIXtISH5yvRGPJBNKt8z3YCR2KtjcLyeXNwWp/GRjOJDldww1xkRnarGa0vukNmXCiQ==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -10516,7 +10504,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-ocRCs9kY8cAtIuDbWNUtC4Vf7D8yEog52GW90ELrewG01+dOsHZG62Zn4DEe9gRCVoJ7Idrj3QedHwUOejpYhg==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-5QoX9AcVm2nyBI4a7MGeQfNq13pokknA/EZm//Y8SKX1er9l6MPl3TLaHLtxkjWhXmBGZ5z3imW7q70OH5BpgA==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -10540,7 +10528,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-caqHKV/A9aCelY5zUbNmYepxDH+eb/2g5mp7LgjLMSdIZUVgPV+hmg/METzpZ4S9Moup79vpjehjKAfm81sndg==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-uPE98WZ1lbsANbSaNM8pZeINf0kHRJsEQBurLQD/2jTsyBdc6FHi9urtmrdw3zSSlF3zEhmr9d4wn1lMo9qj1g==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -10562,7 +10550,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-47wRTEHH4DoN3bYaaMVAL1tTPGlRO/6vxJgEivzcvESD0tN5x42dDGy1m6i3GaiZSvODBTjE/DWIXj/KIYUzWw==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-6cXUC1OZ2zFoJpO6Up0Sy++3Uy3DfXdmAgqPP8NZSOEtH1bL91Tmmldh9UCRiJqaR8W94xyYzC7kivyLiTRi9Q==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -10587,7 +10575,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-CUqjGmv1s/M+vfD7BwFannxYNX/0Xvu0qNmn7QkG26DGQtBObeHxmqca9urMpMbEkqLN7thQoz69lvOuEuHesQ==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-NbAbHuCgqHgf6PY5S4NJkWjjq+UCF0DbL7urKDROtuI0K1bp+Kj7e0b4xhFkKXJYcASQ9yC5q3tHvbbjYSRE1w==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -10611,7 +10599,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-NUDJO9U6zQ7FyYhe/3ETDLVJq90VFTT6enzYyinbsYE4uECJyaROl9BLK7X+QUO2eLrvEI5ytA58b9xZ8/kVbA==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-06/Fg0h/M0UOpFHXyq0LhHcgXn35vFXwCywnxdlK1oKOqk/hqxoK6XfhFVq6N0rcqnb72VxNkQO6i5wffPlv/A==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -10636,7 +10624,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-Tm6VlvAl/VVSZO90E488dPlYiKJSK8ABKMLdGX1GV6S8KM/mC9Ma8xbmWoesYtF98sMR1fY3YIA5dnnvqUjPQA==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-eTTY4B3BCdKWVQs2FB3jkI6SAnvCkKQEwFOMX1i5eBUhVHBAmA1FF26l4MlzUuwIOIxH2AmxwG8eeKu1qX+nWg==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -10661,7 +10649,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-I1VjeZb+2lHZz+zxkGmupseEMQNuwBmBbbZW1jvT29X3Yc/iK9pp5eKxnrT34p7DA2sukJdyFwA6NFG+foX6yQ==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-e0Fia47IguVWf8oc9IfgjfJD1/N4pnTKi2mwoqLp1p75W7fOJa/snu13FMb0TKwCOko7R+rSp9rehMogRmx/Aw==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -10685,7 +10673,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-oFZuffM7TQBCbo2pZLraMHnXFZEs5qBb7JNYzatiXJieypgVUTSet2fsqTxLeNWyDwOqKlh5jogrQAIwPJPoaw==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-fJvwQqWRK1EWl5MaOXgZXpAuTZsVZw01Cixg+hJsuu+vhx6IBbprwN38eWjdHL1jdlWYig2lMWHM4Sbqwe1hmg==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -10710,7 +10698,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-J6Kp94d6lf95C0mcq1D5ulnGBFqsOQw6IBKX83DR/cvpjr8SCvJ2ye+jX8GbJTrNvpyP98rFrkkCllO6jgyHxA==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-eW/d3eX7qtqohxtwlFzSSSYSfJsc4ar3vMDQOfpJjJ46ZX1vtmEPNS8tuXCvAlWjbxte8p+YiNHhghrpjMD6Dw==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -10735,7 +10723,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-3Ffh4tBpe6cNA2FETOdQX4kLvgQRKv2T7ce0Nw0w3v5pGwZd9P1PP6NXBJsbjO4hIxCOugWAnsaXYw3cv2XxuQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Ey1u1DdRrnnnpbUAJICUzHAvqL3thLfrrUGuLN9rs5wL2GGmI71+b3Ea2go4oKgNWMhNqUvqhQKrDIUBvXd5jQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -10760,7 +10748,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-te7JSffnS6emEkQvTyVlKdl00BOP4m9l6K26kaMtKt2nPgndLluml5K5PTmmWqd1Yo08re59vtfbxbLHQc0IeA==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-uXPMtAPzK9Bn3voGqlnvXfhkmdQEPnd2cS5dSlWs2rDKVAgt63RX7vK0t1i2zvl7n77VxZ/FTOhf0hZpA3fmDQ==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -10804,7 +10792,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-xF7S5/rzpoPkORxGbNtW6PRyhl+P3+pOgau6ZiZHpNBpc0vv0O+kzJYsEkOJEtN3TSbRA6A86dW84ue25LDvtw==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-U9J5NyO7hKtGy5gsHO3S3U/I0RlM12DuFiI1R4347i9/dv1fgkFEa6c70rGv/v6ACq0OtDVVWE+wEq9EAqkqew==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -10828,7 +10816,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-puBhMSrcm0X8sRR0gy+YcKgnkBLzIGV77lxLIhO9gh4LvcNPBnrDwT7EXZ4Fq3uUoN0S06mjpd/sjlRF8K7w6A==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-L+uwHhhrKpiwDqmIfJSIMXZwsq9qS9SoTy7dxccWOPY0OXXBweChdXi13ht6DH5N4nVAXVgD8wjU8mpkPziovw==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -10853,7 +10841,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-/teoyMTLncU7QYqcQEfdO/QW7bULeYg/VM2NMk2OnM5NkSYtOrqs8gdJU+D7/jh+Ajk0UjCyrHtf1OdEJK3sZg==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-nLVjh3A93IYrITlf1qCxOqypP1ZFhAzLeZrfAf/sBPVlrIQothVTxhcr+rJz6wQC3t3Wqhfv1q6FAtBF50BqsQ==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -10878,7 +10866,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-zHjra+GG7SgCgFskOs/3bEqJWPGBSzlmAet3kvXiRSivT1aXmzJRG908H2itjCZH4NUnqktd/5WdLrr20W8m8Q==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-+2F1Kv78ZER9v49DBIb2NRtm1USM2ajypw65DeBaZtjkTrI+572TGz2X1egjsyeiadS3OEZUBqb35+cgsBXR4A==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -10903,7 +10891,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-ZK0GWcuTRPvzpv0E24i8O4C6p64s4fMKTz99I2jjJymH+3yfCMkGwMEC4J0HCpLoOZvYKVy0TczBt2nUHfsN2Q==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-rHKBpSvBDEJwrFoAkxBiCHw8YumLk7nUvhshTwvtALMTvDS7rT8siKhri3Hu2hTOCtUhG1GCykD2d4mndFXZbQ==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -10928,7 +10916,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-NDrfnSn1kUBPObEImHdWVKHwC/FjSn3eqlDicuKz+OZzNptrZYBoL7cjo07nWXiB6Zz8QO2aMzpW9voA4zuY4g==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-Ml706wc0TB2UP+2XgnLDO1KGXErlU5sF0HU4sIzdSTUCkyqoGdj35bcFAOEou+xlliYyRnPK+82fXO88KkBgQA==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -10953,7 +10941,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-iDMDOtHZ97/MkhFgjirQ17XNtPdmDndgb2HOCjRBklsLWPsQWkjpHiCoQAwWDYBYLbTTq6knqH6VVLFDYsUL6Q==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-3tW2AACYWAQsdcl39u4cytSBN9I6ZX8fq0+Hct6LWQDaV/k8YixKG2LkEnLQow8fewjcy7czzNGYDqAAAebnFA==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -10977,7 +10965,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-Uuxxph1zJzUOhlhhOiY1M7Jk/ZxWm5Xdd/0V5IMoIWdXx9eauNXSWAsq2A0wh9jQtJK6nDGMsuQ5wzl8JkMNJQ==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-6pgruPO4BB7wTq09510NaAUKNG83O47FEYf+oatOZ1gZsKbU3cq8OZC2os1D7URwULHvweMOse8hNmdmhj/A9w==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -11001,7 +10989,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-M8LufT4Sfh69jIa0Jga3Nscbtwt8IRlVB8bESS1UHhHiKMriLB7A4mqYEhQ/GGpwE56s2D4DORtB/tDr0woadg==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-mY/tK4L6k36/EprixhS3PD0RVqei1wtyQ0Ljq4J+1oNAR59P4jhqSAMHQuzerHBquFwYpLizOnCCc07+Zb/7Ew==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -11026,7 +11014,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-Dz8Yurl0IJF9a8TZdEKhbNVKKaVUOCZbEbHJXyaJjrSDi0kt065LLub3OB61h7hzV4GLbUdukKHQyVo8SQsX2Q==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-8Le7YeOKmFHQs2mbQeJ7dxVD+sjVip7BXdt39+Hla1osSXeqR8mcIKKA7J29+5OoMAjt4iMnIJwpxWJtSP/Odw==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -11051,7 +11039,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-MNRsEc7Cdk8lkzwrdzO9NVHA/gOpZ+u56gssOrWtFq3XNq+hVOYzFfWkH2q/NS3Wozh+5wbblVwIhPDrJBhN4A==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-JdX8p69h996oRDKT3p6h3987ccXckSsKn9kxdLn8VmewD/s4T6yL0Q0GPtdYGelrpOD/xkqbtkIw62ZF8ivFxw==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -11076,7 +11064,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-53HpXSUcmbqdGG5plwLVD868PGxGPSXzMbwgMlOwiQ5ZwsePMGzW+2OyAffHfpN7V4Y+t/scgSWv+W0ZBvxdSg==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-wOILBDXSaIH4KIXS7+GxelydJIGu/yH01deoZQWfnt+f3Dq9bXmRkHObIFsiP23dqxYBeMdh9YmIje7npCZk6Q==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -11100,7 +11088,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-fxR7CsNV8f4AhuSHgCcgU6XIMV9+f6Js0N3kxOi+fDE9yPoVhXlSGSCKycXAIE+7PSY6T8Ax8UMsMzeQAA4wBg==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-OEGFJ4pdIvLmuZ6a8Kd+au/nzlriHhg2GxHBBzIRuoUXcmVR0/pU7Nq49BzqYxIi4BlP16jRaz22KaJOKt5fvA==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -11124,7 +11112,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-W6ou7vVyMfUiEYvH0wyCpILbxXAMhi+l293WU80zPJ32LOH51pqhcfpP3E0R8J8MSfdpU2XBdAY6rzNlGySCzw==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-9wvo70rlFk0HAhFHW68RdC8gmXTFfwrEzBf7LADTrRJvoGhjADVVyPn6tzVxhCTKMfg8L3f17b8tdJJXV4xgmA==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -11149,7 +11137,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-lqNE25zilcqqcvUZ8FrPJBEPZRV/2wW30csTkKd8GHb5XtF6QahnnGAGqFzX96CLlKigaDzgw6dSYMx9RwoGFg==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-Vk/t0OOehpgWfzYGEAEQNqNB+YWXGnaNrKI+txh8/Jjzr0qfKCi3+cr2vI+5if7FYpbA8Cfy+/aOM8dxpy7rIA==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -11174,7 +11162,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-nZJ0HeewCIyJ/FbnPEUrOLNtw3PMWkH7pxSvQOfls0ZusBMrqkCZkSR2cjU05kbXhROVHg7zTop0v/HDGmNu/g==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-jRfa+sr+aDplyHyzn1XZcDjLyZAkJx1FHfO83ya1hsR2ZJEORi8tJoeFZ4FuREcsZxPB8NviJw7YceNjn12LJA==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -11198,7 +11186,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-QwndDtZyr6sicbvuSKhDYHi264WCM+yHQReMi2aUqCQlI5qN+E5+DuZZYg+q82G8R6OPJxxwi5fwM8Wv+R/F6Q==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-U+53YLqBl3DmErXW9glVzD+hP6pA58tpTcHqN13AL6aru5tQawBPW/utqB/usJIKGcBkZVVkVScxSU+YBSVNow==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -11222,7 +11210,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-5HM35m2VD0DAgtw9lo3YsnXqqwvBAnczpAFxJpuU9bZ2gBa4/wryQ7vjn9m1lyocjeeaS7vmjIk93npv1Yr6Lg==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-8Dll77YDjgujpTNawmQf+OwblyeVtwXw093LHmvw1S89ar1zTshiONi4IbaK8TzLIFQBRsRReNZQ/pI30b+Jag==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -11247,7 +11235,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-GhYbxkaZfxQRAhXe60u0QOcAyZ5JAYx38PteSo0Frh+c+HXPrVAXguDJNPwIJwPR8pJ+1KT3Ai6gN/ZHf/VztA==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-iRH0Oo39F/4mHOAq3ul++LrsFc9YWx4AiVqMcQzYZq3tyda9ood4t3JwCnuchXJBYDPh2u+u2FT6o2TIrTM71Q==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -11272,7 +11260,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Uy6tdZ+veC8iufCM73jYyvNxMZ4JKgz7+BshDQEXRkuDgtHBqAW50RtaMEJUZxl6G1H0GIFoL8tyr5dlL72xhA==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-seNIv9GwC05l51THNChasmlwGyHtDHBSQi/2nDJ1oHQdZvdEENff+mrTL5AS6AkqSPWhBvRNb5nBm/qoSaL5GQ==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11297,7 +11285,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-xSJ9iUa7E9TEm4ycKRn/Ed+JyMYuWRYMUns/gs1jxHYZ2b8MKtELJAJ2I4X1fpEjXgD64Vgw8BaDMnOHiW/J8A==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-7i8r7IU8NL7XAqtudSkQTfBgRxwEYtPDkyVWBP19DuH+m8YLU8WvsUl2WmA6cm5jMK0qK42fvgiTHoN+ecbWgw==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -11321,7 +11309,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-L+dtsJierPzzipS7DXxzq+N4uYx9/Gx8IZM5nUyCLyt4r1fJScrTlaPbzLBZiml6uVX+SCLttfv+RvegbC2+vA==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-DclJyNpGXpGzT1e/lNIcwf1FU/4k+vANyEEUMzJQxfF2cy17IOXS8qo1h2RUQRbLDm0UZIAd/6xjOG3pwpCJ3Q==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -11345,7 +11333,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-gzQ6ikNbxOBBDo8TThS9oxAhv/XfLIk6VwP7SqdIcffjcndOq8cHHmmG+Li8+az9sera1n2jrggfwm6FNq/B5g==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-2hWJ/aTBmQIto14Ktu3qcZbTTlYFHPGerJIvWgaltcA4DidEzkJZr5G8YaRdQpZ2QFvjH4dRGefJutZHxdwVdA==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -11370,7 +11358,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-/fsYCj+D6c3PbALmfyGay0YVZ8oGySe2b56dqDPkrdpdxTResBg2qQMBQqESyNmfeCdXBpAfGewdvT0BuSR44Q==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-GNH6eYlcbf2q/gL3gSeFIrGTeu55MJKUeTHcFvtpwckRU5Gl7M+amBD/C3WcgxE9eiMwGdSh7fnY2u9I3kN1Cg==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -11395,7 +11383,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-n1y5GNuX5ttl49SRTAvZgLQPhrdxeZWsV/r7bf3gXuD9QPWzaI1bNqcbROpENxKKIFTAvQ1lY7COrLy2dqLo0w==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-7tPvSdbHOo9NhM+eHOBSpbtJfxWtcS3HI5shMUriEWU1Jf5dtbLLbj4KWBaRcmBzwy7QWJJzvEVPoJbAlMa7xQ==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11420,7 +11408,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-kWT7yit6Lb6/P1tekHyg+GqHwtOEx4DGLGnRf3Nsn2VywfIJ4RENLFUtA52iiX6KYO3UcWc7cmWsN50Axpx+qw==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-l0ZioJDcuCfgBQvrWRCtT6jnnygpKC4TkWT+M6BqOnOhOdTM8bxGaxmfcXLKUShb4Xd2zZo+FOj+0eimg3MJCw==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -11464,7 +11452,7 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-NMBGN+p3i+kc2sFIcd9JK9XSr+R9WG/rXztICPBzOgiQqI0e1tome+F8i4jXSsPXltACpUDORVdyeRq6rDyLQQ==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-sH4QiYpDqMB+wGx4obRrD941cexcAU7c85LUhOO86ShGBFXJUoHLGrazocFeeRkYMi+qnh/Ld2G397UGa4qj+A==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -11489,7 +11477,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-8AXp4gijJp0q8/cyArckZW8As9+azk6AMcEuLw+9AyFNPKyNFkUdMlDw7GO5ErYF75kGi8Ai+ZLg3Pht9F2MjA==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-JSPKGO4/zJ/wdi3EyoReq94KnfkCEEcAdoXLMWhJlg/D/LJKsxQPwP98n0042z3iT9h8PYO/SNswvHL+IpALNw==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -11513,7 +11501,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-55NyBuozUFie9djQ8IqqFB8Lh7IiPM/bKSa5E2IP+yE0aMT3aQJNYLcyeea0TYqcXEPu47y8Xfzu0W3oYK8QBw==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-BWHzfNnvA2ly9hwzmPRAjr59n2tNP4QKX6p1lWp4G7NCN1rvXUBSLaWeuxfjklLBY2W/Dfr1kkkoF74L54RNGw==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -11538,7 +11526,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-5CrpppWgiGxr4X3Z7mlwVWB0n+ZwIf4VCaFjSwDE+TtR34x98CdLXTb9PttneJHQkIOe4Eaee06SaENe7mshmw==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-/nHNUUJxZj1+kZt3crFi/w/38VmTwG/bbqQuVzEcEodwfxTi9qFEb8c9y+bV4gPsjOjc5R+yiacMkdsQ+I39jQ==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -11563,7 +11551,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-WSvuwm/vBUrzsRxD5PuUDRf8so1+8fZlox0b2XZf4Y5TgObzQ7+tbzI7chR20mU2+DUry7XRAcIffujkJFhHbw==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-5pEMrbgMeJhHnB0D1TROTJbZfHWMu4N8OkQY0Dw0hPWawntnq8DruNOa74fkdluri5WDyp+t33m3Rcthsdd/6g==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -11588,7 +11576,7 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-yenTfukpcmOA8IuKPaskytC/xe5tgQJaHMgnWMEbqZ9l2ZgzCWy2FUhayP8X8ungz5skyJX4oPNFusU24DN9HQ==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-NJ7XQgGZASKL93L/e7WLrIviDOC7uTV7SBZEWMQO/9smQX4NNEDYczfc6jhqMBhASgdAm4/7BDHcWGpDiNUj4Q==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -11613,7 +11601,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-x0VWQX7xveJVTuUgHr5+ttYEFEUUwaUlZL5TlL8QkqXKJ8r9BBw7xurxmZ3yK2ThysNnH9lnMH+YEG+tsp9sBA==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-bB0eUxNbv5WW3sBQ6tl9NjzYNct6zp4f7HW8QFdLwTdLAam1ril6kA6+dGgGDiwoZ6jzm99wVmPBR7JRTaraUA==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -11640,7 +11628,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-oKOMccbnse3TH177/IBCYL3goJb/YHrJQTK+MAe9H6MMbXKHHiJ5hYN8pOJGTDsf2hpZE7KGEmu8gs8l/9zIGA==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-lHKHJsxxOicFOzH2h32cxHnrE2BdDLNbiPH9w2hhzQ3j2z84vuX5OhtVda5b8WuydMqRWsVlkJt4xToeZGyklQ==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -11684,7 +11672,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-r6OT38Td0rJX7x+jjsjrRwYvdC2eoKf1C/AT9nb3QOX1/PDb/4f/siNpJhRJC06TCW9QQixklP471uUA4t32pw==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-ob35LS9EjLIoNi84sSQo5JDp6MomzfS0J1hXpfq9OoXav+NMJUWtSbXUKOl5tj5Drm2Ba6F732evF+KpS4f8WQ==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -11711,7 +11699,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-PjJZs1Efj6yKkYuri8VY5svphYGZFPRlpPT42b7F3Q1BhpkFOh81ycMbRDuJEcbYRmMSWlru+s2GDGXtwGA+wQ==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-0niv6ZwyYlOVx+ldtZ9j05NaazieXbydzF2ysNlhXKD/qG3NIFRWlo7r7z/Jl952TjX3fBKOH930LLW5cSLWsA==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -11736,7 +11724,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-Mt4BWo9lV0NIcYEIlgjoKacIUhG90T+qrNfgBfVG8YaCpRl5UM8AZ42+y04vz3DzresCoY9p8mhJ+YkEX2dmRA==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-VO0h36j1qX5o0J0AlXBshdcFWVJEOFFUqYPfLk/sLxWiRxJLnJE7rAhbMihQh7OmPd+fCMXQIEwC+cAF/ZE5ew==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -11761,7 +11749,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-qafujtPfIZvPmbc/FJG+9pKvWvFQQlraZCojpjfxnkST09xfIzd5NsKJSf5ftsnUW61fLmueuV9HTtL8ue8Wdg==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-qbC0PY1c35TR11HCN4u/wx/Ayh0uyZ/tnqOacirKHK6YuQCj2HoOVJabQnwIxL3QsmppNtccryZ9W+Wc1BniQA==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -11787,7 +11775,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-J2ydmXcRjUCkJQtM9b+DiSvq9LIXXHfuRlKtqD4wMyEWMx4V1pkfkurcLchDZx6txP8PTnYZUbeO4U7CS/QsWw==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-JsaFKhh94eGo+ymMVHHtcyvtikJPO/kOxH3uB1nQEI4iFqRf90G1Cbn+O/BZMi7DPO3T5JhEvYvjjq+muII9Jw==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -11811,7 +11799,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-naHc7vwHg4yBIuDUDLB/vEp/yn/fcQhf7Lp3zEwxgFKlIqt+GhmNOLxcJkiicbBrI5ZLSz6tTAkK4H/ShZ298w==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-d5XAq5BTKzMu3aCbYwlopL6p8Iq9938Snb+gDdD9vFFFFsBNczKm0pZflM5eNvCdIAImzBur3lEgoG3MRDRmmA==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -11836,7 +11824,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-sCWt+vC3rjlgJC14FdS1suuj+VvOrbTAcivZDyntDh9iXt9oGy4KArtiz/dfNB2KST1bGSWSzhgg8bym3L2Gxg==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-dn/m5CgorTWXxkYzEm5M73bguuJBIIeMNRWZzNr5mBFskfhlL212xBVyzV2AsEwENCE21tGYtB5KM5ym9XW5mQ==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -11861,7 +11849,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-HurfeC799syAyJonOtD8R6rZoXXN4bVmUVwIZ69IRCBGFVeI5AJ27lBXXal9p+VWzQl8RmG8HbBojcYArWMeXQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-8Xe527cWe8HZtJSsXqOO/q8Sx7HtlUGOzLGO6xli5pW5ftjCYgVwXN8EvGwKDrX7xhm/N/ceQ8HZL1355rVY3A==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11886,7 +11874,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-gZYq0oMH4F0HgJbSYOIcFs7gmXEvWvFNLKf0hu0WjsjRBAejGGN2EDsicmNaPdzQnB0HYIrOBzAg/OCOkRO6Zg==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-LrD+CEVGHnjAHnZkNHX6VtziqeqvUBLXpyM2b7WrWaQVEXyNPNtmNlOiudeAXS+DLJLMtHWcJE3DQycLtXIzLQ==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -11910,7 +11898,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-HdxY+hq+aXT2cTQ/9iZVaiyNJWUIxv1c59YFXiAF/gBEFLZch5f5aeq8NqKoaVxERJSG4lazTv20MMWAztjz3g==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-JUk2vDTtQu0ZSzgyW9yQQXDiwOnSxj/ZaCVwyrmv4HP47fLMCV1q4tQYiEz9YxoTsr9J2yzuf7glCQVwMFNtNw==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -11934,7 +11922,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-9ucxaxrSU1Iss5FI4X9Gv2zlMduOW5SqKI28N6OlhzSG5YQ0i21N9YrMGzi7ChmZtWTQHu/YERqhaYhnDGj5nA==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-Oxg6Tf6nvePMZyn/2muUZEQtGCVggHWh4TPJH5SxlLNdW6C0fZkxItl61KYS5bAXIqfG3m+CF7m4V/hOu5Sbqw==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -11958,7 +11946,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-o9Xdm9r4/zWUUoBNvVmgKede3QFdjH/2eKMJYGK0AxZVPCf0UoNWKd+QbdWPvU4nnfDPgqXNc861b05+dUYLSw==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-ZlX/MNFKiK+uC5BiVWp+BxPfBmUpLTZgEKmkWqXGkNBpi/KCU0FpetMFeH401UjSpDOyBmHHzafHc+SxK5iKuA==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -11983,7 +11971,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-e0BT1WGbZ5OKpiO1hU01FR5A9/S0znfpchXX3qIrU9Y4/+opNPWYwEkLi1JvAknJot5NosLVLij/IcZ//+W0Gw==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-tWDNEjQbnYroisQCzm94pwEkzyZ6dj36Kfxk5ZeLB7btuvUgLyB7b57zgZxhF0YZJ9VeSHDmWYMwI+2DdCJcxA==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -12008,7 +11996,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-vVlrJX0i8aN+O87dVNu8F7JeNwHcczuovkXcl3nbmVZcpft6pk7UHU4ipajUoRX225I/2r//I50BF/23bL8Y4Q==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-VpayDv9zO+8+aahoGDReAl6OObBqnSnnXx7iSO0reloIz3l9ziI0TQ4b1D+DEbtSy6Ec5r8wVuC3zye86G9sZA==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -12032,7 +12020,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-sYu8DxRjN1eocAyVm4YjfU79LfKQmDjAtpmz5cK74b8fPnVlUkwc9dbp29kuo+53jnnOnCfEIDQPtHE6vkD8LQ==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-va6dfZ11YYTvzqv/plaBBSZEt6A4suFXkzkJFcZM3xa2V6x/8hM7aa++tUDU7FAHPLAWXon9ZCiTDWg7UtL9PQ==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -12056,7 +12044,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-cfrQe2TV9OIxllQAiz5dvdlLmK145/eF3J2c4/760pK62eLtyfdgmr9taKXybhsIQ7e05rCUoCDPOMiyQPl+7A==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-fbX3LFgjnpFsuNWE875EHY/b3hwwL7EzqT/CGl/ijIFhhtr5kCRpgrovJGaceVXjLrE8H2g90M3ZPJ30FHk/Mw==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -12081,7 +12069,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-ty2QxX+niHf+QO1KlfFAHUqfQCrMUkpJeNxwWNdIAUqONdbH+xqx5FjZ6o5jXwn3sRD/s5ah58l4FMB9wc12MQ==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-6IehsLfhqN5PvJcxd8wEco7h51BZ3zj2D6P3VLSBas9Tce2OazZcyJwe2qHmacJpC7zknD3S3mKWrShgqm8oSg==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -12106,7 +12094,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-myNmVqEGLvogEtswoq3V1kqJB959E4+t/TJoqnlioDS9xublTiEU3S4seaoV1J75lq9/7rGNs+DIpWiZIrRAYA==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-zhAvZzjdmqUDbPdBlRoXzCDqt8UkOHAjJZ6mLvST53Nr1EVMeh0hxLJCmxJhBv6WmeuHy7j6JqIbAemNkgqhCA==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -12130,7 +12118,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-RK6sFSTJ9c35vxEVx+caxiD+hyfUBFuiaY3Q2/ePXwrbPkmNIncKjQrynmQgg7VTi/aUaXddAj0V6Q9VlOIy7Q==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-PCPedV/PuxGgESNuEKTPdRHDon5WHZknD/yPvCGIuDFraL8VXe+vgjABNurZzfpYjqPbDLYoS1ollsEk3jug4g==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -12155,7 +12143,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-IiLRzQ/vBrI7ZpcNsEbOjvjtm3CgBHXMKIgpyCTQymjp0WWghatECrP7KWWRDSFPEZuBoF/udW+o1i0uCJHsDw==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-KnOhxtbMIxzLhzg1STzXmgNbM4v9muAhM6ZXgV3Zl23MbdsvK1vE/XNZnqMuztR29e5fKzOmynun+1voTaLd8A==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -12180,7 +12168,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-3GB+uvRGunqx8FrY6Bd1wIfOashycfMXmE9lEkecAR07dRLZ/+WTl/Y78UiHMZ8E0xIem84hlgRxL81Dg4G9SQ==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-bSSjS/SsVJ9fAob6y4cSpYR0VjOeb7L3RuHjuTd0fFlnhIbpFLH+Y2vttfuuHWRnzxA0yM4JnumH8JoW5lYM0w==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -12205,7 +12193,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-hHgOmtTazAEwnao35VNG0VTuUyI1ILYYvfn9cRGxjA8I/z1ML1Ox1Gzh06Zy8UdIOZyWzhLkrBKzMmDUCwU2Vw==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-YjN0sl/JK292G//yixUwKFZ9vEiD7jYFxWS+/2qsxR8wwXCnJvbI+7xSSMuYF+hXB/LDMrS9XudLO04U7oBDHA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -12230,7 +12218,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-19IC1U+UYJiagQM7ghe2YsDu0xYYYuL+QDMLIsBNbPfzVrZmNHS5KElDwfCmOjrcZ2UZWcPP6aqvJFHs/SaEGQ==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-jN1+ValoE81o9tL3an8SWyvjW/rpnREWNZtEc9brokNmq5HlJbPn6v3c3AyCjqQPWmIUUTzqOGL36DokEYQrjw==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -12255,7 +12243,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-50pH3OUvLxsSfo2vqt4cjvbKIZhM9jd50Ch7tEt20+4ubj9NSzAnfEG8/JNl+0nmyq93KJasTqdzJAu0CkSjNg==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-Rg1Fs/Mf0wm6TECKrDfN6C8yVsV6whMxakBsIzpOAt7e8bY4AAE7KrCZuS09qTplcCIrp/wKFUWnr4kMJGHp5Q==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -12279,7 +12267,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-hWqDtXZxWhG4UyRu1HhrXKq1WVMNTAoiaTNKAx0VMkAz4q4C1GlTYKIKJRS3PKgs2CtzflVAwa3SvRTYHJv3zg==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-0AYnQLOa98MAjnGlxInlH4A2SAPkZOA4jJgKe5BI4kmVF87Il7CI6fedLRdRlDYOtbCV/ay3ZQJLsf/zypPoHQ==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -12303,7 +12291,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-FvnZ1AEKzNHnOpDrhxpJrSPU8D0wJgTLeu7YBnvWmSvsW4Leh+idcUwBHRElPIPu8PEQ+KmPoTjmi7l9M669Fw==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-UA5nvlYH4a6/2UGUJcqevitjqM2lAArZh8fzIsvD3EtDvqWi8y3cF2aajfWhD1FznjosFpIBCT3360LLfFxaHQ==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -12328,7 +12316,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-lSfAUugiGoDdwbVIS2lJxtB/rEf2cDQYSpwqR/y1RcJpWkwqfjdgvK47Josok4Y6NuXtaoosgkNFQ3AyMUWnIw==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-+6QpGVxZ4qFTixTOkOpOlNgJnwMb5PWkOYVrUV5ttQdff04Dw0uUo5Xlkeseht20naDnzGouH7vxu2McVfaddA==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12353,7 +12341,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-MR01Sje8p2oEOes6WKpKN8NiKP8m51G0JbaIHS5S5h1GrupaZQevwqWAEU812CEyKyoupX9Y0EIKXtwtWirAdg==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-DiliIrArh682XWn4g8cer3ZcXfU2kbGF84KuK55kBThJtI8t54FQAkA5GXXQRg5FzTj86Uh7vClzQee4O/Bmxw==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -12377,7 +12365,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-+F2MIKIUrC8FT6RzDUKIQ7/aoHO4J7myBRT7ltTsldWc9wgpmCVTFmlx63JvtonGt+i8P00S69/vIpiD2pYoPQ==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-2gmOhI24Dzh566GuyFHGvBZi6hhl6L7inPMQuxSxaA2Eda4GpoLAuoj5SGzZFipr3Uk3Shy9Ry/iLg442F+kvA==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -12402,7 +12390,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-JPL0wlYTKvsI38CLd5lNKIHjAAOIhN+3N7Qmn3EqFYn5RCC8u0ThCns9MIvpYk4iDkaZPozVj3B5AfRMaaaZWQ==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-qE5/S6G9GnahHBsa9CxAgXm+fOxa9+iYSV4o2qNK8Wov9rP8iu5MUkooricWjCFkRe/uEaJRJSN04Elu/VzJYw==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -12426,7 +12414,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-DtNOPJwhrboyixoBli3jWJRFl4nl3iOQhHrkh8FETFsIP8WYq/5ZYF1PXOAQGVVbXy/6QDCVC6q65a6ShpB9hw==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-uRQXcxDca7Vhb76LwypmR5c3/djLe77+TGfQXlAvz2mvBOKNVG9S+mMuqO5pJ9NKuT7bB9Wsc5B1rHZfyaCbOQ==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -12451,7 +12439,7 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-BKSAHaTn5C9R3+w1DQdlN+VfK9NyI4SrdWNPEjjtSaMU8TGnYPfHX7NLh7WKROWlAasK6afHrr0ber+yqDqFUw==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-uOp+Hnq0oSw1S8DXlu/Uq7a+SB29xFfNmw9Up6iU9TXj2EDpk+CqAmEZ+LEwR+q43+k9V5TaBYfwHDhdYOU8/w==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -12476,7 +12464,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-pfDEREbBX+xm8pnRKMNtVwkDcUT0lGydKyPcoWVWz2PhFvzBeCNmXF4SQjWJw7G6rYOrobh9Xizz7IoD8mkIpg==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-K7kWNwAl4dI0P0yDpqVf5BB6RE3BUUaCdbNCXVB9zy/iQPAx62l6tHm4aPAgPzpqF/BqeD7vXW8ZF9WEXxcNUw==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -12501,7 +12489,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-LzlhNkrx3dfF3BEl2pUBGp5EWSZ/i5S1T6tV11Kgn0gbD9FbAKVaiJlnXajz2zyh+8J0Zt8TqnIUbfqhnLWAZQ==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-F9tljpG/o/GZp6tqUyRZcrh69FSEB27+/qQ3LUatpIVBjBGIk5FTrfyIj3rh255l2YQ47SgQRDHt4ZpFkNv1cw==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -12526,7 +12514,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-3WyGsv9+MeLtTcF6nkEobky/e5NHBeFqjNfVsdLCRvXM+Gg4Dep5l5WcgrTYC3clV3LFTGHOI9qaAa0tuoo6cA==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-A/V2fh3Cti01yjGmdetZ3+444yDy7d7WK6iqWABSRfF5cOb4z7hG5070finzATxiq/dKhRX9xZkt7As0mGRZRg==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -12551,7 +12539,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-vrZklKW3Ud6K18wQYDvilGf9j5KGvgEpMlf2plTq7uzIrDlYB3vKfXFrZmp3U3hfbuQ3L89dfLoOiHpBPn1tGA==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-xEfFaDzQiHtYVUgDRZd223M7rRQgSUJvWBa2KRJepdGrvUPARe2HsjZIGFoyUROlMc1oO4Wb0ejJ5uwBDTXiww==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12576,7 +12564,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-JjSl4nZwYs0ihTKBM2+U66po+cp4d1oMw1QtfwEf/5DoGBkFDGXlhz8tEElHEYwESqj5teE+c5iACT9qlUOLaA==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-MfPrGJfNBWzwigKTkYZc19i+yeMfEcS2Qqv4b12H6wCup7inRqS3dpnGKQ503XzVVwaaYNzqHdCTrYZo27lo6Q==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -12601,7 +12589,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-5/WvVLQb4eBKMsaS3BPo/fXYUXfEknoQSLa/BNK1XhMp500+CZ8khnxlNxe1flt80tEcJdbGr5QPyCilitBFQA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-aYV8RbZs21lLFW33C/sxUiD6e2UYTyn1E32oxuyIGyxt3ToBFw7MyyDQEKpilU/6baKQVi7judAObcbMBwBU+A==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -12626,7 +12614,7 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-PsAPp/y5g4Du/xSOk7VFhonOTZ1NxI1Do/PgV+hdc9rC0GuQarRj4VOpjBiDiHS80UwOgrMFFDA7FtfQJn025Q==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-73VI4IzvKvfyxA73Z92X5QZfVjbR7AB7d/4hHd2HnfimfCbRZYE0ymm+YzERPQ+gvCSqcrnpCXqha9JMgfUT1Q==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -12650,7 +12638,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-FHuTbZtwQeJu7YeXu0EVDxWOJiAy3mMUVFn7Ony9gCVTfD5N7CaT8kZop9ywpyKTbUBOc9IRRrVHbXpyxEj8DQ==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-uxfhs4GkEvK0iuR1LlEFcPpmsRx8B4V2ibBfD7GbLxw9P0gC2OG5yWuuEEpTd3qH7XUkNUrMWo44xo6Yfla4nA==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -12675,7 +12663,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-ebxkPi/3CkXnuhbjsiAfYyvMkYJrccO86O8wa9AlAYJAdzcvDtCDmAxs3Dl7PXMCLAyFR2aFpT/cO/GG9tMjLw==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-j9VNw4s9B0+HakLVIhNq2Bq/TN1EbbyPw2cbbzrpESaz57MnKzfxcdBEZguqq6NYH8BvZUu++N4MuMoYE27dUA==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -12700,7 +12688,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-eCVCh6CoYpafVhWJMxSuzJpxM4Yf0BK8QeC1+vg+jk/mNZz01TShwXzlKorXFLTAOVZk7d61yQEkKM83PW+b2w==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-/mMz3n7eckT5YTbB3GJeV26clwQiJTJ/Stvw98ricb1aZ/yctfIcbf0ENRZaWRiC/tKjoHkTTui7INGvkv6Ysw==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -12725,7 +12713,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-Ifc7DpGeiMdnhyxnA7xsNRYC/RpyLbw5K6aGr73blme69OkDHp/OKaGfj1KFSsJb73kgTtyuGj1hxIVYVOhP2Q==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-Kd4qj8hErip4Nn7aqmu1J8qG+X1frgbq0pyLJVP+XqPdhnoIhxwApVUtVnvtdH/uqhi7+zjVMxdqPev1ODLd4g==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -12749,7 +12737,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-9CkGYTv9drv7l28Ch91vQPTddATLt0G8P/8nt+1tZFKcgN1UIKobKwT4qMnhkQoB5UI5G5UoGNwKgmG96PcOZA==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-4NYL5ou264KwjD8+axMbg/iD/Fbix9J1QrgKHowRB6bziNPzPRIA0/xwDoIqBoMZip8NCqNvn/EuqrpXpoUJyg==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -12773,7 +12761,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-wAIv7L4dACGlw/OKYHOtWtpbHukhKQqxhQNJX2y+i5o1bB1NCBWUBuAOQLn8zirBCIK+05eLHmPiaAtgC0EOYg==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-ixtzggysQv/FU5kgLpToNuJjeQYH0rkdCva0yKXgc6XsBAW5O4Rd5CwWuvAoefCwG8m4YhgEcH3GPp8aurl51Q==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -12798,7 +12786,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-a9kkuakLeUJe3v40xWtZl7DX+PC0Mzs3wJh8Nq+3J+/rmASS0U4WSjmApnx1rPfkBSqGzvpmXAweY9Q3qSsm0Q==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-nPa4wkwd8EYlQycTQ2dJg/+p+UcQrPjh8/RA1LAkUrWyXe7u2fmDb6wI6UYLSWr05L0gg+gljA9SpYavTo3Liw==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -12823,7 +12811,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-Ka476qW9Qj2k6uZaFSqLkgLlc3UXlGOfLGejv3e6XP8hEG2kf2kIx3gkXwZaC7l/tTmd1mkHwSX4WcUtOZK8yg==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-r12Vf/hbUwL4nMe37kYL7hzoX/YWwy3RLmqqdv9uG8Bb+G5fYeEqF/agaMnyfcF0KOMGPFlyI3OKVmjWkfeX0Q==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -12847,7 +12835,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-mk1N0ogqR7ypaf4DFaXLdxHS9KJf0h4gg7Q3yaPzOpDHdcwnn6bpLNNQ73Ga6gpI6YIBXb+YVh45kl/EGpTPSw==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-39Z3FnRxvLIxyM2OL3tvvzcGGG9GRDUFkqaddU6PG2Edbr8FZp7lMRMDV1ysLaKycrgV+jY+NUXggWEqJqyaHw==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -12871,7 +12859,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-A73A6R/cnd/0SaK6KQF5ip0QpOzOEhnmbCHKeKdH8BJFMbhpgB4AWfxAwlp+ItVoisbpGH8MrM8FBidwZdMmdg==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-Y3iJVJtRl6bJLvD1VQN+OBZY8xMgQrre85pap0uyLLnGX0Qgt8nfJGqXFlHKeKvXbEAleyUafE3UWe8nOuM0/A==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -12895,7 +12883,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-12uBkaEoYjECAUT8dCcrUYqg3tvuOrQ3hKbdlbA5hvw+cckEFku0JPwTGl5FXgLONPPRYPuKD1juuzHpDYTQOQ==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-Q5EwtIhDiFExrALr0Qx3GW1vZO2T0CqjqGR1GnpPI4G3WbCElKrb2pmmYTPaJaTb1vlilAGVv0tbEPt1BzRJ6A==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -12920,7 +12908,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-My+DuFodiSBPDQwUdnQq+oB/iJ+QIuGRcotsehiSb7G4lYbD54xHrnWAmyFLJF3lvN2UGDQPLAFaQlDUnseyXQ==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-rHQwbUTpcESBUr9hZEWnD5JURWIfu2fkE6bJlyGpE/Hqi/W33lvWieN2qPXtPOH0Tlzmeu+soq+7eVgg5h2qWA==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -12945,7 +12933,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-KVFWZbMiv/HsFl5Obz4QqsFmsOWiTVpsiXlrb3VIDZadPLwUsmSo0g8jhOy4Y/VJoWb0biSGif8SmJlKOwV3Mg==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-1FD3X+vRU1it4Cmny44gwwvE4fi8+s0wSgyPHfbUTDSjuaQ1D/XWgaGik3SLJY3qs642s5IRtnw513a0JGzjXg==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -12969,7 +12957,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-U+TP/Q6AXq4bmKKfVoYheqBPUHGHBRbo4zI0mvoFXGfSRuKLupTvyRxmRsDa0Mzd3DRNfj8HB7JRhVDoHnAGgA==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-5xhT4Afs/nnEBVg0V2kJPrwtneezT8HR7rXEQ2l2e/BWDisgjRNhu0d1qfJxD9g1OsjXClmhEXqocSXGkNMhoA==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -12994,7 +12982,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-TKehVwPEfnFMaeOQAJFUKJlQCR7D4dRkpvSqnDJsGc9SMADbRmWQzltBOrTbC0lNyvJFBhBDYcmjAmq83KqinQ==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-tbbgo1fKyzYlshctA6FaQYkhLu9Cj3d38CYQCVt6bv6qnIMz8sB2K5mBwWJGS7UFBmfJV2lYenWRtL1nM5CFTA==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -13018,7 +13006,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-UlcktMtjSOho+wqkh5IP5hv/hQNgRSyTV9h6ScftyWmHwrO4HmySIzMd05engzLVVkSgZwhuLNZClbBrZLVMjA==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-zA7L08cWQgYZUXlgpTZFEmKBONpbsys6NjwzJRdx35JWuhbog9HSriKOtPlWvy9Q8wFltv59rVbsdk9FfETJbA==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -13043,7 +13031,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-A9lekEsuiWwTdw0S0ZwMsIkzXVITjLvpfzDsi/P7vOyMSX4zLc+7p/RVXz8EU4g0Q5lkSFNNU6URs9A8GL/E3g==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-9i0Av/kQEfhe0NtvnAXc1MOLVUZFAsB1XoAUlbtc306SmTuAqyJu/PmhRpySef9sHTXIGzaRSBie2UIUBFRQjg==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13068,7 +13056,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-uPGpaqiC+UPYvjEVetxxpgG5RdSHEKSkh2Nlqz871ZO/j7CqlKKlfZ8RR2JO+T6hkTy7ADe6tE65wef6iMk1rg==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-8qP9N1ewKGJ46/4u+lfnJE515Ua1P6imdIjzI8HogM7lj3R9rZvatPiC00iaxqsnJ99BYBd4T/xsMZXBi947uw==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -13093,7 +13081,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-UZXHzq0+55lJ87m/LgDB/hBK3aYmd1ORZl/MsYCBJSBqU9fr8uUnUG+YpwepuTWd5JUCo+VVuhKDw+spyvGTsw==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-B88g/kGOoov8ZTsTHeOfwjjqlM2Fwe6qw343mmHvE732Xjw4udHVqNleYiwKhMhyMYIK1zp72ZlXMTavTI8f9w==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13118,7 +13106,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-wTrETtSwJA2HaqmRuTCpKlLzLfEU9pF1X9xDjH18VW56oXUkF7Bn+wUTi5lCJXHm+zYP8nLTouUjiA2AUWjTKA==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-XwLOPJr+2Cd1Qqfvxly7iuH/n0xxIWXBPhbyMoQismOv+QmUyp5mPV+uzm7yLqDoT/nt8jZ0rDuSTgdrBpxtJg==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -13145,7 +13133,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-qkOzLt4mz7Vp9VTdfKLRMnzr8vqbp4GTC0aLOoQwuZCW2ltvYnEfVC//5MNTpiBe0ucWcno4mw1kvKpO17bmxQ==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-v9kpICEc8qK89fhRE0cnU7PlR1YLCQOoKW0AMdzrU36vWfSI9HzPfFCJY89s3+uGCx+xZwB7ZTdRVr7elA0dyw==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -13170,7 +13158,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-FlnYcqqrNyy/GIoBh8w+ZE2znX4gn/ShAiJ3695s1RgggZ2WkGqd2mTui42DSvCtqRVjTC6TIDqAygYPYf1OHg==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-puoyfH1gmm8ThnHaeKeAoBYTI6ftiucqWdKxEyTg4f6tFVcDxV+S1Fz39rRGPI1L/o/Tr8jhV9H4wEP+wKi3fw==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -13195,7 +13183,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-7dvEmYWTFxITmbbiLB5DdHggOfzzQ3ZPvCK+871SSse4QjaxhySj445dQDEcRvN9SjbtXQoI4ubfqUlD5+7ksw==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-6P3Vg0Us5yjTj/JyZf69ziITvMUaeU2fXHTZEd4x3qqSeo48wfw8F9fbDhn0C2LSpyDI2NBhA8MPiQ1/UxnNrA==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -13220,7 +13208,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-VHitX3x9QP9/AVA1T1eWRiTrCN6h5qIhk1kVkLxje+WdNwPxB2AwFe4tTxxU5rkQZgu53pUNCsSLSyeTwrXQ+g==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-QnQUc0vJ/Saqt/0YmlnG1jxOfGFn4+leDjpLVE0Gnh9MKnLESwDO29wVpI4O+85u6rOgVX26vjgl/uJYaY9VYw==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -13244,7 +13232,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-0N/I94Eo1EpdrmwqNvx4SjHANuKkpI2YIQIK+bKq7SOiBE65zOXC9SVJ/I73N2f1lBcf2iAwit+yyTukuqep6w==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-puzgsvoCpuax6zrbuGkZLJ/idHagZIk9+a7537OZjIwrcrFP4qu64SPwkwZosb6to8tr80LjxiC92htk/AxXWQ==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -13269,7 +13257,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-mLrlOfuuEAzRNkR9MES+IXiyNGGFKXcToKdGKWtgmC7pN6BVcP7FbI5XNbV0tgItkJcFEFIp2+RYGeaCgHqlZg==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ftuIIzqGxXV/RaCGPTWVULjVnq3ysER0ykkGIaf/j5eO8Oki4geQRF3XNjoTNRRzSTEpp9/JYHfG4qHNyy6Pdw==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13294,7 +13282,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-zKFE6jHeoqv5ffuURiwDgUVt9gRoOkiXl8ItIU0CfJnjDGX40DiXjX4ISpDyj2JYBHsOktNB4eueFIGjJNHW3Q==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-94xTc2vXU8VXC0dNd7kFQuGTQGuKxmkC8/v834Ls2TVSOM8IlFPzYwzDBOksNSXMo5+GHOUuNZlV7MXAZwvSNg==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -13318,7 +13306,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-Eh6vtTue/ko5PffPwxm9iKEkJj7X+SW4C5yHZ+XaOeuiRhb2M6AI27KTz5Y18Wp7MWO9lnjsbZV0dOnF7Ymn2Q==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-GACPAFd4xBmbu+r0D8NAS6g3lnS7xLkWGT5a/nP4Sn1Sy7isZYUSF/suNn4RMl72BtEnPyekJut+KXg5Q5floA==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -13343,7 +13331,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-M2nNHoCjjLm2IMeLC0EOGqCUkNaC4TGnk9UaLSXzfwN/lHPCaxMGz4ZdZV4S1Ff/+1yrpGpkOgnBdS3QabivvA==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-6bZ0NqSi+BovXu1NdCxyxP7+Op62WyUKg5kbH8u+QB9+1QASB+QTITOL7oV1Hx/POWc8q/PXqiKYn1VsQH8F6A==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -13367,7 +13355,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-/41bLsqsNPqA1jFwD0ZTFHbHSqO+Tf2xHOxY9ljEI4NDku2vgOsy2ScdMqEDtSCoYdln4enDVY2powvcxaYaww==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-kgEnhNuzas1FDoFKg56Ucq4bi4X8rl9C3sekdUWyk9SThn1QoCv9q9Ec62yaCYJPJQMw5Cntu8ZdJFwlNFSAQw==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -13391,7 +13379,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-r8VPX7auQEAs76z3qNS8Lv3m9YOiLaHG8jaT9vxjYO55Ftc57WB+h5eWwFdwuTRT1je1CVD9RDlKRUqcaLPyrA==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-cE9VKfUZR/2BqIHtctgFXFn9KRBqDlc87bSTS4CDMFnIBHHSopTvgChXe5nTHTpjV2L8LrXr88VumRDwKn63kg==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -13416,7 +13404,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-BMKjRGXBdxxqUthI1ZYeQ96HMnzDepcFJfBcD04bkOE9J1259FDxeHICEy3GJwtQJzV3rXiOU2YpsNbt1LdV4w==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-hst0PH56kaRQk6ysC9l6iDPAC/UHa4rtxbeO5Z3Vh3txnJ7NUxXk2w+nvL5+Cnz6u73RDeb1r64hX8qEOvXlHA==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -13438,7 +13426,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-SMDnjgDyr5rameHs7+y2QNHBJHK3GwOgoL7Izc3opuvMWuO0S/bPxXET/tm1NgKPLVt0+3PP9+RwqTQBzH2cGA==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-TXwaskNL9KGRS7hlbbePM6Cz9U+GBcfbaGIWQX/sJL26IdYy7iw3CjjQfiXb7y8bQy/37OvbcbIErPz6MNI7eA==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -13463,7 +13451,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-aa4FOS1r1/5vmIvOCmHWf5MpUj9VWpAeDATAOkXniAQoCRmvk7W/Yb12I/IgMLno0J4QruWPYh3HEsi8BYicWA==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-w8FPAC9S92w00YbX7tR4vN5X1hSoA66sCzwbBy9AQwcIWaYM6MCKH/ZJ2ht54WtCb/AS+WAXkdWrPFSOqKqYzA==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -13488,7 +13476,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-QIFRHIXSpwUzb2DLLwbs4r3JR+N6RlObpblDCct9xRyNij97b7IaGE964rcZmgpXpST7Pk+ekhCubxl5FGeWaQ==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-RECh0IzeH4u9VGMpo7hm7C837oMvIhnwqmTIEVQNFuZAq6Wk6K86POr3wEX6lxS84o8CaUvg8LVBOYRBiGtyOg==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -13512,7 +13500,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-qdNxjRUMn3a5WvKdbvt0CzJdNEAGKppTABtgxBqlq4g2DtG4qkQ0fTppXzmG1B6qguR3BFCLEROYOYKMqzv3Mw==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-T+6eJDOzXs1AyrpGjOiOtmJFCZZxRZX3xZ9/qTB2sJwps3j7jy1bRwT8vlizJsFY99TZxo4bHgCR6V6ktcE0yQ==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -13537,7 +13525,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-+XlygP6gkmeLbaQS244rzfvlF0LywTr3v6VNFnLtX2laP+1aKPl7ZJBDd3ugaCgZfrdpz5vZ02NXrCrbO6Pkhg==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-N3BPWnbKLHANDINbO6zeggn2qRXWWf+JLSwdxfOzWtWGs1Rx9qtsmpU1oRXBNDR5gxeYJ+CcvRWvdLmY0s/Y1g==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -13562,7 +13550,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-sug2XbA+ZffVFpDrHWvGdB7X1sUkjsOgRWMh01FyoEvcHW3JA+D7KhntbggVb/M8zSgiJgDZrgbmEedpbSrjkw==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-azDoVfIJXtBeJh6EjRfpOv94y+ccsk5qwWMzkiDSu6hFjaAdrUps7eQmM15Zz5dg7n/wchGU8s7rKF6buvB52g==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -13586,7 +13574,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-J7bE8QMMRJoi/6ZMZsCs8+gihw2znTl6E8fBuKTqZBujfnamGR23uaKjtSzMWuFNl5qEz56yCzli4qBiebxi3Q==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-7t2NIvtSmM2EF47DbnlDblA54G+V92gEHgJ2kdqw35G99e4T/MuPf8ob68NbOozE1gM1nJhOZdJF2Jj72yBxCA==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -13611,7 +13599,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-QsQI3NYRwLm1c8BZzkfcqerfRJeyZAkQL/tqOYrLB0aIqelJaL+wzNmYNZNV9wbCPACYMZ8YsXvE1dXO+8qPsg==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-OPwyai3MfADcAaTvIibG5XdIeHEFyin90TGvNhN5ARCzfXgwFM+Lt0LYdnQNKrRXsml08mfLD9Ll1NtMMRmi3A==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -13636,7 +13624,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-YB8tlqxYPdlmzLHTmsSkyjYtIxgOp6yxYzn3H5pQ+IQWu98rJW+q/ROxHaEgOVJseD/J5NwZ5KGkkyQyzdiSqw==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-ZZrIq4csKPZh4DrK5L7EzaQcTo36InofLfb6Z9idF44Hda6DqFEeM6I8+GwqUBAd3GsTbFAPORo9AJa1o38X9Q==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -13661,7 +13649,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-qhDitBOZQJ8wZu790uxIHJFlc6lkigeYZeRIyE0ZSPLoPhbdS5HFFI5l9ZXOTwMpDvtbS9g+mcjsVZS0gslM5A==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-TFBvqMviLuVaFiL+41PT970i6IacVvwKbsdGdBAzcp7LCoBPfk3bsf9tkNIlohiMQhEpYlbX2rDHOfwXfp6Ogw==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -13685,7 +13673,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-i8ue4biYTH03mDI7GbFTkX01HcRSsYJ1riU3Vd4l0E+7FcmQhEm48BoCz92LA2F/WCnyk4nqftxuUwKP0TmJIw==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-UYQJEHTggm+sBrPPuq0zJ6eREQf/1KBitRQEXfanGXyldyc7kfCzUXvVrWilxjB+0zVbHjkBSxcphcZ3rScBIg==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -13710,7 +13698,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-vkKc4uSPMNDYw6D8MphLk2bxb2j/8+CsxG0+o2NbCo6bMGwJMrCQTeak0mXjqGcI3lP88CFDYXWj/E6aM82PDQ==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-aJXU3FuqXK0gZbzRK156P1uNQiMR9kfc3Ikcmw36VPd/af532E96mPNGyypOt3k6kkmZ6vwrDkW7VDJiMRHYLw==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13735,7 +13723,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-uHNqolyfYFuu3h2ClUCHrW71njwo0NEjcdBP53F+PKqXm9EGwKNWvvFe7LDTkZWmUFrUI3ia7FQ71/gonVHgYw==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-Y1VZukOZZynij3LPMM+/n7hJb+m/c7bh24g3s07ALYMcqAVEY8lKmb2tXl936TH+vZ0c3205V8wDBqJDK0etiA==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -13760,7 +13748,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-D8r+6WD6eo5W2BJElt4lpYgGZIaxl9uXyNGm+lQSNGzxoMuFSe64u6R1CgJTRtdHResaHx7lk46AYnWTIVX6mg==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-F6iSrG1k6662/uCjJpJyPqVqCec5zbC67rKcb/jtdZqPeCEMi9s+VN82ZQNKY7Q2uuGiwhlF5900+rX8HvvL/Q==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -13785,7 +13773,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-Ljqsgq5fzUCZ5FbLFj3O0DBol9nsFaOtB2Bd92DcnBCZt6PZK3zl+UcwxD3DHLa02aalofZ1ZGP8DLa+RZltVA==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-yWeTlJgl9+LeYCwY/Th08SJEMqLqmAsBRD5UYZS+N6EK/+YyVdhoFARx6Ld4kDiGXm+BIz9hDpCIZVqEFwHYvw==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -13810,7 +13798,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-E+nkN1CqaTRlY7gpcI1N9aotWzTF+9uB//xv29f7Glw1je04OMbPQAvEVw54buR4Pu1k1L+LZHUI6EX0peNBhw==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-oRdiYLuEaw0UcufGbPiQDAJlxPQIAitdNwOiumw4pnZTRRZ1n0+GDJZWnRcHF0C5MqgqMDU+oQGPsAmdrGMH5Q==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -13834,7 +13822,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-TZ6D1v/Nv02dYjNku+uU6vdKel3xluxh7f9tBGDiuOQiYdcCkD0Egtzp4N96Utxnvel7S52MTG/Z5bMRsoSmNg==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-dDSlOw1FGiLZaY/Ecli3PmW2xRYDMRmTq11XOjKVtSufSxzf/NItMMPsvQqIu/5pY7kb0J4ESj39Toj0Knnp5Q==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -13859,7 +13847,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-oGiTbTAO3FPkAcJEY+Wklhn8oKmy7gPCiJgAaGFN4ItQfaHhSSs2oA4T+W31vhoTflm238KyDiO3aGklXR29dQ==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-k1AJlE2JlD5JBpEeGn4+wPVcHfP5xwEO/wYGWneUym/POypcrsT1bNajpqRfMXgzWByzcIQwSoBh33OoD3tQow==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -13884,7 +13872,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Ogh2n2HjogyMHWe38HT+OZnt3WbozJgXRex7VrMaNFy6OEusT9w3IcrG0hF1OX304F9CMwnW7YzIcShKnuiSmA==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-OrUie9Xr1Ea+//hi0vKEwklfdWDzxwcmwuMQd1Haykl5FF2gXboBsZCSvV5gdX8ssK+AhKqcfCl4pYIwNipDdg==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13909,7 +13897,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-+Yb9aIeSHW+nxvYeKSNwm3z3IBdQAR135dGgzQT9Xsvhm82Q2ZnS5rcxBeHTgJS9cGHYqrtpgmuwykxu3Qa5kw==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-y46TVsPsb5qcF5ZkO5Z2l60Idnn0pF/JRHuzmJSqMd9nSrJs7+mLBi+95Y3E+lFsc9uyDjiBp8N27B6T44Nmdw==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -13953,7 +13941,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-I6XQ88iWP6NNj4DLncSU/9GeuAywo2niDxRlxNCUBbAwy46+5VnYjZb2cVif7TpIrvitW/bCZHk9p7rFKuNWTA==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-9UdBpHF3HxnT78YHxD9XOQ28tiMGVxV/PxHuMQpag3Uy6PsSwyMdqyyLh8axKea1msxbeGcq4+/Dxrbzys+twA==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -13978,7 +13966,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-Z34zqzhjMQDZk772wnk5Tf3ima0oNuSFaNmfytpGL9Anx89rGnCXwAR8BGoE+XNMa6+gfDFcnRec0La+DUTF5A==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-AHIMa3aD6JwCd6CCJl2kbZpzNgqeLqOFuBcbMqTcp1UsKDT+H7CFhAWzm77BwJ79fyBD7tvX5D5oqN17EXc0UQ==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -14002,7 +13990,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-pR/QUYlHGYFSPUDm7DHqFKuzh+9bf3Fk+dgow060+YTa0FZIepPrFJFPDr1UWT3bRdVlEE7WJyfNNxKqyeTfjQ==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-UdEx4JEu/jq049v+jJ/Z/PWc8+L0Hdu0dSyUMUMBU6siWdR2TEjxiwpJlDofmme4gHfrLyn/z0gT+lYB8qk67g==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -14027,7 +14015,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-39QX17Ub/nhHKFJMKCvjEYqYfVibWlUQ4vf/guUhlDu5Ll3NvTUkeodNedd+V8k1m44hoR1tZspFQhYSebiCMw==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-9u6ync6F3jVWi3v6KRt0QfNzX9ghcXNPE/eOFOpJTB/7fEqrx6ql6tmgvt5Nl8Rs6x1H6vTq98EI3DSTT6mUlQ==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -14052,7 +14040,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-JHndkNpdJWl0Gnvj/3EoudQLx4FmDMV1bFVVX3dROvrdOrnNmJJa08L7E6+oPGTQMz63eMcjfImO2cHfqgQUNQ==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-6L5cFCYlcqJ7twtKMV6GOmgx6RGQ8t6P5LhT/yB/ctoyhqkgwnsWngBk9ALgNAqufNWNJYK/rjFXQKthiN8Sgg==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -14076,7 +14064,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-G4TDZHWz6ZMuNOEblWTJfqBWfETl/EJO6qFYF9W+Hq1s8+cEYN/6DmNRVS9KlbMY+zHaR1Zd/vWgq5Xo/xpNEQ==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-R/eMc9R3dO7VlW5yZd/Vb64jJqyY+UFtGyDTmyCRd0DoVxQcRJ2OJ9reKeqT2vpcb9/Ol0Zgd+OJMFpWkn/Wvg==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -14100,7 +14088,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-nORWi4UhgNecalX8NhyDEQZpP9GGeiLNvxFhSHKhLGnPa80yyahrS6rHf8rZE/wlOE3eWTfm9gU6wIuvfiIi3Q==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-c5LiJMYxfxMLDfPMWUHTb/zcyX7Y0KxCLM5fRvg+jWJqqvxrh8d1YUI6M+/IotamTFYSZhk8O52K7iE98oVUeQ==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -14125,7 +14113,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-1W5pjnXTWQWNhOfC4Hd+8NPqBHuu6zi084KswcdefIHSvGd7Ju4VgLFHzBYGhLcK7+phH2Y7XCg7R1pVoHfrnA==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-OqG9IymcEpx3CP54Z9ZgN+lYRyMpmdZEL2vhce9mP/tJltxnI1p/JBx+wSPX7snnHR/EnntRbPj2uhpqVuBABg==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -14149,7 +14137,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-K91zHSm8CupehxeUcD1rlajwrqnMpf8TrxREcotrPBpF2X4PzxE+U40Wiks9zleaWRYT+O5VmRvtvMxsw2fLaw==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-b/tDNOMmLYe2whwoJA3nfPv7H88bYjgS7V4T+jsvLhWDnEW7YK0ePPgnHna9bEhTHLKqf1t04H4LK3+43fnskw==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -14174,7 +14162,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-zCldJTwOUvR8lBQK81aD6izyRjZjYD9zZQXyf4j8pIQucN6Z9bTdZOLEmnB2wB2Jxk74QB6LqOVRxXCbVXqu1g==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-iiLwdGzmDz8BL4BKdvXrhwQqZ7aRvxlAfYTIImqmaoKOikQ1HKoKBY/Ie/SWti+Hcro8jhSVplcFkS70gV3esA==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -14199,7 +14187,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-LcXWlL8tiCMUP+WvB0q8HGvpUj/pbl8RAo6aGh2u5F9CENtY33e6BtYe3MERcuCIhBpc3GmW2glFMKEFvw4Sag==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-ogFGSmWM/EBSvZvx6rK9QN43Wi+xtXx3fFuodfkg4SEQKBxL/XPJFHLRjenGhZOiv04mXVZQODyTshRoluExTw==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -14223,7 +14211,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-058WsxcPA0egbQ7qokTE3RVTskYj+8Mkk+PY93DFRMn9zuNFMLH9w5M5EvpHWV0ohRAELjqz5EVYctu3Oovc9g==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-i1ZQRVQHEyJ2YWSwpTsA8oVXN6CKHP7+LtkbSVVSDFrEMLzviL2i0tRyg0jUtp8GeMbKLP90AeTNZPku/oOQyw==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -14248,7 +14236,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-1s+dWhl+gDeyscYhm7HryK0Atythwieh8QUZv99/tB6pseykQeM5viw1sjmKg6c5h8Q7vNXptjiVSQx8bWBOOg==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-meYae/bw8rVIhaEJ1zGS2NEkm6Bdg6DYLvurXXYPgdIFm+9hiMdFusCPoxDudkOMZlRM25/s7a+AAOjtBQshvA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14273,7 +14261,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-vFsMe45uSth2du6MWCBhe8N7V6ePYDQ2NIqEkuyNU0V3OH2i1GkU6pSAOffO0o3FLA1u6D/iOBGWT/0mb3r2ww==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-/dhmPL/hUyUFBeA/k+1Ex91Deni5MOfUdESJsLZf9oiDhsQ0V+pUve/VPCCTPsEykUDOe1gsV5MeifYikk+1Sg==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -14298,7 +14286,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-w5R/4fkIqx0Ftu6LWBfc810c5rXigFPNNhL6UNctPb5ASFRdAHq0zjKsE6CMCViSSwbIqkcjZeERaMjmZNnIvA==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-cgiP+hCi6r8Ujkn6y66WLvnPM/Mo8yac2nK8ZLkSct9mHlYFTVA9uD4P3rbhsl9Ft8wZzABCakETWK1x3KhFMw==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -14323,7 +14311,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-ShC/7USX7awcEq5KW878mhIp1/D4loaXWRzguU+bpbDUzZMfVkCXKjfu1RjajBEGQ2+iTxLY+cBuKxwQT4leLQ==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-bWnYMtRZJNOTBJpNhppjXhsTWxIAJHur4TkgmQ7pwwMoBAkrJMcgskFwVBf3OymRgMr/fVrPwi+W+Qyf9IBaPg==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -14348,7 +14336,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-THH0bGQNNPLWJBg1/U+xrf8TJ2mRED+hmwN1k00PuAV5N9muZ2p75NVWxI10ecibe3lrl91SlaSIXXITBfAp4g==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-YSXJW8BtF9HqLWexP2+bGeo7ooW7lePKmH4y/34/u59si1nTs6BWMY7ud+JWYT1x1jvxonvVFTMrxOlSM0ffhg==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -14373,7 +14361,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-G2qgCCJH/uLQ8H5crgnR4bYy/gCW2ks6lI9JR1KHAGBhxz0JJFJtP1AGoxCgS1paib/8uW5NjRHH1sZ7FAi6Og==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-L6PirKq5QCtBLgt6estlmO8IwC+Kw2ypwkgd9Us80ZHwuaH7NN9CGcvkRBObH6wWSyXkN5eTcxHA48/WDs40DQ==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -14397,7 +14385,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-p6yNPIGPbl9cKfuZQyvYMrCEetivo4gx3CSKEW8Ef6ZWvIFOwT3pnZOzkinlGMWDgEy+qSo7LhhtMRNvj6wCPg==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-KRcXFYBftGakaidKd3nVV6OdCahebrveIqlNq6mvhRa69ZQHPaYgX+M/mCnvkzUBFdVJxdChHh+x1D4atnWu5w==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -14422,7 +14410,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-mUboATACwD6jHF4wAeYOZ9nuSvqPhqjM5ULxuJ41fzaS3ESX7Gy0Xqx83cP4a+IABM7gwTaM3fIdxAkDUFHyIA==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-2bkA7aTvzQB4cbHsMDAVn2DbDI7a2Ul1w3Hx3VOw4vP+YNdFHWUbYZhcY7la33vVtUQu0SN6SKFtoPEP5qh/Hw==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -14446,7 +14434,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-LbDRxF3hjcuxEnaZiffWAV0YyneUB4bsIgm7ACgYfcJPCohB2RD0NMZg+eC+rDZ8myghbzrJDGgeLYsFfsJ2Cw==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-uNEsrxzxx83/msDazOLwXE0Q14EY12ITRAqh860NrIUK7aFJGHdvV7OUdWaT0AmvzeTOaeDO9JdXAUxf/t13mQ==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -14471,7 +14459,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-wFDmHVJchUaudPXjktbDS86GpcZ2+F9+SAPBP1OXBt6UTbJzlvGwnhEkSrX9PblCWTlwEsOKtLZBQyjiAg1DWQ==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-XB+GyXmiByaOleJJatLjLSA7wV4EaArwpeJSEOwAvUJ9YBaX6zJaKKR6I7fHQO5t1QhIXXqh1Y5NUzFg3ZP40w==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -14495,7 +14483,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-Lg7x13oeuWRLbSEjQAck65O9Eo1yQwSjh6H4VW06Bb60O7QtGEQCXKUYSNH+wuibrmUXEL1DHG1WPWpAEnrDmA==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-kjYajqt0+7O7QDziNMHp0/HItU1L4wGEBzW+cCKyGNtpg7g07i6YH/ieI02R6nkVt8O80RsS9DPghL4tzoBHXA==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -14520,7 +14508,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-306lcImA/s/lZCAy0hUrBHqJ+f25iwxsPWgIej7IU8cFdLv28lqral43e6hm+ywHUMctGz3n4SrpUyrf8LkrPA==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-r+ZpyBLMbxRJAMIhTJXSQp86+Xf0WJQl1zbrgE+HRn6VDPkZjtsH9UGSUwlrc7tHXabI8rcWd4VuOYE2v7BQbg==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -14545,7 +14533,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-19DZuU82Td2GTFPwMpzNqIG/IATJztxe0tHhUSZwfs5xZ/XvYFDOu7Dk90VYd98ZE2TaJmeLgbJNP0hmVKZlBg==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-031okDKFAtmRbDMVkyDyaBXdYly5d5QRqyWXRINW/FqI6ZMtWcWnS8nSeUq9oTPANmgk26IJVJCXkFWZhTAdMA==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -14569,7 +14557,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-08qltcJMEXiXdZyYEIYxzYTM/nUFmIz5U3FHQLm6V0dx6+LJm5dhk9cv4p/nM4e3tbQUXkRnKc9v8QCxDkmkUw==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-HNIGWJxJ2M0BuC2cYfGYNxsQDWm/pkVosGywi+fzddIoqa2IjNiHYT+PnXh8uyE1SMAJxNIhwDQ2kdtE3uZJ+A==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -14594,7 +14582,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-G3kP3UhGzqH+YiMfjH9lS13bZ/VRXGPjwouwphUoGtTGDEw6GdyHbY6JSpmGZuaGBEWBaSUgs+eu5Ej0ZO/wjA==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-UGKWR9EpkujjdL9qwb4EjZEzi695Kqo8wt6+r7ooJqsLnHKSMuHgcM4xRndQxBD64XpQ+NkyeBhmbuo3RNd4lw==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -14619,7 +14607,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-t4x34IBbu54Xj2AbTadbgTV2oBbCXTjLNp9hs24NHuofagPorTf5cT1rnVp9ccMVxQr+mxkOlxgiQ5qaCrVQdw==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-kcDzZ8zZXD0c9hnnEDdECXEw+kvmB0NntVRhBW2k//EtS3iAFUwoRGGpkj9mqpnn81MEPX0lmCV1f+1aeGpgow==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -14644,7 +14632,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-mxeU85pSQ6hl42oeCOPNtCYVkBbrDQy/5ZHAZYQfk3VfPOtGRHiR28a9ldmRvYxrZgbVsRqYgx8sgLo/DyW+1w==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-bRCfhhFLoJarbjLwm/pz+xwYGphF5fsQOTkXoA3wQX6yhPgzj+Uwb2zxq4W7exwqHY9s5Gh9wPm046REZUy01w==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -14669,7 +14657,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-0o1UFqEsetX3g5ACd3P9VFUH9WpUs4pZebO7Z7EpyQh3rstkl90EXFcJEzw/dVHxQQIUKjAWfp6r82OBhVRDhw==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-tXv/RXh41XXxV30jK7/85qDP9tzB13GtuDBvAr6RuqLXwgE+MOtPc43LaS/Y3WyUl/bCxBh8AKK/oltopZuYcg==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -14694,7 +14682,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-eYjL3and3MyXXubGQ6Y4sCvv2jfNK3kwsrBCAorG3AbBdf2fzsZjnrXun1pg6my0ALORTw4qC1dnpTqxMGJeFQ==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-ND5BhXf7m1Ykmf84/oju27rULelqMnXlV99b/2SoFvyL25+DvzGfaTAQyRUu3H9tZ99vDlR9+PQJEw+Mz0iowA==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -14719,7 +14707,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-L94Ff+BNvEIsLserehWRb8eI7IDr7IferxUXSxs07677ZLPFT4+yevPfZAamzbo/xWH/CJZiXz8JMzibuFkIdw==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-+4swRJ4OHvAbdFY741PHAZIO9eLaPHYhYYthAXsQ0EZ0pZ6kX4npE1cS0lj7ko5y7YOI+25W9IXPo/+c+R40+g==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -14744,7 +14732,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-AbgdS4UFcd/eB7RNh2wDZsmYDlnq4EIdvwJ9G+TgwUwKAk6CPdmmNWjwx/SJKmsNDbxQVlaLF2QGzrcNYO8OWw==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-fVKfLxGzyjgfo9F7ikrHk3E2AMDQFTQEbkc0gKdLBIN78uxVyrkr/v1LsVuzJpQQVEpBOOxVZVWuLvM8Fnf8BA==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -14769,7 +14757,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-LoLgWSbwiPt1S7dP1ngRWKyiYYnf/7vT6XgDpm/QvM1vOnaGtqAuKDrZ/LTVZ4wxNPUOfp2Ebu+acRR46KzoDA==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-p5ADf/WixmWp49rQR8agb4Ijb+t8Op5EKGULMLw7OGjQMdEL3kfZv9cnilamlScru8PeNXTRzu9v+S8AUTS2zg==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -14794,7 +14782,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-OKP7IQ88SYbxUcSuxY8ncy207KKtVwANKYrNQVZdA3uimF0ePRRv7F2nroHiW15YigixQsXMAIrxjgEljN0coQ==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-Bsj7QzDP1vkWQZ93YhxXaDL3n8LGC7wGna/uQOYmVECuwouW0d3jCQRhyW9DugRT1SL4vjExBzuYQXhwTj9hSA==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -14818,7 +14806,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-g2a2JOXuAwL/uAll63XhZSeDIrrlc5GJSe22faXjd+9u6NkgasScu0w38NTiuFE4v+I+FBNrEGet43GzUN1n4g==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-6nq35xNqfof98SC3mTZrMS9zl0H1pnbhmtPniBPEyj2x/OFNtgj0qB+THpKWhJnCJCszzHGU6NjwgjAXvCV0mw==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -14843,7 +14831,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-q8ID/qQUYqYSJ1pZWZ/+LKQu11+aapPkiegQcn8lHvkCd/EACzOC9bHZ8N4fU4YlZhe5cWVtGcwDFSKnwHzeww==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-V7w//C5RrcaLKZ3pe9SENsOlEeLVAjgWROtxw+TISquRWI4/3kB9Gh4Zg14Ln/1aE83TL3MRlg2OPlbz4TRfzg==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -14868,7 +14856,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-AfgbEwcZrG9JhI0pp201xzPZxP2ligl6HPcQ/111tGcA7BondnhG3hF/gBtonBYxdlGa7/YrqSOKuZQ+expENw==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-1MKPvdl2/am0fUbz9Y4t9EtCyNt9W5dVC0UBH6KY5h2Dj8hWSqpU1RDKKYLxijlO+tiV51URL7Hx/joKnutenw==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14893,7 +14881,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-VAiAewgE06DsuSDC/BLNIuoKYQurFi+3F0kK4j1f6euWFis8eWBzprc47kZ8J4KqAYKqeHFmHj9FiMbGOx7gxg==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-YHy6SVysSN0aGFDukP9Qs6+gPgHGP7TTMm/XukH5QfSb1zC5qfXL+jzHCHHfIsooTiJcRk9aYHHFxpoBqhnZ8w==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -14918,7 +14906,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-4iLlGNSL2+WuAtJ31DfDxsWs1Bcy0Xw7faFJssejzRMo0M1NW9DgYhX0VESprvNRCeuNhft87Yex+8ZNfgBQ8g==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-ws2q0Vy1XQtuQ49TTUZflbpF8KzNPc4ZmsXkPSSt74DGobaMJeW9dSrU3TwjtxDJ5hiKVYpe4SXVujDYmckHvg==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -14943,7 +14931,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-poyL/MzZRUHGkAQJq7AVM8Scr2RMXtfBteombjj/SQknjJFOebLyaaACV3H1qlZBCSpemEWTcuhW35on03wMOw==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-1pm3KCBbcTfcbJTfT+OKYrRukPel73nq5xx7hsWKmckhG3rNC0N8vcidlkqcM40KZxRva8SlbEB1WyveGVg6zA==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -14968,7 +14956,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-qbthjiOrwJZL+IZV6u+un37ythmM+hmnlWgqd36Vhtu73/8qyfUN3RE2P/uWiBmR8H+OmAuuM0kuZx0hYg1scw==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-cQim5x6GXRouIel0uB0s4e78yvMZ/iUyDH5B+Gm2TxtogaSrTKfZDd45uaw1QpZ63fAyDPymZMguHNWGLNrSYw==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -14993,7 +14981,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-YRYr55MYRWq8GAk7k8kQVJoRIGqxCsQYXPwdG3pYL+MkokE67u0OZpkBevsTHL3i+db2hbgRGYOJm2KoS743ug==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-qlG5It2Lcu+sdzlcO09rN1BvcqSsEb1/eoN0sE8LeibnG+XxC4Weuze6V1Gv02rIRrXqwCAQdED1nNmWZINzFQ==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -15018,7 +15006,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-pW6fYDtWlWHwc2rweBXjFS9Rv7cOPIJVSqxmzVf2ah6LOCtWFtW7DHdnFpF7vuWYdQMR7R5Ic5rmKJQNUfvyOA==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-lLw8O1dpdJ4CKd51UlTWBOLl47c8MfxuN1CN6xglprWSM8nXwDjrmErm2RfFgB0Fr0MdRIN90ny5PPE+fsNt4g==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -15043,7 +15031,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-OCQ47FxOtvRQ5QXi6f3Rj30OT3TKctUaAn3V1HosycpeBhOPA50c7oYozYD9O2I+ZzQykLFoQ+bnN4S66OAunQ==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-V920NF0srbNMd3LFvbMknZ9KiSGNOD8NC39XzUBeq1JLoGjXEc1NM7oVKVbmm5QZzR3WGIzgYqXDuGFQmiDDxA==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -15068,7 +15056,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-lomrFohkNyCoBPelGsqfpu4ckb4uh7G+AX7rbEkQKFGBaAxTJtCsUdUZDRmPgSvopF6WsNLuGxJct+oH9UOXIA==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-1FyfSR8kmvpGujopA6EsQTA9RrjYCwT0e/clVBzDis5llxO/TTxbcOdIhDe3SgMa90SmiSrXVvSVSQZVvbqGEg==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -15093,7 +15081,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-euDGo4XtcvJGfyIUEGNXebKlzlYTnBttle0pk8AtYft7zxTyuioAZ77TLrHkfkHEBzhEE3O527sRlNgpSqnSEA==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-WxQ32/J5wfe+N6+OegGnRDloMBscs8RpYAYl6bAW7H2FRzaw1LDJT3YjG4xDOkbWNEXiqM37dQkSE7msCWIAHA==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -15118,7 +15106,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-4M6uaBlOPuBSHWz0B34+BP+Vc9DRxaCOuEB0IGqLo+61m4PsFFGVrkBSE94xXgWtQADE1jLA+lIkEL+4vxVC2w==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-Wbiep63a3vt83Gz+baTKtwpLGaBlJTOoN3eM6kAy7/f1vG35GfUIWSJd0N+8o0L+swo+snap7GaRh1MNB6Ur7Q==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -15142,7 +15130,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-kR28D85jYYRFqkFQ8i7Am8ScuMxX6DRdGg1bXPblEDA+a2VvBoi0FrfriyYIflzKGY0+DmW/sqtdK5HVf0wsnQ==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-tRKEW56Bh/YMfG6pKtOyPYKddIDq1KexHPLM/dDoVrwqYSsN7xq2v9hBCh6KYOKPJjVczFf4b4dNMRxmQlCPlA==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -15167,7 +15155,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-PeWR+rN1C/NOQ5QS9I0oM5775EHeSWLSzayeMuhqm5B2Eu0WJKEn/bEXyYlFyt9s00BGby4ykw19Va+yfWLiuQ==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-XbawmwTxZcwsA7eUSFaw0U5MhcKVN8XwnB4vdgcc4/a9JYKrjgkzM+B7aX5r7/rbwqPwkIOh0sRZrG9/xxqTYw==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -15191,7 +15179,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-s4f9x4CPlnPFMuEliG4lgThfASYrKKI8avGFVWfaMvdWA63TzqJpVMHZhVkLTM5m0vGcG7aX30XkSkC2cGTydw==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-NWzzEpp+dbqGCnlPMLzflMcstOV3hTfAWOfcN1GyWMRU0uUxDTjQRgT6pv7o34P6VDX/8jKJ8+T/YyDf55SPcw==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -15235,7 +15223,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-BRpgxLJXiItpVwSjHuvXfpz+QJFX+KFeBdOwM6uoo2o0vTIsF8BCIUNU/rx4anzmP3L31lypwv7LsipHOoUGJQ==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-OBZ94g/eIbQOP5xv2ezCbvgh2W8r+5VPcXklmMJwUeAepSJe+ENk/KnSIOG9A4VYxzNqQsnOnzRjjBoyI6xh9g==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -15260,7 +15248,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-ssuLky4GbJ/hzsRtuGZHs/P8mENEVOJ9OKjP3wKQM/lkbmGf6PSJFfnLjQ9gDtyTizh/C3gX5IyWdTIUSMWj9w==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-udECqWC7AR8a+LQyDFyjHN/2bdy4xCXgJNElaRUKiLajilsr5yoVpdjaKA2f6+BRuOKMSKtZD1wvGmOFJ1gviA==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -15285,7 +15273,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-dWoxE2cOzAF2t8ofcBG4FZPyxQF4MFTIi+8ELyn8LQmItXT97/eyHx7iAE6tE5YjoASeW8yH6Q2C38q/voXSAQ==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-VtcN3N9nq96VaTS7f6nB/41Fqh192s/6dcXwxJxC9P7odhsl17+QUbjswpmhzuIiW15T4cylshX+TCm+Xn34iw==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -15310,7 +15298,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-cITfJKQB+miSGsH83fzP1FsEcr7wdBTH0GGUVA1XqG+hmfIh7MD7iAtQnVlq1VkFu0xjksc1FYOuKlVv1BdYkg==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-pDd1nqoQHVNRXPFX1zjZ5mBC4DdT6DRSeRqu3axdoXhaosy0xdwRjZeQoOa+XpN+xYW36ce65oTWJa8J0GA3vQ==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -15335,7 +15323,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-dgjcxzILbO3JSqP+6jbLDE5GB/L3xGdFdrO4UZJ8CS0dA/E44LWtWzVjn2w0B2A4VuLyz+6QLGZ+9JbJIx2sKg==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-sd098Hylgwx0MEw6sphmzNtr4bDUw+G9pEHbzbqoKL47BEHb2Y33DPt7QK2nlFgptijGjgWa8cEgABKt1HcMdA==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -15360,7 +15348,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-M1irXI6xWsbb71lwYty06YJb4c4oiwH0U18aSCVv7L/NxEKTfnZW9mQiZAww1QvVulRa8KapuKKeGZiFjNCahg==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-pVbLG2HhS9OvTeDPpS4AGq4LNAbcWzyD8BSYJA7rC8CjPSSIWcnlU9JCUDCZGKufCi0ECSW+QPsKQJr3GlUrUA==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -15385,7 +15373,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-7XJa7E8AmDNs3Z6QOcK5Q+vRfZcoAHqUTZRSOuLfmndTTS8s9/6ufWm6tKNJ5rmCPMrlh3eyiTwb8zbKaKqVKQ==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-0MYK1EjJEHPI1KPd/eZ8Gm9oW0nVx5GFMSRS1B7i5YQu3QuSukJq+OQKcWLgbT3WFVYfmRCas+Krh4yCiiVDfw==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -15410,7 +15398,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-I5iVFNmGoW4zxjRITcTQeCnOdgvDeXbvDQny7UKZDILpe2NQYdiXvwTDj1o6wKtMumOS6gFG8qIfcqOWJ8RTBA==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-t+oN8Kv/RM4u3j0EN/OmQvUUFD19jQdYeaygIImq1n5PbAOTQyCQwcYsKRfAgLotQjjmFTIwNcsEeIbB5gbXNA==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -15435,7 +15423,7 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-M5R93oKLLp8afS2Bb61ORddMBfRkz02DB8WwRvveoLMVidMslsTkJTUe92YOHFELhbyt2TK1uYwy17L+e037eA==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-2kCM0F1/gLy5A55/xqlNZwqdo5k1bcWhJPiKtXp7/8k/3EMO3DknTGaQHwg+5MKyDLEQEwdCg8pXhF0sIVA/5w==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15460,7 +15448,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-/dOgwbfRS1KKv5kf1d9Z0Y4lJQUIRDgsKUK+0TI7C87YKIodWx5/hrJfli0JjZtb4f68Limt8aqbAXwNZAOdBw==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-UuuK+iuMPz/9v9nntW9IKaos0DJR2H30+RdKKHmtmuZdjeABTJvAGSR5M8LFQxf782daemUgBYSWxjY7KiotTA==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -15485,7 +15473,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-CdsKA6CnbPAH1VCdhUqNdadl4nKgEROG0sPzj86DBiWOo2f3I4UwrTXtc0+0IBP5iB53ZCZImtfs4VGF2YsHnw==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-0Tfp1MSGJPOoFQdX5mscGVt3IZOxQgKVP7XIbGn16bUXykBgkFeWF0beCT0LVoLzJAYm4/2sLgg3lK4+G0Mw4Q==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -15510,7 +15498,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-G2uijgb7RNTZrT2Cin5T7L+N60q4kJyzvP65ehKrDd2oYp0tYRX37/43ze/iv14cM1Um+kpYp/UnW2L4ElPOuw==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-gV/SijkpqgeBIV9xM7gZ2ASfNMxkZtdKVxqygcZkGNWjc/5hwohTf4nugO5UdXP0TL/KK59lUwLXVHpSSH7X2g==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -15535,7 +15523,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-ktNjN1cks9TYUEy2eA0ayDcjxVBW8f1s9qn9h2AVDWLyCs/NhrngYuKBSOXnsl1l8L4RUPu2et6FBHGl4oBMQQ==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-XSnhjG8qGTFiCoYLcGZdGUE9JUWluTHpjW955ZKbWwa7V+bdBJo5k+iha1KaFcbhd2OPyOHkBaYkJ1VAtAJHBg==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -15560,7 +15548,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-8+voKlcFEtTdBJHN26F45ZstTpF1JkTjrNBY+DB3bMrz7ZtWa9vdBa+XwjvGLUL4SQtmLi1Bb2dp1wpT3Mdq0g==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-LpuNE9WYTNVLQx/uTXriMB99WDHi5F7vMYfilJVO3S+3ptfiiFpQmN6xCKjDblgrcyTRQuyhMX6ITs28UA9/YQ==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -15584,7 +15572,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-JDIPWRIJRqZgJQhqxGCT51Az7afnw3a4t861fU4xiQW9hxwrzpHmvoZ1Uc9+pWkObNZfr2L+dibubkqjpIlzvw==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-OpHaH0SWRZmb2rdz3R0UD9cmbYak0S7/aHjpl1iSI5IEvSAQiMAp0ZhCIfQPj827yxlyRW/dAPnR9UZnIfMT8g==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -15608,7 +15596,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-evbiJ/RcGkZsic9sHJIDEaHGI3WZ49J5/1N1mYW53HnzzjVRLvRklHzYXikbifXAq1oXgr+33f/QZ2Dfv8NlaQ==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-nqnNrtzAjSALn44C05DUeABMn5HXKOd5nZva7iBWVVAqDNdepRjDn29GKMZWeSNxIBbhyPQqXn8FzN/e2vvP4Q==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -15632,7 +15620,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-nHE9o4kImfvi95Td9KXFgkfi+N1EqM4lxq4cM1mED1h7D6yBYknG+7vZl9NVC5Z0q/qu+vcgdEvExzVzeIBABQ==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-qHZmrtC9IF72tzvOyq6asX4NPnwCHsL6Vum458nj+hhwOvPWBS3qfLIlPeWiF0sl0+Z6v+nJxQWUNDGdCU+AVg==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -15656,7 +15644,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-UCtiDT6RCEoB9eldGXQbmD3orZDbNTo7jGDuEsozFo053biXWtSnvrz03dyEhn5zP8Pms55wto9p0SuRGb/TWw==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-iX2Ry4+dO0WtgLiK0mxNYUNXG3jMIXmZ2n8dRvxhMm/r5/qnRcsWbH4QIabaghcl1eEomKt6vwVVOf7PoWpVpQ==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15681,7 +15669,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-zr8fx5maIk/IHsW2hxy2/vdLhgzHVo5fqDcROeh77WhVYmBwHBsUuWWmNVpKnsujLOHkkoRrYXzHgG7SY/4Smg==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-Zq0FKJCgXp4WqYQ/YNXpewkZ/ZqX3UAJYTLr+ui1Xjdxh4eDpoczIQe/Z2DFN5akf3aA0zYy99CraEi08Mlf8w==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -15705,7 +15693,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-PvrzcMohnBB6/rQlgYnNfmhqTEplq7TOre24jPvq7f63K6Ar3XUS8fPMTVleFM+spZoSjki+J/hhxLRNYet+wg==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-yJpFnh4c4Apuk4DEOOFURajw+gA9DgNfgg3pKT3zDxD+lMsuSQzpzbEku+ZziRcYXv3DyOrlJNTfUpjIZizzfw==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -15730,7 +15718,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-9rm1k1/GioOzMtDruvWBhOTxXeB0JJrXDZuW3AkYgJLgJwEddOMKb7BoZPvtWgGAEEDTRUgz/J5quq+nEc6TmA==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-6IticNMF6QosUvN5Bu+ajhakECsLmFBqq3AaBoC7nuEgKUZ4qH+csO514HHrWzDKvBSM2whaTZjTymkyutJApQ==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -15755,7 +15743,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-3zcC7XdAO0wQDcBEsGz66BExCbi3nTyXfEaMFmGNG8Ks++lecqPjH1IPrxg2eRJmyYNVGszzIw5SFAT/gYolTA==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-AQ1/4GfE52L7URXCOgJogRx8mmaYdddU22c04o+OcyeVVe5kZCBoHrazzv3HYucih9qubMB/BScsBXWC+VyYQQ==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -15779,7 +15767,7 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-iFYKO1gDFUAfrOk059TBF5vSA3sv3a2rMfi15rCPwJdqiahSxKulk2xQxrzdhxn/ufpmseBaRjso0CvnyHm8sQ==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-GrAHoKF41ufFh7t43MGgMlRonxp1hAT72VMBANaXBDIDO9l05+wN+liUOCEP+QZPqYk9gcsMkfXUGfQVcfGsPw==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -15804,7 +15792,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-K0Ldwi/wDDWFg2NaefkwGq+p6JxnDqmS35fjaEQ8jvxUNVjM7hKK8UfeOHFlMU4hP1fqWs2Ns+Mcx+jjtLpLUA==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-zFknqL6yDuvidoTyvxr7rUkDzW/nfV9x7pfmodjiv/b0lbuBtOV41KHppahhRwrwaQaurpDugFncmR1pgA526g==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -15829,7 +15817,7 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-7zVRXq+FbAZBMAWHbYIWnVAY2HxhNrSphU5oarZ3k6sS3E10ptRC1iO4/P/3+qepatM5jyh32cuB+yG6b7ZcQA==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-8BAe0I4p1UzUBl5dFB3zOyeLUzMzXiMymq1rZM1ecC+mJ5jq84Jm9OuJD4DSqlPLxb6utyAFHDBgV46ycMpOPw==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -15853,7 +15841,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-CoZBPQ+ri+mTOAx8mUUnhMkx+yIIMibfIlI65F7I6+M83byjQTX15hqhgWdznp8EBjthpBDHFWJ97k2ryFjrvA==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-Hsswl1Ttm2K3CElnQPd83xR1HrzPLgVwH1d28LivwY2C5R7nfGwb0WaAViH+N5gdDReyk/ZcTalgD5MS9osDSQ==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -15878,7 +15866,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-VuCNiK/M1zgTlNYk1TT2w7YNYI6rwUz79Uf7U5xhJcQxCUdpHFuR4Vy++FVyhpFEPSjPpoLqzSGlY0IXSABeZw==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-tqXkWhjkITIzQMb1m5/qNkEhji0JuflyaBf2T9ZSzeZImWqya3U56D8GcKYFlwVW1tdyYdV9Boi1gsGeSV7u/g==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -15903,7 +15891,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-c+PhgOKFlw4LVofq9Sei6csoce3gGCs6hsrq5CpmEg/Kb2aJg994gf6+wCvGQtN4GWLjzAAf9nLdj6Hs7cNAqA==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-ilGmntyta3Ksfav9Q9/nIPJEdxrENJRnB5UkFy81Mvv0sGOfmDVGOUZaFpzuYz6G3bBJwnQpwJeEU3Jwhl45hw==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -15928,7 +15916,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-JaJup89yW6OAHPKqj1ZI6btp5IwUAC/GV17kw4+FTM34IXrqQ4nVuIKpPI4GIHXjtIO73nWzLk4bm1mWe+vvYA==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-FJ59YDLiigFxqzWZAF5+M+lUnZQluNKadK6VVBcWaW014XCszYQVRlb6b7W1bsQMnAzV+t/pPB2Rs5MXtIdrxQ==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -15952,7 +15940,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-jfCB71jrqOJl5Vmt0zz6EM6YHVcUIjc0RlyI2xffiSVKQeipaF8VDMHX/PxWAKLlrb5GtM+Ef7sgqh/oYgoUEA==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-MTCNetqpLMkgGaEqdG2TxqMu6o9UX0Ir396l3x7cZw4z1J6iIp3Z3++gnqBik6ZBVCz8o3SkZfNmRiChlF4hig==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -15977,7 +15965,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-zSP8FckjXdAxIle6oIy/t/PhULyRbE2o6JwhnbpH1qkXaM2ut+IEajWZmMXu060KegvooaiiQyQAMNXE+Wg09Q==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-WtZ5kDup9BnVSnyskN4rhYGvd1g9PllDLi6C8I/Dh4JRnIPxWEiDRz5P2t0gaJk0GX0PW+L+TEgVWCUatzP0jQ==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -16001,7 +15989,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-PnavYY8GMKOyOw8chclbo5Id2+fNd4DGeYWjQmu23HvggVovRDzgAJA/rM2AmQDDhwDK3CChKFTR4Np/LNhfSg==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-bqUxTZhmWaoK5hXg6Bws0EnLLn7051jhrkyA8BjZUgS2lvgNUuXD+epBblq6Oxv6TYHLPBhVbgBypCHRUDpiYw==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -16054,7 +16042,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-lFP0Hsv4CmY9beFISCmDitKLYwPe+bh7VcLi/4oOmdU2RX/eSaWXDWeIbUs/0ikA2CB0clpKK+aPBOuVtSvORg==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-GKHDrHDdVrnD3by4nDALaglYF5js1MdWdh64q9bauBjs3xeM7GD7TCSCM/eB8GKJy3ElAi9DG2G2qB7Ck6BJGQ==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -16098,7 +16086,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-ZUSlNJl/W5AI5PJ8yabwlau5f5nMd4afecSZXLJ315oc5WIO78FcZd9ZxcjxaHycant6i2SZX5TgCRTS6vDgXw==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-qOe6wz4VYWVtqkS7uQa119WwJzkQTEX70n0uaK4TbAeVobqsRP4JNyfjHn1Z1B1EP29jYtVjCQj2PrzyqphycA==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -16146,7 +16134,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-tHnBozV0bunjSEzPerzP4+D2uzRUpqCTQe8LKl3F4gWUQofGrA2j/ThGUZlxdWj4vsdokpnEBplfPyaT0Uo+kg==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-YGhugGMRvaJzq04Qy/WoHCQkVhv+O4yc/52swRLMFcccVWu1CA2ua3j4wXDSXwc4Te+d2M2uYwLJRLWh5bljug==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -16197,7 +16185,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-+NWUfgZtWMNMXUBQZl8j/sxOgAlIta5f3+lDBF6yhIaIMwCPF6rbvwe72CSQJ7X6xqnmjSwHDVVMLBe7NuYpEQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-cpZJizdbvfPq7/W1vbiIi84z5lrPFWZyjq/qJQLfHuvRg+eH8z84D+KZIgKxh7pH37vKOplhmh0Ard1eEZQrlA==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -16245,7 +16233,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-a83aD/BBmxKlKES1kaby7mWQbWBvYvG46AFUyvFXChEKx2J7YfZvKcGnaoxAsO8u1Q+H40ycmUzZga8kDTf+Uw==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-+crVDA954/42/R172GUf0Os877MdYDQxU1FYcuZQlDfYa6DNLI34JMMxih0EftL7EEbBzLPpBPN1Cv6d6MshvA==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -16289,7 +16277,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-rure1/wUK7KaqJP9kyyej8Zn/ej1Xr7BUO2U83l8CyLjx9XNrvLtlV32dXF+SRvVi3SO9iNfh3XKvEk7FKLCVQ==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-4s8+qrYQen2Z8iQje3S7bNqSZUxXNODc8UMCblPcBuidz9961dxP80YnA9rD5BtvW3yUsQZcAHAgQljMKaPEqg==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -16336,7 +16324,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-69VOjYp2pkxcAHSiczezVuslzUJKfK4kjLxlVy1oIBjGbfMaOZ/NioxMqqm9bInylr8zHN2EcLwF7oRouxiuYg==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-SGtwB5lKmkkszexqlELVjn4kHSZ+1gqNAL8QVsVBWU+MmnkLA4f0kS4UxcqZ9Bnc2K2afFpaEkmDxCB/weJWGw==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
@@ -16385,7 +16373,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-d4tzGan/0Q1BzOLnwGw9M5rdkyoebnyvfTzLKBpb3xLszXq7PMfA9HcJyaer3i3ezAdEcSW+NkCWDyrbwaZ5hg==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-1gDoujnmlmgEcnOeY61CDqgkluK7GxgBaYx+pzDBmXepDpW20tKbxe+9b+aaehszDc623/P327SGHLo9vVP0YA==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -16428,7 +16416,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-42dTlZgRmNoiboPVAGkj5ptcSEm3yUOGbHy63R2xEGHPABNva/Tq365hoZu4pXC39iJ+nN2Y/au1LzOwFHVm9g==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-k5xXBA2btvMw+QV/BtcmE4VC8h7UnQ1uWgLg1a06jiG7C9m+b12S18nsWi2V5yal/0IKdQA9R8kDD6Z8sJfPxg==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -16475,7 +16463,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-8mSka3dHg5usfxsNcsr9Q2obdvm2oz91Lyu/2eBhiIsEZpNM7+S/LKUnxcghnpMzpeDh02+vCwy75jfzrhv5IA==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-YJzkN/6+IrdXgb98voDzbLHMqk5L7QQxHp9+GN+jmSbRD/SDzpy74Gw/+NNjgmQ9M/maq4rfhYFko7su4Iz1bA==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -16522,7 +16510,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-Yj59VsEYA3R7P1YlyDpu4UNIUPnjhnWttfwlIMOvVvfG4AnFkqqnntfW3guwWRDhSOwHqMgC+HRY3N31H+6L2A==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-PtmdDpIg7CNsRDqgsuLdnUIGysYGXztYySW3O8vfbrWrvPJqYy6EZnTPPj6paDuEjAZ2LYnwataS1QXAteqjug==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -16569,7 +16557,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-UZSfXSfSfRVYrlU+Txeue5ivyuia2f3am0TLzKc0kSHaRiSD8ORNfADrYUsA9XBA/95E9Po8pCFqiR0tNxBMtg==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-v/S/7xAgAM7ja+1KAz2ljK88im0QVBxwUrL4j46sWgCsXQegcyHgPCMg+8PwFjYMxrerAyN62Bqwo1wPWe2yXQ==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -16606,7 +16594,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-ktyCTC15PY3Mafb8inJLDlrVUA4vQATLAzGu/9RckDrHIk1m7m/CnqPJG8wVcZNr/vzpDfcOhHiTmAdFGRzjiw==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-oeDIyvEnhwY7TUE5FYKAwQXXhkTGuh0W9unugwd+NsItREsn/GTxSD6lMLg6Z4QygzgLwAFfTRdgklAVcL2csA==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -16653,7 +16641,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-bWqnWyGmzwJOxKmWaSSjdJH5Z7wue+3EBu0dn1+IgD85L5nVmI7hSTr7LVoullNfAXqRrNJOGHWueIiChBsSCg==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-miNELWgalvbBsGtiY3V4NI3p8d6pAhi78IRqC7H0Z4uqrL8b0EJry2t7EkUqieKFjUQHUVfYaNttGFyeeWa55g==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -16701,7 +16689,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-OUI9MJ0bq6I2aHSPIIKM3+QCEiMnJb4Y3/1Wz1NqM866Tt0K9eKWR35G6MP/4TIAyEQl23FTe0mh2i5a/VIVJA==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-Si71/PUx4MnwH9Z/OHmnyf6b6p7wJAhZSmeTxDP/mCXpGfvH+DhXWPCSEYhrv1mX4DJVu9spyRIrnUfk7AuymQ==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -16748,7 +16736,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-vZo+Pg4qpXsIRl1BhSJ2RSyInqCe/BGOhRf2pi3IIRq8G2oUjTNJcV3L3CWOZriogX7fpYdVxLVy4hRyclrz0A==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-XDLhbkXdkR9fGG3HbbyiNK8relswzHW2doc7u5lzs/KUckvtbkH8/voh+KxyD4Us3SCUa3MZyI+LSjBCCxc86A==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
@@ -16794,7 +16782,7 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-uSATx5r3i0Sxq8aR9OKFbQ19Wa7segLKDTnxCVGqHcTrorxc8GDnaA5D3eXlPeDde0bQOY6YGZQhIkgqRjEQhg==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-S/ECzNL1lEj3jLR1eLkrKnTEznFq6mj4EplH8wadR6uoIfFn9nT8k6D6xdZ6TsRtIfWlBHkl4hV2FBkN1xLMYA==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
@@ -16824,7 +16812,7 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-P78wY+Ui87WKrwbAy0djHK8vBLQ6DztKEGuEV1vlsJ5JYfiPBVQYy8qam4iqc33g+Wj1kljgf35u18pb6NJ2wg==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-0Q0cbBufJGvVBlp7DtlwYhwUjbS1Ymz0zdt5GUuABufedbZAfwJo9yOmX0dnPLlbCptrzyF6IkVg27pFfndqpg==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -16869,7 +16857,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-//1d5v2rrONiUL/WH9lFJeJSUrq8s25ytLJAaoZx99EE5NiNQu58XVWW3QgVsimCLdCHRJKB3Kgkq0+CfLS2TA==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-ob3Qfazygr1OtMez20PLocA1Ws7nzKI/X/6RCn+48DnvOsJiMQaR8RFgZhaW4hu/YruF6phz3Vrkkj7FBevQAw==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -16915,7 +16903,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-DijCkHJ/ZWVBr5GICB7Eh8oDu9HRqZ8dcy3LFIi8wlGuwTz2CKOJgUk4ImXzl9iUjCCFutAgK5iPv+mlM1UuOA==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-ak6L9vFEPV1i7MfzsELOzDPiE+shRY5yslm0TWPrlouhbcflUzklAVOu4YRplPL9tWozGqrtypFh4JnBprJn6Q==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -16943,7 +16931,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-DMAnkI2P1hBIrWnNAu8JnUCjNZhBogrf9JUoa+jnfkMCR2oU7o4NeG2SgFuciZyLZCsqQciyuaG+yknvlOJEfw==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-QLGT05HxtycYDpgc31iYDWqnHrmowqJpVcj0hfW8+/JBRmysb/mhonHXmEaEMOmVEwDDOyNudBoSyTx6Ne6QGQ==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -16986,7 +16974,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-rq0pdWG9g2zDcOHOsHRbQUWueDTACBY4wd/rAO1tppQLZ3Wy57QBnmhD6mKXfexJKSHHM/AUauyKndtPw8HhLA==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-1JIkf8oZFmRN52U6Mk+leeoa8KsS9r/4uxDvd8RHuap1P85sbfIRfOtiGZ7QYObAw2yIOD7dyJaU+Li4WZJImQ==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -17026,7 +17014,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-JvDvih7oiDXv3v+CQXoWCGsg00RT9eN7vCt8omIYlOu8HHMKNG+eMc9rbr8lF67WLyYfgCnk3WbiXip6jgfSIw==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-jRyZcwSlOk2Xfj/jm2sooRXpvIl3gfHW2LyMFlKReXRX2D+bKauMuxZhVLN5GBOwlBK9uoJgwh8r0mN01I+tCw==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -17048,7 +17036,7 @@ packages:
     dev: false
 
   file:projects/core-http.tgz:
-    resolution: {integrity: sha512-5uZgLQ1LHpqEoP2YtKQzmu528Lsmu3mE7khgmGUmH9vhlqWZ3YWHPMgJOT7dJ7RCExKliiPb0UzPIGg6vacSVw==, tarball: file:projects/core-http.tgz}
+    resolution: {integrity: sha512-8Dd19gvIGf1qwgzbV4H6poSmaf8ZvjMkrRH3Y2ZR2/1AZQLIrcMp+wCJ6LgIZh4olYY54yn/Chj9g9yd3clImw==, tarball: file:projects/core-http.tgz}
     name: '@rush-temp/core-http'
     version: 0.0.0
     dependencies:
@@ -17113,7 +17101,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-/uasGR5EkQQcBnKwUWUokqGN8dCTtHZaxjZ+kSVtrpItOr3g+hfMr/woxNDICfJEfETkOonF3Tgh6PMO2a//nQ==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-v7GGI9ixernr8jx6guOAks20K0EjawDowfsIWA32rD+q/g1Rp2O2vF0qvnBq2qgc229RU3FFlYVLilUGg+uL9w==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -17149,7 +17137,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-506ZJZYCYM/RN6LwgXtoQ4JwhjDEobr5bXOhOMTJE5tfl/cz6oer5SVuvxaogOuEQXCK9foYMdXh1+PAsDDauQ==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-qDZhjNGr0epW9e/ArCUcRoKz64xNevIg2veXxWuWakeIrBc5Cjx0yKHWcOLFMF5cDKypA/uDC4usvBAICFrxxA==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -17187,7 +17175,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-LhL7Q0gSH4mOwSGxN8vV4Yd8HKNpsGat2MU6+jtBrcvmXPQ8HxwiVk909a+OY5niT58C3ucvyAXqtfH8f+0DdA==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-VXVR9XPqN4BsP9s8v8l7GKSduwT3TUuE9E9tqqQO6hL5JpokBmLbiYZXnq1fSBH25zc/JMNVEF520IZzXJowXQ==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -17239,7 +17227,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-pG9zDuwgSTxdgZ1Iz1NDB3vsjcD6arAgT5QS+m8kxRrhFZbzGSmdPZp8wITWu19yQSG7G+tpqIATZG0RyVcY0Q==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-hLg1OD8X3S/dTg98miMlSdhMML6BqVdVvwJiDu+UBsGUN7jAYIMz96D2cfu11WqmA//pTNHTkbCWFBVclstx4A==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -17282,7 +17270,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-yeMWaajpYJz/QlRIRPFDtpMlw6O6VcZGbp5HqUnXSucJxvpLeNkwyOf6sokt3+Vb7iP3QZOSlnybtyoSOZJowg==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-Vaqz8Xsmah62tXVu4zxg+I4JvrGwELzxZZJRDkz5LOZoZ0PaTdpiGNS5Wo1fg92deIXQGzQFwYcAUkKAxc3yDA==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -17323,7 +17311,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-sO9e0k0JWJaMpRdirObfls6JoeP6MrBFxU0WlRWMy/QrJJN5En5BDJxGDPx91rzH42FnGK3at50HM2MWD1VzWg==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-lWiPjIf86l1HRs6kR+Gsx7BeGUdnWv0e1Nhd4Q6KcR2LcPZb7LM5dzqVbPvsdbJ2qGpVGdyOJ413EqmO+8jRkw==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -17367,7 +17355,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-7tN+R0e+2DvFCF6mCO4QlomFTtFA7c8cGL8ky0QL0qnNmtYlZ5xhTINg5GEpC4NvT/5A7SI57koKBtF/uoPZ3A==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-ZDuwwmEMOEDDitLd3KHdg70vKHUCMzJMuB4ObX1nL5iyiPHEUiQV3wjqUxynZlIvdIYhoImILBZ7KG/YC/LgDQ==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -17409,7 +17397,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-Y7ZqX74ti2MXDVrYzQr455D5dI7MBxtuPSHjueZJuqp1RNJRlLSrUtkmwa/kYd3AIUXlQYKL1YSMWNYsby9Cxg==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-zf9ChsnuVjuse36hZ8TRul1b0H2jUVIjMvqOlhGUKyXHwEYU/DBLo1YF02GZa1YXQSXnej4Ht+tGdpfdlkWdMQ==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -17459,7 +17447,7 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-Z1izDRv/hKpv3meiQyEA4zdgOLtvLn6kuMO7C90dlaa5hDA2NvtVRCT6K1789yJtfG5Wr1Hadg4d/OjMfVsY5A==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-eE8cA3FAPnT2oWs0speaFE9lkhuRQYGZx1CAOUysnPdZzW6uhkJMXuRo6kuzHbyPSQBBZ7sRflqBcqXm1l98qw==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -17507,7 +17495,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-TuuagrwtTOgBl8BDMhTNk+DZ9KAzVFRBIWGPK5ee+pXy6CXCpk4eVLvpg0vfPv0sxoE0e6FhP9rlsx+KjBXZkw==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-vXcTKAxSzXpHciHGjyqv68a2Wv5HZo9RPztPqyDu9xCA7GIXoNoH2fImG/B8FcxAQKYr7ErYS5Fk1dGZdgKV+g==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -17553,7 +17541,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-IwT7V+rIkURT9fFne2yDG9Pqa2DC+9PKmSMXqfONrV7cbIiGFxx6CoMYAQINaY5f82M+DEi9MNEeDj+Xu5cZaA==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-PyKhkqBED7QMfHdGMUq2AFlWDqPeMu/B0cwiLVDRnxME0D0194f9UDKwc8z9XiperEulcnFljkFq+ma7ECIwNg==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -17615,7 +17603,7 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-8LHKaeDccJ06pOp7gj+Uon/ip/QBbrastaHTij4HIeuSDP/AEykzUcLw8RwJpE9zHCy/Q5TMmxt55rnKEqKBYA==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-NFiueb4pPVcZlOjjCYZ7WBM7v10EcEayAcE3jeusQmubzwpr6kasK54j/nt8QOelXDd+g9UuQ3vZ+T9hgXDRIw==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
@@ -17659,7 +17647,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-FowA5HtwyB6ELOUb0DfP2oFrp9JOFfPhsYGtjStJccfne7JA3IIO+s9LJGYt2qzk1CpLflAoVRMyQWl88LBX/Q==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-l+uMVbFFktddq3pYT6nJQTjWEGD6qLgX4gzZx8THNAPS4t2lIvcCIBy09mT4kvbYeSi2rAV5yZ+4HEH0AAn+qw==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -17706,7 +17694,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-TGjqEOOg7UELPSoFLSyRji7PkxoXqRTHm6ptlShunTIhODTohRL0BLTuhS3RYXEF8Kr6hP9bKx+H3AwcNxdwYQ==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-muV+FsQUif3kC8nhfKcW6UkKTO/2Va3IOiEzqnahLfKWwblauDluVM/Sm76l8N0fDzuNBiSMhdbhNQzRH5oWxQ==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -17725,7 +17713,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-dJH33V6Elz/qL4+23stM1mPk/+nHDXUROraQ+grGiR3oCqnxyv4lA5YzAFe6ioSeGwl/qH9JmSwc1sf4p8XsJg==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-8k7makhN1CdGzHgZ+mBEH1Bg4i0NSQImsHftGnDkLMOuQ0VrRu+R+Jqv8Fq3htFGvd0K70sfj0LjXBaeJ8ogbQ==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -17764,7 +17752,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-tZIjaXcnEfkcDByIZWCaxwrMJcPGS9oLNeSH4s+EXM4/1hMsyLsdxM3vuVWYQcL2VMUd24c/XvOHaZ+e0YW3uw==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-8LcfCAoImfUrz8ChJDChIIkH2s+1w2GPuzceyeL4r9JWT4WAJAEcXMBDkB1cywlKOSa9jBzpLcT3WLV5OL8a/w==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -17827,7 +17815,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-YLd1YkJUOrGMGT6gzHV9SOowOKwFf1Epe2row84YUDeCTA9XIF4Uq/H6wMOirOHCC0JWeezL8nlDfoZevjuGng==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-l6NDs5/Y5U0eCB2mIEfApVa40QbK4fiApOQL1c9FOWRbqzsKXu7Cx7C2vpuey2/4pAvGuZQsx/oHBp60OVWghg==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -17874,7 +17862,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-gnKgpu8r3nk7sxdapO/2DotXA3WxeJSxWLPuHR3EgV6LjKfbjMbccl1eRsf/+awY6DWqpjtB7aamkRjYNb55cg==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-SSIOu+KChoiNwvAmo7YWkhj1mYlJIIin7uNSQz7cIAk6lyhKS4KlpZYa/2oWI4DY5tJy3IXpoXueJLNN6yvGzg==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -17925,7 +17913,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-BYMXef4M9Kt0FnItW5uk7floeNPfXrYVQvMqV47sjl6DDUykplY8zq9PTMlPdTm8vTcdb5qGDzlfE2OGVQftwA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-yA5/Av75sw2II1c9VebWPTz/IO6MDkzR36Qg9nrr+clnmdR0xN48J0J5Pe7rQuFPeMBmhtYiGIsww312hZodHA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -17973,7 +17961,7 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-Q9xfYeq5GCiMEf/RvHl+lAwIZkgoQVX1Cg0KmfkMHUbyO8v9xgxnk2gcrAu0+tWQ9tkc63Yvfb0x3i/TWRZXKQ==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-Y7188W0cqgWSVJDqZdfx0abAMdhelI5oCfdbDhvilDWEDQcCvcwwYmC96Cys4SFa5U7b1DJxLwUAmlVR5taxBg==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -18020,7 +18008,7 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-rm+agZ3GRmrK1qgKkY0+pGxyXK1WmM+cH3D3p3KBNcmBySmPViRgr+2fyYpYfoUwQWkusadwed04kNMfiNpiRQ==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-AU5OdUSPP5Qf5herCIRqiBEsSi4LXzej32WVBBTuiNXNZ8h1ek6k+7/TyOIFuhlNoz+oRMD6eBSlTwr42M8p7g==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
@@ -18065,7 +18053,7 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-XKPTMqJqUwRchxw/M+rSgcmNEnNazX8FJ35sPpvUdMR4mZtpV7CSzPOGap4dG+beT2/8AyQ9NwQqxTiGkkhn2A==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-6zrbY04mC2CND0/M5DbEbJtKSdiQ4yvWVJSGAzR1Xd+mfMYzk+lwC3Z7bAroNaR+9XFDI880d1QWpamwXSzP8g==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
@@ -18110,7 +18098,7 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-N0w6nyS02AJnenEwSz1u9/2uHgEm9fPNsICiihIDcJzApx+zx5KHVveldh8IckQ9ISl7ju1+Yd1d3KjbFzGWgA==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-m9BYVQT/Ks8myBDiWGnwSuzLQbQcfNVzTiz/3zDKlwjg+jRLBJJmOEPQxGKHFyBrfRvAL8n6DcdnzZLzSKuWdw==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
@@ -18140,7 +18128,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-GP63w1jPmCkM8x4pJ549EuRdTF5mZcgexEvQy55VIS5xhb8j2QvLNQB10N2AhwdcYGLz8QR25rGdqwj5Xfz1ew==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-6wgdHnbzT3B4hCVA+X3TuuWckkGj3G3GXUWhRN3zpTAy8e32QvABcprEg1j/w3FFJtU9vKGhcsQ/BYhNKU0gWw==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -18177,7 +18165,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-5gkhJRlGruazE7i4zLFSNTukMHqUxqCico0TIhsoWVHfqDTNZ4DrHQ4ObbmPe3sz04qpQB9yJ2TFweqs27bEpA==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-0hBUEOwQ7/uZJuPl87zdv2UDEljNT5KpQtLUGDwuWCqMVKEWWGT+eindLUSE5UxGWcxRiN822zaGr9QuT412fQ==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -18214,7 +18202,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-AWERs+aqoEBCnTPaSIRpuwhuMM2ZxVVAySx0H/86muKBmRewArbnHbsWFgND4zSLbN2D+W1xRTPK8AN2Isbe+Q==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-IPjnny32LYta9mTFQeE24vuFuY3Y6mg6ls7c7Ph8jb2FPcAPS6jT8iqS3NuMTnlpgKU4SCddtAcbJZKJZLYcFw==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -18273,7 +18261,7 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-ru0uvjhXhFPlvEjgTSCZVdzC3p1LfnWmE34ZqjVLthnKVvGUhh3C/Ol9OgfH4s+QhVVi2DS25OYjFZIVjj0mqA==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-5oO9dieSrWCX5+U1dKkSlqs41QCZkSVR3EguVZrgM8AKDpECvhknGOsE55N1kVWlthyuzBKzb2RHUeLBDgh/IQ==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -18320,7 +18308,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-PODCaz3e0yAWBPjYiLaV+cUG62oO3fR6f7Sj3Jqz3kQXL0kTRFpOCA0Qd9ica3ADUB9oOzP2zqzzKSWhxdLuww==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-WjCd1zmJdafVTrbH5icqgYgTvmrkr6AjNZADjMv4IzDuU7l/QF7LX4a4fQM5nqS0W8eEjfdqr2fLVLnYC0pLcw==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -18366,7 +18354,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-rUbeEoo++niqFh4vsjDGFvpCWgcpF9STYG8vYjpVF11vs2aIeMKlaQgAu/06vsNjTdcP7zZOAtZSzgU6rOGvKw==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-fFkrTXU2Q8g1hCbQT1KYDamY83Q3oGz0SAD85juOV2D6kgcsEuWFt/gx94qC3v2AMW4ryxWPQp065x2RS+vb/w==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -18399,7 +18387,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-FzB2bhB54Sn8uJ9l/zJ53YaQzLKsgd0cCyZLbxkYY6fxrM1wNCwdjglm3VEkiRaXNtCB6f/2xAhLc4ChshMIUg==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-5T9qg621fxpcRMVb1lOIBorv6EQzyMnGScR8/eANHFjQxi66gUcQlGqo5oy9TnQQz4BXNHS9Pz3JPJhsOCOBRw==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -18446,7 +18434,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-qq4I/bwY2XLuTxBbovGxWY2AgRibCC4BCZ4A8l8mlJpr1qP5aNRLJMB44P8Og6xXyt8REE5mn/aVv96J6+WLvg==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-S3JWrHrFDif8cnoN1LaaeLdvbgQSFy9TOcUcyPEpbtyXKMutyTU07Lfa8pG4mGsYDMwm6Kmf/sX72kE8is4eLQ==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -18476,7 +18464,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-DsQEmYYjPO05xKNQd29CkIo36ck0F/29Aex/ZuBf2OC2HovgNtld1Z0rak2Y7fz0erD0udGd36C1PdrlYtizsA==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-eDBd93f83jxvB1tt9+4ZKFx1WkFC5LOCT48PVqVW1x2rl9vBElUv7xiwTabYihjlE6x3tpZZycn0DJB0eE+87w==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -18523,7 +18511,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-kxFWntdh1/AJL4GcRE2Vvb/JQaEPiMIwrIWhv3nw2AVW7c+/LFIU+Bx1ELsnTvfP+0oF5RMjHf2wlhc+ZCo86Q==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-eL0LGXUwI2i3lFk7hrdDVdvjbD78GGHP1GBJm5Jm2cfxlekDjQ1zkydG7Q2KfWfRSldPww1wCy7I68+XDM5Btg==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -18567,7 +18555,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-cvd/f2KSA8cePER7o59LQFfBCnqBlFZYJTuEMPUq8AGwUwcKFA+aeiuhtGj9yUaaU5RsnFdMtMWoW9ixb9vz3g==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-z3wVbvCsvjoxVjf13yvmTKUGTRZmO7RF67ZDu3pD4BftlUY0pAOLEPTmWzVzt62vMSdlMqLyIJQjANTX1MPgvw==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -18614,7 +18602,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-oMzKceALfmudi5893gNjldPt+4wxbZxBieaBsaAUXV0BHXrtb9eeNoADnyv+mMhefDCYYhMYX30uL4r4KEvfTw==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-zvzH1Vp6IKVIowMgiDZzKl1gK+E4zT9KaaCMR0F2nJhQQjyiWVdcBcEHu8wVmQcU9wGlNIdKq5tB9O3lbGAFjQ==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -18657,7 +18645,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-piHdQ3ya4Y/73C1B1VoYpDFa+hC5yBSJj2HkZ5Oggk7MNov4CxQVFjw1WWGKr+L4yRUZROUE895ampYXvmHYkg==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-SeoaXpeq2dt1/zC/jhW0rMUlTWb4JZRFSXiLkv6gSxyPLOPfjdxsSlSGeD1BH7fRBjyoWIYdkss05eFbPwpagg==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -18676,7 +18664,7 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-yX1St/LtPGAhuD3az1ZH3U4xEhP1DhHkmYzwXy1xMhMkICzi40EO/9vh8CP36whTuhu1Lo2AbLwuAADnvuYb9w==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-NrxF6ALtZbcsoseAxKBArbC8zIEdcApvr0kWUCxa1EPwnKgZGZDrCEk9KUXhIL0FyessV7BbPMZyEKbNSJQHWg==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
@@ -18722,7 +18710,7 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-vM7XZGL0yj7tV7wAZmIKQcAYq3vdHNmlarpmIF/z7HzoT9Jev2U4OpRhHq9CTfCevNdAg4cBjs45HXbDyhC7cg==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-HKBkbzZQapjtzWK56PEGME6roIazzv5IDcTUU9pMi8Qml0pZdC3GQ/+Y2HHKxemI9b9RTOMsCdsvdiDenSEL6A==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
@@ -18768,7 +18756,7 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-RKOAYeKgGEXT5yYvHiY3RrnTDYf5+Qk/dgWAt4zKkZrYDq03+uL8TD36W7gAiipmSI2+zZhbOmog19aziDrsrg==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-yUp0/Z7O0tbwuSbwIhk8DH1C1IsVraKOf1k9hmq0L/LJY9k6uNTB797DYp/qq6fseJr3gzaAdEiS9/p/iKRqFg==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
@@ -18814,7 +18802,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-lv4dn7gdVwgFCutole43ehob55drQ2tGyvaQAfnHxqxxw+unB7jkfUCZkP1oE+yfzjPuIlRucbqjzkh6pzD9aw==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-0c620IRl8qUpuVvlktAvfGJBBPLJ+GYImP9gYMKib/z4p8fLwBqDXIu+PQ9BAZr989jiTWWtIDVGAAzGTq1M0g==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
@@ -18860,7 +18848,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-+pKxVpu0zi/kmp5lRFs0YNpt06JR+lsHjKt0AejWvcyYmRSCn1l/KF1E/dNwoOJO0OFaCZd5nbtfa8msh7cfIQ==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-Ewp03jxmkQL3vpEBcwlzMqrcKqlAW9yJmWyEzckeWUoTO6wcDJURw12dtFfTZ0CEfoJCI0xg7yEHW3UvyOeFnA==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -18904,7 +18892,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-S5mj/yQzBnqzbFq7FRJBpkoQO9Galm8T0WCNSs/6dNoCXkY7S2/3Gamdeb/F2MYiDGXQgl1P4Qej4cFeGYn0tA==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-FdyrkzFJYVEg+W/qjMc+H7e+E0sbq47YO/HbQLWkcdyER3WgFYX64q2owL/eh1pVkq7uOSHZPhwW0vXlqicEMA==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -18952,7 +18940,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-0AzjVYdEPIkAebZrkiz/T0dMO4f6lNY3qT7vVUCUQpknXWKWHFFxtJXeDBN+Q+ld6GaIYVAa7xphp/0SClcGig==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-jc5AkUB2PPWZAFy4qszwG81q5J5THbkJ4xxhJFDptFxP2DUIvD8fD4XSOsbdT74ZYK4UL0wSBvW4VCrGriK8qA==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -18972,7 +18960,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-YHrn9xBJI6FyBRiFI+/HlrnoWznqBkfsmVcBTU+ATAMC2ysorLiESAoSclT47N/0PyhkopgQWCSYNvzSqvmeqg==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-Nd87aR6u6NxO1yptnLbaYNjlB/8sKC/Y2/aW3SI11rt7KTA2bDId9f54gkehN1/IrrCjwW78O93wbmzZR0J8kA==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19022,7 +19010,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-SdqvvFMi3xwm7UBoehJfdJ6bnnsQs6H6iBeFctfANjHCdModedU9yAt9BcC1jDf3uV5t/8AfUR7C3IydJRXCMw==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-FGszKi9uEyS9W6kUbw3iCPcNsHCHSG8IrfzRnQGm+JiNntU/E2VMaMhDyj8kX6kAmyyYsvFkFPQ0coM4zPJQAg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -19061,7 +19049,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-L6m3YZDJNNzBAmhwxSPAjxCS46TmAJLlRUHNcRIGDlOAymRieaDgjQ7XPXW/++SYhR2SQ/FUmECik+QC+1Ap4w==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-EmBEgQQ3+pISJwE/J2jOTCJM7Rl2/M1h2MbDcchaIzoZBg1sdOugwyD+fiuqCVr5eC84W97SOllnugoUe6EGWQ==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -19107,7 +19095,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-10qgCv4wOYoyBFnGLTJ6yNWylL/3S4PjNeHeTVzF+O4Sy576RBOQIT+hsks9ypVzUCWhHX/r2ZHlJiQMJxEX+A==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-1aBHYTTDSjN7cbLkDYpC4GOpvoK7hKLLZWlFgglybvbDkiak++oA0m0VhZA5s6/H1cvFDLkPl7MY89hc3gnjNw==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -19155,7 +19143,7 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-6hwnmX8oRJ4ciI0MZ9KDsU/U4CdopU/Tcqgmvv/y4EXf65cOv8ArjR9IGfIu4TVpkp0h9tjh9VTOrnaYKPTabw==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-reelA1qEW+iEwulyW+eEAvwqoXCIgKkRJ/Hix2lpAPdCC2WVan3zqMloP/hptMSnx9dv5X88uORVt5Hrn5+obA==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
@@ -19200,7 +19188,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-YhGh6Ic/Jz15mreOtnXciid+Q7k4gKTxZ3iYZLZLPI6Qwdr2I4mp54lH+gZ7sJYNV4Sfb9r4xKI6ZpVgpKOqaQ==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-k2irDR1Yxhn3opTM9MZvcerr7pOLOd2iB0m571RQ/xZFAJXGRnzW8uqZG//8gZSHVPoTKDDGSJTGMdadr+4BAw==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -19247,7 +19235,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-0J52WP0yVi6MN2r2IqnyUNWj9GLClFwvEGmDxEDOFaoswzmCPkCXtqg0r6gvOu1/2dAdACGsjikSOBcWLrrWiA==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-s28MA3JOdaXxw8cSJh1ODS4Z9F/pojmw68YXc1q0agZRyB5i6MQinepnXKsSCLc3QV75uwokrBNP8WBgzNyqVQ==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19297,7 +19285,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-U6TVsiXb7vcvgdejr04sFG/grqSIdIvVJA7DbOsypKyf1xvuPPIl3GVEZJG1Oa4pFAtzjLyT9Y5ybg8drTVpPw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-Or2R/yHGQcqBDlm3e+vQbXTTFW2F4TTP3RAT0pIqAwaKb9ZSTYI2knAqU554PTr+dhc+rqkQIg+e2y2WW4iVew==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -19317,7 +19305,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-NqSj2g2Ce7Vu2IReCReJWkt1EGhpHIgylRkeKpio6tVBz7XbKQf4uT/AtuXNkCftuIVE2u3B+l/3awqGIWshxQ==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-s5yoPQIxpfAgk9R4x/XEbY+HcPFUYmwD+QQLnw8Y0XGVv9OtkLceU2fG1EFUiEix9QIgeXBKeaMp6V04w+eCkQ==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -19337,7 +19325,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-RPuvtv3VQRsrBqUN7Y2nhWVKXVl7Ec5N/OV/fjOcx6u0dKqdNFkIMkccPITdEPMUad+UJx6c/O3ZVtJJAer+gw==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-zGBajAFPIPa3nhyeX1Dr2mzaG6EjMCPl8dpvv5gUPIPl6jnhkYfBk8774m6IC9GrUyqqNoR+CP9sWmTE+1DAvA==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -19356,7 +19344,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-Q8C4LBxhg7N6EYnAckkjpTZAWvdSjbtAEaUmXTImOsqgW3SImWJE/ciWL4cBe3zRVrlXJfqFv2YT/CRcxrcxZw==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-vLCyCy6c9f479p0LKqhZ4MXjKAOd9ybMKCJ+ehfvXUpAvAAjXnrZ2EHaDer8Vke8gcJE9yMCuDATAEPjSbH6ng==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -19376,7 +19364,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-LjFTZPED1vx1D//gtnkCpfoEfMOkoXh8OFDFEss8AjzDJ9mVIbSt6gwLkrrKy3yYauofvu0/rBoUbYnc47JaEQ==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-0FRVhJOgqeR+0EIQNDjvhOKjOP4fYeMJiToPAsL8hfmM6JoIvXQAF9BR7fR7jokRyXxYVuCiKWE8OenlSCTWQQ==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -19398,7 +19386,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-5t124d9vVt0N+SL8YZPsrBhRD90QZQgIkudg4GKRunTIhJWTpsu2IO8eiyIeChv7g429WqMnMW7k2ZMs+qmHWw==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-L0nSQOyA+WVwwkLnjeUMx80ad0IvPyGHOgSldeZhtpCp6YptVfgZ33GT1BOwtj4ZgYrmVz7mUhbxgfCkKdAAug==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -19417,7 +19405,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-0RiWSctduT29aiUC1zf0hFtirnX/BuRJyaWmTH+vEv4TzigUcAI7pmLEfcmm6afg6WeNriSLqYH1THhQfXuVUw==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-YmpnkSB9PbsOTAYMLstsLlBfs0AHXz+nqAWbBm3JgeRtUUmAU79e7a4LFuATpeQMBf019LspbPGkE+tyPykhVQ==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -19441,7 +19429,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-4mM/JDYRRuuDDjZtEg3rBioWuqOquXG70wcTTO6AdfbYY8ARjurpG93HkAto1Fj6O+e6Jn2ZBpwI1qgJJ2BDEg==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-k9k+WP9yY0rjPGpkvUadlRRKZg+/PgyoWGk/EqPMXRf1qOvw1zWMlVwjAwDy09fVkocKR0j2iEbO4U+nmbz4pg==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -19462,7 +19450,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-lt3tzCKLbGRAojGlNqCg2OWriEs/zuOLSZ6CBamAk5E+sWXA3RESHNkvXElBzVNdWvz+1JE72oKc4buxDhRYYg==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-TOU0pZ0hXxny38VxxvQI54/ogtYlytOtv1Ji695lKv+T/cTfhZ7U0zojU2E8iX+vkWaJH+NBaRWy+lTBG+nUzg==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -19484,7 +19472,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-oBI19OXzBnmRTkR/PVSKp3XqzW8+WGv/WXTUtKe7uOUm6bygAzRS0Jg1W3flMb/YPWz1bYB6sYiQIxAP+EK0jA==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-lx4inBtuJqg2EdBNQD6+2xTCc43BdUmrl1ZGe8FKHqtO8iqRP197bT33gk/vSjSxicFI765E8x1LT01QBRURFw==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -19503,7 +19491,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-x1H+8ipkBaSfFzOopUTcnnXVKuwvYxvIxdFyCp2TBfj2dJsGVAFqC4PsYdMKmbNNurdRK8t3q3uv6kASsz3A6g==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-JyjEYpq2qx53p/wi/DUeTMPfh3re017LdADgzm5oAd6/MV22QwEHP93Q2WYnXQ/HrvjWb3BB7TBZnSQ7GxGa2w==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -19524,7 +19512,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-uW/U0qhO513tlkthLkHjI+XGOMXbD5ZKlHljvmDy0ZkAVfxeQBCBdM2QH488nAqu2ZK3+Zqdt5KH8zk0LQxdLQ==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-QTyKG+VK6rw+JICsfnSQ4WkjrCA8jSr03xpLyyqm4c/C2HcUuw5iO5H41jzeczIkAPmGXhMsYyA5YnRXTw0CQg==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -19547,7 +19535,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-Ct0jkAszeRWVVVahwgsdjS2vjU8u1kz4rTVWJiynVXzFKPhWjn4JvjkWl18nEdvG7Uy7QY6PgUFXmBgKb9asBw==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-tqTq2dN/qnkvX9Ip48vFGcP1Aw4/jLhYwEnz8QoiABwCeuLcxEF4/G4OJwtFXTbyRDpW2eYtd1SjTZUGbfUxzA==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -19570,7 +19558,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-o47+h6KJRAQcEKPVah1eiuQW59wuv3Dm/JESztq4JZewPNd4Zmem3V4XmyApOauhepHxwieiGsl40tzH0s2tQg==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-y6hWw0b5hzcYl5/Sx7E5pM7k0nwglyNDPNJxmbF3jp5CvmeD/r34SXKFSFqSKHhpWYz40eez/TQ2fcehDCuiZA==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -19593,7 +19581,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-j0ZdSh/RVx/7GLpOrismZBTZb8yAPXoXRp362VUUSe1T+DVtbLCT3wLNB98xF1RQgw6zBn38VZGa7OxVNO5uxw==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-Fr0DEr0BvMIUYCMRxAqMbZOtzmx6/68tkffA/TvTtz11jKoa3zrZVAJ57A+1LG1ulHSJyIonsFcp9YhVSVeJiA==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19613,13 +19601,13 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-nCiuFgrmUS2qgLKTQEZkxBexenz3RT+QeAFQyjvZLOQrA7bDRYEeRH6OfQ0MbJpDqCeVSnOTxG83l3+xv3yJyA==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-cT9NDxaufuITNH96fIMsGOWnARq3Of0uBj8vPTbLh06Q4t143L2XtI9RMTgfbk3LR6FVDYe9bIvcFBxcAHAXeg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
       '@opentelemetry/api': 1.6.0
-      '@opentelemetry/api-logs': 0.43.0
-      '@opentelemetry/sdk-logs': 0.43.0(@opentelemetry/api-logs@0.43.0)(@opentelemetry/api@1.6.0)
+      '@opentelemetry/api-logs': 0.45.0
+      '@opentelemetry/sdk-logs': 0.45.0(@opentelemetry/api-logs@0.45.0)(@opentelemetry/api@1.6.0)
       '@types/node': 18.18.8
       '@types/uuid': 8.3.4
       dotenv: 16.3.1
@@ -19637,7 +19625,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-cr3NnpE1cTOEZHqTMwOo5YaPLvDT0YqylVjTG1nMYj24fJj2fSamR6Vn1eukPJjkGqr4jF9SgYrqIgOd4Zub4Q==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-nXHqWCSngbjp81+y9gdfZfqAOjO6Eota9P5V8EX3OFWh4EVJmcMw6p/SJlJ6jlRIlJyPQNxXmyA58fgYWjgVEA==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -19657,7 +19645,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-raym/RD7gz+2AIBTBMBcFHETMwgKGoPHArxv1Glc/ebznR8wrjHXVqZHlkexfPcGKun/KidUT+7eoCjgOfhxWQ==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-FtaeyYffiiHtYCvYhioGtrh8BjDhQLkSePZc0IQuG37fcjnzZPvHnG6HJILZo7WQgUhGMrX4TCpSV8K52CoOjA==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -19677,7 +19665,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-aXhSjY5/pJKeX+Qhtsip3gtEsQ3gO7EfEJPzipWeeZa/gj25oq9tAEZr754BA1/UUJa0JgiT1kNgqnqa1AGp4w==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-vXV+j0S7IdX2kRxK0nN8ZU0e8mgpDuyC7bEkGug8OIZwN28G1MTlt81lwW8cMQoz2zvM373Ig4daPRi5ly6Reg==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -19697,7 +19685,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-evYXFgwOjx696bKu4M3FfPf4EkLBycu44xONUF6oDSNxMb6hKFRAQgusDZHIvhvtho868HpVioWnjDHOgT/9Dg==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-1aQB0idm1A2edB59J6kYSWQjEhpZmW2rVhIksRoUR6gdRLZk8aMlO20xwra8VJC/Ggrn76Z2FoOAFvEG0/txVQ==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -19718,7 +19706,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-3SRkcJwCF77su/ziV1TQ5J54Hkvvov8rwyLQo4X4sRstD1rapPXifcricKLYFgajrovSmrc1rAn4nFYSTd86bQ==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-Xq/HBvsecy11GjHvNOzzXM0fUJGwc5/RM7I3COVS/e1yBYt1vFwnlpcWtgpxoIG9vEcU6pNLabxlssYFoMR1lg==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -19742,7 +19730,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-UPfH7e+MSIBpcOC0dgMHptWALYI8BbFyiL38w1QmCbpZtphOIANEDPSVxHkqvPgqMTankClUiObwWj1WsPbcNQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-Ujw8AeWpVE5C9gQ0oq4sX+Gs+bsrHa8bsoPLQjyn8GY67JmpFbxcHGJ8dTVngMG5oJUbs+vBgUdOGN4i1bIO8A==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -19765,7 +19753,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-5bTK39IJCy3g/r+qhUQVZ/LE+Um2stsntVd9M/DfjAuDxty+R3NXkIFeYwuVDlnaki1Ng6bZm7qAEj2dej7FVQ==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-0t+FHGWVEUWNM+Tkam59lIKZVYBZr6wVfykCLLhh8G6H0GUDEemakYg7xEw4iwUN7H7HOU6OkIGHxcvF3qOZNQ==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -19788,7 +19776,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-dMbTJPNZSBmNc1VrwtI5exnIF/r76bH76ivlj1LkvWtIWU5AU4R7vW5Z9/u8ExEirbKZtIms115sUeeAHNnq3w==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-oJsdMHdlfUMcK5MN1kD8v48+V1fJJ/TFIx/GtcCDUpM/ZVQPybO1ZTY1NNdwNFzV1qU2EEF3CmoaS5TH8Jfvfg==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -19811,7 +19799,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-/kZMf7x3Bt01w0cul/EBFdyHSpV1hlY8vFNJHl2SzdaC69KqV3TYa8fPO2fQvBTvw1sVWkfz/YF1FqQP4fxagw==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-47wOUEmWoCTfww9iU9hfFMe9Qc7iul9DJ3wcpor+0SWnVAzoB6yiB9ci2rIvilw6gjefqU5goWpmJOhBTmd+vQ==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -19855,7 +19843,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-GWDbv2gxaQdg7Q3r22uhBK+PTfmV4IOipWjaxcDiWyrp8WFscr/LeR0X1VnOZzhmQjVKoGVC00ArAFJ6hfd63g==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-ctZdYRlNdkgSyWSPYnQZlttcMfIK6zJSVrOf0/tnH5skZhAzRJpXI+VAcynkbERGEDvfA34XPtQQcCyP1oXLAQ==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -19899,7 +19887,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-lImf2k2N4f5xnmAoSQF2m9nJ0NtCJjodaKD9/Y+7QGUO1oDmt7eLoB7lm/4d/IwqRZqfzFvHSNH8JlJucDFOVg==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-4W4NArb+7ZJC90OovMyAjIZ6reA8d2l6AytYltVo4zXWq0QZ0pq+gNmCmr0CPLFZPUGfYEIGvbjB3ENoecb2tQ==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -19943,7 +19931,7 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-4RzMaT3/pTgE6vp0haThiYdHeeiwuDn6VRE88Ds9tMATDirAHkSwPV2XbjRnS8sqLa2i+xy0fkLryrss1X8AaQ==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-KYeO8UhV8LIhfckRMdQpZLlot00lHbBW8Zfw2nnICDJOufr0NYFzJs3vNTM0emWVELAyeiuDrORYiRvVT8sMqw==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
@@ -19988,7 +19976,7 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-EY+WHo6UhYrayUuLYzD74FBuR9rWDSivFNuyNgM8wAwz21hPKrIyH7aa2OMvsKtPBlTmggyNhi36emKV6yy26A==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-Lrwg3bnpPLciSbBcY5fC80gC2Vu0xY7BIJdjdHTAeDwNJo670LiTIVSBQtYWk+GXDFirGFXBZRQWCFcSIx7eCQ==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
@@ -20033,7 +20021,7 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-zZD91HxYdb3zOAAwFx5h5TJw3ygKImxeDDEAN91Ii3H+F6A2J0MbD8XRjlZMfUwMzqrMcmfmorVVeZtC1U8H6w==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-BQrNqHXKBMVp33AIWXqdQPM3K6D+ub+Wb+hVSU5ZcJIC/nqb3lMg2o2Rrx5341zyAZLgstgwem61vx/T0WiWkw==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -20080,7 +20068,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-KVOSGQ4WEkTcNPgteiNTRt5gcP9HmubsrDkDVfB32EyFBu3Se3e0PUIr42BKPw2Lp1NLHFIwSgWJWPLChWP5Zw==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-gCurE+JWjtyPjjGy64MjOhkmqS17jVTlqHRAfD/9JH+4G/FEhw59mttHbIrM7a9Aown8bj9lG/qXW3LypTHo7A==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20133,7 +20121,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-VxW6onEDXOzAd/p8ai6y1833jJfNT95WsMuKZoO3hcEG9la6EYCFqESbzeBZYbK28hvy7h5Lqb/Uirf9q+ufjQ==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-0OV8fgxchrKATGJiPwV1hs+JnNFvEd14YN48ocp9EiCQtMSaqL0DXRL6nRh8eEzP72oqNUJJKyZHzy5viqmYFQ==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -20176,7 +20164,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-e0AGlnbKM9Yh0GmkMycm7m92umWGiicheeTM/9/GMyuf4t6MIqbR6BK4enmFmB97uqcu0tc5iFmwJ0ZIVeCriw==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-gWbbZ0hfotv6iVHqpRVG/xb/mBjQ8K7XtFzuZel2EdHrfGs/ccg7SqfCPC3/4XtHUNlHNorMaWGBD1FAxFLX8A==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -20217,7 +20205,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-iNRN8PxGdnXX1zKh88La1myD7nSWi5nLDfaGUDFso+mP2ZtQqFouwo8RtNvIdzYmxyjCmGJzLoMWspRGmL/JBw==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-0pZMh8DbB3yAifhzm6MJ1gW7xr4NkD1W85usneHfwACVVrZSRtZN5Yt64VxM5gY2SjjlbiVeVhY9nLzlDWsRJw==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -20264,7 +20252,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-6QicmHeN7riyWH+0gnqFY+yeFql+a5dEdBQ5C7qU5zh9xJ2VbZ3bqWcyPY+ENkKYyLliFJ71NWg3YlYlA/A5Cw==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-7Bs7scwEEMKK8j8unTjMbFJv92Bd/plFGe+aCdq8EOA9ZcMHZUHNZ12VNJBvc64Ff/VwbTC5Xu/9ZsmLVx4qsA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -20329,7 +20317,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-xPKa5aMACSl19CoVzZAFpkP9rbLCejwIIRhspWoCexiKZVoyOTQt+r9TkjOA9GUuRgajkgSMda2mFdvvL1onyQ==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-yia7vjlgwB215lkpFb7HutCCeXTZvqXmPVKM/kp6h51cyFfHII0gxF5xiZ7Iy1pgust/SWqWBkP27qEl/AyRDQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -20381,7 +20369,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-gQLcoctkJuKhvNNFxmCWPQO2C9kKiRIjLDE98H3+8ydoMJrrIyBhBaHRmZi1unF2wvAQb1q7GCWqZK5yrGU4jQ==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-gGGHQF1eA4+C6k1V86i3inO+WesB2SPSmxtM9tirpf5krEUTzio3EKBgxk+BCo6XKWI7xZ/dDeKivNT9NaRbWw==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -20433,7 +20421,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-3+/WhJFZxwNr+BklG9CrGiOmTJdtx3vY5nZ7PSSMpP7di/dzJ4+FWr2b1HDQt7VQqZQkiuvZfJjpSYR2gwttbw==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-h2SkQZxVzyqLs9NuuT4jxYloau0n78yQvnPegssr2uzrsjcdnX8py4eoFTjcoSY2NBaWOBTtOYXaFgV1jLhFNg==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -20486,7 +20474,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-nHxsFUJkFGnWObcSmg6HCfLZG5vJPTMq4rpWdk7DilLXE1g1lUz8i/nkSUjlHIuP3jYHZlko8FJtP6lQgV+r5w==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-cElx8OY4OhnGLeTTxL6P+Y9+1krsptOCY82lNRi1RFirPFEYptgQO4uu3PzSSi10nVD7XZCUufej5e5CJvCQ0A==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -20539,7 +20527,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-CQoevEIqI0BNlDLarKEswvkADjHVrTh1eqQLH7SxLhpVAonMqf4IkO4y/mx44tWpac+BQWu/BpHGH2jXiCWStg==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-r8KqanAzDe64LQT+/AR41ws6CE3d7W/7ZTwk0/GV7GVYzHW51jsX9v6l+yeUKfIxDRhxSeoeMTlvD1vPNt7SYA==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -20586,7 +20574,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-xXUSOIsYt44UJTVs+xwNcKOBsPWRSOfS0bpa5jfKrUBDkH15nE2fWMLA5qGmA64gcw821zPwmE3XzTXlPIYhVg==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-ohzSwZEa4zMIoTrT5WQLA/Zqd4ujIVJ3R4Wr7OzTpooyFe2BwFv0nMgb2HdwIZbFJpi/Ga0RokAA8bQML5QUsg==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -20636,7 +20624,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-e6LY+dn5nQY+nhMwoNqJHMf30InDFZd7kQhNqyB/w/6V73CP+KXiRW1hEUyUvrhNeIEO/d2A4SBvtRKugT+VyA==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-AOI0IfVzlc7tfY2ZjngYPg0voB4E+eDOPSaTB6cDfQYPHFfTZvA9tAP4KbAj9p8RUXBWwMl7mBxO8R6rL3KEHw==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -20682,7 +20670,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-wBvPX307nYthX+UzakERXJe+j+vu8/YHTouUQDTaRG8s1XQQv1/k1enNDOVSZzdKDD9ShCsZNSIScyLL0ybCvQ==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-gJ+o8nVqcNNTBAeczYJ3DacwxAZ3BGzaKvI4lIcYLPOH34qme+yBB0nuZ9lubwT1Or88Qab+dfLG62NwsRpD3w==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -20732,7 +20720,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-4o/SWAimUnojO0SFd2OpSwCuc/oMQgF4S1Xlo0eHdTIgg6I9v0Va2OHIV62uJNiM47vD3Jg8ap0/zMqSjWreeQ==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-d2Sw89GpFrVXLyP4mU/WuiKaYLAgBnjeAP5HF2PeGyQk8FqD1jDi0uVkDKF3AZ+xFPivSbZjuWNZvo0zQWmlpg==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -20781,7 +20769,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-yBbRp5TqC6dT7pQ8nBqk+Mi6sn3brkPgu4psHea6BRoP5KsHc1Vf8DRvALbUVdkc6FTLF1Rel3vhmodRmTT7pw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-RBtvzZtVR0fNe9UkZw1F/NkCY8IjyyKZCvlUPeldfTsYNaFCKvvk35NXrnxAtTeI3itMSt04hPdB7T4a3+/HRw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -20824,7 +20812,7 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-CIwbNRZW8/qZ93iEeTn1HqzNAuyou7PFLQnZ+/gCrPM6Unx0yOVVSP2iZQk1EkO365XVTNu2CX8hsq6/H4iO1A==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-e4yQbRxUQnY/WvUoQHgFAm1THPs8x/FxGXdjuvwj7013LqzOHEWbTGbAvH6OvRzL7APulnNE6STu/4x/BzCUNA==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
@@ -20860,7 +20848,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-86fziXtA8dau0vjBDCsT9K3EepPuE71mg6nUfES+NK7ATQ6nSzI/x9hI+idVhqw7hKtCPORUD1+DfWiR7CUE2g==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-QtXVbD5+PtkO91N+n9OqgKVqM+sPQgZEej2WXG09umwsCARV1AQ8fql1xDjl8tznpc5zOdFTu5eJ4DixEhuhww==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -20903,7 +20891,7 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-xLw3u31dmWAZ8xBi/rnkSKLVy2hQsSInGGswKwg4KuKRoW6+3bIHkQLVayMDb0YEScNx/stfeb67xkYWKF6+nw==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-qyk7ve4Y9b1DGoOotRz2aX9GVKfrWoADT09WYVdSUeJnwgMMWo2qHPjG56/fwJMyAHe9E1iCXexmEGJv1seXsg==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
@@ -20947,7 +20935,7 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-HXxreZi3HMhCTpFBiY0YOmQ73kLDWz1HSNL+8ELX2lAp16DWnV9kRj9uJmuN9z8dJmd/jty09FWloXdUXAsBhA==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-TtLezoctYAmW1syJkG24OGpU7IdNiLibELzy6yVcV3Vic53FrqXE72uoR7nRA6n6b580r4+bmAqQBVcODOZ8Rg==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
@@ -20993,7 +20981,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-Z48JUB+N3+lQRq2wf1gjMZifKJDAlUcVaf8LagNKfPzMTS4XwvRD6cLxkJpyH3GnGSPlEY1SAoiiyUc6s0YyUg==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-54S+0gLOPkh7hDKxWRlMptwTT9XaLEgUT+48q613z+f1v5aeDBQcBwIDMjamGZmF6fLjuvj0sdLqfCnrI4+jUw==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -21012,7 +21000,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-rw5cgkqjXrjang5ENAaRRwe4OmavDgMOCbKDRzo5gftQ4YaGvnnfj/+Hdl3vboai+Wx+HTD3QTxTVDc7StH9rw==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-pIjq3Pny1yMcp5pI4TVB0vtFO8oGjRAg6gJ3tQBzJtsBrdg1fiQhI2biuTNsiEDd9c3kAF3zajDrB6yMOmOptQ==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -21056,7 +21044,7 @@ packages:
     dev: false
 
   file:projects/test-utils-perf.tgz:
-    resolution: {integrity: sha512-639hGi6iSeMbiHHyzMeIcw5Imc8EhoIghRIp0q5pDs0R3U4ZPBSMN6XECgxaUfK6JxtMqBmEudZTv4SyxZy4yg==, tarball: file:projects/test-utils-perf.tgz}
+    resolution: {integrity: sha512-FCp793KXwDF0zbPLd7v2e8yEqtrTdhwnvbkayDvW4FudbWOkr0mgaRddyc0QwKA+jtzB8il3lCAtBRI01AZVLQ==, tarball: file:projects/test-utils-perf.tgz}
     name: '@rush-temp/test-utils-perf'
     version: 0.0.0
     dependencies:
@@ -21088,7 +21076,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-ZVozGOHJLsqJ8L1rJnKoK+aYGMfB5sm2hFZQ4f73ON3Q6Lbiwtg0hG716RskGc2QjI+ojqaV2TgAGWNmrTAfrw==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-1hwzCayOt6nTTxPhsgR9WSdqmVkfRCTKukr8gqdrsKwyo1U0cKHeafJc4nLTe9j7h6kszPyNM96HmHwGc6z95Q==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -21125,7 +21113,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-E2eSHZSubba91KxiGmFZSMCS4NzlPYo+E/QGWSdKttJ2vKeKlSJIutkDEiYsNtcDlhfhoFisHlrqhgK9joPgRQ==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-3x1Ofh7Vqr0fD4B3ee1i64wpXNVDI0HHo8m2MXX4M99a2X9Qe8ub+bwqXDLtaYvDZyAzuWJrFfnwZVaaJxYRqg==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -21175,7 +21163,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-LA5jlBB0jaTwfkmD0Y5L8Z9kL4ZSGOZkU0EWf+AmfIYv/PwqNvC1POYhOkKKjqehaI6RNr2kLGhFWRMHcDYY5Q==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-LhDIA2/FaanRGvM8GXwnjPZb37drO9oHBGMojsS+A1mvr/AdebNIJzN/LQjTo2oziblDKoSUteF1U4b7lHchpg==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -21238,7 +21226,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-i9HLPyBJc2YLhK6OAKBlUBqqBJazh+xhqOVkq60TKjqn7OKM6yy6v5Vp0YUQThYVftsOH4/L9LDdPHpqHlszvg==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-/oSszwwTBN+1h7xWfZlC7048fJueHm8BdcIt9OWfimdAWVc2fOhASGLbRCuHtkwsiNxjNPR16et/nZ8e/WsmFA==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -21295,7 +21283,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-JOAAoRVojlHB5p/5nbCZU7pe8d816dhkOmb/SacnqWjtBYNKf8p6i9GEBYCw7MlbzIpgVBx5zzq4N24BUOtSFQ==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-AwX8Pj1SghP1bfzOGv/b7IL0zE5DOUO9vYz/oka8U7yog0G0DIlKO5C7q0QDfMRL1r8yYWBKRGljtrm0YlY0Qg==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -21334,7 +21322,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-zmsB5Lrgxjh0yxaK5v2p7MJarWTxJR95mCDGK5vkmVAtVuJHBg79EFcGJiRHf1ynqxeSrGVu4tcdfk1A0a8Cmw==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-dlxT7+krM03vzdq3COR8ioYVwvKzpgbngK1f9Ls8pEucVx8Qqc8m5rUX2rHMQTGBByVUe+FF+mk3fGtSBQVX8g==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:

--- a/sdk/monitor/perf-tests/monitor-opentelemetry/package.json
+++ b/sdk/monitor/perf-tests/monitor-opentelemetry/package.json
@@ -13,8 +13,8 @@
     "uuid": "^8.3.0",
     "@opentelemetry/api": "^1.6.0",
     "@azure/monitor-opentelemetry": "^1.0.0-beta.4",
-    "@opentelemetry/api-logs": "^0.43.0",
-    "@opentelemetry/sdk-logs": "^0.43.0"
+    "@opentelemetry/api-logs": "^0.45.0",
+    "@opentelemetry/sdk-logs": "^0.45.0"
   },
   "devDependencies": {
     "@types/uuid": "^8.0.0",


### PR DESCRIPTION
of

> ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies
>
>.
└─┬ @rush-temp/perf-monitor-opentelemetry 0.0.0
  └─┬ @opentelemetry/sdk-logs 0.43.0
    ├── ✕ unmet peer @opentelemetry/api@">=1.4.0 <1.7.0": found 1.7.0
    ├─┬ @opentelemetry/core 1.17.0
    │ └── ✕ unmet peer @opentelemetry/api@">=1.0.0 <1.7.0": found 1.7.0
    └─┬ @opentelemetry/resources 1.17.0
      └── ✕ unmet peer @opentelemetry/api@">=1.0.0 <1.7.0": found 1.7.0
