### PR TITLE
Stop Sending Statsbeat if iKey is Invalid

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 1.0.0-beta.19 (Unreleased)
 
-### Bugs Fixed
+### Other Changes
 
-- Fix Statsbeat being exported when the user's iKey is invalid.
+- Statsbeat will stop being exported when user iKey is invalid.
 
 ## 1.0.0-beta.18 (2023-11-09)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.19 (Unreleased)
+
+### Bugs Fixed
+
+- Fix Statsbeat being exported when the user's iKey is invalid.
+
 ## 1.0.0-beta.18 (2023-11-09)
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.19 (Unreleased)
+## 1.0.0-beta.19 ()
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -155,6 +155,9 @@ export abstract class BaseSender {
       } else if (restError.statusCode && isRetriable(restError.statusCode)) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         return this.persist(envelopes);
+        const invalidInstrumentationKeyError = new Error("Invalid instrumentation key");
+        this.incrementStatsbeatFailure();
+        return { code: ExportResultCode.FAILED, error: invalidInstrumentationKeyError };
       }
       if (this.isNetworkError(restError)) {
         if (restError.statusCode) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -155,6 +155,7 @@ export abstract class BaseSender {
       } else if (restError.statusCode && isRetriable(restError.statusCode)) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         return this.persist(envelopes);
+      } else if (restError.statusCode === 400 && restError.message.includes("Invalid instrumentation key")) {
         const invalidInstrumentationKeyError = new Error("Invalid instrumentation key");
         this.incrementStatsbeatFailure();
         return { code: ExportResultCode.FAILED, error: invalidInstrumentationKeyError };

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -158,6 +158,7 @@ export abstract class BaseSender {
       } else if (restError.statusCode === 400 && restError.message.includes("Invalid instrumentation key")) {
         const invalidInstrumentationKeyError = new Error("Invalid instrumentation key");
         this.incrementStatsbeatFailure();
+        diag.error(invalidInstrumentationKeyError.message);
         return { code: ExportResultCode.FAILED, error: invalidInstrumentationKeyError };
       }
       if (this.isNetworkError(restError)) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -155,7 +155,10 @@ export abstract class BaseSender {
       } else if (restError.statusCode && isRetriable(restError.statusCode)) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         return this.persist(envelopes);
-      } else if (restError.statusCode === 400 && restError.message.includes("Invalid instrumentation key")) {
+      } else if (
+        restError.statusCode === 400 &&
+        restError.message.includes("Invalid instrumentation key")
+      ) {
         const invalidInstrumentationKeyError = new Error("Invalid instrumentation key");
         this.shutdownStatsbeat();
         return { code: ExportResultCode.FAILED, error: invalidInstrumentationKeyError };
@@ -196,7 +199,7 @@ export abstract class BaseSender {
     }
   }
 
-  /** 
+  /**
    * Disable collection of statsbeat metrics after max failures
    */
   private incrementStatsbeatFailure() {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Aligns the statsbeat feature with the spec such that we no longer continue to export statsbeat if an invalid iKey is used.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
