### PR TITLE
[Customization] Fix import customization

### DIFF
--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -245,24 +245,26 @@ export function mergeModuleDeclarations(
 }
 
 function removeSelfImports(originalFile: SourceFile) {
+  const originalPathObject = path.parse(originalFile.getFilePath()); // /.../src/file.ts
+  removeFileExtension(originalPathObject);
+  const originalPath = path.format(originalPathObject); // src/file
+
   for (const originalImport of originalFile.getImportDeclarations()) {
-    const originalPathObject = path.parse(originalFile.getFilePath()); // src/models/models
-    const modulePathObject = path.parse(originalImport.getModuleSpecifierValue()); // ./models
+    const modulePathObject = path.parse(originalImport.getModuleSpecifierValue()); // ./file.js
+    removeFileExtension(modulePathObject);
+    const modulePath = path.format(modulePathObject); // ./file
 
-    [originalPathObject, modulePathObject].forEach((pathObject) => {
-      if (pathObject.ext.length) {
-        pathObject.base = pathObject.base.slice(0, -pathObject.ext.length);
-        pathObject.ext = "";
-      }
-    });
-
-    const originalPath = path.format(originalPathObject);
-    const modulePath = path.format(modulePathObject);
-
-    const moduleAbsolutePath = path.resolve(originalPathObject.dir, modulePath);
+    const moduleAbsolutePath = path.resolve(originalPathObject.dir, modulePath); // /.../src/, ./file -> /.../src/file
 
     if (moduleAbsolutePath === originalPath) {
       originalImport.remove();
+    }
+  }
+
+  function removeFileExtension(parsedPath: path.ParsedPath): void {
+    if (parsedPath.ext.length) {
+      parsedPath.base = parsedPath.base.slice(0, -parsedPath.ext.length);
+      parsedPath.ext = "";
     }
   }
 }

--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -260,7 +260,6 @@ function removeSelfImports(originalFile: SourceFile) {
     const modulePath = path.format(modulePathObject);
 
     const moduleAbsolutePath = path.resolve(originalPathObject.dir, modulePath);
-    console.log("paths: ", moduleAbsolutePath, originalPath);
 
     if (moduleAbsolutePath === originalPath) {
       originalImport.remove();

--- a/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
+++ b/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
@@ -16,6 +16,8 @@ import {
  * For example, all classes will be grouped together, all interfaces will be grouped together, etc.
  */
 export function sortSourceFileContents(sourceFile: SourceFile) {
+  sourceFile.organizeImports();
+
   // Collect all elements of different types
   const variableStatements = sourceFile.getVariableStatements();
   const interfaces = sourceFile.getInterfaces();

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -52,9 +52,7 @@ function augmentImportDeclaration(original: ImportDeclaration, custom: ImportDec
   if (customNamedImports.length) {
     original.insertNamedImports(
       0,
-      customNamedImports.map((specifier) => {
-        return specifier.getStructure();
-      })
+      customNamedImports.map((specifier) => specifier.getStructure())
     );
   }
 

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -128,9 +128,15 @@ function removeDuplicateIdentifiers(
     return customImportDecl.getDescendantsOfKind(ts.SyntaxKind.Identifier);
   });
 
-  const removedModules = customIdentifiers
-    .map(removeFromImports)
-    .filter((moduleSpecifier): moduleSpecifier is string => !!moduleSpecifier);
+  const removedModules = [];
+  for (const customIdentifier of customIdentifiers) {
+    // module specifier of removed import declaration, if the thing that was removed was an
+    // import declaration and not an import specifier
+    const removedModuleSpecifier = removeFromImports(customIdentifier);
+    if (removedModuleSpecifier) {
+      removedModules.push(removedModuleSpecifier);
+    }
+  }
 
   return removedModules;
 

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -20,7 +20,7 @@ export function augmentImports(
     Array.from(originalImports.values()),
     customImports
   );
-  removedModules.forEach(importMap.delete.bind(importMap));
+  removedModules.forEach((removedModule) => importMap.delete(removedModule));
 
   for (const customImportDecl of customImports) {
     const newModuleSpecifier =

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license
 
-import { Identifier, ImportDeclaration, ImportSpecifier, SourceFile, ts } from "ts-morph";
+import { Identifier, ImportDeclaration, ImportSpecifier, SourceFile, SyntaxKind } from "ts-morph";
 import { getCustomizationState } from "./state";
 import * as path from "path";
 
@@ -125,7 +125,7 @@ function removeDuplicateIdentifiers(
   );
 
   const customIdentifiers = customImports.flatMap((customImportDecl) => {
-    return customImportDecl.getDescendantsOfKind(ts.SyntaxKind.Identifier);
+    return customImportDecl.getDescendantsOfKind(SyntaxKind.Identifier);
   });
 
   const removedModules = [];
@@ -153,13 +153,13 @@ function removeDuplicateIdentifiers(
     }
 
     const isSoleNamedImport =
-      importNode.isKind(ts.SyntaxKind.ImportSpecifier) &&
+      importNode.isKind(SyntaxKind.ImportSpecifier) &&
       importNode.getImportDeclaration().getNamedImports().length === 1;
 
     const removeNode = isSoleNamedImport ? importNode.getImportDeclaration() : importNode;
 
     const removedModule = removeNode
-      .asKind(ts.SyntaxKind.ImportDeclaration)
+      .asKind(SyntaxKind.ImportDeclaration)
       ?.getModuleSpecifierValue();
 
     removeNode.remove();

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license
 
-import { ImportDeclaration, ImportSpecifier, SourceFile, ts } from "ts-morph";
+import { Identifier, ImportDeclaration, ImportSpecifier, SourceFile, ts } from "ts-morph";
 import { getCustomizationState } from "./state";
 import * as path from "path";
 
@@ -10,57 +10,17 @@ export function augmentImports(
   customImports: ImportDeclaration[],
   originalFile: SourceFile
 ) {
-  const importRemoveCallbackMap: Map<string, ImportDeclaration | ImportSpecifier> = new Map(
-    Array.from(originalImports.values()).flatMap((importDecl) => {
-      const namedImports = importDecl.getNamedImports();
-      const defaultImport = importDecl.getDefaultImport();
-      const namespaceImport = importDecl.getNamespaceImport();
-      const map: Array<[string, ImportDeclaration | ImportSpecifier]> = namedImports.map(
-        (importSpecifier) => [importSpecifier.getNameNode().getText(), importSpecifier]
-      );
-      if (defaultImport) {
-        map.push([defaultImport.getText(), importDecl]);
-      }
-      if (namespaceImport) {
-        map.push([namespaceImport.getText(), importDecl]);
-      }
-      return map;
-    })
-  );
-
   const { customDir, originalDir } = getCustomizationState();
   const importMap = new Map<string, ImportDeclaration>();
   for (const [moduleSpecifier, importDecl] of originalImports) {
     importMap.set(moduleSpecifier, importDecl);
   }
 
-  // remove identifiers from original if they're present in custom
-
-  const identifiers = customImports.flatMap((customImportDecl) => {
-    return customImportDecl.getDescendantsOfKind(ts.SyntaxKind.Identifier);
-  });
-
-  identifiers.forEach((identifier) => {
-    const identifierText = identifier.getText();
-
-    const importNode = importRemoveCallbackMap.get(identifierText);
-    if (!importNode) {
-      return;
-    }
-
-    const isSoleNamedImport =
-      importNode.isKind(ts.SyntaxKind.ImportSpecifier) &&
-      importNode.getImportDeclaration().getNamedImports().length === 1;
-
-    const removeNode = isSoleNamedImport ? importNode.getImportDeclaration() : importNode;
-
-    if (removeNode.isKind(ts.SyntaxKind.ImportDeclaration)) {
-      importMap.delete(removeNode.getModuleSpecifierValue());
-    }
-
-    removeNode.remove();
-    importRemoveCallbackMap.delete(identifierText);
-  });
+  const removedModules = removeDuplicateIdentifiers(
+    Array.from(originalImports.values()),
+    customImports
+  );
+  removedModules.forEach(importMap.delete.bind(importMap));
 
   for (const customImportDecl of customImports) {
     const newModuleSpecifier =
@@ -70,6 +30,7 @@ export function augmentImports(
         customImportDecl.getSourceFile().getFilePath(),
         customImportDecl.getModuleSpecifierValue()
       ) ?? customImportDecl.getModuleSpecifierValue();
+
     const originalImportDecl = importMap.get(newModuleSpecifier);
     if (originalImportDecl) {
       augmentImportDeclaration(originalImportDecl, customImportDecl);
@@ -99,14 +60,15 @@ function augmentImportDeclaration(original: ImportDeclaration, custom: ImportDec
 
   const customNamespaceImport = custom.getNamespaceImport();
   if (customNamespaceImport) {
-    original.setNamespaceImport(customNamespaceImport?.getText());
+    original.setNamespaceImport(customNamespaceImport.getText());
   }
 }
 
 /**
  * Given a source file at {@link customFilePath} which imports {@link originalModuleSpecifier}
  * from a subdirectory of {@link originalPath}, returns the relative path between the output
- * file and the output module.
+ * file and the output module. Returns undefined if the module isn't in a subdirectory of
+ * {@link originalPath}.
  */
 function getOriginalModuleSpecifier(
   originalPath: string,
@@ -134,5 +96,69 @@ function getOriginalModuleSpecifier(
     } else {
       return "./" + outputModuleSpecifier;
     }
+  }
+}
+
+function removeDuplicateIdentifiers(
+  originalImports: ImportDeclaration[],
+  customImports: ImportDeclaration[]
+): string[] {
+  const importMap: Map<string, ImportDeclaration | ImportSpecifier> = new Map(
+    originalImports.flatMap((importDecl) => {
+      const namedImports = importDecl.getNamedImports();
+      const defaultImport = importDecl.getDefaultImport();
+      const namespaceImport = importDecl.getNamespaceImport();
+
+      const map: Array<[string, ImportDeclaration | ImportSpecifier]> = namedImports.map(
+        (importSpecifier) => [importSpecifier.getNameNode().getText(), importSpecifier]
+      );
+
+      if (defaultImport) {
+        map.push([defaultImport.getText(), importDecl]);
+      }
+      if (namespaceImport) {
+        map.push([namespaceImport.getText(), importDecl]);
+      }
+
+      return map;
+    })
+  );
+
+  const customIdentifiers = customImports.flatMap((customImportDecl) => {
+    return customImportDecl.getDescendantsOfKind(ts.SyntaxKind.Identifier);
+  });
+
+  const removedModules = customIdentifiers
+    .map(removeFromImports)
+    .filter((moduleSpecifier): moduleSpecifier is string => !!moduleSpecifier);
+
+  return removedModules;
+
+  /**
+   * Removes the import of a given imported identifier. If the whole import declaration is removed
+   * (in the case of a default/namespace import or a named import with exactly one identifier),
+   * returns the module specifier of that import declaration.
+   */
+  function removeFromImports(identifier: Identifier): string | undefined {
+    const identifierText = identifier.getText();
+    const importNode = importMap.get(identifierText);
+    if (!importNode) {
+      return;
+    }
+
+    const isSoleNamedImport =
+      importNode.isKind(ts.SyntaxKind.ImportSpecifier) &&
+      importNode.getImportDeclaration().getNamedImports().length === 1;
+
+    const removeNode = isSoleNamedImport ? importNode.getImportDeclaration() : importNode;
+
+    const removedModule = removeNode
+      .asKind(ts.SyntaxKind.ImportDeclaration)
+      ?.getModuleSpecifierValue();
+
+    removeNode.remove();
+    importMap.delete(identifierText);
+
+    return removedModule;
   }
 }

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -122,9 +122,9 @@ function removeDuplicateIdentifiers(
     })
   );
 
-  const customIdentifiers = customImports.flatMap((customImportDecl) => {
-    return customImportDecl.getDescendantsOfKind(SyntaxKind.Identifier);
-  });
+  const customIdentifiers = customImports.flatMap((customImportDecl) =>
+    customImportDecl.getDescendantsOfKind(SyntaxKind.Identifier)
+  );
 
   const removedModules = [];
   for (const customIdentifier of customIdentifiers) {

--- a/common/tools/dev-tool/test/customization/interfaces.spec.ts
+++ b/common/tools/dev-tool/test/customization/interfaces.spec.ts
@@ -84,7 +84,7 @@ describe("Interfaces", () => {
     originalFile.addInterface({
       name: "Human",
       properties: [{ name: "pets", type: "Dog[]" }],
-    })
+    });
     customFile.addInterface({
       name: "Pet",
       docs: ["@azsdk-rename(Dog)"],
@@ -96,6 +96,8 @@ describe("Interfaces", () => {
 
     expect(originalFile.getInterface("Dog")).to.be.undefined;
     expect(originalFile.getInterface("Pet")).not.to.be.undefined;
-    expect(originalFile.getInterface("Human")?.getProperty("pets")?.getType().getText()).to.equal("Pet[]");
+    expect(originalFile.getInterface("Human")?.getProperty("pets")?.getType().getText()).to.equal(
+      "Pet[]"
+    );
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/dev-tool

### Issues associated with this PR

#26947 

### Describe the problem that is addressed by this PR

Imports weren't being resolved from the correct file. The behavior we expect is that imports in the generated and custom layers are propagated to the emitted output. If something in the generated layer consumes a local import, the corresponding emitted file should import that symbol from the same relative path. Ditto for the custom layer, but imports from that layer take precedence. Also, when the custom layer imports from the generated layer, the corresponding emitted file should import that symbol from the path of the module relative to the root of the _generated_ layer. This PR is intended to implement the above behavior.
