### PR TITLE
[storage] allow insecure connections

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.23.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Allow HTTP connections
+
 ## 12.23.0-beta.1 (2023-11-01)
 
 ### Other Changes

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.23.0-beta.2 (Unreleased)
 
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
 ### Other Changes
 
 - Allow HTTP connections

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.23.0-beta.1",
+  "version": "12.23.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -331,6 +331,7 @@ export function getCoreClientOptions(pipeline: PipelineLike): ExtendedServiceCli
   }
   return {
     ...restOptions,
+    allowInsecureConnection: true,
     httpClient,
     pipeline: corePipeline,
   };

--- a/sdk/storage/storage-blob/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClient.ts
@@ -48,7 +48,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-storage-blob/12.23.0-beta.1`;
+    const packageDetails = `azsdk-js-azure-storage-blob/12.23.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.23.0-beta.1";
+export const SDK_VERSION: string = "12.23.0-beta.2";
 export const SERVICE_VERSION: string = "2023-08-03";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "latest"
-package-version: 12.23.0-beta.1
+package-version: 12.23.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.22.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Allow HTTP connections
+
 ## 12.22.0-beta.1 (2023-11-01)
 
 ### Other Changes

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.22.0-beta.2 (Unreleased)
 
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
 ### Other Changes
 
 - Allow HTTP connections

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.22.0-beta.1",
+  "version": "12.22.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",

--- a/sdk/storage/storage-file-datalake/src/StorageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/StorageClient.ts
@@ -29,6 +29,7 @@ function getCoreClientOptions(pipeline: Pipeline): ExtendedServiceClientOptions 
   }
   return {
     ...restOptions,
+    allowInsecureConnection: true,
     httpClient,
     pipeline: corePipeline,
   };

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
@@ -44,7 +44,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-storage-datalake/12.22.0-beta.1`;
+    const packageDetails = `azsdk-js-azure-storage-datalake/12.22.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.22.0-beta.1";
+export const SDK_VERSION: string = "12.22.0-beta.2";
 export const SERVICE_VERSION: string = "2023-08-03";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -21,7 +21,7 @@ core-http-compat-mode: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.0"
-package-version: 12.22.0-beta.1
+package-version: 12.22.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.23.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Allow HTTP connections
+
 ## 12.23.0-beta.1 (2023-11-01)
 
 ### Other Changes

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.23.0-beta.2 (Unreleased)
 
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
 ### Other Changes
 
 - Allow HTTP connections

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.23.0-beta.1",
+  "version": "12.23.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-file-share/src/index.js",
@@ -138,7 +138,7 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
-    "@azure/storage-blob": "^12.23.0-beta.1",
+    "@azure/storage-blob": "^12.23.0-beta.2",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^3.0.0",

--- a/sdk/storage/storage-file-share/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClient.ts
@@ -35,7 +35,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-storage-file-share/12.23.0-beta.1`;
+    const packageDetails = `azsdk-js-azure-storage-file-share/12.23.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.23.0-beta.1";
+export const SDK_VERSION: string = "12.23.0-beta.2";
 export const SERVICE_VERSION: string = "2023-01-03";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "6.0.2"
-package-version: 12.23.0-beta.1
+package-version: 12.23.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.22.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Allow HTTP connections
+
 ## 12.22.0-beta.1 (2023-11-01)
 
 ### Other Changes

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.22.0-beta.2 (Unreleased)
 
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
 ### Other Changes
 
 - Allow HTTP connections

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.22.0-beta.1",
+  "version": "12.22.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-queue/src/index.js",

--- a/sdk/storage/storage-queue/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClient.ts
@@ -39,7 +39,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-azure-storage-queue/12.22.0-beta.1`;
+    const packageDetails = `azsdk-js-azure-storage-queue/12.22.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "12.22.0-beta.1";
+export const SDK_VERSION: string = "12.22.0-beta.2";
 export const SERVICE_VERSION: string = "2021-10-04";
 
 /**

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "6.0.3"
-package-version: 12.22.0-beta.1
+package-version: 12.22.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
Storage accounts can be configured allow both HTTP and HTTPS connections. Azurite also uses HTTP.  Unlike core-http, by default Core v2 doesn't allow HTTP. This PR sets `allowInsecureConnection` to `true` for storage clients.

### Issues associated with this PR
#27813
