### PR TITLE
Update Node version in .nvmrc to v18

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen


### PR DESCRIPTION
To fix Codespaces using Node 16 by default