### PR TITLE
[Customization] Fix duplicate const enums

### DIFF
--- a/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
+++ b/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
@@ -50,6 +50,7 @@ export function sortSourceFileContents(sourceFile: SourceFile) {
   typeAliases.forEach((typeAlias) => typeAlias.remove());
   classes.forEach((classDeclaration) => classDeclaration.remove());
   functions.forEach((functionDeclaration) => functionDeclaration.remove());
+  enums.forEach((enumDeclaration) => enumDeclaration.remove());
 
   // Add elements back to the source file in the desired order
   interfaceStructures.forEach((interfaceDeclaration) =>


### PR DESCRIPTION
### Packages impacted by this PR

@azure/dev-tool

### Issues associated with this PR

#26798 

### Describe the problem that is addressed by this PR

Fixes enums being duplicated by the customization tool.