### PR TITLE
[core-client-rest] keep request body as bytes for `application/octet-stream`

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Keeps request body of raw bytes for requests with `application/octet-stream` content type.
+
 ### Other Changes
 
 ## 1.1.4 (2023-07-06)

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.1.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.1.5 (2023-11-20)
 
 ### Bugs Fixed
 
 - Keeps request body of raw bytes for requests with `application/octet-stream` content type.
-
-### Other Changes
 
 ## 1.1.4 (2023-07-06)
 

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -172,14 +172,11 @@ function getRequestBody(body?: unknown, contentType: string = ""): RequestBody {
     return { body: JSON.stringify(body) };
   }
 
-  if (firstType === "application/octet-stream" &&
-    body instanceof Uint8Array) {
-    return { body };
-  }
-
   if (ArrayBuffer.isView(body)) {
     if (body instanceof Uint8Array) {
-      return { body: binaryArrayToString(body) };
+      return firstType === "application/octet-stream"
+        ? { body }
+        : { body: binaryArrayToString(body) };
     } else {
       return { body: JSON.stringify(body) };
     }

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -172,6 +172,11 @@ function getRequestBody(body?: unknown, contentType: string = ""): RequestBody {
     return { body: JSON.stringify(body) };
   }
 
+  if (firstType === "application/octet-stream" &&
+    body instanceof Uint8Array) {
+    return { body };
+  }
+
   if (ArrayBuffer.isView(body)) {
     if (body instanceof Uint8Array) {
       return { body: binaryArrayToString(body) };

--- a/sdk/core/core-client-rest/test/sendRequest.spec.ts
+++ b/sdk/core/core-client-rest/test/sendRequest.spec.ts
@@ -27,6 +27,19 @@ describe("sendRequest", () => {
       await sendRequest("POST", mockBaseUrl, mockPipeline, { body: foo });
     });
 
+    it("should send Uint8Array as bytes for octet-stream content type", async () => {
+      const mockPipeline: Pipeline = createEmptyPipeline();
+      mockPipeline.sendRequest = async (_client, request) => {
+        assert.equal(request.body, foo);
+        return { headers: createHttpHeaders() } as PipelineResponse;
+      };
+
+      await sendRequest("POST", mockBaseUrl, mockPipeline, {
+        body: foo,
+        contentType: "application/octet-stream",
+      });
+    });
+
     it("should handle request body as string", async () => {
       const mockPipeline: Pipeline = createEmptyPipeline();
       const expectedBody = "foo";


### PR DESCRIPTION
Currently we convert request body to string by default. This isn't always desirable and could be problematic. It breaks Image Analysis scenario where request body needs to be raw bytes.

This PR keeps the raw bytes as the request body when the content type is `applicatoni/octect-stream`. This is a short-term fix to unblock Image Analysis SDK while we investigate for better and long term solutions.

### Packages impacted by this PR
`@azure-rest/core-client`

### Issues associated with this PR
#27748

