### PR TITLE
[ts-http-runtime] drop `form-data` dependency

### DIFF
--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -90,7 +90,6 @@
     "migrationDate": "2023-03-08T18:36:03.000Z"
   },
   "dependencies": {
-    "form-data": "^4.0.0",
     "tslib": "^2.2.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0"


### PR DESCRIPTION
### Packages impacted by this PR

- `@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

Dependency is no longer needed with new form data policy
