### PR TITLE
[core-llro] Update logic for fetching resourceLocation

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Search for the `resourceLocation` property in the raw response body if it cannot be found in the parsed response body.
+
 ## 2.5.4 (2023-07-24)
 
 ### Bugs Fixed

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -23,6 +23,8 @@ export interface ResponseBody extends Record<string, unknown> {
   properties?: { provisioningState?: unknown } & Record<string, unknown>;
   /** The error if the operation failed */
   error?: Partial<LroError>;
+  /** The location of the created resource */
+  resourceLocation?: string;
 }
 
 /**

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -180,7 +180,7 @@ export function parseRetryAfter<T>({ rawResponse }: LroResponse<T>): number | un
 }
 
 export function getErrorFromResponse<T>(response: LroResponse<T>): LroError | undefined {
-  const error = accessBody(response, "error");
+  const error = accessBodyProperty(response, "error");
   if (!error) {
     logger.warning(
       `The long-running operation failed but there is no error property in the response's body`
@@ -304,7 +304,7 @@ export function getOperationStatus<TState>(
   }
 }
 
-function accessBody<P extends string>(
+function accessBodyProperty<P extends string>(
   { flatResponse, rawResponse }: LroResponse,
   prop: P
 ): ResponseBody[P] {
@@ -315,7 +315,7 @@ export function getResourceLocation<TState>(
   res: LroResponse,
   state: RestorableOperationState<TState>
 ): string | undefined {
-  const loc = accessBody(res, "resourceLocation");
+  const loc = accessBodyProperty(res, "resourceLocation");
   if (loc !== undefined) {
     state.config.resourceLocation = loc;
   }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-lro

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The LRO polling helpers in RLCs set the `flatResponse` property to the raw response object (not flattened) which confuses the LRO engine in how to retrieve certain properties from the response body. This PR updates the engine to access properties in the raw response bodies as well.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
