### PR TITLE
[core-lro] Fix resource location check

### DIFF
--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -316,7 +316,7 @@ export function getResourceLocation<TState>(
   state: RestorableOperationState<TState>
 ): string | undefined {
   const loc = accessBodyProperty(res, "resourceLocation");
-  if (loc !== undefined) {
+  if (loc) {
     state.config.resourceLocation = loc;
   }
   return state.config.resourceLocation;

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -1478,6 +1478,42 @@ matrix(
               assert.deepInclude(result, { id: "100", name: "foo" });
             });
 
+            it("should handle resourceLocation being null", async () => {
+              const locationPath = "/postlocation/retry/succeeded/operationResults/foo/200/";
+              const pollingPath = "/postlocation/retry/succeeded/operationResults/200/";
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    headers: {
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 202,
+                    headers: {
+                      location: locationPath,
+                      [headerName]: pollingPath,
+                      "retry-after": "0",
+                    },
+                    body: `{"status":"Accepted"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: pollingPath,
+                    status: 200,
+                    body: `{"status":"Succeeded", "resourceLocation": null}`,
+                  },
+                ],
+              });
+              assert.deepInclude(result, { status: "Succeeded" });
+            });
+
             it("should handle postAsyncRetrycanceled", async () => {
               const pollingPath = "/postasync/retry/canceled/operationResults/200/";
               const body = { status: "Canceled" };


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-lro

### Issues associated with this PR
Failure in https://dev.azure.com/azure-sdk/public/_build/results?buildId=3285449&view=ms.vss-test-web.build-test-results-tab&runId=44507543&resultId=100042&paneView=debug

### Describe the problem that is addressed by this PR
`resourceLocation` is returned by the service as null for some reason, so we need to check if `resourceLocation` not only present but also is not null and not an empty string.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
