### PR TITLE
Revert "[Customization] Fix import customization (#27808)"

### DIFF
--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -12,6 +12,7 @@ import {
   TypeAliasDeclaration,
   SourceFile,
   ImportDeclaration,
+  Directory,
 } from "ts-morph";
 import { augmentFunctions } from "./functions";
 import { augmentClasses } from "./classes";
@@ -20,7 +21,7 @@ import { sortSourceFileContents } from "./helpers/preformat";
 import { addHeaderToFiles } from "./helpers/addFileHeaders";
 import { resolveProject } from "../resolveProject";
 import { augmentTypeAliases } from "./aliases";
-import { setCustomizationState, resetCustomizationState } from "./state";
+import { setCustomizationState, resetCustomizationState, getCustomizationState } from "./state";
 import { getNewCustomFiles } from "./helpers/files";
 import { augmentImports } from "./imports";
 
@@ -230,47 +231,94 @@ export function mergeModuleDeclarations(
     originalVirtualSourceFile
   );
 
-  augmentImports(
-    originalDeclarationsMap.imports,
-    customVirtualSourceFile.getImportDeclarations(),
-    originalVirtualSourceFile
-  );
+  augmentImports(originalDeclarationsMap.imports, customVirtualSourceFile.getImportDeclarations());
 
   augmentExports(customVirtualSourceFile, originalVirtualSourceFile);
 
-  removeSelfImports(originalVirtualSourceFile);
+  originalVirtualSourceFile.fixMissingImports();
   sortSourceFileContents(originalVirtualSourceFile);
-
+  copyCustomImports(customVirtualSourceFile, originalVirtualSourceFile);
   return originalVirtualSourceFile.getFullText();
 }
 
-function removeSelfImports(originalFile: SourceFile) {
-  const originalPathObject = path.parse(originalFile.getFilePath()); // /.../src/file.ts
-  removeFileExtension(originalPathObject);
-  const originalPath = path.format(originalPathObject); // src/file
+function isGeneratedImport(importDeclaration: ImportDeclaration) {
+  const regex = new RegExp(`^../(?:../)*${_originalFolderName}(?:/.*)?$`);
 
-  for (const originalImport of originalFile.getImportDeclarations()) {
-    const modulePathObject = path.parse(originalImport.getModuleSpecifierValue()); // ./file.js
-    removeFileExtension(modulePathObject);
-    const modulePath = path.format(modulePathObject); // ./file
+  return regex.test(importDeclaration.getModuleSpecifierValue());
+}
 
-    const moduleAbsolutePath = path.resolve(originalPathObject.dir, modulePath); // /.../src/, ./file -> /.../src/file
+function transformGeneratedImport(moduleSpecifier: string) {
+  const regex = new RegExp(`^(../)+(?:../)*${_originalFolderName}(?:/(.*))?$`);
+  return moduleSpecifier.replace(regex, "./$2");
+}
 
-    if (moduleAbsolutePath === originalPath) {
-      originalImport.remove();
+function copyCustomImports(customFile: SourceFile, originalFile: SourceFile) {
+  for (const customImport of customFile.getImportDeclarations()) {
+    if (isSelfImport(customImport.getModuleSpecifierValue(), originalFile)) {
+      continue;
     }
-  }
-
-  function removeFileExtension(parsedPath: path.ParsedPath): void {
-    if (parsedPath.ext.length) {
-      parsedPath.base = parsedPath.base.slice(0, -parsedPath.ext.length);
-      parsedPath.ext = "";
+    if (isGeneratedImport(customImport)) {
+      const newModuleSpecifier = transformGeneratedImport(customImport.getModuleSpecifierValue());
+      customImport.setModuleSpecifier(newModuleSpecifier);
+      originalFile.addImportDeclaration(customImport.getStructure());
     }
+
+    const originalImport = originalFile.getImportDeclaration(
+      customImport.getModuleSpecifierValue()
+    );
+
+    if (!originalImport) {
+      originalFile.addImportDeclaration(customImport.getStructure());
+    }
+
+    if (originalImport?.getNamespaceImport()) {
+      continue;
+    }
+
+    const originalNamedImports = originalImport?.getNamedImports().map((i) => i.getName()) || [];
+
+    const allImports = new Set<string>(originalNamedImports);
+    for (const customNamedImport of customImport.getNamedImports()) {
+      allImports.add(customNamedImport.getText());
+    }
+
+    originalImport?.removeNamedImports();
+    originalImport?.addNamedImports(Array.from(allImports));
   }
+  originalFile.organizeImports();
 }
 
 function commonPrefix(a: string, b: string) {
   let i = 0;
   while (i < a.length && i < b.length && a[i] === b[i]) i++;
   return a.slice(0, i);
+}
+
+function isSelfImport(module: string, file: SourceFile): boolean {
+  const { customDir, originalDir } = getCustomizationState();
+  let projectPath = file.getDirectory();
+  while (projectPath.getRelativePathTo(customDir).startsWith("..")) {
+    projectPath = projectPath.getParent() as Directory;
+  }
+  // e.g: ./sources/generated/src
+  const relativeOriginal = originalDir.replace(/\\/g, "/").replace(projectPath.getPath(), ".");
+  // e.g: ./sources/customizations
+  const relativeCustom = customDir.replace(/\\/g, "/").replace(projectPath.getPath(), ".");
+  // e.g: ./sources/
+  const prefix = commonPrefix(relativeOriginal, relativeCustom);
+  // e.g generated/src
+  let originalSuffix = relativeOriginal.substring(prefix.length);
+  // e.g generated/src/
+  originalSuffix = originalSuffix.endsWith("/") ? originalSuffix : originalSuffix + "/";
+  // e.g folder/file.js (with the original module being ../../generated/src/folder/file.js)
+  const index = module.search(originalSuffix);
+  if (index < 0) {
+    return false;
+  }
+  const moduleRelative = module.substring(index + originalSuffix.length);
+  const sanitizedPath = file.getFilePath().replace(/\\/g, "/").replace(/\.ts$/, ".js");
+  if (sanitizedPath.endsWith(moduleRelative)) {
+    return true;
+  }
+  return false;
 }

--- a/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
+++ b/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
@@ -16,8 +16,6 @@ import {
  * For example, all classes will be grouped together, all interfaces will be grouped together, etc.
  */
 export function sortSourceFileContents(sourceFile: SourceFile) {
-  sourceFile.organizeImports();
-
   // Collect all elements of different types
   const variableStatements = sourceFile.getVariableStatements();
   const interfaces = sourceFile.getInterfaces();

--- a/common/tools/dev-tool/src/util/customization/imports.ts
+++ b/common/tools/dev-tool/src/util/customization/imports.ts
@@ -1,168 +1,68 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license
 
-import { Identifier, ImportDeclaration, ImportSpecifier, SourceFile, SyntaxKind } from "ts-morph";
+import { ImportDeclaration } from "ts-morph";
 import { getCustomizationState } from "./state";
 import * as path from "path";
 
 export function augmentImports(
   originalImports: Map<string, ImportDeclaration>,
-  customImports: ImportDeclaration[],
-  originalFile: SourceFile
+  customImports: ImportDeclaration[]
 ) {
   const { customDir, originalDir } = getCustomizationState();
-  const importMap = new Map<string, ImportDeclaration>();
-  for (const [moduleSpecifier, importDecl] of originalImports) {
-    importMap.set(moduleSpecifier, importDecl);
+  const importMap: Map<string, ImportDeclaration> = new Map();
+
+  for (const [, value] of originalImports) {
+    const module = value.getModuleSpecifier().getText();
+    importMap.set(module, value);
   }
 
-  const removedModules = removeDuplicateIdentifiers(
-    Array.from(originalImports.values()),
-    customImports
-  );
-  removedModules.forEach((removedModule) => importMap.delete(removedModule));
+  for (const customImport of customImports) {
+    const module = customImport.getModuleSpecifier().getText();
 
-  for (const customImportDecl of customImports) {
-    const newModuleSpecifier =
-      getOriginalModuleSpecifier(
-        originalDir,
-        customDir,
-        customImportDecl.getSourceFile().getFilePath(),
-        customImportDecl.getModuleSpecifierValue()
-      ) ?? customImportDecl.getModuleSpecifierValue();
+    if (isPathMovingToOriginal(originalDir, customDir, module)) {
+      continue;
+    }
 
-    const originalImportDecl = importMap.get(newModuleSpecifier);
-    if (originalImportDecl) {
-      augmentImportDeclaration(originalImportDecl, customImportDecl);
-    } else {
-      const importStructure = customImportDecl.getStructure();
-      importStructure.moduleSpecifier = newModuleSpecifier;
-      originalFile.addImportDeclaration(importStructure);
+    const existingImport = importMap.get(module);
+
+    if (!existingImport) {
+      importMap.set(module, customImport);
+      continue;
+    }
+
+    if (isPathMovingToOriginal(originalDir, customDir, module)) {
+      continue;
+    }
+
+    if (!existingImport.getDefaultImport()) {
+      existingImport.setDefaultImport(customImport.getDefaultImport()?.getText() ?? "");
+    }
+
+    const existingNamedImports = existingImport.getNamedImports();
+
+    for (const namedImport of customImport.getNamedImports()) {
+      if (!existingNamedImports.find((x) => x.getName() === namedImport.getName())) {
+        existingImport.addNamedImport(namedImport.getStructure());
+      }
     }
   }
 }
 
-function augmentImportDeclaration(original: ImportDeclaration, custom: ImportDeclaration) {
-  const customDefaultImport = custom.getDefaultImport();
-  if (customDefaultImport) {
-    original.setDefaultImport(customDefaultImport.getText());
-  }
-
-  const customNamedImports = custom.getNamedImports();
-  if (customNamedImports.length) {
-    original.insertNamedImports(
-      0,
-      customNamedImports.map((specifier) => specifier.getStructure())
-    );
-  }
-
-  const customNamespaceImport = custom.getNamespaceImport();
-  if (customNamespaceImport) {
-    original.setNamespaceImport(customNamespaceImport.getText());
-  }
-}
-
-/**
- * Given a source file at {@link customFilePath} which imports {@link originalModuleSpecifier}
- * from a subdirectory of {@link originalPath}, returns the relative path between the output
- * file and the output module. Returns undefined if the module isn't in a subdirectory of
- * {@link originalPath}.
- */
-function getOriginalModuleSpecifier(
+export function isPathMovingToOriginal(
   originalPath: string,
-  customPath: string,
-  customFilePath: string,
-  originalModuleSpecifier: string
-): string | undefined {
-  // Check that this custom file import is local, but not in the same directory (or subdirs) as the file
-  if (!originalModuleSpecifier.startsWith("../") && !originalModuleSpecifier.startsWith('"../')) {
-    return undefined;
+  currentFile: string,
+  resolvePath: string
+) {
+  // Check if resolvePath is traversing directories upwards
+  if (!resolvePath.startsWith("../") && !resolvePath.startsWith('"../')) {
+    return false;
   }
 
-  const currentFileDir = path.dirname(customFilePath);
-  const moduleAbsolutePath = path.resolve(currentFileDir, originalModuleSpecifier);
+  // Resolve the path from the current file's directory
+  const currentFileDir = path.dirname(currentFile);
+  const resolvedPath = path.resolve(currentFileDir, resolvePath);
 
-  const moduleRelativePath = path.relative(originalPath, moduleAbsolutePath);
-  const outputFileRelativePath = path.relative(customPath, currentFileDir);
-
-  const outputModuleSpecifier = path.relative(outputFileRelativePath, moduleRelativePath);
-
-  // Check if the module is actually contained in the original directory
-  if (!moduleRelativePath.startsWith("..") && !path.isAbsolute(moduleRelativePath)) {
-    if (outputModuleSpecifier.startsWith(".")) {
-      return outputModuleSpecifier;
-    } else {
-      return "./" + outputModuleSpecifier;
-    }
-  }
-}
-
-function removeDuplicateIdentifiers(
-  originalImports: ImportDeclaration[],
-  customImports: ImportDeclaration[]
-): string[] {
-  const importMap: Map<string, ImportDeclaration | ImportSpecifier> = new Map(
-    originalImports.flatMap((importDecl) => {
-      const namedImports = importDecl.getNamedImports();
-      const defaultImport = importDecl.getDefaultImport();
-      const namespaceImport = importDecl.getNamespaceImport();
-
-      const map: Array<[string, ImportDeclaration | ImportSpecifier]> = namedImports.map(
-        (importSpecifier) => [importSpecifier.getNameNode().getText(), importSpecifier]
-      );
-
-      if (defaultImport) {
-        map.push([defaultImport.getText(), importDecl]);
-      }
-      if (namespaceImport) {
-        map.push([namespaceImport.getText(), importDecl]);
-      }
-
-      return map;
-    })
-  );
-
-  const customIdentifiers = customImports.flatMap((customImportDecl) =>
-    customImportDecl.getDescendantsOfKind(SyntaxKind.Identifier)
-  );
-
-  const removedModules = [];
-  for (const customIdentifier of customIdentifiers) {
-    // module specifier of removed import declaration, if the thing that was removed was an
-    // import declaration and not an import specifier
-    const removedModuleSpecifier = removeFromImports(customIdentifier);
-    if (removedModuleSpecifier) {
-      removedModules.push(removedModuleSpecifier);
-    }
-  }
-
-  return removedModules;
-
-  /**
-   * Removes the import of a given imported identifier. If the whole import declaration is removed
-   * (in the case of a default/namespace import or a named import with exactly one identifier),
-   * returns the module specifier of that import declaration.
-   */
-  function removeFromImports(identifier: Identifier): string | undefined {
-    const identifierText = identifier.getText();
-    const importNode = importMap.get(identifierText);
-    if (!importNode) {
-      return;
-    }
-
-    const isSoleNamedImport =
-      importNode.isKind(SyntaxKind.ImportSpecifier) &&
-      importNode.getImportDeclaration().getNamedImports().length === 1;
-
-    const removeNode = isSoleNamedImport ? importNode.getImportDeclaration() : importNode;
-
-    const removedModule = removeNode
-      .asKind(SyntaxKind.ImportDeclaration)
-      ?.getModuleSpecifierValue();
-
-    removeNode.remove();
-    importMap.delete(identifierText);
-
-    return removedModule;
-  }
+  // Check if the resolved path is within the original path root
+  return resolvedPath.startsWith(originalPath);
 }

--- a/common/tools/dev-tool/test/customization/interfaces.spec.ts
+++ b/common/tools/dev-tool/test/customization/interfaces.spec.ts
@@ -84,7 +84,7 @@ describe("Interfaces", () => {
     originalFile.addInterface({
       name: "Human",
       properties: [{ name: "pets", type: "Dog[]" }],
-    });
+    })
     customFile.addInterface({
       name: "Pet",
       docs: ["@azsdk-rename(Dog)"],
@@ -96,8 +96,6 @@ describe("Interfaces", () => {
 
     expect(originalFile.getInterface("Dog")).to.be.undefined;
     expect(originalFile.getInterface("Pet")).not.to.be.undefined;
-    expect(originalFile.getInterface("Human")?.getProperty("pets")?.getType().getText()).to.equal(
-      "Pet[]"
-    );
+    expect(originalFile.getInterface("Human")?.getProperty("pets")?.getType().getText()).to.equal("Pet[]");
   });
 });


### PR DESCRIPTION
`template-dpg` has a broken build at the moment due to 5dfa839 As the package has since been added to the core CI pipeline, it needs to be reverted to stop spurious CI failures.

Will be reintroduced with #27824 