### PR TITLE
[Maps] SAS token support

### DIFF
--- a/sdk/maps/maps-geolocation-rest/CHANGELOG.md
+++ b/sdk/maps/maps-geolocation-rest/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Support SAS token authentication.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/maps/maps-geolocation-rest/README.md
+++ b/sdk/maps/maps-geolocation-rest/README.md
@@ -82,6 +82,52 @@ const credential = new AzureKeyCredential("<subscription-key>");
 const client = MapsGeolocation(credential);
 ```
 
+#### Using a Shared Access Signature (SAS) Token Credential
+
+Shared access signature (SAS) tokens are authentication tokens created using the JSON Web token (JWT) format and are cryptographically signed to prove authentication for an application to the Azure Maps REST API.
+
+You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](https://learn.microsoft.com/javascript/api/%40azure/arm-maps/accounts?view=azure-node-latest#@azure-arm-maps-accounts-listsas) from ["@azure/arm-maps"](https://www.npmjs.com/package/@azure/arm-maps) package. Please follow the section [Create and authenticate a `AzureMapsManagementClient`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/arm-maps#create-and-authenticate-a-azuremapsmanagementclient) to setup first.
+
+Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
+
+Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+
+```bash
+npm install @azure/core-auth
+```
+
+Finally, you can use the SAS token to authenticate the client:
+
+```javascript
+  const MapsGeolocation = require("@azure-rest/maps-geolocation").default;
+  const { AzureSASCredential } = require("@azure/core-auth");
+  const { DefaultAzureCredential } = require("@azure/identity");
+  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+
+  const subscriptionId = "<subscription ID of the map account>"
+  const resourceGroupName = "<resource group name of the map account>";
+  const accountName = "<name of the map account>";
+  const mapsAccountSasParameters = {
+    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+    maxRatePerSecond: 500,
+    principalId: "<principle ID (object ID) of the managed identity>",
+    signingKey: "primaryKey",
+  };
+  const credential = new DefaultAzureCredential();
+  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+  const {accountSasToken} = await managementClient.accounts.listSas(
+    resourceGroupName,
+    accountName,
+    mapsAccountSasParameters
+  );
+  if (accountSasToken === undefined) {
+    throw new Error("No accountSasToken was found for the Maps Account.");
+  }
+  const sasCredential = new AzureSASCredential(accountSasToken);
+  const client = MapsGeolocation(sasCredential);
+```
+
 ## Key concepts
 
 ### MapsGeolocationClient

--- a/sdk/maps/maps-geolocation-rest/README.md
+++ b/sdk/maps/maps-geolocation-rest/README.md
@@ -69,7 +69,7 @@ const client = MapsGeolocation(credential, "<maps-account-client-id>");
 
 #### Using a Subscription Key Credential
 
-You can authenticate with your Azure Maps Subscription Key. Please install the `@azure/core-auth` package:
+You can authenticate with your Azure Maps Subscription Key. Please install the["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package:
 
 ```bash
 npm install @azure/core-auth
@@ -90,7 +90,7 @@ You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](h
 
 Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
 
-Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+Third, you will need to install["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package to use `AzureSASCredential`:
 
 ```bash
 npm install @azure/core-auth

--- a/sdk/maps/maps-geolocation-rest/review/maps-geolocation.api.md
+++ b/sdk/maps/maps-geolocation-rest/review/maps-geolocation.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AzureKeyCredential } from '@azure/core-auth';
+import { AzureSASCredential } from '@azure/core-auth';
 import { Client } from '@azure-rest/core-client';
 import { ClientOptions } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
@@ -86,6 +87,9 @@ function MapsGeolocation(credential: AzureKeyCredential, options?: ClientOptions
 
 // @public
 function MapsGeolocation(credential: TokenCredential, mapsAccountClientId: string, options?: ClientOptions): MapsGeolocationClient;
+
+// @public
+function MapsGeolocation(credential: AzureSASCredential, options?: ClientOptions): MapsGeolocationClient;
 export default MapsGeolocation;
 
 // @public (undocumented)

--- a/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
+++ b/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
@@ -38,7 +38,7 @@ export default function MapsGeolocation(
  *
  * @example
  * ```ts
- * import MapsGeolocation from "@azure/maps-geo-location";
+ * import MapsGeolocation from "@azure-rest/maps-geo-location";
  * import { DefaultAzureCredential } from "@azure/identity";
  *
  * const credential = new DefaultAzureCredential();
@@ -59,7 +59,7 @@ export default function MapsGeolocation(
  *
  * @example
  * ```ts
- * import MapsGeolocation from "@azure/maps-geo-location";
+ * import MapsGeolocation from "@azure-rest/maps-geo-location";
  * import { AzureSASCredential } from "@azure/core-auth";
  *
  * const credential = new AzureSASCredential("<SAS Token>");

--- a/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
+++ b/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT license.
 
 import { ClientOptions } from "@azure-rest/core-client";
-import { AzureKeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
+import {
+  AzureKeyCredential,
+  AzureSASCredential,
+  TokenCredential,
+  isSASCredential,
+  isTokenCredential,
+} from "@azure/core-auth";
 import { createMapsClientIdPolicy } from "@azure/maps-common";
 import { MapsGeolocationClient } from "./generated";
 import createClient from "./generated";
@@ -48,8 +54,27 @@ export default function MapsGeolocation(
   mapsAccountClientId: string,
   options?: ClientOptions
 ): MapsGeolocationClient;
+/**
+ * Creates an instance of MapsGeolocation from an Azure Identity `AzureSASCredential`.
+ *
+ * @example
+ * ```ts
+ * import MapsGeolocation from "@azure/maps-geo-location";
+ * import { AzureSASCredential } from "@azure/core-auth";
+ *
+ * const credential = new AzureSASCredential("<SAS Token>");
+ * const client = MapsGeolocation(credential);
+ * ```
+ *
+ * @param credential - An AzureSASCredential instance used to authenticate requests to the service
+ * @param options - Options used to configure the Geolocation Client
+ */
 export default function MapsGeolocation(
-  credential: TokenCredential | AzureKeyCredential,
+  credential: AzureSASCredential,
+  options?: ClientOptions
+): MapsGeolocationClient;
+export default function MapsGeolocation(
+  credential: TokenCredential | AzureKeyCredential | AzureSASCredential,
   clientIdOrOptions: string | ClientOptions = {},
   maybeOptions: ClientOptions = {}
 ): MapsGeolocationClient {
@@ -75,5 +100,18 @@ export default function MapsGeolocation(
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));
     return client;
   }
+
+  if (isSASCredential(credential)) {
+    const client = createClient(undefined as any, options);
+    client.pipeline.addPolicy({
+      name: "mapsSASCredentialPolicy",
+      async sendRequest(request, next) {
+        request.headers.set("Authorization", `jwt-sas ${credential.signature}`);
+        return next(request);
+      },
+    });
+    return client;
+  }
+
   return createClient(credential, options);
 }

--- a/sdk/maps/maps-render-rest/CHANGELOG.md
+++ b/sdk/maps/maps-render-rest/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.0-beta.3 (Unreleased)
 
+- Support SAS token authentication.
+
 ### Features Added
 
 ### Breaking Changes

--- a/sdk/maps/maps-render-rest/README.md
+++ b/sdk/maps/maps-render-rest/README.md
@@ -83,6 +83,52 @@ const credential = new AzureKeyCredential("<subscription-key>");
 const client = MapsRender(credential);
 ```
 
+#### Using a Shared Access Signature (SAS) Token Credential
+
+Shared access signature (SAS) tokens are authentication tokens created using the JSON Web token (JWT) format and are cryptographically signed to prove authentication for an application to the Azure Maps REST API.
+
+You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](https://learn.microsoft.com/javascript/api/%40azure/arm-maps/accounts?view=azure-node-latest#@azure-arm-maps-accounts-listsas) from ["@azure/arm-maps"](https://www.npmjs.com/package/@azure/arm-maps) package. Please follow the section [Create and authenticate a `AzureMapsManagementClient`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/arm-maps#create-and-authenticate-a-azuremapsmanagementclient) to setup first.
+
+Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
+
+Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+
+```bash
+npm install @azure/core-auth
+```
+
+Finally, you can use the SAS token to authenticate the client:
+
+```javascript
+  const MapsRender = require("@azure-rest/maps-render").default;
+  const { AzureSASCredential } = require("@azure/core-auth");
+  const { DefaultAzureCredential } = require("@azure/identity");
+  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+
+  const subscriptionId = "<subscription ID of the map account>"
+  const resourceGroupName = "<resource group name of the map account>";
+  const accountName = "<name of the map account>";
+  const mapsAccountSasParameters = {
+    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+    maxRatePerSecond: 500,
+    principalId: "<principle ID (object ID) of the managed identity>",
+    signingKey: "primaryKey",
+  };
+  const credential = new DefaultAzureCredential();
+  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+  const {accountSasToken} = await managementClient.accounts.listSas(
+    resourceGroupName,
+    accountName,
+    mapsAccountSasParameters
+  );
+  if (accountSasToken === undefined) {
+    throw new Error("No accountSasToken was found for the Maps Account.");
+  }
+  const sasCredential = new AzureSASCredential(accountSasToken);
+  const client = MapsRender(sasCredential);
+```
+
 ## Key concepts
 
 ### MapsRenderClient

--- a/sdk/maps/maps-render-rest/README.md
+++ b/sdk/maps/maps-render-rest/README.md
@@ -69,7 +69,7 @@ const client = MapsRender(credential, "<maps-account-client-id>");
 
 #### Using a Subscription Key Credential
 
-You can authenticate with your Azure Maps Subscription Key. Please install the `@azure/core-auth` package:
+You can authenticate with your Azure Maps Subscription Key. Please install the["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package:
 
 ```bash
 npm install @azure/core-auth
@@ -91,7 +91,7 @@ You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](h
 
 Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
 
-Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+Third, you will need to install["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package to use `AzureSASCredential`:
 
 ```bash
 npm install @azure/core-auth

--- a/sdk/maps/maps-render-rest/review/maps-render.api.md
+++ b/sdk/maps/maps-render-rest/review/maps-render.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AzureKeyCredential } from '@azure/core-auth';
+import { AzureSASCredential } from '@azure/core-auth';
 import { Client } from '@azure-rest/core-client';
 import { ClientOptions } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
@@ -149,6 +150,9 @@ function MapsRender(credential: AzureKeyCredential, options?: ClientOptions): Ma
 
 // @public
 function MapsRender(credential: TokenCredential, mapsAccountClientId: string, options?: ClientOptions): MapsRenderClient;
+
+// @public
+function MapsRender(credential: AzureSASCredential, options?: ClientOptions): MapsRenderClient;
 export default MapsRender;
 
 // @public (undocumented)

--- a/sdk/maps/maps-route-rest/CHANGELOG.md
+++ b/sdk/maps/maps-route-rest/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Support SAS token authentication.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -72,6 +72,52 @@ const credential = new AzureKeyCredential("<subscription-key>");
 const client = MapsRoute(credential);
 ```
 
+#### Using a Shared Access Signature (SAS) Token Credential
+
+Shared access signature (SAS) tokens are authentication tokens created using the JSON Web token (JWT) format and are cryptographically signed to prove authentication for an application to the Azure Maps REST API.
+
+You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](https://learn.microsoft.com/javascript/api/%40azure/arm-maps/accounts?view=azure-node-latest#@azure-arm-maps-accounts-listsas) from ["@azure/arm-maps"](https://www.npmjs.com/package/@azure/arm-maps) package. Please follow the section [Create and authenticate a `AzureMapsManagementClient`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/arm-maps#create-and-authenticate-a-azuremapsmanagementclient) to setup first.
+
+Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
+
+Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+
+```bash
+npm install @azure/core-auth
+```
+
+Finally, you can use the SAS token to authenticate the client:
+
+```javascript
+  const MapsRoute = require("@azure-rest/maps-route").default;
+  const { AzureSASCredential } = require("@azure/core-auth");
+  const { DefaultAzureCredential } = require("@azure/identity");
+  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+
+  const subscriptionId = "<subscription ID of the map account>"
+  const resourceGroupName = "<resource group name of the map account>";
+  const accountName = "<name of the map account>";
+  const mapsAccountSasParameters = {
+    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+    maxRatePerSecond: 500,
+    principalId: "<principle ID (object ID) of the managed identity>",
+    signingKey: "primaryKey",
+  };
+  const credential = new DefaultAzureCredential();
+  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+  const {accountSasToken} = await managementClient.accounts.listSas(
+    resourceGroupName,
+    accountName,
+    mapsAccountSasParameters
+  );
+  if (accountSasToken === undefined) {
+    throw new Error("No accountSasToken was found for the Maps Account.");
+  }
+  const sasCredential = new AzureSASCredential(accountSasToken);
+  const client = MapsRoute(sasCredential);
+```
+
 ## Examples
 
 The following sections provide several code snippets covering some of the most common Azure Maps Route tasks, including:

--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -80,7 +80,7 @@ You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](h
 
 Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
 
-Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+Third, you will need to install["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package to use `AzureSASCredential`:
 
 ```bash
 npm install @azure/core-auth

--- a/sdk/maps/maps-route-rest/review/maps-route.api.md
+++ b/sdk/maps/maps-route-rest/review/maps-route.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AzureKeyCredential } from '@azure/core-auth';
+import { AzureSASCredential } from '@azure/core-auth';
 import { Client } from '@azure-rest/core-client';
 import { ClientOptions } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
@@ -223,6 +224,9 @@ function MapsRoute(credential: AzureKeyCredential, options?: ClientOptions): Map
 
 // @public
 function MapsRoute(credential: TokenCredential, mapsAccountClientId: string, options?: ClientOptions): MapsRouteClient;
+
+// @public
+function MapsRoute(credential: AzureSASCredential, options?: ClientOptions): MapsRouteClient;
 export default MapsRoute;
 
 // @public (undocumented)

--- a/sdk/maps/maps-search-rest/CHANGELOG.md
+++ b/sdk/maps/maps-search-rest/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `/geocode`, `/geocode:batch`: Turn an address to coordinates. Replace the v1 `/search/address`, `/search/address/batch/sync/`.
   - `/reverseGeocode`, `/reverseGeocode:batch`: Turn coordinates to an address. Replace the v1 `/search/address/reverse`, `/search/address/batch/reverse/sync/`.
   - `/search/polygon`: Supplies polygon data of a geographical area outline such as a city or a country region. Replace the v1 `/search/polygon`.
+- Support SAS token authentication.
 
 ### Breaking Changes
 

--- a/sdk/maps/maps-search-rest/README.md
+++ b/sdk/maps/maps-search-rest/README.md
@@ -82,6 +82,52 @@ const credential = new AzureKeyCredential("<subscription-key>");
 const client = MapsSearch(credential);
 ```
 
+#### Using a Shared Access Signature (SAS) Token Credential
+
+Shared access signature (SAS) tokens are authentication tokens created using the JSON Web token (JWT) format and are cryptographically signed to prove authentication for an application to the Azure Maps REST API.
+
+You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](https://learn.microsoft.com/javascript/api/%40azure/arm-maps/accounts?view=azure-node-latest#@azure-arm-maps-accounts-listsas) from ["@azure/arm-maps"](https://www.npmjs.com/package/@azure/arm-maps) package. Please follow the section [Create and authenticate a `AzureMapsManagementClient`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/arm-maps#create-and-authenticate-a-azuremapsmanagementclient) to setup first.
+
+Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
+
+Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+
+```bash
+npm install @azure/core-auth
+```
+
+Finally, you can use the SAS token to authenticate the client:
+
+```javascript
+  const MapsSearch = require("@azure-rest/maps-search").default;
+  const { AzureSASCredential } = require("@azure/core-auth");
+  const { DefaultAzureCredential } = require("@azure/identity");
+  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+
+  const subscriptionId = "<subscription ID of the map account>"
+  const resourceGroupName = "<resource group name of the map account>";
+  const accountName = "<name of the map account>";
+  const mapsAccountSasParameters = {
+    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+    maxRatePerSecond: 500,
+    principalId: "<principle ID (object ID) of the managed identity>",
+    signingKey: "primaryKey",
+  };
+  const credential = new DefaultAzureCredential();
+  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+  const {accountSasToken} = await managementClient.accounts.listSas(
+    resourceGroupName,
+    accountName,
+    mapsAccountSasParameters
+  );
+  if (accountSasToken === undefined) {
+    throw new Error("No accountSasToken was found for the Maps Account.");
+  }
+  const sasCredential = new AzureSASCredential(accountSasToken);
+  const client = MapsSearch(sasCredential);
+```
+
 ## Key concepts
 
 ### MapsSearchClient

--- a/sdk/maps/maps-search-rest/README.md
+++ b/sdk/maps/maps-search-rest/README.md
@@ -90,7 +90,7 @@ You can get the SAS token using [`AzureMapsManagementClient.accounts.listSas`](h
 
 Second, follow [Managed identities for Azure Maps](https://techcommunity.microsoft.com/t5/azure-maps-blog/managed-identities-for-azure-maps/ba-p/3666312) to create a managed identity for your Azure Maps account. Copy the principal ID (object ID) of the managed identity.
 
-Third, you will need to install "@azure/core-auth" package to use `AzureSASCredential`:
+Third, you will need to install["@azure/core-auth"](https://www.npmjs.com/package/@azure/core-auth)package to use `AzureSASCredential`:
 
 ```bash
 npm install @azure/core-auth

--- a/sdk/maps/maps-search-rest/review/maps-search.api.md
+++ b/sdk/maps/maps-search-rest/review/maps-search.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AzureKeyCredential } from '@azure/core-auth';
+import { AzureSASCredential } from '@azure/core-auth';
 import { Client } from '@azure-rest/core-client';
 import { ClientOptions } from '@azure-rest/core-client';
 import { HttpResponse } from '@azure-rest/core-client';
@@ -335,6 +336,9 @@ function MapsSearch(credential: AzureKeyCredential, options?: ClientOptions): Ma
 
 // @public
 function MapsSearch(credential: TokenCredential, mapsAccountClientId: string, options?: ClientOptions): MapsSearchClient;
+
+// @public
+function MapsSearch(credential: AzureSASCredential, options?: ClientOptions): MapsSearchClient;
 export default MapsSearch;
 
 // @public (undocumented)

--- a/sdk/maps/maps-search-rest/src/MapsSearch.ts
+++ b/sdk/maps/maps-search-rest/src/MapsSearch.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT license.
 
 import { ClientOptions } from "@azure-rest/core-client";
-import { AzureKeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
+import {
+  AzureKeyCredential,
+  AzureSASCredential,
+  TokenCredential,
+  isSASCredential,
+  isTokenCredential,
+} from "@azure/core-auth";
 import { createMapsClientIdPolicy } from "@azure/maps-common";
 import { MapsSearchClient } from "./generated";
 import createClient from "./generated";
@@ -48,8 +54,27 @@ export default function MapsSearch(
   mapsAccountClientId: string,
   options?: ClientOptions
 ): MapsSearchClient;
+/**
+ * Creates an instance of MapsSearch from an Azure Identity `AzureSASCredential`.
+ *
+ * @example
+ * ```ts
+ * import MapsSearch from "@azure/maps-search";
+ * import { AzureSASCredential } from "@azure/core-auth";
+ *
+ * const credential = new AzureSASCredential("<SAS Token>");
+ * const client = MapsSearch(credential);
+ * ```
+ *
+ * @param credential - An AzureSASCredential instance used to authenticate requests to the service
+ * @param options - Options used to configure the Search Client
+ */
 export default function MapsSearch(
-  credential: TokenCredential | AzureKeyCredential,
+  credential: AzureSASCredential,
+  options?: ClientOptions
+): MapsSearchClient;
+export default function MapsSearch(
+  credential: TokenCredential | AzureKeyCredential | AzureSASCredential,
   clientIdOrOptions: string | ClientOptions = {},
   maybeOptions: ClientOptions = {}
 ): MapsSearchClient {
@@ -75,5 +100,18 @@ export default function MapsSearch(
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));
     return client;
   }
+
+  if (isSASCredential(credential)) {
+    const client = createClient(undefined as any, options);
+    client.pipeline.addPolicy({
+      name: "mapsSASCredentialPolicy",
+      async sendRequest(request, next) {
+        request.headers.set("Authorization", `jwt-sas ${credential.signature}`);
+        return next(request);
+      },
+    });
+    return client;
+  }
+
   return createClient(credential, options);
 }

--- a/sdk/maps/maps-search-rest/src/MapsSearch.ts
+++ b/sdk/maps/maps-search-rest/src/MapsSearch.ts
@@ -38,7 +38,7 @@ export default function MapsSearch(
  *
  * @example
  * ```ts
- * import MapsSearch from "@azure/maps-search";
+ * import MapsSearch from "@azure-rest/maps-search";
  * import { DefaultAzureCredential } from "@azure/identity";
  *
  * const credential = new DefaultAzureCredential();
@@ -59,7 +59,7 @@ export default function MapsSearch(
  *
  * @example
  * ```ts
- * import MapsSearch from "@azure/maps-search";
+ * import MapsSearch from "@azure-rest/maps-search";
  * import { AzureSASCredential } from "@azure/core-auth";
  *
  * const credential = new AzureSASCredential("<SAS Token>");


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-rest/maps-search
- @azure-rest/maps-route
- @azure-rest/maps-render
- @azure-rest/maps-geolocation

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
Add SAS token authentication.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA

### Are there test cases added in this PR? _(If not, why?)_
No. To get the SAS token, we need to use the `listSas` in arm-maps. However, it requires start & expiry time, which cannot be recoreded for playback test, and I didn't found the `listSas` test in arm-maps, so I believe we don't have a good solution to test it now.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
