### PR TITLE
fix: core-util version

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -111,7 +111,7 @@
     "@azure/core-client": "^1.4.0",
     "@azure/core-rest-pipeline": "^1.1.0",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.0.0",
+    "@azure/core-util": "^1.3.0",
     "@azure/logger": "^1.0.0",
     "@azure/msal-browser": "^3.5.0",
     "@azure/msal-node": "^2.5.1",


### PR DESCRIPTION



### Packages impacted by this PR
@azure/identity


### Issues associated with this PR
I did not create a issue but this PR to solve the issue right away.


### Describe the problem that is addressed by this PR
I tried to update azure/identety to version 4. But internally this packages uses the azure/core-util package. Here it uses the `randomUUID`. The version 4 requires the core-util in version 1.0.0 which does not include that `randomUUID` function. This leads to an error since the package manager does not update the core-util package since it was already installed in a lower version e.g. 1.1.0. 
This results in an error at runtime, sinde the function `randomUUID` is not defined.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Using the version 1.3.0 resolves the issue sinde this version includes the necesarry `randomUUID` see release notes: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-util/CHANGELOG.md#130-2023-04-06  


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
