### PR TITLE
Revert "Bump @azure/msal-node-extension in @azure/identity-cache-pers…

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1503,6 +1503,16 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
+  /@azure/msal-node-extensions@1.0.0-alpha.25:
+    resolution: {integrity: sha512-7pOUdE2OZO2omA1DBAJhVGHJo8laqw+x5JgV/XLzyogapduAzps3lbM/G3VV+VuEb0KG1QHkpaOF/6eftPssKw==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dependencies:
+      '@azure/msal-common': 7.6.0
+      keytar: 7.9.0
+      node-addon-api: 5.0.0
+    dev: false
+
   /@azure/msal-node-extensions@1.0.7:
     resolution: {integrity: sha512-RAit1BOmxB0lbCV0iQzS08g35NyoQ5/0gi3ALEqByNec5xrCTfAn5uwtA55ZQnvOwUUuxZ3714F9+AUWbA5wSA==}
     engines: {node: 18 || 20}
@@ -1834,16 +1844,6 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.54.0
-      eslint-visitor-keys: 3.4.3
-    dev: false
-
   /@eslint-community/regexpp@4.10.0:
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1868,11 +1868,6 @@ packages:
 
   /@eslint/js@8.53.0:
     resolution: {integrity: sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
-
-  /@eslint/js@8.54.0:
-    resolution: {integrity: sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -2899,7 +2894,7 @@ packages:
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.18.9
+      '@types/node': 18.18.13
     dev: false
 
   /@types/fs-extra@8.1.5:
@@ -2946,7 +2941,7 @@ packages:
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
-      '@types/node': 18.18.9
+      '@types/node': 18.18.13
     dev: false
 
   /@types/jsonwebtoken@9.0.5:
@@ -3312,7 +3307,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.6
+      '@types/semver': 7.5.5
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.2.2)
@@ -3584,6 +3579,13 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: false
 
+  /autorest@3.6.3:
+    resolution: {integrity: sha512-j/Axwk9bniifTNtBLYVxfQZGQIGPKljFaCQCBWOiybVar2j3tkHP1btiC4a/t9pAJXY6IaFgWctoPM3G/Puhyg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+
   /autorest@3.7.0:
     resolution: {integrity: sha512-E6RXXd6S8Kyc0oNY7Ar0IARSMTodIrww7FBR0FZSuQT0J8P3udvqXFexr2K290fr8qm7kAl7OUsWq08FTbIJoA==}
     engines: {node: '>=12.0.0'}
@@ -3608,8 +3610,8 @@ packages:
     engines: {node: '>=0.11'}
     dev: false
 
-  /axios@1.6.2:
-    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
+  /axios@1.6.1:
+    resolution: {integrity: sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==}
     dependencies:
       follow-redirects: 1.15.3(debug@4.3.4)
       form-data: 4.0.0
@@ -4913,53 +4915,6 @@ packages:
       '@eslint-community/regexpp': 4.10.0
       '@eslint/eslintrc': 2.1.3
       '@eslint/js': 8.53.0
-      '@humanwhocodes/config-array': 0.11.13
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.23.0
-      graphemer: 1.4.0
-      ignore: 5.2.4
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint@8.54.0:
-    resolution: {integrity: sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 2.1.3
-      '@eslint/js': 8.54.0
       '@humanwhocodes/config-array': 0.11.13
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -7276,6 +7231,10 @@ packages:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
     dev: false
 
+  /node-addon-api@5.0.0:
+    resolution: {integrity: sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==}
+    dev: false
+
   /node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -8352,12 +8311,12 @@ packages:
       rollup: 3.29.4
     dev: false
 
-  /rollup-plugin-visualizer@5.9.3(rollup@3.29.4):
-    resolution: {integrity: sha512-ieGM5UAbMVqThX67GCuFHu/GkaSXIUZwFKJsSzE+7+k9fibU/6gbUz7SL+9BBzNtv5bIFHj7kEu0TWcqEnT/sQ==}
+  /rollup-plugin-visualizer@5.9.2(rollup@3.29.4):
+    resolution: {integrity: sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
-      rollup: 2.x || 3.x || 4.x
+      rollup: 2.x || 3.x
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -9945,10 +9904,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -9991,10 +9950,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -10036,10 +9995,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -10271,8 +10230,8 @@ packages:
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       dotenv: 8.6.0
@@ -10342,9 +10301,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -10433,10 +10392,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -10916,9 +10875,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -11580,9 +11539,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -11805,9 +11764,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -14090,9 +14049,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -15410,9 +15369,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -16606,10 +16565,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 2.1.0
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       chai: 4.3.10
       cross-env: 7.0.3
@@ -17768,7 +17727,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-xDH2qAsjOVswdGEu06HPZyvNaC8Myk2d9H83uSe3IZqUSl9PIEg2xb4E4iKk2ABi4wljeMtuF+qJGpRLHZaQGw==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-ta/vZagzkMgIO5lCoIBNl0feRRrtzU9NEHpMLqBmNermq3UdmDhc2dv+PkUh9tIZsmib0JzXH3bVp/HGHKsATQ==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -17785,8 +17744,8 @@ packages:
       '@types/decompress': 4.2.7
       '@types/fs-extra': 11.0.4
       '@types/minimist': 1.2.5
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       '@types/prettier': 3.0.0
       '@types/semver': 7.5.6
       autorest: 3.7.0
@@ -17835,10 +17794,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -18241,10 +18200,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -18286,10 +18245,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -18356,12 +18315,12 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-41UuqHHdudEuNwVtppFRxztKnZZzmDoDL2tza3QZfxTQwabkIU19zzszxpv0lliEwnOvhgrR2T3oo5A8rEUS/g==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-5ZyIwNm/54vfUv/NYYSExJkGkEVt16Aef5gNFxI+9Ueam8oHdlSOSeY9n9PJ5P2FMh4skt/+DnO2Q7RAihH/fw==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
       '@azure/msal-node': 2.5.1
-      '@azure/msal-node-extensions': 1.0.7
+      '@azure/msal-node-extensions': 1.0.0-alpha.25
       '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
       '@types/jws': 3.2.8
       '@types/mocha': 10.0.4
@@ -18898,10 +18857,10 @@ packages:
     dependencies:
       '@azure/identity': 3.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -18944,10 +18903,10 @@ packages:
     dependencies:
       '@azure/identity': 3.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -18990,10 +18949,10 @@ packages:
     dependencies:
       '@azure/identity': 3.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -19036,10 +18995,10 @@ packages:
     dependencies:
       '@azure/identity': 3.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -20163,10 +20122,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10
@@ -20208,10 +20167,10 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 3.4.1
-      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.9)
-      '@types/chai': 4.3.10
-      '@types/mocha': 10.0.4
-      '@types/node': 18.18.9
+      '@microsoft/api-extractor': 7.38.3(@types/node@18.18.13)
+      '@types/chai': 4.3.11
+      '@types/mocha': 10.0.6
+      '@types/node': 18.18.13
       autorest: 3.7.1
       c8: 8.0.1
       chai: 4.3.10

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -62,7 +62,7 @@
     "@azure/core-auth": "^1.5.0",
     "@azure/identity": "^4.0.0",
     "@azure/msal-node": "^2.5.1",
-    "@azure/msal-node-extensions": "^1.0.7",
+    "@azure/msal-node-extensions": "1.0.0-alpha.25",
     "keytar": "^7.6.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
This reverts commit 9baa991c5695b4eca44a46d4630d002fd08064d0. This should have not been merged as the current version of the extensions does not support Node 16 for 3.4.x


### Packages impacted by this PR

- @azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
