### PR TITLE
[engsys] Avoid running eslint plugin unit tests on every analyze

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/common/tools/eslint-plugin-azure-sdk/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - template: /eng/pipelines/templates/steps/common.yml
 
       # Run lint step for all SDK
-      - template: /eng/pipelines/templates/steps/run-eslint.yml
+      - template: /eng/pipelines/templates/steps/test-eslint.yml

--- a/eng/pipelines/templates/steps/test-eslint.yml
+++ b/eng/pipelines/templates/steps/test-eslint.yml
@@ -10,3 +10,7 @@ steps:
       node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk
       node eng/tools/rush-runner.js lint "${{parameters.ServiceDirectory}}" -p max
     displayName: "Build ESLint Plugin and Lint Libraries"
+
+  - pwsh: |
+      node common/scripts/install-run-rush.js test -t @azure/eslint-plugin-azure-sdk --verbose
+    displayName: "Run ESLint Plugin Unit Tests"


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

I noticed that we were running the unit tests for `@azure/eslint-plugin-azure-sdk` as part of the 'run-eslint' step that gets kicked off as part of `analyze` for every SDK package. This meant we spent 1 minute 30 seconds running unit tests each and every time we ran CI for any package.

My (perhaps incomplete) understanding is that we added running the tests so that the ci.yml for `@azure/eslint-plugin-azure-sdk` could run the tests as part of CI, but I don't think we intended to have them run all the time for everyone.

This change creates a new `test-eslint` template that can be used by `ci.yml` and removes running the unit tests from the normal analyze step.