### PR TITLE
[test] fix flaky test writing temp files

### DIFF
--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -769,8 +769,7 @@ describe("ManagedIdentityCredential", function () {
     process.env.IMDS_ENDPOINT = "http://endpoint";
     process.env.IDENTITY_ENDPOINT = "http://endpoint";
 
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    const testTitle = this.test?.title || `test-Date.time()`;
+    const testTitle = "azure-arc";
     const tempDir = mkdtempSync(join(tmpdir(), testTitle));
     const tempFile = join(tempDir, testTitle);
     const key = "challenge key";
@@ -838,8 +837,7 @@ describe("ManagedIdentityCredential", function () {
     process.env.IMDS_ENDPOINT = "http://endpoint";
     process.env.IDENTITY_ENDPOINT = "http://endpoint";
 
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    const testTitle = this.test?.title || `test-Date.time()`;
+    const testTitle = "azure-arc-with-resource-id";
     const tempDir = mkdtempSync(join(tmpdir(), testTitle));
     const tempFile = join(tempDir, testTitle);
     const key = "challenge key";
@@ -910,8 +908,7 @@ describe("ManagedIdentityCredential", function () {
     process.env.IMDS_ENDPOINT = "http://endpoint";
     process.env.IDENTITY_ENDPOINT = "http://endpoint";
 
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    const testTitle = this.test?.title || `test-Date.time()`;
+    const testTitle = "azure-arc-with-client-id";
     const tempDir = mkdtempSync(join(tmpdir(), testTitle));
     const tempFile = join(tempDir, testTitle);
     const key = "challenge key";


### PR DESCRIPTION
These test create temporary folders using test case titles. It started to fail recently likely due to newer NodeJS version 21.3.0. There are some changes around `fs.writeFileSync`.

https://github.com/nodejs/node/pull/49884

Same tests were passing on 21.2.0.

This PR changes the test to use simpler names.