### PR TITLE
Temporarily pin NodeTestVersion of v21 to 21.2.0

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -20,7 +20,7 @@
     "NodeTestVersion": [
       "18.x",
       "20.x",
-      "21.x"
+      "21.2.0"
     ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"


### PR DESCRIPTION
Latest 21.3.0 contains changes that breaks `writeFileSync` of temp files on
MacOS. This PR unblocks `js - core` release pipeline while we follow up on the
NodeJS issue.