### PR TITLE
remove unused "util" dependency from `@azure/core-amqp`

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -82,8 +82,7 @@
     "process": "^0.11.10",
     "rhea": "^3.0.0",
     "rhea-promise": "^3.0.0",
-    "tslib": "^2.2.0",
-    "util": "^0.12.1"
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-amqp`

### Issues associated with this PR

none

### Describe the problem that is addressed by this PR

It apepars that the "util" npm dependency is not used anywhere in the `@azure/core-amqp` library. But it is causing problems in our environment. We use `@azure/service-bus` which uses `@azure/core-amqp` and which causes the `util` npm package to be installed in `node_modules/util`. But that dependency is a polyfill for the nodejs util module to be used in browsers. It can/should be used by bundlers like webpack when bundling for the browser.
But having this as an explicit dependency of `@azure/core-amqp` causes the install to `node_modules/util` and our nodejs code now gets this polyfill when it does a `require('util')`, whereas it should just be getting the normale nodejs module.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We tried to prevent the installation of `node_modules/util` with `overrides` in the `package.json` file, but that doesn't work. We also couldn't find a way to prevent hoisting of the util module to the top level node_modules.

### Are there test cases added in this PR? _(If not, why?)_

Nope. The "util" package doesn't appear to be used anywhere in the library.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
**I don't think so, but I am not familiar with the SDK Generator**
- [ ] Added a changelog (if necessary)
