### PR TITLE
[test][eslint-plugin] run unit tests on .ts files

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:samples": "echo Skipped.",
-    "build:test": "npm run clean && tsc -p tsconfig.json",
+    "build:test": "echo Skipped.",
     "clean": "rimraf dist/",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
@@ -49,7 +49,7 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "unit-test:node": "mocha --require source-map-support/register --timeout 10000 --full-trace --recursive dist/tests",
+    "unit-test:node": "mocha --require source-map-support/register --require ts-node/register --timeout 10000 --full-trace tests/**/*.ts",
     "unit-test:browser": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test": "npm run clean && npm run build:test && npm run unit-test"


### PR DESCRIPTION
instead of .js files. This allows running unit-tests without building them, which is consistent with other packages in the repo.
