### PR TITLE
[core-client-rest] Bump dependency `@azure/abort-controller` version back to `^2.0.0`

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.2.0 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Upgrade dependency `@azure/abort-controller` to `^2.0.0`.
+
 ## 1.1.6 (2023-11-30)
 
 ### Features Added

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.5.0",
     "@azure/core-util": "^1.0.0",
-    "@azure/abort-controller": "^1.1.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/core-tracing": "^1.0.1",
     "tslib": "^2.2.0"
   },

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/core-client",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Core library for interfacing with Azure Rest Clients",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
### Packages impacted by this PR
`@azure-rest/core-client`
