### PR TITLE
[Search] Fix result type narrowing in `SearchClient.suggest`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8922,6 +8922,14 @@ packages:
       streamx: 2.15.5
     dev: false
 
+  /tersify@3.12.1:
+    resolution: {integrity: sha512-VwzXGHZSOB4T27s4uvh9v8FYrNXyfVz0nBQi28TDwrZoQwT8ZJUp1W2Ff73ekN07stJSb0D+pr6iXeNeFqTI6Q==}
+    dependencies:
+      acorn: 8.11.2
+      is-buffer: 2.0.5
+      unpartial: 1.0.5
+    dev: false
+
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -9186,6 +9194,13 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /type-plus@7.6.0:
+    resolution: {integrity: sha512-ijsLw2QQDynAMpANnCc4jWUfeo65EGDHXeiqUaUKxq6bxuoTvcXHJGbOihGQMhHjxE4159pkWiTLP1xu/6xdhA==}
+    dependencies:
+      tersify: 3.12.1
+      unpartial: 1.0.5
+    dev: false
+
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
@@ -9328,6 +9343,11 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /unpartial@1.0.5:
+    resolution: {integrity: sha512-yAqaXcachjgZUnM2yIkf+4KJhmyuoj7stBvlnlZpB15OYVbKnLhgJfmLW7qkpzLHCdsm1bEFvhyN9hCmlZ3uuw==}
+    engines: {node: '>=6'}
     dev: false
 
   /unpipe@1.0.0:
@@ -9789,7 +9809,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-eY0ANDvF7Z5wu5uxSuIRnu/BnH+fj9pHIwFv5rVCYonP+N8tgNriyavIx9GEwxS7M4qrWOzGRs/lsd3zsmmn6w==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-OLqTtjWvicZS8EipiNw0w+OZxeyLYO9o6i4yNCU8HKcxfRtJDg9+MS8xDVTKbG7sVn05d4gmOpBMVrqAlYbpyQ==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -9828,7 +9848,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-a6lGPH/+deAbreOMHvKro3MuLWKw4qvlI/HjFU3ku3EhBS36ht9EOAGtTHW2FQx6jUFcG6fjZohsEKpg0ctWkg==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-aaVzFTQsc+kkxTC3GetTxDcDKDKfhPNkM+RPpXnc9SDsi6zu2qJfbA4hSFaQmzqXwFJqL0Me6DB8+ePWIZ25zw==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -9874,7 +9894,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-Gh6xTsSoCRrtNVsKQf2JCtsUHGyhEblge7xteVj+pvssbpoZzB1XiJWZ8jTORddEGWhVibXXR/WgeHoQR76K/g==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-3QhJ+oA42jRAVpSMHDx7cCY/RdVrrhvpgBmo5/HHkFgRiQX3ls7jX019icrvPjBz/jEIDInzTJ5vuWpykJXgDQ==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -9920,7 +9940,7 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-qqPFJY5IU8A9qk+Z99N4QyvsGWgdvdEu6I2Wtw2X4+742A6a8BNfk3C2yR3zwPh7VdVx4qF87mu9olXxuy5pww==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-sN3EzUQXnUzw/JxCZ665p1eov+BkcPi6xQP5xJs2UWcwOjEVqkgS5FM5YIhA4D0zJ1Zud7DK/meyJaDfe4Qbng==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
@@ -9965,7 +9985,7 @@ packages:
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-tr6TEKtR+hZHfvyc6OBnHY3J3l5d6bhy18id7T9krnH5SnFHLFbpKqNFTgzMBBnFRlk/imT6GkA6A1O2cXOY6A==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-v2rLF/T1ZVaeKe2X9mSEHwCsYp1dU6Lr8kPMaMYPnjpLd0l3Pv+7dzuxmRuGTfMWK+tG+tQiiKUPp1ZJzGNNmw==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
@@ -10011,7 +10031,7 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-NbwhF30mlK7vwKNF1vC/DePhTGGMExoZTnH9J64mWN6CpswjTPuhC87HPWLWK651eRKQgC3uD94V5yYRJpuGFA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-cRdyJLKq2E9Ru/00Gg40qro4VudDSN7oGJ6fziGwRA55Ho/lTH1Dq0KNBMQYuflA5mSJEUtThiNZaOZ1Qv7lOg==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
@@ -10056,7 +10076,7 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-8+6RGiSTH31z91dL1/5sWEvxvl18i/wYIdHqnvz2yhylZf2xJJ7wTyY0gVBmSscKgBEDdBvCowbJz1bbGOlUFQ==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-HWPpj+lRX4wG5UQXLEf9z7kSzInNjfr5ea7ZVkX9tP4nndinMV/VlskdRhD2m87MhhbnkJaifowufm3F4iPE5w==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -10105,7 +10125,7 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-Vjdy/W4X4TLZdJ0OQvwEuVC4Fl51K72TgrMsBjwqStOUtfElKlm9ZVandeMOtUU8H5hlLUTxLcAf4boL14rG+A==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-jKIfPABXWTMjVLVfJQZCPgOmk6ECZMvNv91ya4mh9xmRxZ9x8PF2/E2WQz4IY8FfwGo6gqhC2bgqabtMUgqlWA==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -10155,7 +10175,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-+n+UgT6z4MZfAeWvhVXl6uDK316r/AVUJlarl8p7TNRY2s6sykjHjHkuFer4XMe1ZJcLvoau7xEP9o3xgjabIw==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-16O5eijTlBOwn3EKgZZaFwriQyoy+Dy90p6ia5Fb6x6zDjSNl9U1baCML2yGA6JITsNpGh4jrmP3nJiaki2E0Q==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -10204,7 +10224,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-wmR2P7LwMR8EeKM1vFVx3phMipNnF+5VriLmluJPmqjs8SZ7jZ16zd8wM+P09vcn/bCqpwMgdyA06NtzykclCQ==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-229rm3bUc6yfaecBRyW5Ylqdp6d3+udh6XDJcEP/fLITXkjGytWUIyWb0z1S/voLdVAet90Y88gBFfouJcUYGw==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -10229,7 +10249,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-zPw1q+stwnfsC3uWN7CTW7lRJaPAUM7b86ofHDuzkAGzF21T1cmMKd1h6jK5VBQySk5dr237CtlWn6EruBCd+w==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-Dt5TDVRd40a/cZSaJOrHv9zKFDLMzdjRdHYTz0G4GPd6Bvexj24+x+w68IBW6fRWGmvccIRpfJv1vOQZNyO+qw==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -10274,7 +10294,7 @@ packages:
     dev: false
 
   file:projects/ai-personalizer.tgz:
-    resolution: {integrity: sha512-0spWl1wNEzWU96JXAQ0eY2y1fIIjXB3Tn7RG7JpV45nmid0MCU7K1/F0DoWbrW+vo5xFgt4XQZYv/G0sw+gxTQ==, tarball: file:projects/ai-personalizer.tgz}
+    resolution: {integrity: sha512-UizrYTAypADGmA92YLXUx4kbSgZamuf30LaYUY7qTy1yiLs6e1e6DSBKpCOZhtuin+UcFffiJDbnBpLVDgVBcA==, tarball: file:projects/ai-personalizer.tgz}
     name: '@rush-temp/ai-personalizer'
     version: 0.0.0
     dependencies:
@@ -10318,7 +10338,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-83OPNdLvf7s/uJ8ciVQGcAjxQXjExqyY6jCEjaYu7QHhehG+z84/ogU6zhjhbMQQcR6XdlbMCpjhNLVMUhpWtg==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-hJDH1uNzDALVLzArQbYEyDBbUryFXoqEyDA+qZKuRTCGZynwv6EIqr/uZY2tK0LfhGyZzswZ8jsnvM01fGvjeg==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -10366,7 +10386,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-gVagqnCbjJpBWtovHkMEav3BbGTcyaKJ3sMTR2iaXk0rGU81sV/D1JuCUIxMIX0WfTe0DJ43ANQQKz4OM2pabQ==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-9rg3z/jobQmchF1LtOkcxeOr+r0oiQx75poXNtdRJwGenTd9Xlv9YjeNpjJMA1c3VRxrinle9XGWi0forJHAbA==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
@@ -10411,7 +10431,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-gayIufMdbQa7N37gGSV/RrfkwA2kJ8orf7b0aAw5Y2kYBEC+uskzCKZdYyK2/NTCbouNjRwiFkreyb1/wKtNwQ==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-8stJCBm/KzbCjsdyhhU5V8jt1m0+ng88vXVs3qv37LhXw5nQ/kINdjLv7iktUgRGgoma9QolHBeU5iNOiL7fOQ==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -10454,7 +10474,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-7VjrswAqYhPLYAUBR6aQ4CuTo1NuV6l0gOnj1ADMj2c8HE37f5FV4RoMh2PpJlhZ6sXuNmzh0He1tB4VpkfItQ==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-Ge+ptrPXWFIDxMPrUt1o3Vbl6kgvFTKYZchpMzhF+Iog/c6zDdr/wAgrHYr6tALk+NsCHsPe/IcxoYvuJQaL5Q==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -10506,7 +10526,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-+ODXG36wcm+SwadtXq/VHs4kXmLzg/uTcNLF3fT6qeQUwwXlEcpo1w3pchjwZKM0ggQebOU+l3oRKQtRzbq32w==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-FFJtFuf7EL5nclFzavIfY31ntp6OxSHA1s4g3O1Rz2V4H5sRQZU3lPC6xbSGtxWawM2F25QFNekbt3b4Bf9y0w==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -10555,7 +10575,7 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-jTXTZ9QddKjTVOEIr24F2tiUfvixYuEeAxkq/QnyNroAvSxqLO6PiLtj4CGzB2dP2wSoBxXotbENKljzxs74Bg==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-oECkAlHkzO+Bm+U1zykhRhSFcZSM/oeKVu2A3eV+SDtwbe6HDanVLjQAfSV4enj6K+K6NC3aFbPgyscFUGWm1w==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -10580,7 +10600,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-k3ERTABcZobn3481hmimcF6+9FWz8+FJMotyo7NFBSa/8W29wgTEuVLp7jVbzth+QSJJGAcdu3esfwCti4Wf4Q==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-fqYXvfpbFKsXYet59+XcC6z8bhcxNXwXBK06s3t97gnCJ2fYitjtYmlJo21ybVa0u5QNky/fDIMDloZmg6IVLg==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -10605,7 +10625,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-OtrC88QoJGrJC9I4jh952/ptrhrYJb9Z3den4UmqcBJlgFSpwKa7Q7ljZem+ZGV14BxXKSbRwF11Hg+iQ4b6Dw==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-v6I57Q7qHGVMnOYXYleZrT2sQOBw1qwkR0Tfjns4zn2SZNF+P8sUsFXPVgTr2xVGSmBNE8kFBIVR3TD610MnbQ==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -10630,7 +10650,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-caqHKV/A9aCelY5zUbNmYepxDH+eb/2g5mp7LgjLMSdIZUVgPV+hmg/METzpZ4S9Moup79vpjehjKAfm81sndg==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-uPE98WZ1lbsANbSaNM8pZeINf0kHRJsEQBurLQD/2jTsyBdc6FHi9urtmrdw3zSSlF3zEhmr9d4wn1lMo9qj1g==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -10652,7 +10672,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-kgGy7E99BY0Lcs1gjFjg1g4t81sXadIX7+5nWN157j5nt83rZlMFMLoi078vWTL86O33dFtmekiwDIZ2sg82tQ==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-aUIPHJpIBNiMGThDS8aCvNTjNUwjoZbmrzEs/QKGMaKWzJ4L9hEgqNUryoTGYy1+R9EiSktarTfYbRTXsMRE4w==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -10678,7 +10698,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-w2oxyX2Hf8vfA4+GEqWR63XPOuLmLCEi8H6ZU90ygeIDMNme1NpzFavsPCDqz0xBh5UsnfZ495fWeEGoU0RmCw==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-5TFTbwQFh/B3QzO8jW2l5zbfVwR70VsYuyfcohJj7Cx5Im2vm2WLj9pMuHmim4+ZtAiII0lIcspxQocvgPUqIw==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -10703,7 +10723,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-CY+pkcUCRWO0qVpKS63VsGcFdzchT3Rkc4rKzZsxFg5w3iYIjVVDyAMGwamD6nvDh1LGdD/vQ/z+/PXbzIf5JQ==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-Wu1H7NbbtI70j5ikJGv/ELPxahIPDFCZe9h45kIw7TNvPW99afTtjkbdT+15qQrolX97JrGUBBROSvyDUbkysA==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -10729,7 +10749,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-fbQepRLxW+cZvlKkb+spCDy/rQvEYis2VCEG2UFSuDiUqxQB91L0EBqcaNxta9U4RPKadSAq21gHJ2um/SUC6Q==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-iQQADbx5dX3OQ0zPpD1V7xmyDB6OS+6N869PbUnWcke3n+p0DGxrLJdg7B6h9taQzbLbVlKHzU3c5k9jxUsXhw==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -10755,7 +10775,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-I1VjeZb+2lHZz+zxkGmupseEMQNuwBmBbbZW1jvT29X3Yc/iK9pp5eKxnrT34p7DA2sukJdyFwA6NFG+foX6yQ==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-e0Fia47IguVWf8oc9IfgjfJD1/N4pnTKi2mwoqLp1p75W7fOJa/snu13FMb0TKwCOko7R+rSp9rehMogRmx/Aw==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -10779,7 +10799,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-+4iYY6oltA/wBq6LpyNyCw8zs1szvmrNOQJ1tBZ88thR3lS9XDxpOsbind8Irym43odq7hRAJxjV7ikUSsCUmA==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-Yi+mt51sh8fmOKAR5sKV2YuuvmKkx46Rm/+C1MYcc5K8G/vgMc1ot2RxqjQxcmqCYXKrKU6QIid9dDMbQm8iFA==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -10805,7 +10825,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-ypnAR76w61ycvSU38TCosjeP0Z0D1X+sde3Y0zXEl6hXa7B488yYpcNlGRrLbRwdyzrObeYKtkeTahH6c9SrLg==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-QM0eAzM1MGgyzH1jJaR6jAivRq069YLJ1V2Q6Ky8ela1KGcBUDGmoCIvdMg5Mio387ZZyDU4MW0UElpRm7zD6Q==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -10833,7 +10853,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Exc1f3e+qRGJKVap/k5GFrNh0PU/71NPniibYJa8Op7KqZffzv3qAQhmSerAUjp0ldNbNoLPBs5wfbTs1gDnEA==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ogoH9hCA/EMjkTbUY2gNcovgNKWqqOts1O5vBkIu+yOUAJrQLS7HdiqRqY7AHCqpfDMIGpSIfSjp4qTNGNDcCQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -10859,7 +10879,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-te7JSffnS6emEkQvTyVlKdl00BOP4m9l6K26kaMtKt2nPgndLluml5K5PTmmWqd1Yo08re59vtfbxbLHQc0IeA==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-uXPMtAPzK9Bn3voGqlnvXfhkmdQEPnd2cS5dSlWs2rDKVAgt63RX7vK0t1i2zvl7n77VxZ/FTOhf0hZpA3fmDQ==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -10903,7 +10923,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-xF7S5/rzpoPkORxGbNtW6PRyhl+P3+pOgau6ZiZHpNBpc0vv0O+kzJYsEkOJEtN3TSbRA6A86dW84ue25LDvtw==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-U9J5NyO7hKtGy5gsHO3S3U/I0RlM12DuFiI1R4347i9/dv1fgkFEa6c70rGv/v6ACq0OtDVVWE+wEq9EAqkqew==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -10927,7 +10947,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-puBhMSrcm0X8sRR0gy+YcKgnkBLzIGV77lxLIhO9gh4LvcNPBnrDwT7EXZ4Fq3uUoN0S06mjpd/sjlRF8K7w6A==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-L+uwHhhrKpiwDqmIfJSIMXZwsq9qS9SoTy7dxccWOPY0OXXBweChdXi13ht6DH5N4nVAXVgD8wjU8mpkPziovw==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -10952,7 +10972,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-+bSDrUetyscsdS2aLzRmcIoGJUngkHeBLJka4qq5fw/8FEJ6OHV+vEjqbZembR7KJED+I5no+MDQNovoRneUIg==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-RnYDRHxhRymU+IMz1Bzc5izYVH4rnuPx3QyKrYgHDedBKpnWB+d5hkpFnLFNfftzLJ1Gv0minJDolgeEDiMQaw==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -10978,7 +10998,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-zHjra+GG7SgCgFskOs/3bEqJWPGBSzlmAet3kvXiRSivT1aXmzJRG908H2itjCZH4NUnqktd/5WdLrr20W8m8Q==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-+2F1Kv78ZER9v49DBIb2NRtm1USM2ajypw65DeBaZtjkTrI+572TGz2X1egjsyeiadS3OEZUBqb35+cgsBXR4A==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -11003,7 +11023,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-yV8qy6AFS9+RiJU8QI685JTxJ/+XoRwHVVkiiAbx4o1A/JjLKRtRinGIf4vAalIYADTivEOW6GoxPdCNA6os4g==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-7DQCgW2FJiXujB1EwL2CTeObfFTLlJlpNiqHVQr3F/mk0/X/Sck+hfwtpcaQbUzS6+wiRJPHj4pIH8DMIwTOGg==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -11029,7 +11049,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-oxVHjSFLGq09KDJlfgiO/V51IvSgdM+rDquyhPFE+dar34GVM0zexBmyheGDIdmjkDNamYr+joHP/DwVxNIhmw==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-/dUFyYYCHILzn0NTeu7QgZl9LxwM1dHXN+j8vOwfZ6isLQlN0b/pLv0PE7h5IgCgNpT9wYaezVrjqnUrvcX/9Q==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -11055,7 +11075,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-M4JdJKzC2ex5JOjZ1ieCX4vuL8oVSkJtfZMkJyAQBVMv2g7+uTF4283+oiVm59Nl7XsdbdKda6elZ9Kh/vnNxg==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-8BVvpPhXSLq1eOKRGvDEfWmHeoOoSP+RV74kAWPZ7qsiJjh2EHqoMJ+FoCvj+G9zlJIDGeGo7OjM5qwyWmJOhA==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -11080,7 +11100,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-Uuxxph1zJzUOhlhhOiY1M7Jk/ZxWm5Xdd/0V5IMoIWdXx9eauNXSWAsq2A0wh9jQtJK6nDGMsuQ5wzl8JkMNJQ==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-6pgruPO4BB7wTq09510NaAUKNG83O47FEYf+oatOZ1gZsKbU3cq8OZC2os1D7URwULHvweMOse8hNmdmhj/A9w==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -11104,7 +11124,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-KF1F+rJo94A1aEq90oMQAcWBLmH2lDcHeLn/NXc1tc4ptYr2J7MAtzQXC5SYEtYS2Jtqp1GkAcRs/6N1xBHmwA==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-ZziaYVjY0uSP0zh+3F3rHPAj+iZ+EjAepiEB00DE5LRbYLPxWDuVeW6fwIH59oVuqaSzsRl+NI97gV2EwbaUrg==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -11130,7 +11150,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-lDve1hS1zgT03xvKZ4mFZm/PVHEKkiaO8dwiGiMMxFllFPssvFvXMlNg1pAzMEwFjgwrgJGYaIddelGJpnEEyg==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-Fx0pFVexB7eCG8BkD6jQ5AD9p/oM3z3Eu36r0XTF2Cgy3N+XWjpPS3hHOM845s/DMX26Qw7fqaZ4BSKEHvjjZg==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -11158,7 +11178,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-DqVVwFzMUVjdNIoiPiVKlnu27j9Nm3XCkHjLJ0LBQ0cayxx5Oti32wIpvyzeEbKr81LyMToTzIPNke/1+nzNUg==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-blR13TeYoGCxL8kVF8a6rLce/23twpkkBrGZyu05heabXP965/K3fCNKCdtW3rMnvQLcOnFVUA++LdwvX7XKfg==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -11184,7 +11204,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-jr1eFK12CCrzwPnKCbfiNOu/POrTQhu+7EK+N+70ZllihV6GmaL5wPWvXCxGcOBsN3iJY9yAFfYwMrh6XpVZJw==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-gk3uQ43PpCxZzgF8b8jaKYouu0x76otqu9WDK7LO2D0T2oRK+wUocyvLlzTq83F9v8Qtexdz5lewGnOL4+cmmQ==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -11209,7 +11229,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-wlH8KtMRAyYZ/x7u2yVCSlx1nx2VX/peZsusYwh+dkreQ1JP+8nzo4eFBrLiR25P083BbLuZh//S7bqskYub8g==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-VVgauPIQ0zLgHN1QfdTX3M1IwOfvdV5ypeOlmjFd04fTI8JWcBxB8t2k06/93nKkClfYEfAV/WfFmjcrUAbwuQ==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -11234,7 +11254,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-8kYXx0ZtmByj0m8oYc2R+SG0AO/MDELf7V///biZRLV3vtW5X7xqe01TCHw2NLxpJlyJ/1HZ0xi8pWdCCgoE2A==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-K01ZXoujX87+N4bXpRDz5sAUTxc2DU4lrjQ5pU8pYVk50DA78Z9S9oleg/SsIkPuBSPnXLgN5sHBpb9mKpt5Vg==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -11260,7 +11280,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-2Z/TdVr3/byWxAJMufoRrBu4pIvH4jaNYDZofdwDc21KtFebNoNuvWhpYO/iHr9CL0HHoEJ86BwtaZKenf9FYg==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-Jy7XgMQvmnU3x0YSwFheNz1B4Nx2rCEiIqKvt/s23x9kXzlgibFweU4qIADNv26I3qQ6i4hDiymi/Lc9nA5QEQ==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -11286,7 +11306,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-nZJ0HeewCIyJ/FbnPEUrOLNtw3PMWkH7pxSvQOfls0ZusBMrqkCZkSR2cjU05kbXhROVHg7zTop0v/HDGmNu/g==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-jRfa+sr+aDplyHyzn1XZcDjLyZAkJx1FHfO83ya1hsR2ZJEORi8tJoeFZ4FuREcsZxPB8NviJw7YceNjn12LJA==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -11310,7 +11330,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-QwndDtZyr6sicbvuSKhDYHi264WCM+yHQReMi2aUqCQlI5qN+E5+DuZZYg+q82G8R6OPJxxwi5fwM8Wv+R/F6Q==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-U+53YLqBl3DmErXW9glVzD+hP6pA58tpTcHqN13AL6aru5tQawBPW/utqB/usJIKGcBkZVVkVScxSU+YBSVNow==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -11334,7 +11354,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-ehlIc9sdRaoNxK6So91Zskn5fYtI46qr8Rib2AAVpXQGWqfVDcG/lJTwZnzwS4VX+gajZEm+y8MPH9kXms+Xsg==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-2eIbg+mR0LzTsnJ/q6/rBdH6JJcNcPYXbYCt5aJ/7ZnUmNn7G4rZdLy7CVIiYgrH5wCpZ9mr4UL9hH2XzIuSwA==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -11363,7 +11383,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-mj+imqVs180x4PxJpue4A2YcAKjxf4AXbtE58Cb1HfdRBcL0Tl6NoD9inQ6PUtT0uutosdEA/HgT2nyS6Q2scw==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-rkqrvp953U81qYhguj7pXZ2k+zAYjAifWOUeglGr9hvb96YCbtmv4k/WZwl9M/QmV2qjVEUrPZimd0vaRqtOgg==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -11389,7 +11409,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Uy6tdZ+veC8iufCM73jYyvNxMZ4JKgz7+BshDQEXRkuDgtHBqAW50RtaMEJUZxl6G1H0GIFoL8tyr5dlL72xhA==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-seNIv9GwC05l51THNChasmlwGyHtDHBSQi/2nDJ1oHQdZvdEENff+mrTL5AS6AkqSPWhBvRNb5nBm/qoSaL5GQ==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11414,7 +11434,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-xSJ9iUa7E9TEm4ycKRn/Ed+JyMYuWRYMUns/gs1jxHYZ2b8MKtELJAJ2I4X1fpEjXgD64Vgw8BaDMnOHiW/J8A==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-7i8r7IU8NL7XAqtudSkQTfBgRxwEYtPDkyVWBP19DuH+m8YLU8WvsUl2WmA6cm5jMK0qK42fvgiTHoN+ecbWgw==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -11438,7 +11458,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-L+dtsJierPzzipS7DXxzq+N4uYx9/Gx8IZM5nUyCLyt4r1fJScrTlaPbzLBZiml6uVX+SCLttfv+RvegbC2+vA==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-DclJyNpGXpGzT1e/lNIcwf1FU/4k+vANyEEUMzJQxfF2cy17IOXS8qo1h2RUQRbLDm0UZIAd/6xjOG3pwpCJ3Q==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -11462,7 +11482,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-eUisuzUEGQICywxqvTXxrvbd1p7GYsd+45APBlHw+1X9xWQsF10sguvv1UX1P0ZvgPvOqs1Y/c5w8ewZyQMaqQ==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-hYzrEfMH9fnEGReMDLPog0VEz91Ha/RoUiWoqdLYIu2f8TU1lmMANP7zBIQUIbCaXZCtfwE45ZRwtn3ZtosZZw==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -11488,7 +11508,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-WMmi5GrMm+QYr1pPVOU9sfqr3fSWtbUPyqYAz0kV/Jih2fEfZjsNFBgyfyv36fBz9lGdT0/y23T9Ui5ZcAGvlQ==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-5URTevdmyUD/dKTTw1++D2MNpFOIAziwXmcTnF5QqCWpY0+dLQLSl60A9ZTTN7k38RhFM9vaXPJho86PY9T0WQ==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -11514,7 +11534,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-bX5ARk5vGBofxWd7i4VJKqA0/5T7GpkQkFNdNzwX3dcsZuO/WE3gjUr4O7Pn6yuuk2OCJ3HTveGtRv9LdI60wg==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-iqg3PaAz2MIFcKCgmXb0sE60R6Z01cdFgjv3bagqa1bznQepuKqIJ+YZtoz2RHG3xDB2NgTrds3L5yUhGjROHw==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11540,7 +11560,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-kWT7yit6Lb6/P1tekHyg+GqHwtOEx4DGLGnRf3Nsn2VywfIJ4RENLFUtA52iiX6KYO3UcWc7cmWsN50Axpx+qw==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-l0ZioJDcuCfgBQvrWRCtT6jnnygpKC4TkWT+M6BqOnOhOdTM8bxGaxmfcXLKUShb4Xd2zZo+FOj+0eimg3MJCw==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -11584,7 +11604,7 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-EF39ala1qmHZjcsDVMbFz0Y5STJHyLp6CKsbSdgpEnGNU0q7vTl5beXhCEypdmZUUlCuyM2kGwnbbcAsqDSqtw==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-wzomTL/O4Kz8fd96BElXwXjr/Uwk6JsDdWzp0qx+1YrCCv/V96o8pdSd5GJtpN6t/JKLL6DpX9FYghKrLGvKdw==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -11610,7 +11630,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-8vx+yVVJDv5kUYmFBGQViuthnkchSVPukYkSvpYniR469kNhelDNsREzjNPgTTbvws1JTM8IyowLckOCrVz1bQ==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-BNkHTTy43RrXyfVbGyoM0H45drzD7+eL19mEfXO3SJt12QPbXzt3c8ZcGEKrbV0Bgi5upRet1TottyjdZoJomA==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -11638,7 +11658,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-QKb6i4+Ga6q+OMIhOZH7EX9qRnsPMiA9CDcP6uFxQoY0CJCjUhswour+IienVJpHJYjfDtc0sGREDN3GzbhSJA==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-eomzHeOsUKHVi0sKH2vQmHxnOjNVvus3vhAaic5QEZchAd+qti5tPx+tte0Ed6DVsAMdHq1sYSBJmBR+sR09yA==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -11664,7 +11684,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-5CrpppWgiGxr4X3Z7mlwVWB0n+ZwIf4VCaFjSwDE+TtR34x98CdLXTb9PttneJHQkIOe4Eaee06SaENe7mshmw==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-/nHNUUJxZj1+kZt3crFi/w/38VmTwG/bbqQuVzEcEodwfxTi9qFEb8c9y+bV4gPsjOjc5R+yiacMkdsQ+I39jQ==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -11689,7 +11709,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-9gptIVcTv+mbNM3BhG5qZwRYTaXtfdlGWSYvbu52rdtW/4HefDUmsYb79bnJDDPyw7XThMes5K8h2AZa2e5a2w==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-TGIAprWwN+lgmBywTB7FRrM6hVqHJS56QFqqcYZ5vz53XN8aS879tN9PyghbRn+ha6mv/MQzw8qTeMUMG8uqVA==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -11715,7 +11735,7 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-xTeLwEptDFhPK49RB9u6b0PE4GtcAi8fyh0qaT8MWyKqg8CSTdvz1A4RqjTwBSc3U5UgTQEqKjGpWDebXSWDaw==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-APQ99oxZrKpvqtcupjHwsUStay81pkof5FyTzXNcJKzzrlSShH7hCU4yIbbh6Yc87DpgZsoZ4yrEkCfNR6E3SA==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -11743,7 +11763,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-Sv0EImJukikF4jOWAlL75rM9d72MaOzX9T/uV90F2EVSzDinJx3xzG4PWSNqbFPOQP6nc4LTZzv++CtStdkPiA==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-PK4WTaWAbl3JFM+bElXUTBNE3/WlcueTSdhL0jtQQyfYtOZRiawSKk6rR5NXN0EMQS7pNZ/rCVooB0Z9Q21N+g==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -11771,7 +11791,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-oKOMccbnse3TH177/IBCYL3goJb/YHrJQTK+MAe9H6MMbXKHHiJ5hYN8pOJGTDsf2hpZE7KGEmu8gs8l/9zIGA==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-lHKHJsxxOicFOzH2h32cxHnrE2BdDLNbiPH9w2hhzQ3j2z84vuX5OhtVda5b8WuydMqRWsVlkJt4xToeZGyklQ==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -11815,7 +11835,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-MyFnPMzKfNFmGKrdXar+xui/paQ4rWIV4zOZGb4rDzSOx2hwdVEcp+4EOz4eMeSVgC8JDT9uVMFL67juIjT70g==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-mriv1VgBYTEF/mKdx+JN1Lz+Cx9fEl2eal3MS0Tiql5MXTpV4Wk4okxyCPrfy5xKpcBhpN++kjOMrBwhI12D7Q==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -11843,7 +11863,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-6THEEROj1la0EmcBpl/1d64G1+pGaF03ta+FXtxBVM4UVIRfaM6LdEQmlgvd8wqA4q6oxeRlCHp7zCWGownInw==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-CHd3UEfBCFTPPXwv3FZlLPJEWAwn/qTY/9c6Me2FMGmRgoz2hj6AIhJmINNb+NC8FsirRqXbwamO0ZVUst1Zng==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -11871,7 +11891,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-2oXGnxhGSZ3OmYh1FmtTH+YZidE25SJoZrh4+wNPcN+eChkuB62kV+QZgzzltpi7gQZFVyVhV1lZvGqfmeuAiQ==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-fUThGq9gguK3UaQusZPGF2LH2G1KXq9QThW9nGGVr8X6Af9OKUZiE45J2wXczc79QR2L4dEloWjHNPsEmW+58g==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -11897,7 +11917,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-KAawMpZ7Liack1pCUyy3VqtkKL2DFqT+iBDW5d6DYo6CNQzs9zH6SKDOow7QkdKD/+ROUm0dtojTaWX7YF5LpA==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-1+ve+PypoX558Bh09oyoAetCqUICKvsnjekIeVKxOe5bEYZxTLYy024p3jWKSSGngtz1k5UgPR59iNepIVQIEQ==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -11924,7 +11944,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-mwWpPB1RKp+wK3RHPLMf5hQXj72lXqaAcnXtH14/BjradmryZS0mPYcA7Zi/UCdX95214ph0op+Q9P5sBdmgig==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-wh0IHZacypUFb+4ygO9cjODt/mVkjVftGL9gFwGPjV/rEmFWypz1yj6SukSzm7HmX7CZ+vo+f0tpsSOkNNwrLg==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -11949,7 +11969,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-h2co+rIJiLXXtsexDBuQs4kNlSKEGsxEH5e6/1+E01B/zGruXenQ0ts5pCR+rIkGcGBVjPwe+zUIaklWPNPv6g==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-ILe04RhZ0r1nMlmuoqPQElPisReIKyjYj5cXq98AmRUyfnxRiQ9PzIsx9Bojj0HgwD2ELfy2pGFFEnkwWfZ9ew==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -11977,7 +11997,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-Zqejk90YEJLCu7v+UyH9rauIiZVbpXBWO9RdY8pqLfq9LYOFTrG1oGMYIphE03jmIhQV0yyaDdatCHu4hpwIuQ==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-IHoKeHCSfMjZNHQjsqxJpAdts6NBFhdW9fsegxLlyNj4OEAmSpOIecOo8dhwwnOFW2zomvLEwnArMZIsIR5WhA==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -12003,7 +12023,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-zXIXJXyohrH0FFbDY9GM9YEu2OsV/XjsW2FsgpJg3lJwir/WWn0BydklluqH9Icf934WckhWqePfcMtiFoHWDw==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-tehlRDzRnhEHgD1s80XeVt+5Kpg3iWjgzbv7C5YFYiiD+ReYcOXB0tRfwmhk1YYAP+cqAGjbQKIKllRWD2uxZQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12029,7 +12049,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-QF6xUc59Kka4IW879apwJ0YDO4m2utDUagMst9RQm6V81Rg6WV1MDgkl3h0Epk+8ftkDY5y5ruDtaD4uCHPmww==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-N4wxQsHm1DGyNdYNwppuODmd1pTFUA5eZ3oA8fe28362yxYlqA5j+lJgpC/ZdQd2/elZLtcdTjJfHvCKr90mYw==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -12054,7 +12074,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-G+qeIBUeQ2KVWJ//LAwUuaJYdVnXu7m3usLIVRKcwY7WGfByZSwQUzfRjvautDGtiCHXMrQ3XfRfYM/agsYHZg==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-Fo9UL7zLFRBnqQ8lge7HVw8/DfhDX7J0XUUHO0Um/RrkU1KfYrYEEKCdXXMGSQbOHp+mOIbYEEIoE/kbXrleog==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -12082,7 +12102,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-oWD6uRRY7+JXqInwEydTQJ2MKrS+8sipkpgLUtHSayDljg8ZKAyv+HAdR5ePdxK8KiUC8xizwClgySXk4/J/Dg==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-0uVskZwadjGzLmR+Idedz0hC52tN5uwi3YLZ8iUGT5jr4ZsIY4QTtXYrMteqDm0wUX/3FbBmp0AIjQ2mRnUFRA==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -12107,7 +12127,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-KzQ7ykYfhOOx5bvgjLXRRTIyWEpHbowOPX3fFSAFtNlwpb4WiiPFddFGdt2gqw0NHDfNcqS+pfN5lO7DpeAGVA==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-I30FoJphE9S2msvWHDmI3uPXXOvwuPXgsVRrQi3FiWn8oMwAYwl6wJC1tEbbBU5EgcFtcZY468FOQUMDotqZtg==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -12133,7 +12153,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-rNjEydaYK2ltiFfcZ2H4Q2nls6LnlGTpDRMBYicNjHLvlCpN3assh/hKjCP5ea/8qXKTylA+h6rDwzVv/8XaAQ==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-y3qXnWzxmyjdQqdm3bpnUK0hKm7WUzzFZvHw31Ieb7wAfP/p7a7pwmaPC/0fYuJy6hjJt9AHjXGuXpnOwBAMyw==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -12161,7 +12181,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-CgWzys9+xRUJsrZGIW0Z8/dWMowOTA6V/9dOxt9r+HaSLIohP1mrfdAB0DUmAd4TgzaN7O9JePcr28+sbE1i7A==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-vo6Cbw+IHBeE5qX45N5abfWZYk4n5iAVng7CGWmQpKgwTh3Lz1WbpiC0mSIwpQUd3m3b+3xhETcRIKb/iO5HpA==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -12186,7 +12206,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-TKBopFshHx7yYh5oha98eANl+RajSUNapfRHrSzMjXe5LoEnpYenFNXHk47r0ClfFT8SHzRU8zhCpUs8ESHzqg==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-y72HSgdeaJvw2nu6g5nyCOAnELKuyp71WoG7MyXFeMAZdH/Lb8i+L9mN/dgZ19KSx150ppvB3oNFaSollT2uAg==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -12211,7 +12231,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-jHVYae6tvgB7vu9GHl+ygIJI5Zp3BOfedZpmFlXgp29HUfS4cY5AZOeyvWa1h0HOxL+MjvU/iAkazGd38OLLpA==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-/HYSXKUqoXw7ItgHKd9geFxTbUghbv3KD4BlNnrvYD8FzzFhKp0JtTW1IIMvI0zxN3IkmiR58H+QKuH+IETg6w==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -12237,7 +12257,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-qKme07Mv+szFt8nSYXiAbDT1eksF8aoHIQsXqc5znczX5zOfD2GEifoiwaDzwdkqtF0w/AOyKEuCkYxmDe5Fmg==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-KWLcL+0x1OoKwCSFDIaOZkkN1uaNJq8KjCE0xWJqnfwD/D7PQnhZeGeHe7XIK6M62aLxYWporhjgIoOLDWIi1Q==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -12263,7 +12283,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-dykBNr40d6L6M+ANYejef8arNOY5n1tEOjFw5X8/iPLzrIm3OsTa+S1ZIO99CJeVN2v1lPhF4uAbs6/dLZPZ2w==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-XTLM/t7Sd4Yc2ydjuGauYo6wTxhJYnIHiRp3Tcopv6FhQldocUFltmUcgqI0YA1ukTCQr2vV17VFLUxvB7NRqQ==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -12288,7 +12308,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-RK6sFSTJ9c35vxEVx+caxiD+hyfUBFuiaY3Q2/ePXwrbPkmNIncKjQrynmQgg7VTi/aUaXddAj0V6Q9VlOIy7Q==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-PCPedV/PuxGgESNuEKTPdRHDon5WHZknD/yPvCGIuDFraL8VXe+vgjABNurZzfpYjqPbDLYoS1ollsEk3jug4g==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -12313,7 +12333,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-1PYDooPA8CJOHRa68IMHheoSEwr9x7aPQtnpngbmnPf2LSBAakZCPonbQmNf30RDeBYvlZQNQhT3UxwEzYEqTQ==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-mcwHHO9qj41Y/XjIyO6GcwtBlrTFSlIXwIf+Icc6Ebj+WEI4Fi+oDc2j91NmyPyin69+KLrKbK7uCg9Jzv5O0A==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -12339,7 +12359,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-3GB+uvRGunqx8FrY6Bd1wIfOashycfMXmE9lEkecAR07dRLZ/+WTl/Y78UiHMZ8E0xIem84hlgRxL81Dg4G9SQ==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-bSSjS/SsVJ9fAob6y4cSpYR0VjOeb7L3RuHjuTd0fFlnhIbpFLH+Y2vttfuuHWRnzxA0yM4JnumH8JoW5lYM0w==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -12364,7 +12384,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-xfgI1km6QQUNhb02EAvt16hp0hWGRP8PctjDxb1aYj7qJpBagqTAZnfQhOnarsXzzSveE81aD5ihS47Ub+JMBQ==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-pwChOW5Y6XSGQ6trZHPoB67nu2atMjoJcGn75lF9DalEGSedbp3g7M1Dp87oedTkePatVAw9rI857oqiAIrxhA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -12390,7 +12410,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-aeylCXzTpWJuSr6Ah1sJd5f6NVbU4bRkngP2S4H9OUzBdeROiDJB2zan6X6o0w5AZeP2txkiFGhiUZh1j5FPBw==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-QfgtbUUfqWAENkSLylG0HTKRdZQZGLqp6lZ267iYnpuSJ0GIEOpj6RCQwbrvPSY529O8TvFbfKE4i8crN9HhHg==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -12416,7 +12436,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-+9Ab6n8I1/CUkVLadxvLymofDxAsLyhigDV6FaVtWGRliYQtJrZ/Y0fmmBxpsHBza8V+pEhOb7dI2hFs3TwwNA==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-VpFn/To6BX7vwJHNMigSAPibphlcJG2b9lleoAcxsgtdSX2b9gO91/NPrI3/8FfAG1w64hdmYzBE+846u+/7gQ==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -12441,7 +12461,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-yOkn+WsJLx/ABElPq02E16NjuHkWItohaU/iYaSy2DEUFaXGVo9DC0LuvSW9JdZLE79dh1KC+CGGn1DvRQp7IA==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-EMU9LO/B3Ru+P2Jlm8dt+UyjVd3doQU6fkY5iPNdzmVu78FRJM3khqBFHQ7Um0xy2Xe+PCZoa0JV5rGATwkuhA==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -12466,7 +12486,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-DgGkBRsW7f+wZg2lMkSmdwzF5X4VGmi+C7OCP5V0u9sOtPrYrrziQxkLgYTFgU8lsNKC08O7FKUyJOnN3mQUvw==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-QSRH56FFOeNO5lWMWInGUXzYDjKsmL/sGBc3Sz+0lLI6lK4TbOu/WKVfIqf79/jWs4hQOh2+n8QXf7PiKvfihw==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -12492,7 +12512,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-JXbckHMq8X7YqlPfwW1fwA5Bpa5CfQzV0aaLTe6W3blWmo8ogUnuAotBnD2qcLynp74HpHeDt8lr73IY98aUww==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-XEhbzSLz+AcsLGEs5h46M1Uw6h87sHZt7RDrZDovMf5NRFvHtz9GbbmmhVt/ZAXDmUfVVUcPKwEHhbH68qHjQw==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12518,7 +12538,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-429rkHbX+rfJzQkQNXnnoDyEg5INtm9CUtPTV5Ytkxwf5uDq+Zp27aX9eZ5IHwGET5a5rxs5kNnPO5gFcjT0pw==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-11WTPWST0FOvgaKYBI9MNiz28AeJ6qhVrZvqZOfHhq25niTVTPfRGRusR1zd/nF3oQIHVS684bz9fWzPrOhJtw==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -12543,7 +12563,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-GlO4Lmt31PjGVWPv7KGWUrqPgcvxin0FbE0sCHtgAGsNJkxtDGC9uFhRfq3vBsw1Qvs4eCzElCBVPjPqvg3HHw==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-WvHM6sRvW+a+qBjIP647zYNXIcwqYOWTfI/zHFrcmJ+OH4lcOBYqCR4/TRCQri83DUryZs96YzHVvjFNt44vNg==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -12569,7 +12589,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-chqF+6W2493doFEaIVFTyh1Ajt30S24T1bPya3QRWPpILcmOx/Fc8v0qaP1HgrXTjCLzGHayVtCZ6a3PqFRjKg==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-kCZf08Xrki1rN0qRBkzsIYviizAlfVbo66Sr1ZpGJectVIre0N3tVjaYZgFknzd//Cpe6Sg2LPyfHqhFKynJlQ==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -12594,7 +12614,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-Avhy531NICpCZCBfHcg+hPEFq0iH0c8j8czP4UkHDX6icM7Ed61sV2otKih23hdUZAsB+RjedYRlh/cuODlq/w==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-vJwhtFgZ9ZStOLilQcvHSs2Ud3WjUHBNsCNjS6jlaCz0PBOdVNHxkplYfm6IRuIxrESKrLB4gSxMqD6a0oNGWA==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -12620,7 +12640,7 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-BKSAHaTn5C9R3+w1DQdlN+VfK9NyI4SrdWNPEjjtSaMU8TGnYPfHX7NLh7WKROWlAasK6afHrr0ber+yqDqFUw==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-uOp+Hnq0oSw1S8DXlu/Uq7a+SB29xFfNmw9Up6iU9TXj2EDpk+CqAmEZ+LEwR+q43+k9V5TaBYfwHDhdYOU8/w==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -12645,7 +12665,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-GCy5riN+s1XXR+KweSNbbxjKnyj2rptYRUWw6SbESPGYW3o/alsKW9SOu6mQrLMa+k9QaHq/DNMDXNqbnV1Stw==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-hjrGUFyoe6zqyKzcV5wiWfutSrfJCgAPFyfnWEB3SgDTXChUxJ1CHVrFz1dknkteb3QyPo95AajWjljcARFsHA==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -12671,7 +12691,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-paB2UTa/ym/LyKRvgueRVSEwKly+RiTM68GLSsEmrlPUFlfTA3OpTjdm7V6HYjYZ9EXB9aHJRAmKAcIAyki58w==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-MAcRdEAkDyOCRMp7lzWsb17S9wxJL/h1E+MHN49+3ZgP8bFbmIM9B5S4IuhUyAaAWcXoN9Q5+tycoUF37tN+oQ==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -12697,7 +12717,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-tjBtJu2eMS159Yn+z4AVN7sHfci8B1emHbgp2ByP5ZihuPaxByq5swFyeak3kM/i30JiIGD7vsnEqwuAYMCPCQ==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-fWRrB1Tc70xFmURB4HO/oOMkeNvfqf3RtuS0ill56w6dNXW4RpplZKJ720TyMxCw5WpH+AceJEkKGp5yolKy1Q==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -12725,7 +12745,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-MqEEobfDU00H3kPa26dXWSx6R1C9zltFLoGolV5/1IGUaxmEvXrcTdZteFrn8ik1K1ldRCpgYbbnOBtPtaLG2g==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-u5w0QSttzZqd/KROKfv1ZR1o7rEzHCUgKJk10mYiZjJM1CttxyiPJc2V51wH+CeZxVsDeSsQ52h6+JsVkAlZDA==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12751,7 +12771,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-zjBEAszvhXFQjyldFLyTclNPYcUyg5XYRzP/VxS26Nt/rikF+6zrB6/H4gRV1f4UEkhEmPOsmSZxyfEuzu2tvg==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-bsuT6G4XNabaxdggAHerWLlKMzk85NCe56SRiUBDAbr/Kk5wq4X2xacb8ZQBbDjRco8hbr9xW2AIwmNf4+W7Ew==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -12777,7 +12797,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-f9sp+QPsoIuWptx4icS891Fnz4bvYsp75lrGTquLOCkXatFjF+VaotCvvSoyqhXo6RgNEajUvB4cVMlLpkCzHA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-gD0/vITTqG3qKqpWEHlAtrHMlEwqdAdPLCM+H7VyNkFwZTzBJYc3xIbipOfBQGK1lrz2IizBCSxkNwPEZbhx9g==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -12803,7 +12823,7 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-PsAPp/y5g4Du/xSOk7VFhonOTZ1NxI1Do/PgV+hdc9rC0GuQarRj4VOpjBiDiHS80UwOgrMFFDA7FtfQJn025Q==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-73VI4IzvKvfyxA73Z92X5QZfVjbR7AB7d/4hHd2HnfimfCbRZYE0ymm+YzERPQ+gvCSqcrnpCXqha9JMgfUT1Q==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -12827,7 +12847,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-FHuTbZtwQeJu7YeXu0EVDxWOJiAy3mMUVFn7Ony9gCVTfD5N7CaT8kZop9ywpyKTbUBOc9IRRrVHbXpyxEj8DQ==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-uxfhs4GkEvK0iuR1LlEFcPpmsRx8B4V2ibBfD7GbLxw9P0gC2OG5yWuuEEpTd3qH7XUkNUrMWo44xo6Yfla4nA==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -12852,7 +12872,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-V/oPpgMfNRtXueIt8eNUEiCmWeyPQ4s+AOnXj7n4cnMtYIaKDLy8tGtsE/EePcEJ/mZjFtto/0GuE2ZgSaVTbA==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-PB7j+888ewazZTNZ5f6pU1K8elT7FbEhKDaofu1Xh6Qkl5DW9GNH+T0YCB9bn6EiN4sMdncqJKVALHT9tChojA==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -12878,7 +12898,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-qBtAEmy9EakW2AGtrHykEzw35vJCY+ACs3mmGbMHFYUSlgBfMansy7Jlf3wYZSWlQHqe1jMw/xPbIsRguLTPDA==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-kKBVu5jbV3NlUd/vqNVoHsScWpK4VyzK83Ptxjv9b6DJsZdLHEOYjkTZPvPIMS1pMKmJhdDExSHVzMxFq2Gj4Q==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -12904,7 +12924,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-nfITb+CqO/xUX8VYCiLUjUkChdj2oK/G+jGw5HRxmW8lqwlmTYURxLhqn8DOs9VY9gMbfDDLi2dNp/YKafFQsQ==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-CRfnVnNun+4GSUVKHnx/IHg6fzg21UqE7fNHZf5eGw5ss9ahoHVYQYI1eoCo7oz5tvZGVokxIuqB72c+DCMH0Q==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -12929,7 +12949,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-xu9vC+S2z1PzRtQrBdKupiJjcAMGdkwuPdD5FtwIZWXfT6ogUY+nKfIKFRjUHSvOjanV3svC+R/ER0BRGwRw2g==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-J5IfwnDgnUYdpVdzb9TUjFLpXWJxbZirFJIIO1ZsRZBeio0O5A+wqAxc6AHKpMLp9rc8qb6oXPDbsnm7nxA7TA==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -12954,7 +12974,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-ax7rrLI7ov9YaLmkbBotf93PU+9xjZW/InILwoAORZO5jS+Ot6XDTnxsw6iQ4mHnB7dCU8EleB+SnH+uuRKyLQ==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-B/RNfE7cZsdz1T/QU24liEuhA+uB3KvqDKbESpQ7B6bSemjXMmLW5b64QEkiuHJ54tExLuJYbfX9ojQOIZY6+Q==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -12980,7 +13000,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-GWybZlIfCgnGKft6nUbXC1d+xApSumecb5ukjJsyFrqYAdtSO11WqMEieM4y+lteBt1P13qGfnFKrZ+r3ispqw==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-MvDTv8XJ6hr4iOdamJ5oaZpR9NwQXhFd9lb6GNKjZ2L7PObGqH3aEHI6rqeTsEzgLhrk9u5LX+yrygdwmNTgyQ==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -13006,7 +13026,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-sL+XD7H8YwEF/kpe8H2EsXEhZOBmjQ+oQgivScbgaREdqZnAfPMI8f+fa/CV9LZwC2guTfv5Di6INILCxX6ZNQ==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-r5kSUSZPFIbFLKGetjkD+/GLpFqJnaDcw/VTiYzFqX/ymjZ4A/xqy1bEJ9oECnVI1k1W+bh4PTqZ7zsmxpw0iA==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -13031,7 +13051,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-C+NGHnRvp/xXIj7dBBBowSOjJoVYnPrQKys14jdjSnJjscJxEVqw7jKRy+1clD/LwAmIGYxUjIEFHCs3X2dPPw==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-BKRjUU58qQij+LSvc/DfUqAN5ZNbmC9yKS6ACnmEyEmp0a3qj+E1z0L6ilukRB/bwNSQyt2ioAOgVEy7T18mWg==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -13056,7 +13076,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-lALSSHwR4imCPXEkggEB9GBvYf8DqI2oVkQHRdBGNGbGDqRp54jysF1kY2lE3bwBHbrohmfUUGkWARDWSpGhfA==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-wyGvqOwqBrBFQo4GrdN7iTthZGdQkmvQeuayXpVC/NofQh705ME7CvyohessswNQRJLZ5mBskxE0OBzYJ22q/g==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -13084,7 +13104,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-12uBkaEoYjECAUT8dCcrUYqg3tvuOrQ3hKbdlbA5hvw+cckEFku0JPwTGl5FXgLONPPRYPuKD1juuzHpDYTQOQ==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-Q5EwtIhDiFExrALr0Qx3GW1vZO2T0CqjqGR1GnpPI4G3WbCElKrb2pmmYTPaJaTb1vlilAGVv0tbEPt1BzRJ6A==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -13109,7 +13129,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-q4cD7MZkB2AAEA9fzDGce3QjKlv0BTKRLW79GgbKgMB8SGmQrqTL/TkEYW1Uc6oSuflSI0rMGV/V4hmU9A6D6Q==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-11XWxVEhOceREirCiodxXo2SOCluJiBHF79nn3GvJQf1gO8so3SSBZgBa1gmLbUU3zqMumhDy8wpdrbkTsLMDA==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -13137,7 +13157,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-ibQgjEsQRDB4ZeyeYO974Z9Q3Q/wWqCSJHVD2LQ9Mgtfe4Vh7zBEuUPYNYc6S7RMROxPEfbIVmuzV8AEga++pQ==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-10+Muv3HpA7K839zrtaXO6WQnvEGhPT0k9mUIGPr0/KvaDUiidq3k0m64Ph8T5bAMIHdfhHRPFyvvxfITNqKkg==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -13162,7 +13182,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-4TI0AexFtLdcqlLYvvSljX1crU0VF8/C3pcApZrWwyUhRgQJ1lgN/DK+QivYxrEceIKSO5uYajWGp6Z1LOIV8A==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-3R2W+3kcy+uVoqNoKhclt+WsIEk6hUESAEGmnqYEdhT8vCxPy6O4W65v1oWB82c+gbxqyaGh3kYRw9Bdw3y9cA==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -13188,7 +13208,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-RvxSMWlilR3V082009oboUQ/TI1Ckwa6waqh3QWoK6RQqZhs3CBcncd4mUXGfld3wDE0LsMshje+1kTCEevVMw==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-zDkG1dKWaMZcCs9XwC9Ki8Cw44XPseQlzuQEvz42fcYhgXpw7po2tiM62PS8nRu3G/cSNgbF4HDCjhbsDXmxEg==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -13213,7 +13233,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-UlcktMtjSOho+wqkh5IP5hv/hQNgRSyTV9h6ScftyWmHwrO4HmySIzMd05engzLVVkSgZwhuLNZClbBrZLVMjA==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-zA7L08cWQgYZUXlgpTZFEmKBONpbsys6NjwzJRdx35JWuhbog9HSriKOtPlWvy9Q8wFltv59rVbsdk9FfETJbA==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -13238,7 +13258,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Z7MXpWaQx/BK1x/23QvIRkSkD2sKArgmSUSu0jbIqNbdnq5Qf5Oh6I/sRlgYVZf/gnSS9AA6nkV0eeDH5LJQbA==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-HM620QXQaf76X97DFDKWH2cRWKcnsy8qgHDD0o0BGhoAmrKDo1VtB7mJjdY4L6geUw4ndkPqCG5N4EZx2lSN4w==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13264,7 +13284,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-RUw/JJPWVXjH+b2zErfVrNA5ZUFVOlMcZrpShxI1txAMT6stNgAN8L08eec1da1CRqoZo55Pnosg/SmD5kT0xw==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-5b/JNkJQ+XSh0pmsJNKOKGskx6T/HKW8uoil+03LmvB94SNa2DpTAvWV7llBxz3PGZ4e+GgdXC3SsNanTKRETA==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -13290,7 +13310,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Sak8m6gM8L777SCcQabmUu843qmsHqGRwyDOhZmzr1Y8WMP78oNj1zAqkD0E776gbK9Ec6jCmm1MgrZRLVGY5g==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-hQ0FONgYYCN2UadgU6z0GaA0+cYXPGa2JSN3ZWhcOnRzvNUDtFUggInDPyHv38DMQk8RG2T0XpDHF6D0Xzrgmw==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13316,7 +13336,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-U7RFd4n//k+/e8c7v4domUshasWYYn1dPmW/qzBZuxq7b3Fkgt4dTB8LSm8CcLHRynT8Nbl/K9GMJfyR6ChFbw==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-7WJm+hvSRiXjzarsZEG5b4xU3kfX7eIB0cfMIhG8mw/ei8ItTp/btJlpMjhSlGrH8IdM7JBDNrpgsj6+Y5jvnA==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -13344,7 +13364,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-TuUgsD4n7EYDL665QNXvsrFKpHVVRPwlRdIax3j1V26sdyGNV2yEK1hsbLUW42E85fhhGOcyg4ecHh8uB8zbog==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-TzAhlESGzWZaxlokZB9tmVuqmt6yeBf9QavwYv4p6AKmh7vESdZfu4DwUop0X5mwn1qICQZsARwqCPJXTfDP1g==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -13370,7 +13390,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-O5CzwP5H28inSpwYVwnadaH6s2gS6Xt0zJjYblXibSUVrU762+RzQdesp0p+Ru20L/iGEMszPP5zVy7k+gVY6A==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-64H4h2KkWZhnS/uihbbmJ0iBamX97s3iOqaph44HIl2UUsp/BwUtFYXj3zlOGr0QEuZbLTV3+vgMWb0l1Gm9iA==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -13396,7 +13416,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-trswSL/O01h1sb3uA959eYl54RMmtxIkSBXFwD8JfoQ30RqDLaiwr6B7o1Qpawi305kjepSB15JlThAWoUiypQ==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-U8+A6XpSAdLtxK1jOxW7hxN2i0kKVDJHvNfYihMPGqCV3e5D8ldShclKcIeDWsE8U7MdiHgxLyD49NyyNtJtvQ==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -13422,7 +13442,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-VHitX3x9QP9/AVA1T1eWRiTrCN6h5qIhk1kVkLxje+WdNwPxB2AwFe4tTxxU5rkQZgu53pUNCsSLSyeTwrXQ+g==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-QnQUc0vJ/Saqt/0YmlnG1jxOfGFn4+leDjpLVE0Gnh9MKnLESwDO29wVpI4O+85u6rOgVX26vjgl/uJYaY9VYw==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -13446,7 +13466,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-908gq9pt1bphLNck3dHGEl6uW6fAkFxfb3eyCY+tI9oM7Eo9GKHYtKH/6A8X4V/rtmyCFvFF2WE1cYbwDcP/Og==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-OckOAAnIzMtM2N6y2CfThZkUaEw0jla8me+NfoBaA9At4UTwBVYVfnhobJrLHmu1xqYdiuB88uUN3N1rjU3FmA==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -13472,7 +13492,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-mLrlOfuuEAzRNkR9MES+IXiyNGGFKXcToKdGKWtgmC7pN6BVcP7FbI5XNbV0tgItkJcFEFIp2+RYGeaCgHqlZg==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ftuIIzqGxXV/RaCGPTWVULjVnq3ysER0ykkGIaf/j5eO8Oki4geQRF3XNjoTNRRzSTEpp9/JYHfG4qHNyy6Pdw==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13497,7 +13517,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-zKFE6jHeoqv5ffuURiwDgUVt9gRoOkiXl8ItIU0CfJnjDGX40DiXjX4ISpDyj2JYBHsOktNB4eueFIGjJNHW3Q==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-94xTc2vXU8VXC0dNd7kFQuGTQGuKxmkC8/v834Ls2TVSOM8IlFPzYwzDBOksNSXMo5+GHOUuNZlV7MXAZwvSNg==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -13521,7 +13541,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-6nILt+dLgYUTl/4q0TP/Yd5d3djxC3d1w5Pz8gHP/14rdI/rFSNuLPeSKTJTFZKeD25rG/8j+J0WRy1/uGtD9g==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-O858c3Ei5BCHRuYE6jG/TrDo6cFH5idMHi5OrUSwZ0Ft7lr9g64oHvkxBDkaOQlUTsR3kxbvfAeppYcAn1kTdA==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -13547,7 +13567,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-RkQZRD5cjGc/sFkm6qxHvdLte5pzFdjaAZ0lj7hp99Er4E+NtpuTW0jIhqbSTos0DUb8sAKJD/+hqk83VtjQPw==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-Zyj3R5XhvNOEb7j8nYkituAAm46UPh4V7WiY/QJgPOHVYLu3JsEkzFwUwoOQK9TZql5JFo6moGQK/iPOIqR7eA==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -13572,7 +13592,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-t0puScZZAua3OYcwwEVekDVsr3H5bNDrfl+xH/DCGqtjZNTzyxmcds8UpBtvnpyweU/8H16JR1peXUHgJQhUPw==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-RbZxMK7BOgvXPqrloFd86JGAN0KPrRmDMsWwc/JztQIoVDtl/OmffpLp7AoROmXyYcbrwOf0pok+S5X0w99LEg==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -13597,7 +13617,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-r8VPX7auQEAs76z3qNS8Lv3m9YOiLaHG8jaT9vxjYO55Ftc57WB+h5eWwFdwuTRT1je1CVD9RDlKRUqcaLPyrA==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-cE9VKfUZR/2BqIHtctgFXFn9KRBqDlc87bSTS4CDMFnIBHHSopTvgChXe5nTHTpjV2L8LrXr88VumRDwKn63kg==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -13622,7 +13642,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-BMKjRGXBdxxqUthI1ZYeQ96HMnzDepcFJfBcD04bkOE9J1259FDxeHICEy3GJwtQJzV3rXiOU2YpsNbt1LdV4w==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-hst0PH56kaRQk6ysC9l6iDPAC/UHa4rtxbeO5Z3Vh3txnJ7NUxXk2w+nvL5+Cnz6u73RDeb1r64hX8qEOvXlHA==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -13644,7 +13664,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-SJH8moGt+NmYKLq+4ty28cEo91E5pgECXySDb13vLVAZBbVbZ7VR7KA+A+6H8foN70Aqog84NEXATBczuhJusA==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-NzY9zcpeRv5ySa5c+5BQ4q4u32wyhgknMpN1TBxsnzVo5HKBNv5w52yWoxzOIi899PrPBq5KVB+6OtGqY6cWDQ==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -13670,7 +13690,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-4iPzPFOLT/yyP5FjyYE3cy0u4IyiH5CpCKGkr70C8m+OD3qEorwqx8GQPIQaKIGw8ldGBkKSL6X9vU4J2/mzlg==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-k9LNvTE+EQboAZOMprtuI8gMLY35NTJVWQbdf7M6JX4sFOgqZuNU6CmF7vmEyDE87bqO1HgraXagc2gSC0gO1w==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -13696,7 +13716,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-wTAuekhnZmZuuyDXxmluLMEHXZDzD0YznXCHujWv/TVJhSCtJJQqnCFCIilJX1Hry9a/+QmOGDfoh2xjjiDD3A==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-H0H5+w7SolpETTq5k0VtPYv/KOAzCqFcfrL1g0pujuWXrVQ0rRyBCnZGaVEUcnNYZYZSYMBa4Pn3LOO/2Y46+g==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -13721,7 +13741,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-qdNxjRUMn3a5WvKdbvt0CzJdNEAGKppTABtgxBqlq4g2DtG4qkQ0fTppXzmG1B6qguR3BFCLEROYOYKMqzv3Mw==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-T+6eJDOzXs1AyrpGjOiOtmJFCZZxRZX3xZ9/qTB2sJwps3j7jy1bRwT8vlizJsFY99TZxo4bHgCR6V6ktcE0yQ==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -13746,7 +13766,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-+XlygP6gkmeLbaQS244rzfvlF0LywTr3v6VNFnLtX2laP+1aKPl7ZJBDd3ugaCgZfrdpz5vZ02NXrCrbO6Pkhg==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-N3BPWnbKLHANDINbO6zeggn2qRXWWf+JLSwdxfOzWtWGs1Rx9qtsmpU1oRXBNDR5gxeYJ+CcvRWvdLmY0s/Y1g==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -13771,7 +13791,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-vSzDq+ekNF2fvVYJySWUTVYmEO0rYCC/hRmQB7jKRrr1L7sXwzmmAUzIEHhYCBrNRtzjoyz9dPUbgoo8NvOmug==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-XIF8YQDUumDdqTI1epjbypGUOIatHhkz00KplkVpPdZc5xfQRn5p/zDfABk9WInqbWohEyRYhBm0Kjlj3atuqg==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -13796,7 +13816,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-J7bE8QMMRJoi/6ZMZsCs8+gihw2znTl6E8fBuKTqZBujfnamGR23uaKjtSzMWuFNl5qEz56yCzli4qBiebxi3Q==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-7t2NIvtSmM2EF47DbnlDblA54G+V92gEHgJ2kdqw35G99e4T/MuPf8ob68NbOozE1gM1nJhOZdJF2Jj72yBxCA==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -13821,7 +13841,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-JCe9wk68ULfSUscfpF1UX4NiTdHcb+rJmaE4qGYoPIO9Al43e2Ze5+7Cv4u2CBmpgXQl+X45GZ1OvfQlj5f3qQ==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-BgnrQdDFWUSFDz3Tg1TuCufWx7cWzdxPy5jiE4Vahh6q1Sau+ZXkImuQfgCPBewbwuD5YRzmog90aij2pixO8g==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -13847,7 +13867,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-YB8tlqxYPdlmzLHTmsSkyjYtIxgOp6yxYzn3H5pQ+IQWu98rJW+q/ROxHaEgOVJseD/J5NwZ5KGkkyQyzdiSqw==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-ZZrIq4csKPZh4DrK5L7EzaQcTo36InofLfb6Z9idF44Hda6DqFEeM6I8+GwqUBAd3GsTbFAPORo9AJa1o38X9Q==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -13872,7 +13892,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-qhDitBOZQJ8wZu790uxIHJFlc6lkigeYZeRIyE0ZSPLoPhbdS5HFFI5l9ZXOTwMpDvtbS9g+mcjsVZS0gslM5A==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-TFBvqMviLuVaFiL+41PT970i6IacVvwKbsdGdBAzcp7LCoBPfk3bsf9tkNIlohiMQhEpYlbX2rDHOfwXfp6Ogw==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -13896,7 +13916,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-o5njt659N6LnhWKMcBW94pUuASthX6ugfVujtXIwfBqi05c5JUORiVaslXFC3Md7hKlbZdEPhkDSZiLQ/3bEHg==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-PHpzsUSyfWwqlY0TdByDCPCP/iQa+TXFBE8/YZA8EZ7yGBFMYAqQyWJ9L0Zfyo8udc2XbVnMe8slvF9ymztMmQ==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -13924,7 +13944,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-vkKc4uSPMNDYw6D8MphLk2bxb2j/8+CsxG0+o2NbCo6bMGwJMrCQTeak0mXjqGcI3lP88CFDYXWj/E6aM82PDQ==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-aJXU3FuqXK0gZbzRK156P1uNQiMR9kfc3Ikcmw36VPd/af532E96mPNGyypOt3k6kkmZ6vwrDkW7VDJiMRHYLw==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13949,7 +13969,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-I7QRyHkxkvKesZFJv95GWdzkfC4gg3o9Zf0LqJozkhHwfOwqCN6NpIDBkGvnkNsE/Aii45sYahHHmx2S5Dy7Jg==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-v0zJ0dtlJc1rm6YzH+O+cpCGAmGviH8i9oMX83LMnxTMA+Q/fzmcVU+xlFTmqX07B5FIJ4+WWp7vytDPrwAe2Q==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -13975,7 +13995,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-D8r+6WD6eo5W2BJElt4lpYgGZIaxl9uXyNGm+lQSNGzxoMuFSe64u6R1CgJTRtdHResaHx7lk46AYnWTIVX6mg==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-F6iSrG1k6662/uCjJpJyPqVqCec5zbC67rKcb/jtdZqPeCEMi9s+VN82ZQNKY7Q2uuGiwhlF5900+rX8HvvL/Q==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -14000,7 +14020,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-GarbkSf+Fgjr2djQmrmh8/Bx/POxLBFcFH75rhdZIQGj58UBmX4ZAIIzlFu2WFfHX3jkeEkIczfvW2hJ6hajvA==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-buMqNIpmdDN+xqwZ6+4h53cSp5JKJfh7xGk6BN4KQh/S3sxoS3r0PntW2WFe5d8Nao57V2pvKBUBf0glqeOpzg==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -14026,7 +14046,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-I7Epx9dLt3HonBwSByjs3ZcgLKQx6WbazNeY2B0URJ7pZ47AxLjGTMZA1HN+fWUDDyWZC2JtgvUzNr39q3hbSQ==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-BYh/m9H21jhhvhw5MkbTQJiJOnIB+tHjn8sDiWiDv7xp4ApuZIfz6JQRf1z1Dlql1a3I948LN908IvpDNAICRQ==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -14051,7 +14071,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-JuY85pR7uNmqpQRYf6M0GWE91ff4gCo9ogQOq7p4L3clH9H4xIMfM8RJR7+pUCmalg6V5wBSklwJPFWEka0iDw==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-2GYU+6sudKy3nfxEWxPj/SBRp0salcxdon8IeunY30fQBM/kcS0rZs/5xmzo5rDg71yxc8kP5dEDTMHBJRVb+Q==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -14077,7 +14097,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-0JOoNH3kIr1+/ypCJ7dSLYHBKCcRUf9jscjtFyPzXXF/ZluhXGQl4DRifegtyVjlgKhe4eUYM5zcl7Oopv71uQ==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-EOkTKTuakf2YQ3NwxPkQskyW7VeYgnmwq+gRfnHBWRSFaUc7569ZKEutSsnVzxnnoppnwGDPLEsw9A2B2KtNhw==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -14103,7 +14123,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-dH1S7kO282L5a7nQbsdLL5vi/+cNwPogSg4qDEgcWcgXDonQEpQvlAzPhayJITVDrFzjhOGKy7DVg3bx7x4SXQ==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-MNN3OIbtYpCQj24XQH7l/2fuvWMdT9mlEMJcxZHkzrUxxzla8YKjFp1kvIMEz/m7Wj3wABVhEn4R85mW6cI8Yg==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14129,7 +14149,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-+Yb9aIeSHW+nxvYeKSNwm3z3IBdQAR135dGgzQT9Xsvhm82Q2ZnS5rcxBeHTgJS9cGHYqrtpgmuwykxu3Qa5kw==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-y46TVsPsb5qcF5ZkO5Z2l60Idnn0pF/JRHuzmJSqMd9nSrJs7+mLBi+95Y3E+lFsc9uyDjiBp8N27B6T44Nmdw==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -14173,7 +14193,7 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-KZUU1ybquvEDlFPTsPTxrPcGHztYtX+mHHY4P9iwz9rRZPV90gsFitigEiVFm86NvB+XgK9+zRxPQSpGSzJQPg==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-DGsIaGvwvr0m+RgkeYRngC2OAZj5IAYn2wbMa3tvXjvkFqy/KYpbI0tsoeLShzAZ+FYUvd/XRNXRHLXf78m4ZA==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
@@ -14201,7 +14221,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-oCjFQd6DTvWkUnz/bePDKGTVDtBRX4P5uZjCYZavzcbf2pjv0XXIp34h3i2i8eoqwOPfCByEpzQ/ASjYQf5soQ==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-wl32nnEop7mdoiWNUWi6esbKN+Kx3H5LgDkjaMhZdDp6mkeEiCxTKi75wBAyuecSoyArjAOyuEXioe1Dw7rz3w==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -14227,7 +14247,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-L6MSrVuDyh+8JLAy7a54qpZnQAdsOz77GfT59pifIlfX6qYA0M2Uz/w+3XiB6jXVF16TeSF/vnPkc1wT1BgXeg==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-qsnYQ6abPJFFm6KHPm9n9NQcNHMKdQGAKroIds4cSSAimRCtM0QMiFOFaOkb9IKm+RoQD3G++y8LUbKIaQdZIw==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -14252,7 +14272,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-wVVS6P2Gzmo2EMlE37493ylmsp50XNU/ZJJ80p4L1/xLGJ8lK8rNNz5BdOgjAgs+7O8dL9vX5/lUesctnDvXpw==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-GSeksFsLsnuqT5AChec3MDgdoZdIxX5lByM3sBM+wUkkh27fe1WS8umzbBsyDy8iqhagKmOI0Nhv9bdxSPqSKw==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -14278,7 +14298,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-hP2O8USlWuBY+IeEq4VgU/d3FxHu3uL/NtogNQihHGMtf/AiIaeVDTK1Lb1OMxHV+BfksrR/6YNDBq35kPwNRg==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-rOeUkKVUcxrV9QJn1mLZWoR2683ZwwFsrK7+N7PDokroeQjBMT0wECdx/8vWBDtad59HRNLFkjNhEvys4+VnMg==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -14306,7 +14326,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-rN7tyedxzNW9C0gOgT206cHF50HIQ7N3UOJ0xY5BTBR6MHoqX2YIhzTVfMj748yxlRnRJXEC8Pf4badNAWw8Ng==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-N+1dIYZX//qKs6r29vLpRU/mC2UuNesoVCgKDEFYUdM5tmmSaE3EcDjflJjevt1kI+9HAeEILgrFeCl0c0A7cQ==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -14331,7 +14351,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-gFkLaRzSYOeCcghIoGXEIc9nmCaNgSQtWQpzfd0bF3UT7tsTex9G1rgX9Rn0kUG/S3CZn9xuKucXbkLY6KBBoQ==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-p4grfrBplJDSZ8wQJf/+deFfNlowGkpv/fj3sDR3CtGkaCX/3TiGzNkN7fljs936o0QKbtDqCNpBSRwuvieaPg==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -14356,7 +14376,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-XLM7LkduN6MaEjnp3zcYDitxRDweA/3ra+ZhOUCgh/gqoBCgtpi81I5ku5EeHioEL6sXiINrSpXmy0rDEpqFhw==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-nU5jIq0YisLsLyVTRFVAq4iar2UcEyzyuyfW0SBTdVVBHFv8p4A8Zl+To+GLR3+WEhIzRwOgLTaUd1mt13kBGw==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -14382,7 +14402,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-UuykXiaAPATox5WoIaN61k3uFbDfg0KXKSX+dZjWLQwGCNgiqoxmK0LTOAFbc2zZC1bextfffABD51nqeFpOZA==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-+YaOQpB487AIduj88GLrfZoi+G3aTw3cTcYDeik3FaTCPizAa45aML+dF5GlVlvyEWAInRzPSdgz90k7JwPTJg==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -14407,7 +14427,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-yD1Ek0R/o7bNgjMML6DAKq8JqtJ13iuE1FxnA+CB+Y2SQ/FVPiycNxp144IZ6MiDausC9lmnh2+xekPrLlF3Vw==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-4ftVPzRzzRlRWFp/rLcyynBy3Pw2PG1B5MiFZ0exagsZ+GiaqL2Y4NuwGhmHYpfznRy4/+VDRMtC1tCiyOPYhw==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -14433,7 +14453,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-iWlLycrW9a/c4yhAA4B/0qqT1AzE6VVYhYnsjS7EWkZMwD8BlJKtJwqtB/vxOPvkZh8cLFyc8+xhk11qI2QgSA==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-SL3jNpPdvBFXxF2hc6Ta6PE/iGj0jdjPsg6YobpFVPhnvcEvrt+fJWwuBn5K2gXFSThB9yFbzpT5/4AiZDkcmg==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -14461,7 +14481,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-LcXWlL8tiCMUP+WvB0q8HGvpUj/pbl8RAo6aGh2u5F9CENtY33e6BtYe3MERcuCIhBpc3GmW2glFMKEFvw4Sag==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-ogFGSmWM/EBSvZvx6rK9QN43Wi+xtXx3fFuodfkg4SEQKBxL/XPJFHLRjenGhZOiv04mXVZQODyTshRoluExTw==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -14485,7 +14505,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-oRNGZ+YV8D47kU3d7lxhMT1LnmCaT5tZ0Ysu5UJkNe9kf9t5n8xHXpUvXLUPq0RSW8H/qYQ+VhsApGTPxUEw2g==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-2paCi/N54KxV2p+KXhXk+5VBFXcQtznfg4mLLktyVijLUCBAmUnSPe3ZKgQdF6UPxrsCnmt+yaxqxB5QH0p5lQ==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -14511,7 +14531,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-1s+dWhl+gDeyscYhm7HryK0Atythwieh8QUZv99/tB6pseykQeM5viw1sjmKg6c5h8Q7vNXptjiVSQx8bWBOOg==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-meYae/bw8rVIhaEJ1zGS2NEkm6Bdg6DYLvurXXYPgdIFm+9hiMdFusCPoxDudkOMZlRM25/s7a+AAOjtBQshvA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14536,7 +14556,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-vFsMe45uSth2du6MWCBhe8N7V6ePYDQ2NIqEkuyNU0V3OH2i1GkU6pSAOffO0o3FLA1u6D/iOBGWT/0mb3r2ww==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-/dhmPL/hUyUFBeA/k+1Ex91Deni5MOfUdESJsLZf9oiDhsQ0V+pUve/VPCCTPsEykUDOe1gsV5MeifYikk+1Sg==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -14561,7 +14581,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-9QgUKSFGrpUkvwaJvLPpFVWLNCbNEGOK4CQrBr7JKJ1ZbfzrCiDhVHEaVrpTGTaNOIm/RvZf8NvDKR/I2E4vQA==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-827/iTns+nxVxMCbBsUl+IDz5nzUl8zzkzpCQxecDaSuc8exbndgJdw8gjt979fqewSiSLGsqPwtqgLPAKVXUw==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -14587,7 +14607,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-ShC/7USX7awcEq5KW878mhIp1/D4loaXWRzguU+bpbDUzZMfVkCXKjfu1RjajBEGQ2+iTxLY+cBuKxwQT4leLQ==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-bWnYMtRZJNOTBJpNhppjXhsTWxIAJHur4TkgmQ7pwwMoBAkrJMcgskFwVBf3OymRgMr/fVrPwi+W+Qyf9IBaPg==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -14612,7 +14632,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-aal+/jxBqEm3ZCUOFIkbPsbsk8bX17xOvdzsLZ3YVWSHemWihfs2Jlrq29q1yf0KJ5j1Bbzqjm6GGwb6WeN66w==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-+pinZUCLY3osKk2It9Cb/Kz9RHg7I5/hYD1rFx4EnxyPtzXCyebcaclarG/z/Mj2Q+VxiZD/Ya2OTYCXq5Dt8w==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -14640,7 +14660,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-X3FWW+TKvExNm3l9lMOFVmuIZ9mkU3bfbk4d9pq+r36dh9m8PRZsj/8RBSujRrVvALLztV0M3rRNAlRwZuKqNw==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-NdHSMtiPL8TX3eydRfQX2bLx6X3HOAy5b1jNI0eaXqkKHrZdwa6ZFbkyiV1/1xIvnLjOxGnnIRSCR6mnf+Sq1w==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -14665,7 +14685,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-oPVjoe+1O5EER76zFp06mb61gWH30VLqMbOfWxcSlmtvhDw1vfT4+5bcqPHRSmonEx+mTK96Mp4rHAde6cV1bg==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-b0230GhgMlSfg0rCRaDTxRl9gbLBng+5FTu/8aii4/DibzWS30j2hhB2gfC34yKE+r2ogtxTxsrE4cut6QEj5g==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -14691,7 +14711,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-CVBbxNlfW+Vj/YRcCsHjRvQo4dfML1Zt+AFaAhq+0HpuC+ndg+sA+xor+xiI0tXqTZCiRzptV4/n5WVi8+FXEA==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-ooOm7r/prkWBsD0tWktpHHoIWoZ+NDW3VKccLhenK4QP0xROUSCRcpN8YhKIPAH9GJazu+sVLeXvpcJdqJhpAA==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -14716,7 +14736,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-T3S/1HMicVST5970M0bZGYNA7TcWTTNhkUvbatmeki7j8UR3RpOQ3sktOO2evnAlXqIZHEO0J+TWdJnLB+hi/A==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-ohzYAvyZ+jBCancO/rV1yS1T9MFdYZR7eI5OH5VqDXIslKgGbeqUcHUHoJ39+HpWHUcj1IEgJQ59VEJmISqCSQ==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -14742,7 +14762,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-WWQd4B0nMxJpS2NwkX1hay+Genti3k2955UNtTT5AvAn3l0JiZnir9Z8fFyOpl6I6R/B5Oc2SnMmZyjyc132Iw==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-SjuWr4owhgUGtuEM61Nk3J2sG5mO3Hec1jznf7ewhls6YGu/klJDbLib7Y/vhGs9vK98XcJvU/QBB4E7psXgZg==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -14767,7 +14787,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-LFfbG4hOrqdD6IAQ2bCDyg0EZuQFXiqSz4k4HIYEDC3SMo47qiAbfHHL+Je2IBMqJW8w452hQC6Xn10jWwzscw==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-+bm/Ntyil5fvVu3EphArLIXi0MxwS25YNZdk5eWPQuRnncomVybWv59nYt/7Qhx1gqbQLX7mkOI7nkZFiIDa1A==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -14793,7 +14813,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-1TgEOJXMp8d/1yj+jLvx2Mg6nq85AzGRlaXWr4TguM4jQxAnMSZEdO0Gbg7Xv/upBO3OQjk4tU8lVwPmQgAr7A==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-cAqFqhEq3ATyf2572aMpizb/9pavF96MbS1io+iF45Y1MdqulkLJi0TR/MD815jV6GNJqOpRICcTNhptG6+pkA==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -14819,7 +14839,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-DaQ2RKgvW4CCU88WfwJqh1AjGLsVIY/KRQoF5IFLTgFt70kabtY82x7Z8wKYLdiBht2mK6E0X25mbiLkLMgOaQ==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-VBCKFeQTlpIhyU8luFD/jcjWhqSO4zEJdtVMfX08G9Vp8lf1aAWavtT0RxrDXbsSxDwJlimnAnsbd6bxLCCHYQ==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -14847,7 +14867,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-Vkah+13nqznTXublTWuEJhop4jZAmZftvVOKX8l3eNqdYCBoAsLd6+NcFx+B/kMYx39/ZWUlWhsndMMQ89Lb2g==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-pdaTJnXJpNqRnx/K4PXz+m9Ldc6arEjQYW962zrvcHcaf/uBGpSgOXYP14/XEMPuRSP3wkADz/9Eo5JFi8pdGg==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -14873,7 +14893,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-97TvNpWxr4p8qEV10Jkeds46MUvjgnIsSaaLKIityV+hjFeoztYOp+sRaf6iRXOQZlTMsft4jzFkywPebdOx+Q==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-m+bA6gb7E7mnzz2PMS527B/N7yP/qJUhkVaIRKBxllRDCAwHDSckKkjGMPp2IygOhm8Y3HDsU10e2Xx/jmfZ9Q==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -14899,7 +14919,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-HuZb7tUpp08nfKRc9DijBqThTPX8wTeiW/EElm/4StOh2hyghhG8DwHGnfhCSmMxzyP/Xybb4TrEreustyB2Og==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-PK8WaUceP03en3mGDM4LOqDX3kw+oib5FXLt1tA9BIGmaZikcSrQwCAhB1/icwbBXtLVFP8kHHU7iNW3mFN4Zg==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -14927,7 +14947,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-HSXCqCJKzTN9xfROr+mkLaqbtx/SItu6AtuA0OcqeiRyvKJkluih1u2VUgJbA69FbjTuNJJ/23+awzFgzqNCRw==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-Xo/AzGa7YlmZ5SpTUvHS/786qYM3UxzEwgYZQkUrF3LbTKkSeiRc+cVY9GexRnwWm+aQw8GSKzleW/wBQXVRmg==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -14953,7 +14973,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-ugd8ljVo/gjN15fXMxIkyN2WiVKn5zw68cWXGqfS5PtQsRIasBOXxheU41FqbCCL2DlUDHdp/35heHigY/493g==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-rhIodN3fKfqJTu7Bf+fgdxA9Dv5fqhgix83TC2SrEPLN7nuPa0+SL1QojGczqf51srmfx4sPZ2nIhVkE7htmwQ==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -14979,7 +14999,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-acezpwVP448o1W19Qn/g1IY4afaMIo4hC045wBlNfArWunSQdEo1T0SZ7WOQtQfLPT46e3PAJXZrp6K76vzpCw==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-ltwVRdAuf8h0pjQd5+puqD4nOIrYLcxvsTKcDBm7ZWYebytlibR4VnDHmU73uxv/5XCrYOoa6SpqpfAXfXc0aw==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -15005,7 +15025,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-eXA9c0W96TAsD9Jl+yAxlr3ZpF5nzoKgwjNTLNKzK6TrCQGxTfA3WE5g8G0yOHD8g+ewrbGI/2kDc9+sUfWdFA==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-vLfWYFznGUQZLN4nK08boCzlRtcgmA9OmaOXGUiGorZZvReoPUTmFlUKlHl7DvnHlDsqgHN8s8hCa6stRSK4RQ==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -15031,7 +15051,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-U5oDYTo90gMGpDNd84y8RtiMfjT0uOqzLCEMKj7tjl7XOoWbKg3TYTeP+14uYya1dIpynuVw2lzjTYqPzl7ymA==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-E2rR01NHzQG+i55GJgzLImzpdBq/3NRUvB2T9vHmOtKWhwcuhNyuy+9xqWwghx6dyCPfcZZU/x6BDN14cSS3Zw==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -15057,7 +15077,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-1odIBZ++9iqQETiYMIU8ILz1A2cJUN7jKtT4njMujdxnn7UgO3RrY5hsR4aZkbrRiIy0ybftpbJ2UCJLC9YfFw==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-IcVsimeIglGo2zPWWAclJXhuqt4MWIHTDHNxcUXbxwv5C1qysuHjDSl+waLYGneolH2sDqKSt2IRdwqDTzUfFg==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -15083,7 +15103,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-OKP7IQ88SYbxUcSuxY8ncy207KKtVwANKYrNQVZdA3uimF0ePRRv7F2nroHiW15YigixQsXMAIrxjgEljN0coQ==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-Bsj7QzDP1vkWQZ93YhxXaDL3n8LGC7wGna/uQOYmVECuwouW0d3jCQRhyW9DugRT1SL4vjExBzuYQXhwTj9hSA==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -15107,7 +15127,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-g2a2JOXuAwL/uAll63XhZSeDIrrlc5GJSe22faXjd+9u6NkgasScu0w38NTiuFE4v+I+FBNrEGet43GzUN1n4g==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-6nq35xNqfof98SC3mTZrMS9zl0H1pnbhmtPniBPEyj2x/OFNtgj0qB+THpKWhJnCJCszzHGU6NjwgjAXvCV0mw==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -15132,7 +15152,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-QM9ewsM4Ks+2XMjNEurLsVJQUWqplGUwoR5Nb/2M4PZWwkiEJmjSfPVEdpWDw8joE8Mq2aeu3lpeurP9IOp1tQ==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-fFU4bOQKePOIxBQlLdiq0OFEcR5MeqPBKO2OikIxFBSsk4LS/TxFOLnlQFDKdy9X3K6OscstiP4Q2VqGBw7sZQ==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -15158,7 +15178,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-SZ/pVg+FAqORyoq8UYPkXxyLi+Mimyx84A+5KlHtkZKOkKEsDDVMrv4DOIVcKE/5o+siNqjpDTx1aZYJ9Ix2Gg==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ck2j/Sq+3hh70zehAAfsIjj6whIl5brGufm8+hoJhZ40RyKWuxI9IHRq0oyRElN//g6ONADb8BJze/iex+VDXw==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15184,7 +15204,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-VAiAewgE06DsuSDC/BLNIuoKYQurFi+3F0kK4j1f6euWFis8eWBzprc47kZ8J4KqAYKqeHFmHj9FiMbGOx7gxg==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-YHy6SVysSN0aGFDukP9Qs6+gPgHGP7TTMm/XukH5QfSb1zC5qfXL+jzHCHHfIsooTiJcRk9aYHHFxpoBqhnZ8w==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -15209,7 +15229,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-/t5+gAFX7WNnDoRlihKRasQqe3dZTJFmAK05+VInGiAjkhmKuh6wuNBXtnDfXAe94AfQZNzT6d2exR0jrsv0oA==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-PaCcUqwetzI4tx1HuiW0ZK+f0dRrt5pdsQRj2FiJW2msNxoDVDXQi1oVVfEuwDs/EeHUXQpHk0rK2q25WPg0hQ==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -15235,7 +15255,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-X7rUhN64iAoQglYWtg6xgPvO0n1JYPL0fcDZ6NewFPTtf7EQyFrkpYq1iByM6SQB6ts/CWEAiuD06yxQJNhEcA==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-CxS8maBQ9OpcmfM3R2LQ7/g0x61JR/+S/i8J4NMVNqMKFtP5iJGpcrWOal0PeY/cugZBz0NWSZop+1mOtSc2ag==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -15261,7 +15281,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-FjQCeXqzoX2T7Uxn/pANTc3Zxs7Cofx+IbVmLQpGt3viqJzIGDdtc3iEJCh236W4uFQJ0OWF5YeASs6FxPl28Q==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-WxRmPTYMkqLGvxbme4lHaMr1M4ei9Edkz1pA07QAq9ZRj5+AGLJVBB1k1jwVwPck4/INZr5Zw4e9lJL6v0PDmQ==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -15287,7 +15307,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-IjwX4Ud/kMf22P5x5RPc3ce3jIAHaWM22PRx2r0+nJElz9EpZm+aLoSp6pCTjdtZ5Ps0R76lIWI5ROW52b8qrQ==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-Kzxc0XxTyF6FbPY8T+ENqaT5abKTHnwNWejhrHQB4/FF2WGGC8bWqTZGg2gM1SfvKKogkmXAo6I5YANrBlqlyA==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -15313,7 +15333,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-UxcufdBvVLr6cxwYQudYksT4P5D9rAFOyz79IZYExnmSA05sIYItlXX8f5E4lJB6xJWkZcrAYG4pfusbY6eGGw==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-BgTvWlnx24iABUAjVhOFXeG341+nKojsKGIjBfJ90dxJvLY92qZHfDi3RkEZHd0GoJuSFotEW7BSfoeUWyefRg==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -15339,7 +15359,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-2EMy6pvNmfEM+zF/cny41o8mJ5XRwE4MxlDRHPFEYzR3EcVFAqzYWSlww4bZEqXstheUzbNcwVtj0nJsX5xNhQ==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-Mw//tRnQY+ZfF3IpBM4xkv3Cwsbntd0v4DXTlOFKNyRNQYBJWy11vsJaS9GzKfTmwiq3UQ6bV5vMDZwbvQfxUA==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -15365,7 +15385,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-zTjeQICOt8epVOHIK2anALXq0a8ZD1jy2JTZENoBhyotliPuPkfvyYWmh8hsp7qt5agIqkbI9w52pqhabubqSA==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-wUbYgWNXqfHog+3/i+FyIxH+itiu1hq9LmoJ9LFskzRzC3dhVUxSwdcACEsP1OP4n/0OC97FOd+MP4QpAOoJHA==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -15391,7 +15411,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-X+PJNgAH5gt181nvOVnJU1u+uOD14rCv+kJJDo/x7n1Q+VjIqFDQEpidT2Xm24a2Ph8f/BfpX7E/XA/xZXc8EA==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-I2D4Nw41CkC/UzLq1eqTLBpKYWRj/JRWGfZb91veLqHgzyOCbharjz6fuJWLQtY3p4T/Ur1xYlm0iwpuo6qmZQ==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -15417,7 +15437,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-4M6uaBlOPuBSHWz0B34+BP+Vc9DRxaCOuEB0IGqLo+61m4PsFFGVrkBSE94xXgWtQADE1jLA+lIkEL+4vxVC2w==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-Wbiep63a3vt83Gz+baTKtwpLGaBlJTOoN3eM6kAy7/f1vG35GfUIWSJd0N+8o0L+swo+snap7GaRh1MNB6Ur7Q==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -15441,7 +15461,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-yM0HP2VUDY1DT5CSqU1aCyoah7ef35zYcj+KL6Na2zf4z3Self0f7x0sxemkAyxs++9r/RyOl/ws+yyVLfijbw==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-nK3UinzHy2f8qGGeqw6ZevborwpksZ103z6pLSVVxYmnRQPlM4bDTg/8e4ln3j8AriDYVf3gwwjayZuFkKQy4A==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -15467,7 +15487,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-cIUSGqF22J/36I5bcwLeMFMQrpQGVp4gNix8x6P2A8uO4TURYwnO/0Ry0bXl6WsE1ja0UM4HRWp2i+hy7EMi6w==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-+ZjwYGH1ICPx0NRPj7SU1q5Gv1R8N8QMuseP/IFdB08pENsObiwLKNaSIHmr8gvu+z/zfOjtdljF+4PP/ZAv4w==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -15492,7 +15512,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-s4f9x4CPlnPFMuEliG4lgThfASYrKKI8avGFVWfaMvdWA63TzqJpVMHZhVkLTM5m0vGcG7aX30XkSkC2cGTydw==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-NWzzEpp+dbqGCnlPMLzflMcstOV3hTfAWOfcN1GyWMRU0uUxDTjQRgT6pv7o34P6VDX/8jKJ8+T/YyDf55SPcw==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -15536,7 +15556,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-BRpgxLJXiItpVwSjHuvXfpz+QJFX+KFeBdOwM6uoo2o0vTIsF8BCIUNU/rx4anzmP3L31lypwv7LsipHOoUGJQ==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-OBZ94g/eIbQOP5xv2ezCbvgh2W8r+5VPcXklmMJwUeAepSJe+ENk/KnSIOG9A4VYxzNqQsnOnzRjjBoyI6xh9g==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -15561,7 +15581,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-S7Woy1OsRRV7zWVt3VShwZbUfT1M02PFqFXeRvGdb1Cm3/Twon/T8W9lxDol5oRDE75tIOpasNLsqXqeVKuejA==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-mqBlE0zc9U6wDMIT0jsD/AYQxcWev3OQvDa95WdZ1E40K/M9RsARfIWbwURCMgpZi+zHrvjJgkKkarBp61k5nw==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -15587,7 +15607,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-dWoxE2cOzAF2t8ofcBG4FZPyxQF4MFTIi+8ELyn8LQmItXT97/eyHx7iAE6tE5YjoASeW8yH6Q2C38q/voXSAQ==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-VtcN3N9nq96VaTS7f6nB/41Fqh192s/6dcXwxJxC9P7odhsl17+QUbjswpmhzuIiW15T4cylshX+TCm+Xn34iw==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -15612,7 +15632,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-drWD5io9xkwx7+3IPgpUhbtxotXCiOWv36U7gMIkUOKmlizEvNcr/e/b7Gk88DUPK2ARTHynLG4sUacRYkPylw==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-zA14CS562FRwLWBvxhVFZ8eUNMSwSfrujCXstgTTDWG5as9QawbXvZsskF4ufh8DWsj4u3EfhsEFBp2AOdOiPw==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -15640,7 +15660,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-MuL3HhbOtp3cFb4eJe6HfO/aAjYkPrpJlHReTNv5kbLY+o/Q2eUpkL41Xo0xEMvPti9KzKW2OdRqpTcQaId9tA==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-r7qSfceryhq9z/r8lUe+oXVEd3dBGVYmK80Rsu5gXPfty8T9FovtbJqOAEIK9QF7kVCRwCIbOtFUFhn8R+Gmeg==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -15666,7 +15686,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-snHuM0z6D9H4Q+WDvDdcFoQJqMK+ZjZuo6PSFX7DKVsVs7BbfeMZlHD+J3yRaqvIBd+yifdrcOMKNsb9PkXvgQ==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-fRlA4jVRlu3pQ7HkwWVRTYCd0msB20m8xc7HWe8YB2VDC3dppNRoh2Jo0PDA4Lw7afxchBQA+oj/NoOu0+amOw==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -15692,7 +15712,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-MjeYUJ3wWcZC+sq2sOLK3+9UuZUdSRar72hzZmDSwCz+1YsjVMBUxl8+bK6eznpp8ucQBOQc2LTNdXnWLGhiEA==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-D/unUqpXfQbszOMiYzg68hiySIu/Crgh5la2NEDtUFD/fcA/lCYv4xCQXpnAvArYMVff/tmtrSrUBdPTwj3ebg==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -15718,7 +15738,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-hQrXLeA5wADbywJzhvQ7Akg4poII49bbKXuNwdQLLcyjDoRywx1+x7WjHGGIFmhiQct+z2XSFCUJPCfH1eKo3g==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-vz7nGsY2IGEa4tB2vRjPWJYo8JRv7G8P3WY2iiPSEmPwVdhIZUAmKf+CGP89aEFLNcvAmrWwcj4bg3Bex5OCJA==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -15744,7 +15764,7 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-xyOjYIV2aoRpIMzmcsBtaj+GTLdJBf06aqbyCBkiBHJcrWa5+/hNNkenslTY3MG1BEzu7vCZWG9RPenEZ/11zA==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-9ixksF8lYbq/LpHeVJMSPUtcdLjrPSg2cPR+VXkSaHlcuPET3i63n0h/0W5c15VfK/GSq9nNPDXY+2O190Ua+A==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15770,7 +15790,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-00AXiG1BVR2WexhhIlAUXcCyMJLE/dV2KOLxBhB33Z/mhARrPkvkv7ZpE3vYJJyILS84/xk2EzUfArFhFOq40g==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-DPH2cNtTxtPhFiC5My+yM/1u8GEo2DSg1a1lhYSt+A+25KLRwiLidVexOl4KYsn5GgXO1WBeP1f5XwR4t1H7Nw==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -15796,7 +15816,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-Cmf1MMgI15FDnKVRKVgs1glIYrwYW82ddOQwoMuMuYzI1uZq90GMULXyg0FF0Yyuz5GuBO0GMsq/P00xySxuog==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-RGhMn7hs7f/AgvKEUBeNEbYuIX9hvA9S35q3BSZERd+8wfh58Udkk8J/Z4ez/+ur5rv5dkPTGXG05PYpVTO4VA==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -15822,7 +15842,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-G2uijgb7RNTZrT2Cin5T7L+N60q4kJyzvP65ehKrDd2oYp0tYRX37/43ze/iv14cM1Um+kpYp/UnW2L4ElPOuw==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-gV/SijkpqgeBIV9xM7gZ2ASfNMxkZtdKVxqygcZkGNWjc/5hwohTf4nugO5UdXP0TL/KK59lUwLXVHpSSH7X2g==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -15847,7 +15867,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-tyK5xTIHnFql1KNYR/zcPch2FU3fwwTt9zcnHQIP45YyloF7zkIO5W2cNDu2xDaVtpeleulMxpl2dL0zy1xxbQ==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-Ve4yY3mM4qIQs8qJpwGY1VSYNl5iELzZfbNWhgWq+G+C1z4HSSviShrr8jEWpoeYp88sX9jOIAw8s6X8DpLR2Q==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -15873,7 +15893,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-RnmEUKnw0KbPfchqVHV9jmMkAxyl4U42el4+5txXpAKtIA8pNSh916dopVkwyCZxI34px6WBYpXwgki9bfmj3A==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-9CJk4QIK7ydPqBPu3QnqtA2UcbGTBodB/YKUBMYgGGm3nNPh2zMoMn7GQOczA01XRb7q7c91IiHsyqvuQHgHGQ==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -15898,7 +15918,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-k6voJa2MWoJ0DUfJZAxQufSTD1YuuCrKvP6n7MZgX8SVxCGGM/9Zu0flMmEF1UljZygDWhcvWOD8P9bXQHDC6Q==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-vKPmmHX0luHsxfszJzuAUvLY6hTzhsdw7/g98miAoyWMaHAnlT26rGjXOk+Wh6BeE02O0DJ0o+C2TovbZK1R8w==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -15923,7 +15943,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-ftNzMktJIC/2xPI9rRj1f1RVlq/+IyOsR+DSia2IwX1hh8wd1jlLNaNqDxIewt38td/rGVZA+d8sHYOBAPwHAw==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-nzvXGZXgxujJeurvbBBiVqZy0bgbB5DfPGax02dRshvUUE2ixCrrL90z+AqPewda9shlomv5GB1DtRskJZ3Gcw==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -15948,7 +15968,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-l3PTEN4AJoiBU13ZSqaxD+ZUGeOiMFCJ8yaxXGZWjyivPiBBI+73hNKHqK+xqE+yLx/l6hTLCYNKDLcHJGZeOg==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-rBn58d3a4B5gzcEQ7mU2qZ/52tGMFS9y4lIaRcyDVDpuXZgFlI5F7cfbq96zNP1wa4VDpecVnNcN+0Y1XEacDg==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -15973,7 +15993,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-UCtiDT6RCEoB9eldGXQbmD3orZDbNTo7jGDuEsozFo053biXWtSnvrz03dyEhn5zP8Pms55wto9p0SuRGb/TWw==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-iX2Ry4+dO0WtgLiK0mxNYUNXG3jMIXmZ2n8dRvxhMm/r5/qnRcsWbH4QIabaghcl1eEomKt6vwVVOf7PoWpVpQ==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15998,7 +16018,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-HK73AS0Rz2hlKvSuwiofl99OKnhX8x6m/px2IipeSuuGbCupLPwRkvCLVTjy3Llx6EozZ5LooDo8Qx4iUZsBUw==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-hlIJn7EqvAuk9abEt7U2gGjvfmazgkhbuf/6r9HSf5TPnMSXznGyd6jA2Rr+jZbk67g3v7dtsp2Mcg9oJY/eLg==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -16023,7 +16043,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-WrfTTlMSDEsWG6tqEsrOjK90i/hF9Vp+fhUofQU50jreOUbnijcHIMDhmy97+NVKvtkgMx57g1A6JqcNOjcVwA==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-HUsnqJFA1vuNWAMpbY/d5zZUKQZhLTpk44ZrEUTf7ybfqttrfNtWeubn/HVAyl/at/CNB6c+bS39JlUDJ4riZw==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -16049,7 +16069,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-8+iWu72kqBdcB0LCPRnOYXJBgPNxe9MytDH0R50iOaGCAuqxc4gENZjwWLiTr538qDpNkXoqxW1Crd1r9MnuxA==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-3gH25UaonoWa+UH0Nnml6B/h1wEkzujbz538Nr9mTcccuRZzrkLd7icD3fhx3wLof36b3sHPMER1KWpJAVUEGg==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -16075,7 +16095,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-3zcC7XdAO0wQDcBEsGz66BExCbi3nTyXfEaMFmGNG8Ks++lecqPjH1IPrxg2eRJmyYNVGszzIw5SFAT/gYolTA==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-AQ1/4GfE52L7URXCOgJogRx8mmaYdddU22c04o+OcyeVVe5kZCBoHrazzv3HYucih9qubMB/BScsBXWC+VyYQQ==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -16099,7 +16119,7 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-AfTaCkUulo8/S6g6dlHQCxuYmiJv2HFgeNIwKuQEyYUAzxBLMLG4oIYtDLwzFy377OsyFRHh2k0cJWfiYC88Sg==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-r5DHTKhr4DEJwivYN7h8eP9RVJj58nldZolXBkz4+i6SUYy/KF6mz4p5eOc8d22QFrXPUDrZgGCWiqEdxvEtzA==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -16125,7 +16145,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-K0Ldwi/wDDWFg2NaefkwGq+p6JxnDqmS35fjaEQ8jvxUNVjM7hKK8UfeOHFlMU4hP1fqWs2Ns+Mcx+jjtLpLUA==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-zFknqL6yDuvidoTyvxr7rUkDzW/nfV9x7pfmodjiv/b0lbuBtOV41KHppahhRwrwaQaurpDugFncmR1pgA526g==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -16150,7 +16170,7 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-japIuzrTyi95rX4QwcgbLPrD+yGmwlR4XZYjPp6MRg95s8KLlcXnNyUeudUgsoQHI93+7+rvzdL2HMpG5NKWXQ==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-xBE+K0FfLGmGDoB79mBedsbPmn6dtDFth7O9c4L4BYCtc99tpLiM3Wfk6bx7XjKX46dk55Mq606qp7XtFIISXQ==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -16175,7 +16195,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-ae8OL0M/qFHS13oTZpUdS/HsMHK1tTn9k8O7Jh2ZRW1tibT8DOZSIDG601BM6T8OlBdc+x7UDlnvB+kieLJ+TA==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-cMC83KKBePJSKhCNru6H1CCYfLoX1sMou1RmlOOcEXxbjJ9Lpz8ns/GO8+nFprYfav+M+bz2tVWxJ5JVrer3Cw==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -16201,7 +16221,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-V7mf48ZONTDV/Zsm5KdB751GssUQlPwAcvXFMI0daSMFrKHyPt2lDx8be3Ehido6biHIdXRjWB0B4YQTSHPFEA==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-jO+JldICOVkkcTIOSmpM2SNqGOg5TuvpGy9wTESeHKHNwIaR0RuQg1ZJW3OWXG4WiISY5EG9k/FpQizbibLEFw==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -16227,7 +16247,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-ASmjPc/oioW63kM7egQkymfJ7wRqnkOMyleu4BecJy/ITbdB3BkI333jMdUcxVemolWgwQMWuOA/NZlz4/yUiw==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-f7kVtdOgaxfsbsnFAOrmN6aBvNeeS3QYcygmuOC5bsPbriJHpzXy0W7O5+kqk7BCmvqoWxSoazHemen8/dUhdQ==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -16253,7 +16273,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-kEnEfWZPM/WmI1Uc9G1MHdcPi/gK/mPNPIXphIJKFHU8vbQbf3aOBuWWzLeEU3fqosgVS6qAqAl+ipWIRIPexA==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-a4V+cUcB3Id85R/Z3rzu8LoNe9/p+gaS1Gqm8PQMGeuQfJ/VmHAylhy3jJCS6hQtx0u16mCYvK5PxXQwDeSQNA==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -16278,7 +16298,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-o3QFG3v2A/GbwV7pAZhxq1bTONXnW4wH+2kjzPuSHKHVINnlmbyQnaDKtipUmvCqq4Pcnf+beCsYRJ2R0E1pfw==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-OMe8Fj7JWxcpi8Ar88xlP/euvdrBhhhDmGbPh/5W4nZkxq7GT65kUPkyRj8I3W7NQQtLtRXHUW+mxE/xWh3UEw==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -16304,7 +16324,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-zSP8FckjXdAxIle6oIy/t/PhULyRbE2o6JwhnbpH1qkXaM2ut+IEajWZmMXu060KegvooaiiQyQAMNXE+Wg09Q==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-WtZ5kDup9BnVSnyskN4rhYGvd1g9PllDLi6C8I/Dh4JRnIPxWEiDRz5P2t0gaJk0GX0PW+L+TEgVWCUatzP0jQ==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -16328,7 +16348,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-PnavYY8GMKOyOw8chclbo5Id2+fNd4DGeYWjQmu23HvggVovRDzgAJA/rM2AmQDDhwDK3CChKFTR4Np/LNhfSg==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-bqUxTZhmWaoK5hXg6Bws0EnLLn7051jhrkyA8BjZUgS2lvgNUuXD+epBblq6Oxv6TYHLPBhVbgBypCHRUDpiYw==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -16381,7 +16401,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-Ll3HK9J110sX4P2wSLQ27LELiWgVY4zR1zwrj2rvKoslWTFUkqAgh8I+A+p/hNGs6f8irXaWW7SabEcx7ySruQ==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-D8G3z206Gv2ttmXj5IQUnbsr99lZsfMRj0XkfRuWxpe0HADmgSZuIyrbph/xLP5rlB47Wm95p26Kl1nYauDO+Q==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -16426,7 +16446,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-X4gid4R5xNFUbyw3IPS8JDQJ44uIgg+eOof1lvpB8L/q0Lgnql5P6KMUc45CVsuVj9w9mhjYQQyt1A4OtrWwFA==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-hcax4qp95A7Zw/n4dJXnr+fvlOT78fGH1sorJ9H4qNxtLkhW7u4x4CugNp/kxOBZpFPLgdmLXi93Lr35A/ETrA==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -16475,7 +16495,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-x5b2Of5D5FnLMr7yTT6d1WsplooiwhBLfmAMNsLDfTYyeTL/ZrX6HvlboPhAzHBog6MiJ/SPv5hJxW8xs0xrgg==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-IQUpvntygRibGGit4mxi8OkAuwdiHB9cguot+bxDwsMo62i8ev8PmobpYvGdUMxAY2l1Sjwz2vQMuJBZsv8eGw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -16527,7 +16547,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-d4jZ2G6RGUgBE6KDXYdwTp9wJ5Sx5pJx+kNUSNax3Q4O4pHoF4/7GW/tptzDRrpr0arGaM1gQ1oJ7ibxwj2CXQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-Eh5VUe0q9yCietP6UTUGxhOBs5/qQ1VbqS28DO3UmRppAIPZgnU7mfNbPysDtqnOq44ByGCEzqsCscoX3uL5rQ==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -16576,7 +16596,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-a83aD/BBmxKlKES1kaby7mWQbWBvYvG46AFUyvFXChEKx2J7YfZvKcGnaoxAsO8u1Q+H40ycmUzZga8kDTf+Uw==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-+crVDA954/42/R172GUf0Os877MdYDQxU1FYcuZQlDfYa6DNLI34JMMxih0EftL7EEbBzLPpBPN1Cv6d6MshvA==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -16620,7 +16640,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-wBspInoMgtWbpwJVwnXju4lknVWyxQa87MILlevCkoi+ahLUhcfdQRngeMizuPmLlQqDIH+rYbfSV6m42G1G0A==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-lbe/viYVyHVGVKnlSHD96dVGiL7wryTjt+LtrnwpcXa2iDY1rYoezCxdYJdgOab453+zxxsMVzZAtOHsNjVqXw==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -16668,7 +16688,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-fMxA3BejoxE078hO6QIb3KntJ/AGjzAFN+RQb0Jl/Eff4VIz3F5voWXYVGojafbhL2gAiUA5o5yTHkoOh8qAPQ==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-SLxFNqCq96kJCKYK7gntUGb8SYAIFsuVeNJs3Js2yyfJ8g52W6xjzq5JWDaDLpcB+ALQs4WLgkz+IyYefhMQwg==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
@@ -16718,7 +16738,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-NKetDvWkiV30NXVsxSeqwUy+KNxIfvMcdDDaZvMK4BRzLcVkvitAOt+WIxA+oBfjxu1IEQzs1sKnJovaiz3+tg==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-1gDoujnmlmgEcnOeY61CDqgkluK7GxgBaYx+pzDBmXepDpW20tKbxe+9b+aaehszDc623/P327SGHLo9vVP0YA==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -16761,7 +16781,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-xNKGr2MQ7EVh2eXWDf/8+4rOWeZthn+SAoOI6ETWgZ/bPGiSlYSCsF33DWwJgzZFgqYeBGY6aXzGduulV9+l9Q==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-tOAsRKu95RPWr7l/T8ZNh/Otp7jGjm0QCXj6xDKlwOabEcPOsFmmlOaQ8ORcbCUbvQqfok8XnqrZTaZw1mRR3Q==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -16809,7 +16829,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-s105E+T+1flcY/KJ6d9G8hu04eV9/NJul2px69N/u1eyj3GxjRLofL+FT69vjqI+YVufhyMpNSBlHFpLdvOHdQ==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-RFwrYxqHOk+j+YfanPNt/PhnZEBNPnMKIGSYco3PZLqhPXExhGQtzH12rCFqt2ujzvni95XHimkvfEGhP5r41g==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -16857,7 +16877,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-l7QvDDjVPFDP8lvuN0ZoLmKe7qFNqsD94Rx0zBsLYcifA8JL0o2alamgyGc5iYB4qhAVHqqUrmSg6+7mP0E+xA==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-6n+F5MtSXfdQwBNF2lAP3C2Y8K6005IvbpQxyxyfV45ekxa/hf0rceCZljTPbqOefiqb+vCILRrHuKQCW8dwYg==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -16905,7 +16925,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-30NjuqlQLAQBGIBpOPDuFw0I+povzuwrS8uqVYcD3QkPZj1oKar187I3FsJf/Hct/DKrb8zgO2fYpcGP8WtKMA==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-XvcQkT+x5m5WZmv9SW8lfqZljSszFylhoklEGr7OFfOtg4dFrAumkcHjJOSABmFLkuQ37lBCGNoLCcI3weLeDg==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -16942,7 +16962,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-gpLbvm0kOrfzPIUEeF9uzjERbc+eR/teVNKJ8yDlJKbPKxeR1po99d5xgRv+cPQ3GlIiLtGE1XJXVn/SvCdm0g==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-2clhjecLssCwX4fQ1IeQTjPOdpYH3kXM9kxpXDrk0UJOd/V84LpUGtnXZ7xDOjS7kHdTanmvbPiigkjGtPqhOg==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -16990,7 +17010,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-ktBo8crswaN+3Zc82jdmgAOdeqVpf2veriDT9JEnPzPUPFhc0xNEGuRJOdcSWAjf/lTF0Uid1YUnlC/otkKnEw==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-MMH4ChQlW7ECdP4GMMyUjYSo626yMFFXvSwGBlL8gifqljbrswQQAGTvI3vuqQpV1u3qWzGNs0C2Da2JPzVOFw==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -17039,7 +17059,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-Cilrar7rp2PFyWrrgIP0EQzNoFPoKb5dZuXGBkwNSx5LDGm+m4XQZH5lcrDf/5KrL+SjgEjW2+zfVE+H/10lVQ==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-Tu6prQbhBFOGunp+nvmZD6r8nknN84A6O7kiPsVAN+iF1Mr0znJxQG0lT2sq2xC2N2kaSGyjA1c9bk3Hn0ycRw==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -17087,7 +17107,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-J416h+55R7WbR2CpoEtAXWbLHLS2VCzunwsZSOe9sClXuU09MW8s4fXZCkhOZcInE5/t/LXGvmC6CO5AuoL9xQ==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-3lu0wx9gcMG4aiI8/P71TYpDrlkx7fKJeoLpRugPUGbABTEL/5A5fv4e231XuAHYhWs1hJPvBN1BnbwBXsRFaA==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
@@ -17134,7 +17154,7 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-uSATx5r3i0Sxq8aR9OKFbQ19Wa7segLKDTnxCVGqHcTrorxc8GDnaA5D3eXlPeDde0bQOY6YGZQhIkgqRjEQhg==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-S/ECzNL1lEj3jLR1eLkrKnTEznFq6mj4EplH8wadR6uoIfFn9nT8k6D6xdZ6TsRtIfWlBHkl4hV2FBkN1xLMYA==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
@@ -17164,7 +17184,7 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-x2H43oCbPG4MPHGiP0hhGCzXY0xutLzlnZyAFAhJabvrsqb20s3MMjfhA6NOCJxk/6RM1ixPnvcsVZ/F30YNHw==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-VGhP2g/uxW47t2y3Bkfi1uZ9YPRwHg+l1neCfrbCJ6Rk7jjxfCCbu4CMsXMWxYZqYcjccTWdIRY7qDBfPvOQSQ==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -17210,7 +17230,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-3u/MVN1OUCTBuot9HFnzXqXrLtmrNG/+1tZTCmDgGINkcBAMt5IAWumPl/Da20T7RN6gM0tjSJ34piPs+ZL0QA==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-jv6i/scPE6jZDK4u0T+2aR1PfLlMhAVb1Ihf0zNHIuO/VAxQ7RF2Yp2v5Oqk0PxUHs9MkkzGYZZi6XHboCKz5Q==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -17256,7 +17276,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-LdegBvZqJKL3PTS5NsPwN7EIVX/7E4+BymcZIlhk6h4d6r5R7ABi1GKcySBkroqmX/5An2poDcqiRe8NcYgy7g==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-e9DQMJ3nH7nBtEtG7q9ZNsSiJtMHgQIn9WfkWO5CnISFRhyLtQl4/Zbbo+FYBUd6wNdDZtkXEtOQ9GMDLxRkug==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -17284,7 +17304,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-+xMoVpkFuoKuIKYvouWGk2euDIe6vxr4Hod4RoqUj8PqkQY7yTmSkt6Rz7aSPV+FJUCt5wbqpQ120A7IK2b35Q==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-nd8MylPd2Cl9zcQKghm6YZJ0V+O+FMg66h3jYcRYdR9+nD57WEdAkjJWDemxuC3ZRivwoM8PBDs4hKmtM8oLYw==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -17327,7 +17347,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-p7F5rH2a2HeeIj2+umoz3AECKV2EF6EHSlbjmHxx2KawhpSZ5dSkFCAeYxqUjGKkQQoHway7FHOrVYMFBu5rJw==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-yYvzFAJajgXh645kKgwxjzAE54puS3ONDZcrtDr5eDmF/IGK1ymka9l7KV/btZDQ4LClCqpkUZd/T4Iyx/5mxg==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -17368,7 +17388,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-fnU+Txsprfn3crLvo4c3P4yZb1H5P1YI4aVLscNw/vHJLrtxsuZ+5YJoOLr17YnrjhYWOSvAM7qS2gl52atCxw==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-nF5l9anDr5sA1AgUDM3u/HflcXI3ffxBEpjs1RfBLIqC8hmn2IEDD5N3GIvRNiBoUeRwXVpZ39ZHCLg1R8FioA==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -17390,7 +17410,7 @@ packages:
     dev: false
 
   file:projects/core-http.tgz:
-    resolution: {integrity: sha512-Uq9FoovSrczjBH6yunLJaGgRpeS2ZDhYZThPwsVycBw8tFnA11VupVQjasVfluUF9lpEYY2ZwnoGWbHf093Ztg==, tarball: file:projects/core-http.tgz}
+    resolution: {integrity: sha512-/wAi3d9z58zE6jckHn/8arb1vvY3L637c1nWL0IS3qJrF3nd5Csv2NB3YmfrxRF7jPh518yBmdIl8pRGCdWnMg==, tarball: file:projects/core-http.tgz}
     name: '@rush-temp/core-http'
     version: 0.0.0
     dependencies:
@@ -17455,7 +17475,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-/XHFnzwTkiw8BoLi9VDY0aFfwt/lirsuffvUL2jy4srAi1AM6GE+hTrw9XiKdIG/SuAa4o67Ujdd8amRvPLNQA==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-qFO3CRkJITz/fDmmgzHIaCoQMOS32whm0j2G4l60lsFvDkOQiCxBQoBNUoNrEKVtNia7dFrUqtUOQyVQgveTyQ==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -17491,7 +17511,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-506ZJZYCYM/RN6LwgXtoQ4JwhjDEobr5bXOhOMTJE5tfl/cz6oer5SVuvxaogOuEQXCK9foYMdXh1+PAsDDauQ==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-qDZhjNGr0epW9e/ArCUcRoKz64xNevIg2veXxWuWakeIrBc5Cjx0yKHWcOLFMF5cDKypA/uDC4usvBAICFrxxA==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -17529,7 +17549,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-RpPjvOzA5axwy/Q6rLsSAs4cuXSiPN3hSlYgbjXGhBfGkWUcbapzqf4AJ3423EJT3krnApvg15AsWrDVpNECiA==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-dcm3FtwRD07a+0XMTZU/1UO7FDLN6ywgic5tc9j1jseEApp1wERdNKHWYddK/bw3jR2zJlwN4mn7HoO79Bblmw==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -17580,7 +17600,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-pG9zDuwgSTxdgZ1Iz1NDB3vsjcD6arAgT5QS+m8kxRrhFZbzGSmdPZp8wITWu19yQSG7G+tpqIATZG0RyVcY0Q==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-hLg1OD8X3S/dTg98miMlSdhMML6BqVdVvwJiDu+UBsGUN7jAYIMz96D2cfu11WqmA//pTNHTkbCWFBVclstx4A==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -17623,7 +17643,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-Jt3yMiTLyTkbFsctiwp9q+QUPFDmRS5B7XmHofeeg0MghbUBfE0hpQkE3jTN4FRRH1AhZTeDy1AwpIJqy+n+ZA==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-QTroTSF9vnd6PZS7aMaieEhBD0LacU/ThBNOzHsHI/I7n7UhWor9Nt7txXqULfEqf3qiL2sA/Ku/oaB/jB4gyQ==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -17664,7 +17684,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-XYmNBl06jyj4DgGP9dcOTHt5IxJWWOwtWLXFHYaXYWTYioD3WPA+Wkbs9mwXM28tJmZrnUmNhoGI2dk8Zailuw==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-8ptJaqKNdqu5pZa6l7GXluFjW5LqmI+8ltaH0aXqXIM7CTs8kdt2evBVmLEXNLa7f//9pSvjcL3U4gwgRkiWgw==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -17708,7 +17728,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-7tN+R0e+2DvFCF6mCO4QlomFTtFA7c8cGL8ky0QL0qnNmtYlZ5xhTINg5GEpC4NvT/5A7SI57koKBtF/uoPZ3A==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-ZDuwwmEMOEDDitLd3KHdg70vKHUCMzJMuB4ObX1nL5iyiPHEUiQV3wjqUxynZlIvdIYhoImILBZ7KG/YC/LgDQ==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -17750,7 +17770,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-jV6XlId3/CRW+DTZFDjMMI2b3uvXO7eS9OKNWdWVY7gE+LsjBQ7fDeOKUIpyU1r87n8UevJKj8bc4lseNHrwQQ==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-TfLcoUSut4L1BDFKbkxkSTsiBAP4k2kqHfH+Ep7ik7APth/NfXavThdStlCMHsc7/OeSYnKv96T+O3Nk7yo78w==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -17801,7 +17821,7 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-Srke8YTXomS/dy0cNkEoUThgKv90YnMws7ep0+Zr/mRB3iwzRDnLHsAhQtR/nOklxqJR2yd6fo5u06lH7ty4Bw==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-CtE/x7YFKZgTeDWeMxu/Eo1PAiQC55rJY0DB+hwziCQ+se7hmoGz1x65lIsa+VMlSBmtSRPaPrrL52PlsxRjxg==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -17849,7 +17869,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-TuuagrwtTOgBl8BDMhTNk+DZ9KAzVFRBIWGPK5ee+pXy6CXCpk4eVLvpg0vfPv0sxoE0e6FhP9rlsx+KjBXZkw==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-vXcTKAxSzXpHciHGjyqv68a2Wv5HZo9RPztPqyDu9xCA7GIXoNoH2fImG/B8FcxAQKYr7ErYS5Fk1dGZdgKV+g==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -17895,7 +17915,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-+lXh+KlBW9fnRkMj/vWKkceooGBuzpO+MlhvNS/x47gwfl+ZgLVYUlykSbh6djQz/AGjkmrKQzBO/omjzWK35g==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-jFQSNnyMpAZhm7fXF1OSVfsRI1BMMCQIFeX4ftOxrhTAAd43t4uExV1DokLcXFG6f9Y5ZB9+GSJfiedW60Nsbw==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -17955,7 +17975,7 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-brXycExJAiqmjSvIbK6s+kC2VDRMQTi8+QFlZ4VWLVQM4FZAganjvpKIgXEkzGqqwSckllZjg4+67+83FuImLg==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-NKBHKMxLZPwWAQ65VMXq0MqpSzzbu6uUAL6nyslXsYt5eN5FeBF/KNEY4M6A8G3OLkfTFjXIE2kFGAXw/brX1A==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
@@ -18001,7 +18021,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-fz31jgn73G038e1Joyv2HbK9oMTO7eZauqEFRHDrQTdU0j85ZliMwtb5Bej4DZrNivCCVR6+zPCXEjfSQqwDUw==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-Bevf/qfRcF+/UVkHFEWNCGU8RhEdvRob/B6QZsW/dMfwfYK98LCwJiYK77ec6N+Z4b+f1Ia4t3zlqTI1ChIv3A==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -18048,7 +18068,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-TGjqEOOg7UELPSoFLSyRji7PkxoXqRTHm6ptlShunTIhODTohRL0BLTuhS3RYXEF8Kr6hP9bKx+H3AwcNxdwYQ==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-muV+FsQUif3kC8nhfKcW6UkKTO/2Va3IOiEzqnahLfKWwblauDluVM/Sm76l8N0fDzuNBiSMhdbhNQzRH5oWxQ==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -18067,7 +18087,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-dJH33V6Elz/qL4+23stM1mPk/+nHDXUROraQ+grGiR3oCqnxyv4lA5YzAFe6ioSeGwl/qH9JmSwc1sf4p8XsJg==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-8k7makhN1CdGzHgZ+mBEH1Bg4i0NSQImsHftGnDkLMOuQ0VrRu+R+Jqv8Fq3htFGvd0K70sfj0LjXBaeJ8ogbQ==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -18106,7 +18126,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-FN0BZNHzGTsws50Zw8341p3UOrgosa8Ztek4+pIaBRualZW2coSViRRFH54axI19ynQS5tTOKV65YUSbHe4mgg==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-AwvHOZrs/b1obgaFmkB7lHjtBavLYWY85cl3o+tCrG88g0hoNywfoIe1YHHhcDKuahHQHqr6kzh4C5xrMY0tuw==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -18170,7 +18190,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-JlgeI+DEAwRKI+AqpKOuoIw7rpjH7QcQH/0qosFMHj9WTod8yQtFfEJj4ghrpkrMq3rNk6YB398CoddZwFUFVw==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-4VNGwbYND1htdLuQn3HmLQreYIqzo2DNLhyh8ElEcAD9zSdi2pXF26aaI70JwamzkJ2QJZ7imr9+9AI+D3RCUQ==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -18217,7 +18237,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-FWvX1v3YmsvK45SORK6PDSWvoKIImtmctjrqNKpcvfCXQQEpD9iZCbAdHmrYxgo9AS75+dunS8raDSE+WerQ1g==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-/ldQrj1TmhbKhVmqhFn7LW4XNc7t407Z6X0ey2i8pQz2uPq8ieM4bpdzk63Cbhd+jAFug06FEVgaypAIjTotDg==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -18269,7 +18289,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-jHPfqrIDNcLGf/ILd6x69E5ghOlkoXwisL+jzj0RoL5yBbc62FlRqUldz4vlKRiGGnA2reMsiwoqQFnllV4wog==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-3GmleAhA8cFW6cWuhZoDiTHdw88mHOOfaPlTcO+KG30d9hw2HtIs/uYQExhLR2iV9MrWTtbaQAOOrxWmsIXaIw==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -18318,7 +18338,7 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-Q9xfYeq5GCiMEf/RvHl+lAwIZkgoQVX1Cg0KmfkMHUbyO8v9xgxnk2gcrAu0+tWQ9tkc63Yvfb0x3i/TWRZXKQ==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-Y7188W0cqgWSVJDqZdfx0abAMdhelI5oCfdbDhvilDWEDQcCvcwwYmC96Cys4SFa5U7b1DJxLwUAmlVR5taxBg==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -18365,7 +18385,7 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-Kcpz3AAg06xHgL8bL947t8sDHqa5g6skaUXl8I3kx7Opz5N7WBQNE7Pm2C+K8jKQhLCTMM3xmzO+t1D47KF/ag==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-tvtAkbE9mntxuIZ+Pgj7CJQ51N7teuHN2nhzuvKNW58se/7qT86ZsR/+dgSFG559eHT2LuTUAmdORzMln4n/CQ==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
@@ -18411,7 +18431,7 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-3zwcvhdyoNzFz+55+eWRRq901CPWGwlYvjgZiyKmU8g65wSr0R7Wxnaf2+n9NuVm336wBcQyBhJUpS9OEcGksQ==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-n5kwHCCuWoRe8wKh0gukn32eRqerVoTLcgsPBJj3D2DMUPoOmuqt55CpzaDHfUk/auEzJqVyLXO9/T2B/oJKyA==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
@@ -18457,7 +18477,7 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-rks1l61zr6zXX+wSKOuyAiRUGiZzhTnQiSWa0No8aNqvV1pUiKsqk/qd03WqYLie1538V4JMY/djRWRqWlv+2A==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-Uv4koSu+sIDffq104w8ulSR/Wk9fZqlm9WTcl7rZz92Qrk8XW7gXxfI5q6hN5MzF64c0XLOh3kMDL3z+3QTktQ==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
@@ -18488,7 +18508,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-+nvG984cPlktH/Zzk5Xb4PEX1glBQI0vkYq+EfG4BtHiNyBpJ2OrfYdgvlUWhxjXyOkoY9rtri9jFOjD4LgLjQ==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-5ZyIwNm/54vfUv/NYYSExJkGkEVt16Aef5gNFxI+9Ueam8oHdlSOSeY9n9PJ5P2FMh4skt/+DnO2Q7RAihH/fw==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -18525,7 +18545,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-I8SZYb5xbTEdOiHPTZtsNCtFw8qRrfoz2dcBVwtgwjHhn16sAORlefjP+nunLc4qH3IWuov59Z6rPAqJvYykPA==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-4LPENfwZf4tHGZw+eE3XeZKk5b3udsl2TV5Yuwgbn2L7aHE6V5m1uMqqcN4AsflCs0V6BKN8Z0yOl1svOXHcXg==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -18562,7 +18582,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-7QjbS7kw1GnhX8qrnBtX3/Zq2ZGL7egW0gQkzQ5TEVOXPJy5IbJpIZVr6av3Yy6dHF65bYT7ZH2UibhoG9P0+g==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-Lg6iKCSE1vxSwG+cuMsGDr0dDYi52I1xP5UFP/KoFAXaPcn4VO7y46fRakyAlLdi+otqosiIjSb4VxWURJyYeg==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -18622,7 +18642,7 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-ru0uvjhXhFPlvEjgTSCZVdzC3p1LfnWmE34ZqjVLthnKVvGUhh3C/Ol9OgfH4s+QhVVi2DS25OYjFZIVjj0mqA==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-5oO9dieSrWCX5+U1dKkSlqs41QCZkSVR3EguVZrgM8AKDpECvhknGOsE55N1kVWlthyuzBKzb2RHUeLBDgh/IQ==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -18669,7 +18689,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-/pz83XDxexRtKdXUUYiUKDdjBkolDV5fLHsKvOr7PZ21hg8oe07DUyAqMT4DThFRZee8YOoMSg61pB2wSLsCvg==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-xJoAjNC8HCKswbIJPXIgxgciWySyAEKeUZtXNU5UT6gLuazWtEKIaJv69JpBAwErPTnK4YqXWW6SM1Q1bhVIYg==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -18715,7 +18735,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-J4y09W1oP5YjNsgeuQFXa6yIltc/Gp56qNo1hUSbNmptAyDaCXo29bm2FvKihaJwnJkXuXzkAdV9Ga3SwjJh4Q==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-+npd7BY/2Me5X8NVpuHB2c3+wTHXHB9ZWN97n28kmDWmoaeUf0W2FH/jRabZVQDn3L/7la97KLz0531cxRZ5Nw==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -18749,7 +18769,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-pp37WyqpREs05Ny1ziEp6uLC9cfcoWHkXEvvqXh7JQLbi54eD7gNPbB16LUwo85BebrxKymPmXhAveQ7pfTwVw==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-CtnXg19MnXvjSVUT/MZKQZ02aN2JourZQJm7sHafTh1Y6oXsUsXEIWPTGdOSmpbppMsLS51xN58N/UmuukArYQ==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -18797,7 +18817,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-ppLuSBzgoEzFcqA9YNstoNJT6xe37jHUkvHfFyz2GKwasN8HmUBL4s3w7KAk2Fq1GjfMGXCqn/BGf9+ob7PNpA==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-8ddqfnj9iqAG8wHqdQl6tE/XSx0R/+J/jJ6SfJfgwJ7pUSzo0cQr5nqEWL7cQCgnugh+mza025ELeJl+PPM1Vg==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -18828,7 +18848,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-JGjOIrX9iFW2KtXVzFdvvO8lLl4A8yQw/70fIsyabFarp4UN4G92NQIHnoQAR7OzIRuWaNefT1J8PZSN6N13qg==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-qkH5Lo6rsVNWkwIhR60RkTy87x4VYfznBrrcsVhiKRcCQ6QTccp05Iz/BWKWCC52pyYmQaxBM7bQjoLUnFxjbA==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -18876,7 +18896,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-hE+J18V5/dqAFoReb9kDhgRTKdfvNf6TWDtmu2ZIRl2Hs94UqfVVJsZ/oRW7PziVWt8DHO+yUkiMV5TYSZrb5Q==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-8jV5WpBci4ArMgwQBr5QKh//idVU4DA9S3vROT9LZUDvguXKGPzwFfLNnd+Hm4CC2Ti0pltnsWCeuEpx249Etg==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -18921,7 +18941,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-aCN9M53DW5q5A3aBggb6oSs3hWERvwe+KGwSBtoAYhhE8Q1lfPgE2skjZxFBYdovpaLrMd1vOxA4gq4MXbVjPg==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-xvERTVTqFmVfciA9MemXULypY5ypyio4sj94sy3y6iUST024lYX04k239lzEEyD9cXSKpdpwDw+U3BXBYainmg==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -18969,7 +18989,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-6UK6y9CDxwkGS1dGzXaAA/tBqdHBq15oHy5V8rku/G9DMfkZqoVrU29V2b3XCp+KSqYij/TtXWVcoBK2nRsd7g==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-YMELQpBnuy2KyaF57OKXUBWFXaIKNB9tR4B7iX2F75LNqI8xrsS6Op+1098ivNoj0Wo98xd3JE+QR/CrElAjwg==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -19012,7 +19032,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-7g2+bWHfiD4QRnxT6c1HMvitBLQW2NQdFXyKwgco6ctpNzSeoUov8ntxP8C7p74wcCg1UAEJb29vTS+/6HtP6A==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-wHHQApYtHv3rMDVxJcHt/HwZvgKguuOYMFaMSodJfFodpFkGyKgwnJwt5k7xFJfPANHZD8I0jxBLNJOBzNKpMQ==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -19032,7 +19052,7 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-yX1St/LtPGAhuD3az1ZH3U4xEhP1DhHkmYzwXy1xMhMkICzi40EO/9vh8CP36whTuhu1Lo2AbLwuAADnvuYb9w==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-NrxF6ALtZbcsoseAxKBArbC8zIEdcApvr0kWUCxa1EPwnKgZGZDrCEk9KUXhIL0FyessV7BbPMZyEKbNSJQHWg==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
@@ -19078,7 +19098,7 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-vM7XZGL0yj7tV7wAZmIKQcAYq3vdHNmlarpmIF/z7HzoT9Jev2U4OpRhHq9CTfCevNdAg4cBjs45HXbDyhC7cg==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-HKBkbzZQapjtzWK56PEGME6roIazzv5IDcTUU9pMi8Qml0pZdC3GQ/+Y2HHKxemI9b9RTOMsCdsvdiDenSEL6A==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
@@ -19124,7 +19144,7 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-RKOAYeKgGEXT5yYvHiY3RrnTDYf5+Qk/dgWAt4zKkZrYDq03+uL8TD36W7gAiipmSI2+zZhbOmog19aziDrsrg==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-yUp0/Z7O0tbwuSbwIhk8DH1C1IsVraKOf1k9hmq0L/LJY9k6uNTB797DYp/qq6fseJr3gzaAdEiS9/p/iKRqFg==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
@@ -19170,7 +19190,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-G9vVngJUJKX0jtJKh+VAd4Juhr+i/yg3R16O0VjV4wQvqyDZTJ4cXbd9HgZ0DJ6fzJUpgLTJufAS6x9SxAih1w==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-rQjWla5iqC2+spBVto7uurlHatu/DLuZ87aN78ipQhneziIVkPXxrFBZik8+JhAepgBWTb/O5JodYHF6LZqtJQ==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
@@ -19216,7 +19236,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-+pKxVpu0zi/kmp5lRFs0YNpt06JR+lsHjKt0AejWvcyYmRSCn1l/KF1E/dNwoOJO0OFaCZd5nbtfa8msh7cfIQ==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-Ewp03jxmkQL3vpEBcwlzMqrcKqlAW9yJmWyEzckeWUoTO6wcDJURw12dtFfTZ0CEfoJCI0xg7yEHW3UvyOeFnA==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -19260,7 +19280,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-nS1OgVbPKSgjBqdHFf5fJO2vL6dF/MMK24z5OpXtJxKaMpeEubZt2Sqqxxfhxp7E/SzL91PqW7USzQm9Q/uaBA==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-DPjYTuu/PRJphU8uqDSCEhfoSkfRc7UgImVtk7u5KZcdMC6QFQCoW8Rc1l4pdjMPHRzAs+eOUlL/U1S7/jGGwA==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -19309,7 +19329,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-yaMhHE9TB85T0EGlp/5vbwBCQplc3lVWRsI7czTZLRfbOSa8ucGZcPSHl1WZok6RZhT63Q9q6bY8bpTac5y+eQ==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-/PDlpf5+sBfMSR6aJ7Exs63pfFjt3MHTWygsCf6JnbStCFW0hu3ed3TUkw2h3/RgTfC7vjir+cgLI9RMTLokKA==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -19330,7 +19350,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-ceNnafN0OSbOrYEW6QV1RbW0aBLbxcQn1z8S363QPs0juoXBuaFvIikw34ZQ0LRljOXRM9UYvI256I8YGJ1qyA==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-AjBY+Po+JTYFaszqdCNhVYfsTqTyaLsRFYvYqBzCRLgHAyDLktjXKw4FCZn5wQgYeOEJQ5p2jJkQgy3AoOFyOw==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19381,7 +19401,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-SdqvvFMi3xwm7UBoehJfdJ6bnnsQs6H6iBeFctfANjHCdModedU9yAt9BcC1jDf3uV5t/8AfUR7C3IydJRXCMw==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-FGszKi9uEyS9W6kUbw3iCPcNsHCHSG8IrfzRnQGm+JiNntU/E2VMaMhDyj8kX6kAmyyYsvFkFPQ0coM4zPJQAg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -19420,7 +19440,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-WQWJmJFqoGGwZ1mOvUsUjp8YObxGge05I0D+dLc4WOsof9JUjDgFCza09WySFK5aw2RxiqBP/Fx9jmujkcaBJg==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-bYSRcoXdwAvBtgnqoYEhMSvSC0QMPv6uUgpRfFAwrXb1amn+u52Jqkh+/2dBHV3dq20zvKUkR2wi25oQYsVcuA==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -19467,7 +19487,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-QjCB7d/eVVQP3Y2Vq+qnmePzWglJniGkYaygtchyBGSLnTgFBURDtylf5T5qz3+iPx/37TRXQszDyJjHh5m0Dw==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-wBGFrS1xTwh0NB9SFjn3crDJtHKEAQwldSJXW1TwFlgpsRmCHJchN9zFlODrt7Bi1iFwlo8wtvPyuCMf/YhHwg==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -19516,7 +19536,7 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-WLlSdA4jePXOLOX4LK4c3fHAij70rMV9NzytesGVftrkjNhaQLwRCTDPBzPFo+JNUMRK9ieUFmRlJW31MeFuKA==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-JmE+uqG69W+ZbWQFb2xWZ07AOJjGGJaNMwItminO01DcE0wkjCThw3pOsUTExWdBTyLspIuBa7tuOqFnmh1BOA==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
@@ -19562,7 +19582,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-rx85FOyeOgDOuCU4gZTB6XWVSmMoTeJXBog00SbEfkQDyrFfIRw4AAGn0JnTnbYn1bwz+Uvt/cLxxfNvduyG1A==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-2NMmaUMm6DhMNvbHRe+0wvVl+2l8Sjp9nXbEBMc+HY/s/bOEhZ7hTLRTzSVgB3DtL0WzDTSyQ6QUoF2b3Es7eg==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -19608,7 +19628,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-mSk9FO22xZFaYgUH958R8Edd8Lm1G9eH40xqOjGY9BKwdQhctTCbR3Xx32jDxt+6RI4erU2AqyIvrnyIis6GUg==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-gKZL7ttK2MU6WzHYV+t9gep6OQ6ZTVwYXwrCMrLuDTMmHKGuQlKW6q9G2LLqXKD3KGxkUeGHGbQxL56GbUXr/A==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19658,7 +19678,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-U6TVsiXb7vcvgdejr04sFG/grqSIdIvVJA7DbOsypKyf1xvuPPIl3GVEZJG1Oa4pFAtzjLyT9Y5ybg8drTVpPw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-Or2R/yHGQcqBDlm3e+vQbXTTFW2F4TTP3RAT0pIqAwaKb9ZSTYI2knAqU554PTr+dhc+rqkQIg+e2y2WW4iVew==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -19678,7 +19698,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-NqSj2g2Ce7Vu2IReCReJWkt1EGhpHIgylRkeKpio6tVBz7XbKQf4uT/AtuXNkCftuIVE2u3B+l/3awqGIWshxQ==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-s5yoPQIxpfAgk9R4x/XEbY+HcPFUYmwD+QQLnw8Y0XGVv9OtkLceU2fG1EFUiEix9QIgeXBKeaMp6V04w+eCkQ==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -19698,7 +19718,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-RPuvtv3VQRsrBqUN7Y2nhWVKXVl7Ec5N/OV/fjOcx6u0dKqdNFkIMkccPITdEPMUad+UJx6c/O3ZVtJJAer+gw==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-zGBajAFPIPa3nhyeX1Dr2mzaG6EjMCPl8dpvv5gUPIPl6jnhkYfBk8774m6IC9GrUyqqNoR+CP9sWmTE+1DAvA==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -19717,7 +19737,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-Q8C4LBxhg7N6EYnAckkjpTZAWvdSjbtAEaUmXTImOsqgW3SImWJE/ciWL4cBe3zRVrlXJfqFv2YT/CRcxrcxZw==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-vLCyCy6c9f479p0LKqhZ4MXjKAOd9ybMKCJ+ehfvXUpAvAAjXnrZ2EHaDer8Vke8gcJE9yMCuDATAEPjSbH6ng==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -19737,7 +19757,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-LjFTZPED1vx1D//gtnkCpfoEfMOkoXh8OFDFEss8AjzDJ9mVIbSt6gwLkrrKy3yYauofvu0/rBoUbYnc47JaEQ==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-0FRVhJOgqeR+0EIQNDjvhOKjOP4fYeMJiToPAsL8hfmM6JoIvXQAF9BR7fR7jokRyXxYVuCiKWE8OenlSCTWQQ==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -19759,7 +19779,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-5t124d9vVt0N+SL8YZPsrBhRD90QZQgIkudg4GKRunTIhJWTpsu2IO8eiyIeChv7g429WqMnMW7k2ZMs+qmHWw==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-L0nSQOyA+WVwwkLnjeUMx80ad0IvPyGHOgSldeZhtpCp6YptVfgZ33GT1BOwtj4ZgYrmVz7mUhbxgfCkKdAAug==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -19778,7 +19798,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-0RiWSctduT29aiUC1zf0hFtirnX/BuRJyaWmTH+vEv4TzigUcAI7pmLEfcmm6afg6WeNriSLqYH1THhQfXuVUw==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-YmpnkSB9PbsOTAYMLstsLlBfs0AHXz+nqAWbBm3JgeRtUUmAU79e7a4LFuATpeQMBf019LspbPGkE+tyPykhVQ==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -19802,7 +19822,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-4mM/JDYRRuuDDjZtEg3rBioWuqOquXG70wcTTO6AdfbYY8ARjurpG93HkAto1Fj6O+e6Jn2ZBpwI1qgJJ2BDEg==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-k9k+WP9yY0rjPGpkvUadlRRKZg+/PgyoWGk/EqPMXRf1qOvw1zWMlVwjAwDy09fVkocKR0j2iEbO4U+nmbz4pg==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -19823,7 +19843,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-lt3tzCKLbGRAojGlNqCg2OWriEs/zuOLSZ6CBamAk5E+sWXA3RESHNkvXElBzVNdWvz+1JE72oKc4buxDhRYYg==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-TOU0pZ0hXxny38VxxvQI54/ogtYlytOtv1Ji695lKv+T/cTfhZ7U0zojU2E8iX+vkWaJH+NBaRWy+lTBG+nUzg==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -19845,7 +19865,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-CspqxkKDhbIsF9oLIpgI7cBUjdZ5fZV8tbg29OWGHsg3U6s6TgRxgLp3IqjcUOxAFwNPI+YDY268jDMhfdONhg==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-lx4inBtuJqg2EdBNQD6+2xTCc43BdUmrl1ZGe8FKHqtO8iqRP197bT33gk/vSjSxicFI765E8x1LT01QBRURFw==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -19864,7 +19884,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-x1H+8ipkBaSfFzOopUTcnnXVKuwvYxvIxdFyCp2TBfj2dJsGVAFqC4PsYdMKmbNNurdRK8t3q3uv6kASsz3A6g==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-JyjEYpq2qx53p/wi/DUeTMPfh3re017LdADgzm5oAd6/MV22QwEHP93Q2WYnXQ/HrvjWb3BB7TBZnSQ7GxGa2w==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -19885,7 +19905,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-uW/U0qhO513tlkthLkHjI+XGOMXbD5ZKlHljvmDy0ZkAVfxeQBCBdM2QH488nAqu2ZK3+Zqdt5KH8zk0LQxdLQ==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-QTyKG+VK6rw+JICsfnSQ4WkjrCA8jSr03xpLyyqm4c/C2HcUuw5iO5H41jzeczIkAPmGXhMsYyA5YnRXTw0CQg==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -19908,7 +19928,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-Ct0jkAszeRWVVVahwgsdjS2vjU8u1kz4rTVWJiynVXzFKPhWjn4JvjkWl18nEdvG7Uy7QY6PgUFXmBgKb9asBw==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-tqTq2dN/qnkvX9Ip48vFGcP1Aw4/jLhYwEnz8QoiABwCeuLcxEF4/G4OJwtFXTbyRDpW2eYtd1SjTZUGbfUxzA==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -19931,7 +19951,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-o47+h6KJRAQcEKPVah1eiuQW59wuv3Dm/JESztq4JZewPNd4Zmem3V4XmyApOauhepHxwieiGsl40tzH0s2tQg==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-y6hWw0b5hzcYl5/Sx7E5pM7k0nwglyNDPNJxmbF3jp5CvmeD/r34SXKFSFqSKHhpWYz40eez/TQ2fcehDCuiZA==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -19954,7 +19974,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-j0ZdSh/RVx/7GLpOrismZBTZb8yAPXoXRp362VUUSe1T+DVtbLCT3wLNB98xF1RQgw6zBn38VZGa7OxVNO5uxw==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-Fr0DEr0BvMIUYCMRxAqMbZOtzmx6/68tkffA/TvTtz11jKoa3zrZVAJ57A+1LG1ulHSJyIonsFcp9YhVSVeJiA==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19974,7 +19994,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-4RgifS3p0c4fOWzUJy1k4TR0N8sZK3BWJP8UlytrvTufNWSxh8xyFjPHar0eipBNp8rPNX32h4uxnb2xED7agw==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-cT9NDxaufuITNH96fIMsGOWnARq3Of0uBj8vPTbLh06Q4t143L2XtI9RMTgfbk3LR6FVDYe9bIvcFBxcAHAXeg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -19998,7 +20018,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-cr3NnpE1cTOEZHqTMwOo5YaPLvDT0YqylVjTG1nMYj24fJj2fSamR6Vn1eukPJjkGqr4jF9SgYrqIgOd4Zub4Q==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-nXHqWCSngbjp81+y9gdfZfqAOjO6Eota9P5V8EX3OFWh4EVJmcMw6p/SJlJ6jlRIlJyPQNxXmyA58fgYWjgVEA==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -20018,7 +20038,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-raym/RD7gz+2AIBTBMBcFHETMwgKGoPHArxv1Glc/ebznR8wrjHXVqZHlkexfPcGKun/KidUT+7eoCjgOfhxWQ==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-FtaeyYffiiHtYCvYhioGtrh8BjDhQLkSePZc0IQuG37fcjnzZPvHnG6HJILZo7WQgUhGMrX4TCpSV8K52CoOjA==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20038,7 +20058,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-aXhSjY5/pJKeX+Qhtsip3gtEsQ3gO7EfEJPzipWeeZa/gj25oq9tAEZr754BA1/UUJa0JgiT1kNgqnqa1AGp4w==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-DDE1MKx2kF/oT8813eUn2eJOKXOoIPMz3d2E6dR800q9iq5Hsc1mgutjnCelvChtnxjk6giYYsvsXujdgu/gcw==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -20058,7 +20078,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-evYXFgwOjx696bKu4M3FfPf4EkLBycu44xONUF6oDSNxMb6hKFRAQgusDZHIvhvtho868HpVioWnjDHOgT/9Dg==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-1aQB0idm1A2edB59J6kYSWQjEhpZmW2rVhIksRoUR6gdRLZk8aMlO20xwra8VJC/Ggrn76Z2FoOAFvEG0/txVQ==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -20079,7 +20099,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-3SRkcJwCF77su/ziV1TQ5J54Hkvvov8rwyLQo4X4sRstD1rapPXifcricKLYFgajrovSmrc1rAn4nFYSTd86bQ==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-Xq/HBvsecy11GjHvNOzzXM0fUJGwc5/RM7I3COVS/e1yBYt1vFwnlpcWtgpxoIG9vEcU6pNLabxlssYFoMR1lg==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -20103,7 +20123,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-UPfH7e+MSIBpcOC0dgMHptWALYI8BbFyiL38w1QmCbpZtphOIANEDPSVxHkqvPgqMTankClUiObwWj1WsPbcNQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-Ujw8AeWpVE5C9gQ0oq4sX+Gs+bsrHa8bsoPLQjyn8GY67JmpFbxcHGJ8dTVngMG5oJUbs+vBgUdOGN4i1bIO8A==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -20126,7 +20146,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-5bTK39IJCy3g/r+qhUQVZ/LE+Um2stsntVd9M/DfjAuDxty+R3NXkIFeYwuVDlnaki1Ng6bZm7qAEj2dej7FVQ==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-0t+FHGWVEUWNM+Tkam59lIKZVYBZr6wVfykCLLhh8G6H0GUDEemakYg7xEw4iwUN7H7HOU6OkIGHxcvF3qOZNQ==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -20149,7 +20169,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-dMbTJPNZSBmNc1VrwtI5exnIF/r76bH76ivlj1LkvWtIWU5AU4R7vW5Z9/u8ExEirbKZtIms115sUeeAHNnq3w==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-oJsdMHdlfUMcK5MN1kD8v48+V1fJJ/TFIx/GtcCDUpM/ZVQPybO1ZTY1NNdwNFzV1qU2EEF3CmoaS5TH8Jfvfg==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -20172,7 +20192,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-/kZMf7x3Bt01w0cul/EBFdyHSpV1hlY8vFNJHl2SzdaC69KqV3TYa8fPO2fQvBTvw1sVWkfz/YF1FqQP4fxagw==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-47wOUEmWoCTfww9iU9hfFMe9Qc7iul9DJ3wcpor+0SWnVAzoB6yiB9ci2rIvilw6gjefqU5goWpmJOhBTmd+vQ==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -20216,7 +20236,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-GWDbv2gxaQdg7Q3r22uhBK+PTfmV4IOipWjaxcDiWyrp8WFscr/LeR0X1VnOZzhmQjVKoGVC00ArAFJ6hfd63g==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-ctZdYRlNdkgSyWSPYnQZlttcMfIK6zJSVrOf0/tnH5skZhAzRJpXI+VAcynkbERGEDvfA34XPtQQcCyP1oXLAQ==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -20260,7 +20280,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-lImf2k2N4f5xnmAoSQF2m9nJ0NtCJjodaKD9/Y+7QGUO1oDmt7eLoB7lm/4d/IwqRZqfzFvHSNH8JlJucDFOVg==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-4W4NArb+7ZJC90OovMyAjIZ6reA8d2l6AytYltVo4zXWq0QZ0pq+gNmCmr0CPLFZPUGfYEIGvbjB3ENoecb2tQ==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -20304,7 +20324,7 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-WSQJFuLsAcXlw3bziPDRFoXfrxsKCv1FxwYlKqKGnN16tkuMAunKcqL01/9Q1+EpHmLY7scxEMpJNELiCtMFYg==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-Iv0hPsiJrUg5xJAt5Y50ErLnxE0ce1fzCWDVDz8qB2YO8H5n2431M/Iq2yXIopuWiTbMEHwO1Txi9aPxjxHDzA==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
@@ -20350,7 +20370,7 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-EY+WHo6UhYrayUuLYzD74FBuR9rWDSivFNuyNgM8wAwz21hPKrIyH7aa2OMvsKtPBlTmggyNhi36emKV6yy26A==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-Lrwg3bnpPLciSbBcY5fC80gC2Vu0xY7BIJdjdHTAeDwNJo670LiTIVSBQtYWk+GXDFirGFXBZRQWCFcSIx7eCQ==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
@@ -20395,7 +20415,7 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-Ks4bNSWLmH8yRuLhqb1ToGAIyn1Q11vJsPEh0OszCQeedzJgQ9/6r1ZROpy/A6M4UBDbgYUa8Feio2cZt2owuw==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-/+wf6I3TWLx6QCWe584HTu+dEhQ0/OvSOMtazdvQx/U1c9ue+eFJrnvNqmZ1R6b+zXFgn08s7WE4TkXXsW1HoQ==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -20442,7 +20462,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-KVOSGQ4WEkTcNPgteiNTRt5gcP9HmubsrDkDVfB32EyFBu3Se3e0PUIr42BKPw2Lp1NLHFIwSgWJWPLChWP5Zw==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-gCurE+JWjtyPjjGy64MjOhkmqS17jVTlqHRAfD/9JH+4G/FEhw59mttHbIrM7a9Aown8bj9lG/qXW3LypTHo7A==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20495,7 +20515,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-VxW6onEDXOzAd/p8ai6y1833jJfNT95WsMuKZoO3hcEG9la6EYCFqESbzeBZYbK28hvy7h5Lqb/Uirf9q+ufjQ==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-0OV8fgxchrKATGJiPwV1hs+JnNFvEd14YN48ocp9EiCQtMSaqL0DXRL6nRh8eEzP72oqNUJJKyZHzy5viqmYFQ==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -20538,7 +20558,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-e0AGlnbKM9Yh0GmkMycm7m92umWGiicheeTM/9/GMyuf4t6MIqbR6BK4enmFmB97uqcu0tc5iFmwJ0ZIVeCriw==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-gWbbZ0hfotv6iVHqpRVG/xb/mBjQ8K7XtFzuZel2EdHrfGs/ccg7SqfCPC3/4XtHUNlHNorMaWGBD1FAxFLX8A==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -20579,7 +20599,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-QrjrfKsIdzFUgG+RqEBWZHLkkNImdswHyFKLun+b4orHA8qnxwe2HWyfzM5vUarj0eF3W2xGGkmv5C+TkFSpHA==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-j5/AKSoYQQwjkPU0cz8fVheibhchflva3sBq4+qvBHDrm/g0H9AwXQVfPwrYcp8DTPzTopm4jY8tt3OahXf3wg==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -20614,6 +20634,7 @@ packages:
       sinon: 17.0.1
       ts-node: 10.9.1(@types/node@18.19.2)(typescript@5.2.2)
       tslib: 2.6.2
+      type-plus: 7.6.0
       typescript: 5.2.2
       util: 0.12.5
     transitivePeerDependencies:
@@ -20626,7 +20647,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-k+Y8VE8VpJBfvcsw2nESdJV9sWH4QyBtf22OXmt68H1RHCg7KFNiqvlfoNnBGzbb1NeexnT7RLwpaN7RSzy63Q==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-TaKEMlBC3x8ckqugqlHfTW5eoRs2qduuemVNqbJJIw+i+99zv05gMuLZOPVAfOHqZhdOlkg0ea/bEYSU18gYyA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -20692,7 +20713,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-/jJBRMwfGgN3ZZ3bV1neHyzfKt7sG3ku1GL+G7FSREVsNZFMoA0AnBvqlklEvoVD1g6Si8HjK5ulwxkjv4qs2w==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-juFiRrV9Q7pKAciOvOLbmHM6V/nUSP+OcpDHiVl4GJiWum+Tdo47lIO+YRL/yQysy/0KZPMjLtl1SBkspxSbsQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -20745,7 +20766,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-k4/qx4GARNnPguinc8JA8I9xIsZvZTBDhcPynjGU6PdlUsX5/Y4rMD8anTI0BFH3fPRFgrVwEVf87juoYZBSVQ==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-rLvVxkiy5NjidM+p6a6Ze+bnBmxMS0q+yxPk7awBJ9v+F1MvOpEwIGeQa6hWVcwkiksVSNZHB+25kBsgOhxxgw==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -20798,7 +20819,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-H8h/ru567F+fhMHzZ5d3T/E2QKKxQZ/2yRqXfVdaylobwqtoiRcIWhzp8NhPE2kCQ3FoDN6DUftHVsBnRi5GCA==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-EpkbIpOH5d/p8ZqNRBxFJtypD8ixr46w1FQQ1UFSPIG5ewrVc4Psh6xLwapGDAR044K1dQCKYWuivxrXgm2EQg==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -20852,7 +20873,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-fV0s9DjmvOpr74GJanEPwFUTZmASonBcihCrsXsNiGanAet02/b0GxOLtenhiUncOOM4j7SuwMzwi67rh9T+4A==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-UC3N8VhL3W8zT1DL/MMrK/LH5VC7VQFpo8cdTzC8nVv+U3+3UTWXyi5qJbmCHg724VkznQrvX5bj2pYS2e4m2A==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -20906,7 +20927,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-sOB5jsyFQwrqlanrEgplL8Vr4yH+GRHA3ZZX5IO1SoPNQSSrmFDDcKTc5jxiJ6q0qAk1bmumL4t4iOcnynGfLQ==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-gELGE1o0o4gUVv9F8qgwQjw6TEjPVu3HWVzjtK00TyX4BPXvOhXmw4qR8LbB9BQtpqmMRhzb7F1Ln4EB42jVww==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -20954,7 +20975,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-kGeJLtmw0FY/X/SCgFXvYShwphpXVPqDMa7JIhWVFiYFrS5nQs56TPqAh/4PtJrOv390kDbPZUWh2Q6CFmKYgQ==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-HrkIZYWw/qOodI5gm6WNZ8KJYrRcOa72rqA4ZlZzh+tNrrc5Wz3VIhOucH/0CUkBuTXxinOHW3sdZY1I1qPEVQ==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -21005,7 +21026,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-vnXgDMdd39Yo3b6o+NCeTu7GKQGaa4EJB3W3A4D+XjZGn5bPrIBzMAw6KrF66L7BSjIRvImXEmdf1+FsTO0eBg==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-2/7hekAQ4nrlp/ctEt6oDBjCcviWuU+QQcx67aK0EiEuj+bKWFFvh2dlinZLrqZNTzn3AZxML50F0dvZELOYrw==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -21051,7 +21072,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-n2dkse/7KLWx7HSzABhZsGFQTQUwImH+vetlQIuiJgvgmP5P8y3Epl7V/z6ahxApoCVaSfiQReGe4ORiKQG1vw==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-EYWITQtm2Fz4OCEjiy1GPC+s59596UNLbgDCHqso0TD50Pe4QCc8YlkzlBGtJaG5XsyyVEhK6M2SbRXzNN2+wg==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -21101,7 +21122,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-JWv54L7WNu1tRMDn0IvN4sQfUc8Mt8cuNa0cx2nCgPNPZHi9Lu3cxAQgCLH8WSFeCPDq14eNS1tp8BnD6Jeb8g==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-4UxsRijOsFTpmms6CVdRfOVTqDQ4DhYLyl5S/wrArQdeVOFjdweXiICjJtBOuUsc3DS8YYbIiz3G8mWf6T1b2g==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -21151,7 +21172,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-yBbRp5TqC6dT7pQ8nBqk+Mi6sn3brkPgu4psHea6BRoP5KsHc1Vf8DRvALbUVdkc6FTLF1Rel3vhmodRmTT7pw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-RBtvzZtVR0fNe9UkZw1F/NkCY8IjyyKZCvlUPeldfTsYNaFCKvvk35NXrnxAtTeI3itMSt04hPdB7T4a3+/HRw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -21194,7 +21215,7 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-CIwbNRZW8/qZ93iEeTn1HqzNAuyou7PFLQnZ+/gCrPM6Unx0yOVVSP2iZQk1EkO365XVTNu2CX8hsq6/H4iO1A==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-e4yQbRxUQnY/WvUoQHgFAm1THPs8x/FxGXdjuvwj7013LqzOHEWbTGbAvH6OvRzL7APulnNE6STu/4x/BzCUNA==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
@@ -21230,7 +21251,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-86fziXtA8dau0vjBDCsT9K3EepPuE71mg6nUfES+NK7ATQ6nSzI/x9hI+idVhqw7hKtCPORUD1+DfWiR7CUE2g==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-QtXVbD5+PtkO91N+n9OqgKVqM+sPQgZEej2WXG09umwsCARV1AQ8fql1xDjl8tznpc5zOdFTu5eJ4DixEhuhww==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -21273,7 +21294,7 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-xLw3u31dmWAZ8xBi/rnkSKLVy2hQsSInGGswKwg4KuKRoW6+3bIHkQLVayMDb0YEScNx/stfeb67xkYWKF6+nw==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-qyk7ve4Y9b1DGoOotRz2aX9GVKfrWoADT09WYVdSUeJnwgMMWo2qHPjG56/fwJMyAHe9E1iCXexmEGJv1seXsg==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
@@ -21317,7 +21338,7 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-HXxreZi3HMhCTpFBiY0YOmQ73kLDWz1HSNL+8ELX2lAp16DWnV9kRj9uJmuN9z8dJmd/jty09FWloXdUXAsBhA==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-TtLezoctYAmW1syJkG24OGpU7IdNiLibELzy6yVcV3Vic53FrqXE72uoR7nRA6n6b580r4+bmAqQBVcODOZ8Rg==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
@@ -21363,7 +21384,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-Z48JUB+N3+lQRq2wf1gjMZifKJDAlUcVaf8LagNKfPzMTS4XwvRD6cLxkJpyH3GnGSPlEY1SAoiiyUc6s0YyUg==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-54S+0gLOPkh7hDKxWRlMptwTT9XaLEgUT+48q613z+f1v5aeDBQcBwIDMjamGZmF6fLjuvj0sdLqfCnrI4+jUw==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -21382,7 +21403,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-09CxwiJnjwk3Gybg41W/yC9x6OQBhkbzGjlhq2s9qHpdGnow+fvGlBSrcqVXLr2RzeOPQCb7Wbs91uTtZxiuhw==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-pIjq3Pny1yMcp5pI4TVB0vtFO8oGjRAg6gJ3tQBzJtsBrdg1fiQhI2biuTNsiEDd9c3kAF3zajDrB6yMOmOptQ==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -21426,7 +21447,7 @@ packages:
     dev: false
 
   file:projects/test-utils-perf.tgz:
-    resolution: {integrity: sha512-dOvVvEms2bk5MK7+xyDZdzJhgXQjvjpijm8AJDnvNgFK6maXdBe9zuQnB3f27v36pKSK3WrIe8u5FmKnJYu8yw==, tarball: file:projects/test-utils-perf.tgz}
+    resolution: {integrity: sha512-eEeMvcLwPiGrEAzub8jwqf4Ed+DmPG7iOvFvqYsetuSJkNIg3CgK9Qth8edxqkgRYGBxw5y8ruqc7KiDt+WmDQ==, tarball: file:projects/test-utils-perf.tgz}
     name: '@rush-temp/test-utils-perf'
     version: 0.0.0
     dependencies:
@@ -21458,7 +21479,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-0uZXr1TywcfgaT4ZD+TqIqAeYL6RyqLRW18ufagbipz5QXbFY8Eb9MFpbXioaO91n7z2nvVoxQgJUf2ijxnWRA==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-8ft2lTF6cr8sQH3/csvrLEhN+W04HsEE8A9N+yFDJE4Em6JIE/pOcuWio5fP1aUyDJ5USNXV3uPlrGzZwQjm/w==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -21495,7 +21516,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-rEQGDGZUJSE9ModjokfuCkhoRB943SfGIeH18riZjP4bHC0UuVBHMF9hHHDrR3iaaM9vVP+H987mALGf8blfVA==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-65IgqX3myZ+cSo7FQeo27HZJtHOK0aPfoTKYiCxZCecek7JCwwc5yL07ssAKP/NT2jwCQOviN2lBBszfKGvXHQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -21544,7 +21565,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-s5Ni+mE7VLb6DWDNlPaPYAKI9uV544OVcrKdtaMFMNYCFRTXKJB7XxLoDTaWtb5KdvMgRpqqlyYTGxfVYYVpiQ==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-lgvJv9FldV5+QSJ78Vxvidbr2tM+hN5cteOWI8TogEos0OValYDAU4nQcSefAb56xSc0h+IgbMyXq7BiQrI8HA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -21607,7 +21628,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-yGPzuC8S2d0Wen97ZAYmTVcx1DzGFl/bS1LXDOXZ4ZLBb8XzM8ySF5oR27eLVPPFtaBVetudX5Jru/Rih8RESg==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-MYPtANuVMACVe8jYKBsa1pkkv6SUmCeanF8G6kEcoJb32/vMc6qczNdSlrNTBc7PSP0M8wjDjWkmr/bKeSOmZA==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -21665,7 +21686,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-3URrAG0U+XgZUIfejSoDa67el3CIG5wnDnRbeD0bMebeCVJA0LfxETjBje32DiMZAkCrkTLUZGV0mm/7uFRl1g==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-b8gs5KYCn4dtYUL2HfSz6wUCas5Zi+ACil5mmzoOfMi1eE2gLvJfgWQ4sIISnj+Fci1MFWrZTotQfMp12WoTJA==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -21704,7 +21725,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-O2YvJcNEXM3wK03slG3EDY0PPsl89UVpo5mJ69Z86HC09MJSI+HCoTMVGBgf4qsFxgjyClv+Johb7Yi+iaLFjg==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-nmHhj2va2/L8jwZQRYUIhP1oTDCZF11G83ZEK0UrwBMJMhcfq27V8+sreYghWWfBKrWhlQNdugx0ehRjriyD7Q==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.0.1 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed the invalid type narrowing of documents returned by `SearchClient.suggest` [#27984](https://github.com/Azure/azure-sdk-for-js/pull/27984)
+
 ## 12.0.0 (2023-11-13)
 
 ### Features Added

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -1,23 +1,33 @@
-# Azure Cognitive Search client library for JavaScript
+# Azure AI Search client library for JavaScript
 
-[Azure Cognitive Search](https://docs.microsoft.com/azure/search/) is a search-as-a-service cloud solution that gives developers APIs and tools for adding a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications.
+[Azure AI Search](https://docs.microsoft.com/azure/search/) (formerly known as "Azure Cognitive Search") is an AI-powered information retrieval platform that helps developers build rich search experiences and generative AI apps that combine large language models with enterprise data.
 
-The Azure Cognitive Search service is well suited for the following application scenarios:
+The Azure AI Search service is well suited for the following application scenarios:
 
-- Consolidate varied content types into a single searchable index. To populate an index, you can push JSON documents that contain your content, or if your data is already in Azure, create an indexer to pull in data automatically.
-- Attach skillsets to an indexer to create searchable content from images and large text documents. A skillset leverages AI from Cognitive Services for built-in OCR, entity recognition, key phrase extraction, language detection, text translation, and sentiment analysis. You can also add custom skills to integrate external processing of your content during data ingestion.
-- In a search client application, implement query logic and user experiences similar to commercial web search engines.
+- Consolidate varied content types into a single searchable index.
+  To populate an index, you can push JSON documents that contain your content,
+  or if your data is already in Azure, create an indexer to pull in data
+  automatically.
+- Attach skillsets to an indexer to create searchable content from images
+  and unstructured documents. A skillset leverages APIs from Azure AI Services
+  for built-in OCR, entity recognition, key phrase extraction, language
+  detection, text translation, and sentiment analysis. You can also add
+  custom skills to integrate external processing of your content during
+  data ingestion.
+- In a search client application, implement query logic and user experiences
+  similar to commercial web search engines and chat-style apps.
 
 Use the @azure/search-documents client library to:
 
-- Submit queries for simple and advanced query forms that include fuzzy search, wildcard search, regular expressions.
-- Implement filtered queries for faceted navigation, geospatial search, or to narrow results based on filter criteria.
+- Submit queries using vector, keyword, and hybrid query forms.
+- Implement filtered queries for metadata, geospatial search, faceted navigation,
+  or to narrow results based on filter criteria.
 - Create and manage search indexes.
 - Upload and update documents in the search index.
 - Create and manage indexers that pull data from Azure into an index.
 - Create and manage skillsets that add AI enrichment to data ingestion.
 - Create and manage analyzers for advanced text analysis or multi-lingual content.
-- Optimize results through scoring profiles to factor in business logic or freshness.
+- Optimize results through semantic ranking and scoring profiles to factor in business logic or freshness.
 
 Key links:
 
@@ -39,7 +49,7 @@ npm install @azure/search-documents
 ### Currently supported environments
 
 - [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
-- Latest versions of Safari, Chrome, Edge, and Firefox.
+- Latest versions of Safari, Chrome, Microsoft Edge, and Firefox.
 
 See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
 
@@ -50,7 +60,7 @@ See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUP
 
 To create a new search service, you can use the [Azure portal][create_search_service_docs], [Azure PowerShell][create_search_service_ps], or the [Azure CLI][create_search_service_cli]. Here's an example using the Azure CLI to create a free instance for getting started:
 
-```Powershell
+```powershell
 az search service create --name <mysearch> --resource-group <mysearch-rg> --sku free --location westus
 ```
 
@@ -58,15 +68,19 @@ See [choosing a pricing tier](https://docs.microsoft.com/azure/search/search-sku
 
 ### Authenticate the client
 
-All requests to a search service need an API key that was generated specifically for your service. [The API key is the sole mechanism for authenticating access to your search service endpoint.](https://docs.microsoft.com/azure/search/search-security-api-keys)
+To interact with the search service, you'll need to create an instance of the appropriate client class: `SearchClient` for searching indexed documents, `SearchIndexClient` for managing indexes, or `SearchIndexerClient` for crawling data sources and loading search documents into an index. To instantiate a client object, you'll need an **endpoint** and **Azure roles** or an **API key**. You can refer to the documentation for more information on [supported authenticating approaches](https://learn.microsoft.com/azure/search/search-security-overview#authentication) with the search service.
 
-You can obtain your api-key from the [Azure portal](https://portal.azure.com/) or via the Azure CLI:
+#### Get an API Key
 
-```PowerShell
+An API key can be an easier approach to start with because it doesn't require pre-existing role assignments.
+
+You can get the **endpoint** and an **API key** from the search service in the [Azure portal](https://portal.azure.com/). Please refer the [documentation](https://docs.microsoft.com/azure/search/search-security-api-keys) for instructions on how to get an API key.
+
+Alternatively, you can use the following [Azure CLI](https://learn.microsoft.com/cli/azure/) command to retrieve the API key from the search service:
+
+```powershell
 az search admin-key show --resource-group <your-resource-group-name> --service-name <your-resource-name>
 ```
-
-Alternatively, you can get the endpoint and Admin Key from the resource information in the [Azure Portal][azure_portal].
 
 There are two types of keys used to access your search service: **admin** _(read-write)_ and **query** _(read-only)_ keys. Restricting access and operations in client apps is essential to safeguarding the search assets on your service. Always use a query key rather than an admin key for any query originating from a client app.
 
@@ -134,17 +148,26 @@ const indexerClient = new SearchIndexerClient("<endpoint>", new AzureKeyCredenti
 
 ## Key concepts
 
-An Azure Cognitive Search service contains one or more indexes that provide persistent storage of searchable data in the form of JSON documents. _(If you're brand new to search, you can make a very rough analogy between indexes and database tables.)_ The @azure/search-documents client library
+An Azure AI Search service contains one or more indexes that provide persistent storage of searchable data in the form of JSON documents. _(If you're brand new to search, you can make a very rough analogy between indexes and database tables.)_ The @azure/search-documents client library
 exposes operations on these resources through three main client types.
 
 - `SearchClient` helps with:
-  - [Searching](https://docs.microsoft.com/azure/search/search-lucene-query-architecture) your indexed documents using [rich queries](https://docs.microsoft.com/azure/search/search-query-overview) and [powerful data shaping](https://docs.microsoft.com/azure/search/search-filters)
+
+  - [Searching](https://docs.microsoft.com/azure/search/search-lucene-query-architecture)
+    your indexed documents using [vector queries](https://learn.microsoft.com/azure/search/vector-search-how-to-query),
+    [keyword queries](https://learn.microsoft.com/azure/search/search-query-create)
+    and [hybrid queries](https://learn.microsoft.com/azure/search/hybrid-search-how-to-query)
+  - [Vector query filters](https://learn.microsoft.com/azure/search/vector-search-filters) and [Text query filters](https://learn.microsoft.com/azure/search/search-filters)
+  - [Semantic ranking](https://learn.microsoft.com/azure/search/semantic-how-to-query-request) and [scoring profiles](https://learn.microsoft.com/azure/search/index-add-scoring-profiles) for boosting relevance
   - [Autocompleting](https://docs.microsoft.com/rest/api/searchservice/autocomplete) partially typed search terms based on documents in the index
   - [Suggesting](https://docs.microsoft.com/rest/api/searchservice/suggestions) the most likely matching text in documents as a user types
   - [Adding, Updating or Deleting Documents](https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents) documents from an index
+
 - `SearchIndexClient` allows you to:
+
   - [Create, delete, update, or configure a search index](https://docs.microsoft.com/rest/api/searchservice/index-operations)
   - [Declare custom synonym maps to expand or rewrite queries](https://docs.microsoft.com/rest/api/searchservice/synonym-map-operations)
+
 - `SearchIndexerClient` allows you to:
   - [Start indexers to automatically crawl data sources](https://docs.microsoft.com/rest/api/searchservice/indexer-operations)
   - [Define AI powered Skillsets to transform and enrich your data](https://docs.microsoft.com/rest/api/searchservice/skillset-operations)
@@ -318,7 +341,15 @@ main();
 
 #### Querying with TypeScript
 
-In TypeScript, `SearchClient` takes a generic parameter that is the model shape of your index documents. This allows you to perform strongly typed lookup of fields returned in results. TypeScript is also able to check for fields returned when specifying a `select` parameter.
+In TypeScript, `SearchClient` can take a generic type parameter that should mirror your index schema. With this set, the client will use this model type when it returns documents. The client will also narrow the type of your document to only the fields you select when using the `select` option.
+
+The typing enhancements work best when your model type follows these guidelines:
+
+- The fields of your index should be identical to the property names of your model type. The model type shouldn't have extra fields or omit any fields from the index.
+- Every field should be optional
+- With the exception of the index's key and array types, every field should be nullable.
+  - The default behavior of `suggest` is to return only the document's key. The corresponding behavior in the type system depends on only the key field not having null type. However, as you may opt out of selecting the key, it should still be marked as an optional field.
+  - Note that arrays _and_ their elements can't be null. However, if the array contains an object type, the properties of that type may be null and follow the same rules as the top-level properties.
 
 ```ts
 import { SearchClient, AzureKeyCredential, SelectFields } from "@azure/search-documents";
@@ -328,14 +359,14 @@ interface Hotel {
   hotelId?: string;
   hotelName?: string | null;
   description?: string | null;
-  descriptionVector?: Array<number> | null;
+  descriptionVector?: Array<number>;
   parkingIncluded?: boolean | null;
   lastRenovationDate?: Date | null;
   rating?: number | null;
   rooms?: Array<{
     beds?: number | null;
     description?: string | null;
-  } | null>;
+  }>;
 }
 
 const client = new SearchClient<Hotel>(
@@ -354,7 +385,7 @@ async function main() {
   // These are other ways to declare the correct type for `select`.
   const select = ["hotelId", "hotelName", "rooms/beds"] as const;
   // This declaration lets you opt out of narrowing the TypeScript type of your documents,
-  // though the Cognitive Search service will still only return these fields.
+  // though the AI Search service will still only return these fields.
   const selectWide: SelectFields<Hotel>[] = ["hotelId", "hotelName", "rooms/beds"];
   // This is an invalid declaration. Passing this to `select` will result in a compiler error
   // unless you opt out of including the model in the client constructor.
@@ -399,20 +430,30 @@ main();
 
 #### Querying with vectors
 
-Text embeddings can be queried using the `vector` search parameter.
+Text embeddings can be queried using the `vector` search parameter. See [Query vectors](https://learn.microsoft.com/azure/search/vector-search-how-to-query) and [Filter vector queries](https://learn.microsoft.com/azure/search/vector-search-filters) for more information.
 
 ```js
 const { SearchClient, AzureKeyCredential, odata } = require("@azure/search-documents");
+const { embedData } = require("../my-model.js");
 
-const searchClient = new SearchClient("<endpoint>", "<indexName>", new AzureKeyCredential("<apiKey>"));
+const searchClient = new SearchClient(
+  "<endpoint>",
+  "<indexName>",
+  new AzureKeyCredential("<apiKey>")
+);
 
 async function main() {
-  const queryVector = [...]
+  const queryVector = embedData("<The data to be embedded and searched for>");
   const searchResults = await searchClient.search("*", {
-    vector: {
-      fields: ["descriptionVector"],
-      kNearestNeighborsCount: 3,
-      value: queryVector,
+    vectorSearchOptions: {
+      queries: [
+        {
+          kind: "vector",
+          fields: ["descriptionVector"],
+          kNearestNeighborsCount: 3,
+          vector: queryVector,
+        },
+      ],
     },
   });
   for await (const result of searchResults.results) {
@@ -462,9 +503,9 @@ When retrieving results, a `facets` property will be available that will indicat
 
 ### Logging
 
-Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
+Enabling logging can help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
-```javascript
+```js
 import { setLogLevel } from "@azure/logger";
 
 setLogLevel("info");
@@ -475,8 +516,7 @@ For more detailed instructions on how to enable logs, you can look at the [@azur
 ## Next steps
 
 - [Go further with search-documents and our samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/search/search-documents/samples)
-- [Watch a demo or deep dive video](https://azure.microsoft.com/resources/videos/index/?services=search)
-- [Read more about the Azure Cognitive Search service](https://docs.microsoft.com/azure/search/search-what-is-azure-search)
+- [Read more about the Azure AI Search service](https://docs.microsoft.com/azure/search/search-what-is-azure-search)
 
 ## Contributing
 
@@ -484,11 +524,11 @@ If you'd like to contribute to this library, please read the [contributing guide
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit [cla.microsoft.com][cla].
 
-This project has adopted the [Microsoft Open Source Code of Conduct][coc].For more information see the [Code of Conduct FAQ][coc_faq] or contact [opencode@microsoft.com][coc_contact] with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For more information see the [Code of Conduct FAQ][coc_faq] or contact [opencode@microsoft.com][coc_contact] with any additional questions or comments.
 
 ## Related projects
 
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+- [Microsoft Azure SDK for JavaScript](https://github.com/Azure/azure-sdk-for-js)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fsearch%2Fsearch%2FREADME.png)
 

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -92,6 +92,7 @@
     "@azure/core-http-compat": "^2.0.1",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",
+    "type-plus": "^7.6.0",
     "events": "^3.0.0"
   },
   "devDependencies": {

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -92,7 +92,6 @@
     "@azure/core-http-compat": "^2.0.1",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",
-    "type-plus": "^7.6.0",
     "events": "^3.0.0"
   },
   "devDependencies": {
@@ -129,6 +128,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^17.0.0",
     "ts-node": "^10.0.0",
+    "type-plus": "^7.6.0",
     "typescript": "~5.2.0",
     "util": "^0.12.1",
     "esm": "^3.2.18"

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -8,8 +8,10 @@
 
 import { AzureKeyCredential } from '@azure/core-auth';
 import { ExtendedCommonClientOptions } from '@azure/core-http-compat';
+import { IsAny } from 'type-plus';
 import { IsEqual } from 'type-plus';
 import { IsNever } from 'type-plus';
+import { IsUnknown } from 'type-plus';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -1576,7 +1578,7 @@ export type MicrosoftStemmingTokenizerLanguage = "arabic" | "bangla" | "bulgaria
 export type MicrosoftTokenizerLanguage = "bangla" | "bulgarian" | "catalan" | "chineseSimplified" | "chineseTraditional" | "croatian" | "czech" | "danish" | "dutch" | "english" | "french" | "german" | "greek" | "gujarati" | "hindi" | "icelandic" | "indonesian" | "italian" | "japanese" | "kannada" | "korean" | "malay" | "malayalam" | "marathi" | "norwegianBokmaal" | "polish" | "portuguese" | "portugueseBrazilian" | "punjabi" | "romanian" | "russian" | "serbianCyrillic" | "serbianLatin" | "slovenian" | "spanish" | "swedish" | "tamil" | "telugu" | "thai" | "ukrainian" | "urdu" | "vietnamese";
 
 // @public
-export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, IsEqual<TModel, any, TModel, IsEqual<TModel, unknown, TModel, IsEqual<TFields, never, never, IsEqual<TFields, SelectFields<TModel>, TModel, SearchPick<TModel, TFields>>>>>>> & {};
+export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsNever<TModel, TModel, IsEqual<TModel, object, TModel, IsAny<TModel, TModel, IsUnknown<TModel, TModel, IsNever<TFields, never, IsEqual<TFields, SelectFields<TModel>, TModel, SearchPick<TModel, TFields>>>>>>> & {};
 
 // @public
 export interface NGramTokenFilter {
@@ -2092,7 +2094,7 @@ export type SearchMode = "any" | "all";
 export type SearchOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SearchRequestOptions<TModel, TFields>;
 
 // @public
-export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = IsEqual<TModel, object, TModel, IsEqual<TFields, any, TModel, IsEqual<TFields, never, TModel, IsEqual<TFields, SelectFields<TModel>, TModel, UnionToIntersection<TFields extends `${infer FieldName}/${infer RestPaths}` ? FieldName extends keyof TModel & string ? NonNullable<TModel[FieldName]> extends Array<infer Elem> ? Elem extends object ? RestPaths extends SelectFields<Elem> ? {
+export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = IsEqual<TModel, object, TModel, IsAny<TFields, TModel, IsNever<TFields, TModel, IsEqual<TFields, SelectFields<TModel>, TModel, UnionToIntersection<TFields extends `${infer FieldName}/${infer RestPaths}` ? FieldName extends keyof TModel & string ? NonNullable<TModel[FieldName]> extends Array<infer Elem> ? Elem extends object ? RestPaths extends SelectFields<Elem> ? {
     [Key in keyof TModel as Key & FieldName]: Array<SearchPick<Elem, RestPaths>>;
 } : never : never : NonNullable<TModel[FieldName]> extends object ? {
     [Key in keyof TModel as Key & FieldName]: RestPaths extends SelectFields<TModel[Key] & {}> ? SearchPick<TModel[Key] & {}, RestPaths> | Extract<TModel[Key], null> : never;
@@ -2146,8 +2148,8 @@ export interface SearchSuggester {
 export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>> & {};
 
 // @public
-export type SelectFields<TModel extends object> = IsEqual<TModel, never, string, IsEqual<TModel, any, string, IsEqual<TModel, object, string, TModel extends Array<infer Elem> ? Elem extends object ? SelectFields<Elem> : never : {
-    [Key in keyof TModel]: Key extends string ? NonNullable<TModel[Key]> extends object ? NonNullable<TModel[Key]> extends ExcludedODataTypes ? Key : SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths ? IsEqual<NextPaths, never, Key, NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key> : never : Key : never;
+export type SelectFields<TModel extends object> = IsNever<TModel, string, IsAny<TModel, string, IsEqual<TModel, object, string, TModel extends Array<infer Elem> ? Elem extends object ? SelectFields<Elem> : never : {
+    [Key in keyof TModel]: Key extends string ? NonNullable<TModel[Key]> extends object ? NonNullable<TModel[Key]> extends ExcludedODataTypes ? Key : SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths ? IsNever<NextPaths, Key, NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key> : never : Key : never;
 }[keyof TModel & string] & string>>> & {};
 
 // @public
@@ -2344,7 +2346,7 @@ export interface SuggestDocumentsResult<TModel extends object, TFields extends S
 }
 
 // @public (undocumented)
-export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, UnionToIntersection<IsEqual<TFields, never, keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel>, TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>>>> & {};
+export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsNever<TModel, TModel, IsEqual<TModel, object, TModel, UnionToIntersection<IsNever<TFields, keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel>, TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>>>> & {};
 
 // @public
 export type SuggestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SuggestRequest<TModel, TFields>;

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1576,7 +1576,7 @@ export type MicrosoftStemmingTokenizerLanguage = "arabic" | "bangla" | "bulgaria
 export type MicrosoftTokenizerLanguage = "bangla" | "bulgarian" | "catalan" | "chineseSimplified" | "chineseTraditional" | "croatian" | "czech" | "danish" | "dutch" | "english" | "french" | "german" | "greek" | "gujarati" | "hindi" | "icelandic" | "indonesian" | "italian" | "japanese" | "kannada" | "korean" | "malay" | "malayalam" | "marathi" | "norwegianBokmaal" | "polish" | "portuguese" | "portugueseBrazilian" | "punjabi" | "romanian" | "russian" | "serbianCyrillic" | "serbianLatin" | "slovenian" | "spanish" | "swedish" | "tamil" | "telugu" | "thai" | "ukrainian" | "urdu" | "vietnamese";
 
 // @public
-export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, IsEqual<TModel, any, TModel, IsEqual<TModel, unknown, TModel, IsEqual<TFields, never, never, IsEqual<TFields, SelectFields<TModel>, TModel, SearchPick<TModel, TFields>>>>>>>;
+export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, IsEqual<TModel, any, TModel, IsEqual<TModel, unknown, TModel, IsEqual<TFields, never, never, IsEqual<TFields, SelectFields<TModel>, TModel, SearchPick<TModel, TFields>>>>>>> & {};
 
 // @public
 export interface NGramTokenFilter {
@@ -1804,7 +1804,7 @@ export interface SearchDocumentsResultBase {
 export type SearchField = SimpleField | ComplexField;
 
 // @public
-export type SearchFieldArray<TModel extends object = object> = ReadonlyArray<IsEqual<TModel, object, string, SelectFields<TModel>>>;
+export type SearchFieldArray<TModel extends object = object> = ReadonlyArray<IsEqual<TModel, object, string, SelectFields<TModel>>> & {};
 
 // @public
 export type SearchFieldDataType = "Edm.String" | "Edm.Int32" | "Edm.Int64" | "Edm.Double" | "Edm.Boolean" | "Edm.DateTimeOffset" | "Edm.GeographyPoint" | "Collection(Edm.String)" | "Collection(Edm.Int32)" | "Collection(Edm.Int64)" | "Collection(Edm.Double)" | "Collection(Edm.Boolean)" | "Collection(Edm.DateTimeOffset)" | "Collection(Edm.GeographyPoint)" | "Collection(Edm.Single)";
@@ -2096,7 +2096,7 @@ export type SearchPick<TModel extends object, TFields extends SelectFields<TMode
     [Key in keyof TModel as Key & FieldName]: Array<SearchPick<Elem, RestPaths>>;
 } : never : never : NonNullable<TModel[FieldName]> extends object ? {
     [Key in keyof TModel as Key & FieldName]: RestPaths extends SelectFields<TModel[Key] & {}> ? SearchPick<TModel[Key] & {}, RestPaths> | Extract<TModel[Key], null> : never;
-} : never : never : TFields extends keyof TModel ? Pick<TModel, TFields> | Extract<TModel, null> : never> & {}>>>>;
+} : never : never : TFields extends keyof TModel ? Pick<TModel, TFields> | Extract<TModel, null> : never>>>>> & {};
 
 // @public
 export type SearchRequestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = BaseSearchRequestOptions<TModel, TFields> & SearchRequestQueryTypeOptions;
@@ -2143,12 +2143,12 @@ export interface SearchSuggester {
 }
 
 // @public
-export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>>;
+export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>> & {};
 
 // @public
 export type SelectFields<TModel extends object> = IsEqual<TModel, never, string, IsEqual<TModel, any, string, IsEqual<TModel, object, string, TModel extends Array<infer Elem> ? Elem extends object ? SelectFields<Elem> : never : {
     [Key in keyof TModel]: Key extends string ? NonNullable<TModel[Key]> extends object ? NonNullable<TModel[Key]> extends ExcludedODataTypes ? Key : SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths ? IsEqual<NextPaths, never, Key, NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key> : never : Key : never;
-}[keyof TModel & string] & string>>>;
+}[keyof TModel & string] & string>>> & {};
 
 // @public
 export interface SemanticConfiguration {
@@ -2344,7 +2344,7 @@ export interface SuggestDocumentsResult<TModel extends object, TFields extends S
 }
 
 // @public (undocumented)
-export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, UnionToIntersection<IsEqual<TFields, never, keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel>, TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>>>>;
+export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, UnionToIntersection<IsEqual<TFields, never, keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel>, TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>>>> & {};
 
 // @public
 export type SuggestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SuggestRequest<TModel, TFields>;

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -8,6 +8,8 @@
 
 import { AzureKeyCredential } from '@azure/core-auth';
 import { ExtendedCommonClientOptions } from '@azure/core-http-compat';
+import { IsEqual } from 'type-plus';
+import { IsNever } from 'type-plus';
 import { KeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -1574,7 +1576,7 @@ export type MicrosoftStemmingTokenizerLanguage = "arabic" | "bangla" | "bulgaria
 export type MicrosoftTokenizerLanguage = "bangla" | "bulgarian" | "catalan" | "chineseSimplified" | "chineseTraditional" | "croatian" | "czech" | "danish" | "dutch" | "english" | "french" | "german" | "greek" | "gujarati" | "hindi" | "icelandic" | "indonesian" | "italian" | "japanese" | "kannada" | "korean" | "malay" | "malayalam" | "marathi" | "norwegianBokmaal" | "polish" | "portuguese" | "portugueseBrazilian" | "punjabi" | "romanian" | "russian" | "serbianCyrillic" | "serbianLatin" | "slovenian" | "spanish" | "swedish" | "tamil" | "telugu" | "thai" | "ukrainian" | "urdu" | "vietnamese";
 
 // @public
-export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends any ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends unknown ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? never : (<T>() => T extends TFields ? true : false) extends <T>() => T extends SelectFields<TModel> ? true : false ? TModel : SearchPick<TModel, TFields>;
+export type NarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, IsEqual<TModel, any, TModel, IsEqual<TModel, unknown, TModel, IsEqual<TFields, never, never, IsEqual<TFields, SelectFields<TModel>, TModel, SearchPick<TModel, TFields>>>>>>>;
 
 // @public
 export interface NGramTokenFilter {
@@ -1802,7 +1804,7 @@ export interface SearchDocumentsResultBase {
 export type SearchField = SimpleField | ComplexField;
 
 // @public
-export type SearchFieldArray<TModel extends object = object> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? readonly string[] : readonly SelectFields<TModel>[];
+export type SearchFieldArray<TModel extends object = object> = ReadonlyArray<IsEqual<TModel, object, string, SelectFields<TModel>>>;
 
 // @public
 export type SearchFieldDataType = "Edm.String" | "Edm.Int32" | "Edm.Int64" | "Edm.Double" | "Edm.Boolean" | "Edm.DateTimeOffset" | "Edm.GeographyPoint" | "Collection(Edm.String)" | "Collection(Edm.Int32)" | "Collection(Edm.Int64)" | "Collection(Edm.Double)" | "Collection(Edm.Boolean)" | "Collection(Edm.DateTimeOffset)" | "Collection(Edm.GeographyPoint)" | "Collection(Edm.Single)";
@@ -2090,12 +2092,11 @@ export type SearchMode = "any" | "all";
 export type SearchOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SearchRequestOptions<TModel, TFields>;
 
 // @public
-export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends any ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends SelectFields<TModel> ? true : false ? TModel : // We're going to get a union of individual interfaces for each field in T that's selected, so convert that to an intersection.
-UnionToIntersection<TFields extends `${infer FieldName}/${infer RestPaths}` ? FieldName extends keyof TModel & string ? NonNullable<TModel[FieldName]> extends Array<infer Elem> ? Elem extends object ? RestPaths extends SelectFields<Elem> ? {
+export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = IsEqual<TModel, object, TModel, IsEqual<TFields, any, TModel, IsEqual<TFields, never, TModel, IsEqual<TFields, SelectFields<TModel>, TModel, UnionToIntersection<TFields extends `${infer FieldName}/${infer RestPaths}` ? FieldName extends keyof TModel & string ? NonNullable<TModel[FieldName]> extends Array<infer Elem> ? Elem extends object ? RestPaths extends SelectFields<Elem> ? {
     [Key in keyof TModel as Key & FieldName]: Array<SearchPick<Elem, RestPaths>>;
 } : never : never : NonNullable<TModel[FieldName]> extends object ? {
     [Key in keyof TModel as Key & FieldName]: RestPaths extends SelectFields<TModel[Key] & {}> ? SearchPick<TModel[Key] & {}, RestPaths> | Extract<TModel[Key], null> : never;
-} : never : never : TFields extends keyof TModel ? Pick<TModel, TFields> | Extract<TModel, null> : never> & {};
+} : never : never : TFields extends keyof TModel ? Pick<TModel, TFields> | Extract<TModel, null> : never> & {}>>>>;
 
 // @public
 export type SearchRequestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = BaseSearchRequestOptions<TModel, TFields> & SearchRequestQueryTypeOptions;
@@ -2142,12 +2143,12 @@ export interface SearchSuggester {
 }
 
 // @public
-export type SelectArray<TFields = never> = [string] extends [TFields] ? readonly TFields[] : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? readonly string[] : readonly TFields[];
+export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>>;
 
 // @public
-export type SelectFields<TModel extends object> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends never ? true : false ? string : (<T>() => T extends TModel ? true : false) extends <T>() => T extends any ? true : false ? string : (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? string : TModel extends Array<infer Elem> ? Elem extends object ? SelectFields<Elem> : never : {
-    [Key in keyof TModel]: Key extends string ? NonNullable<TModel[Key]> extends object ? NonNullable<TModel[Key]> extends ExcludedODataTypes ? Key : SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths ? (<T>() => T extends NextPaths ? true : false) extends <T>() => T extends never ? true : false ? Key : NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key : never : Key : never;
-}[keyof TModel & string] & string;
+export type SelectFields<TModel extends object> = IsEqual<TModel, never, string, IsEqual<TModel, any, string, IsEqual<TModel, object, string, TModel extends Array<infer Elem> ? Elem extends object ? SelectFields<Elem> : never : {
+    [Key in keyof TModel]: Key extends string ? NonNullable<TModel[Key]> extends object ? NonNullable<TModel[Key]> extends ExcludedODataTypes ? Key : SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths ? IsEqual<NextPaths, never, Key, NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key> : never : Key : never;
+}[keyof TModel & string] & string>>>;
 
 // @public
 export interface SemanticConfiguration {
@@ -2343,7 +2344,7 @@ export interface SuggestDocumentsResult<TModel extends object, TFields extends S
 }
 
 // @public (undocumented)
-export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : UnionToIntersection<(<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel> : TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>;
+export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = IsEqual<TModel, never, TModel, IsEqual<TModel, object, TModel, UnionToIntersection<IsEqual<TFields, never, keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel>, TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>>>>;
 
 // @public
 export type SuggestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SuggestRequest<TModel, TFields>;

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -2090,7 +2090,7 @@ export type SearchMode = "any" | "all";
 export type SearchOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SearchRequestOptions<TModel, TFields>;
 
 // @public
-export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends any ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? TModel : // We're going to get a union of individual interfaces for each field in T that's selected, so convert that to an intersection.
+export type SearchPick<TModel extends object, TFields extends SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends any ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends SelectFields<TModel> ? true : false ? TModel : // We're going to get a union of individual interfaces for each field in T that's selected, so convert that to an intersection.
 UnionToIntersection<TFields extends `${infer FieldName}/${infer RestPaths}` ? FieldName extends keyof TModel & string ? NonNullable<TModel[FieldName]> extends Array<infer Elem> ? Elem extends object ? RestPaths extends SelectFields<Elem> ? {
     [Key in keyof TModel as Key & FieldName]: Array<SearchPick<Elem, RestPaths>>;
 } : never : never : NonNullable<TModel[FieldName]> extends object ? {
@@ -2343,7 +2343,7 @@ export interface SuggestDocumentsResult<TModel extends object, TFields extends S
 }
 
 // @public (undocumented)
-export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : (<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel> : TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never;
+export type SuggestNarrowedModel<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = (<T>() => T extends TModel ? true : false) extends <T>() => T extends never ? true : false ? TModel : (<T>() => T extends TModel ? true : false) extends <T>() => T extends object ? true : false ? TModel : UnionToIntersection<(<T>() => T extends TFields ? true : false) extends <T>() => T extends never ? true : false ? keyof ExtractDocumentKey<TModel> extends never ? TModel : ExtractDocumentKey<TModel> : TFields extends SelectFields<TModel> ? NarrowedModel<TModel, TFields> : never>;
 
 // @public
 export type SuggestOptions<TModel extends object, TFields extends SelectFields<TModel> = SelectFields<TModel>> = OperationOptions & SuggestRequest<TModel, TFields>;

--- a/sdk/search/search-documents/scripts/generateSampleEmbeddings.ts
+++ b/sdk/search/search-documents/scripts/generateSampleEmbeddings.ts
@@ -5,6 +5,9 @@ const { OpenAIClient, AzureKeyCredential } = require("@azure/openai");
 const { createWriteStream } = require("fs");
 const dotenv = require("dotenv");
 
+// TODO: Get this to work again
+// This worked exactly long enough for me to get the release out the door.
+
 dotenv.config();
 
 const outputPath = "samples-dev/vectors.ts";
@@ -43,6 +46,8 @@ async function main() {
 
   const expressions = await Promise.all(
     inputs.map(async ({ ident, text, comment }) => {
+      // TODO: IIRC OpenAI allows multiple strings in this API now, so we can do this in one
+      // invocation.
       const result = await client.getEmbeddings(process.env.OPENAI_DEPLOYMENT_NAME!, [text]);
       const embedding = result.data[0].embedding;
       return `// ${comment}\nexport const ${ident} = [${embedding.toString()}];\n\n`;

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -16,7 +16,7 @@ import {
 } from "./generated/data/models";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import GeographyPoint from "./geographyPoint";
-import { IsEqual, IsNever } from "type-plus";
+import { IsAny, IsEqual, IsNever, IsUnknown } from "type-plus";
 
 /**
  * Options for performing the count operation on the index.
@@ -789,13 +789,11 @@ export type ExcludedODataTypes = Date | GeographyPoint;
  */
 export type SelectFields<TModel extends object> =
   // If T is never, any, or object, resolves to string
-  IsEqual<
+  IsNever<
     TModel,
-    never,
     string,
-    IsEqual<
+    IsAny<
       TModel,
-      any,
       string,
       IsEqual<
         TModel,
@@ -817,9 +815,8 @@ export type SelectFields<TModel extends object> =
                     : // Extract subpaths from T[Key]
                     SelectFields<NonNullable<TModel[Key]>> extends infer NextPaths
                     ? // This check is required to avoid distributing `never` over the condition
-                      IsEqual<
+                      IsNever<
                         NextPaths,
-                        never,
                         Key,
                         NextPaths extends string ? Key | `${Key}/${NextPaths}` : Key
                       >
@@ -844,13 +841,11 @@ export type SearchPick<TModel extends object, TFields extends SelectFields<TMode
   TModel,
   object,
   TModel,
-  IsEqual<
+  IsAny<
     TFields,
-    any,
     TModel,
-    IsEqual<
+    IsNever<
       TFields,
-      never,
       TModel,
       IsEqual<
         TFields,
@@ -924,25 +919,21 @@ export type NarrowedModel<
   TFields extends SelectFields<TModel> = SelectFields<TModel>
 > =
   // If the model isn't specified, the type is the same as the input type
-  IsEqual<
+  IsNever<
     TModel,
-    never,
     TModel,
     IsEqual<
       TModel,
       object,
       TModel,
-      IsEqual<
+      IsAny<
         TModel,
-        any,
         TModel,
-        IsEqual<
+        IsUnknown<
           TModel,
-          unknown,
           TModel,
-          IsEqual<
+          IsNever<
             TFields,
-            never,
             // If fields aren't specified, this object can't exist
             never,
             IsEqual<
@@ -963,18 +954,16 @@ export type NarrowedModel<
 export type SuggestNarrowedModel<
   TModel extends object,
   TFields extends SelectFields<TModel> = SelectFields<TModel>
-> = IsEqual<
+> = IsNever<
   TModel,
-  never,
   TModel,
   IsEqual<
     TModel,
     object,
     TModel,
     UnionToIntersection<
-      IsEqual<
+      IsNever<
         TFields,
-        never,
         // Filter nullable (i.e. non-key) properties from the model, as they're not returned by the
         // service by default
         keyof ExtractDocumentKey<TModel> extends never

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -753,7 +753,12 @@ export type IndexDocumentsAction<TModel> = {
  *
  * Otherwise, a narrowed `Fields[]` type to be used elsewhere in the consuming type.
  */
-export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>>;
+export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string, TFields>> & {
+  // This useless intersection actually prevents the TypeScript language server from
+  // expanding the definition of SearchPick<TModel, Paths> in IntelliSense. Since we're
+  // sure the type always yields an object, this intersection does not alter the type
+  // at all, only the display string of the type.
+};
 
 /**
  * If `TModel` is an untyped object, an untyped string array
@@ -762,7 +767,9 @@ export type SelectArray<TFields = never> = ReadonlyArray<IsNever<TFields, string
  */
 export type SearchFieldArray<TModel extends object = object> = ReadonlyArray<
   IsEqual<TModel, object, string, SelectFields<TModel>>
->;
+> & {
+  // ditto
+};
 
 export type UnionToIntersection<Union> =
   // Distribute members of U into parameter position of a union of functions
@@ -825,7 +832,9 @@ export type SelectFields<TModel extends object> =
               string
       >
     >
-  >;
+  > & {
+    // ditto
+  };
 
 /**
  * Deeply pick fields of T using valid Cognitive Search OData $select
@@ -895,16 +904,13 @@ export type SearchPick<TModel extends object, TFields extends SelectFields<TMode
             TFields extends keyof TModel
             ? Pick<TModel, TFields> | Extract<TModel, null>
             : never
-        > & {
-          // This useless intersection actually prevents the TypeScript language server from
-          // expanding the definition of SearchPick<TModel, Paths> in IntelliSense. Since we're
-          // sure the type always yields an object, this intersection does not alter the type
-          // at all, only the display string of the type.
-        }
+        >
       >
     >
   >
->;
+> & {
+  // ditto
+};
 
 export type ExtractDocumentKey<TModel> = {
   [K in keyof TModel as TModel[K] extends string | undefined ? K : never]: TModel[K];
@@ -950,7 +956,9 @@ export type NarrowedModel<
         >
       >
     >
-  >;
+  > & {
+    // ditto
+  };
 
 export type SuggestNarrowedModel<
   TModel extends object,
@@ -983,7 +991,9 @@ export type SuggestNarrowedModel<
       >
     >
   >
->;
+> & {
+  // ditto
+};
 
 /**
  * Extracts answer candidates from the contents of the documents returned in response to a query

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -113,7 +113,6 @@ export class SearchClient<TModel extends object> implements IndexDocumentsClient
   public readonly indexName: string;
 
   /**
-   * @internal
    * @hidden
    * A reference to the auto-generated SearchClient
    */

--- a/sdk/search/search-documents/test/narrowedTypes.ts
+++ b/sdk/search/search-documents/test/narrowedTypes.ts
@@ -15,12 +15,7 @@ import {
   NarrowedModel as GenericNarrowedModel,
   SuggestNarrowedModel,
 } from "../src/indexModels";
-
-type Equals<T1, T2> = (<T>() => T extends T1 ? true : false) extends <T>() => T extends T2
-  ? true
-  : false
-  ? any
-  : never;
+import { testType } from "type-plus";
 
 type Model = {
   key?: string;
@@ -56,171 +51,125 @@ type NarrowedModelFields = "key" | "a" | "b/a" | "d/b";
 function testSelectFields() {
   // SelectFields<T> where T has properties should be T,
   // otherwise string
-  const a: Equals<SelectFields<never>, string> = "pass";
-  const b: Equals<SelectFields<any>, string> = "pass";
-  const c: Equals<SelectFields<object>, string> = "pass";
-  const d: Equals<SelectFields<Model>, ModelFields> = "pass";
+  testType.equal<SelectFields<never>, string>(true);
+  testType.equal<SelectFields<any>, string>(true);
+  testType.equal<SelectFields<object>, string>(true);
+  testType.equal<SelectFields<Model>, ModelFields>(true);
 
   // SelectFields<unknown> should be an error, as unknown should be cast
   // @ts-expect-error
-  const e: Equals<SelectFields<unknown>, string> = "fail";
-
-  return [a, b, c, d, e];
+  type T = SelectFields<unknown>;
 }
 
 // @ts-expect-error
 function testSearchPick() {
   // SearchPick<Model, Fields> should be Model when Fields is not a strict subset of
   // SelectFields<Model>
-  const a: Equals<SearchPick<object, never>, object> = "pass";
-  const b: Equals<SearchPick<Model, any>, Model> = "pass";
-  const c: Equals<SearchPick<Model, never>, Model> = "pass";
-  const d1: Model = {} as SearchPick<Model, ModelFields>;
-  const d2: SearchPick<Model, ModelFields> = {} as Model;
+  testType.equal<SearchPick<object, never>, object>(true);
+  testType.equal<SearchPick<Model, any>, Model>(true);
+  testType.equal<SearchPick<Model, never>, Model>(true);
+
+  // SearchPick<Model, Fields> should be Model when Fields is exactly SelectFields<Model>
+  testType.equal<SearchPick<Model, ModelFields>, Model>(true);
   // SearchPick should correctly narrow the model to the specified fields
-  const e1: NarrowedModel = {} as SearchPick<Model, NarrowedModelFields>;
-  const e2: SearchPick<Model, NarrowedModelFields> = {} as NarrowedModel;
+  testType.equal<SearchPick<Model, NarrowedModelFields>, NarrowedModel>(true);
 
   // A narrowed model should be assignable to the base model type
-  const f: Model = {} as SearchPick<Model, NarrowedModelFields>;
+  testType.canAssign<SearchPick<Model, NarrowedModelFields>, Model>(true);
 
   // If the model has unknown properties, SearchPick should yield the object type
-  const g: Equals<SearchPick<object, any>, object> = "pass";
-  const h: Equals<SearchPick<object, string>, object> = "pass";
-  const i: Equals<SearchPick<object, ModelFields>, object> = "pass";
+  testType.equal<SearchPick<object, any>, object>(true);
+  testType.equal<SearchPick<object, string>, object>(true);
+  testType.equal<SearchPick<object, ModelFields>, object>(true);
 
   // SearchPick should reject the string type when using a model with known properties
   // Ideally, this would just yield the model type, but we haven't found a way to make that happen
-  // without losing the type inference that powers the IntelliSense behavior we want.
+  // without losing the type inference that powers the LSP completion behavior we want.
   // @ts-expect-error
-  const j: Equals<SearchPick<Model, string>, Model> = "fail";
+  type T = SearchPick<Model, string>;
   // @ts-expect-error
-  const k: Equals<SearchPick<Model, unknown>, Model> = "fail";
-
-  return [a, b, c, d1, d2, e1, e2, f, g, h, i, j, k];
+  type U = SearchPick<Model, string>;
 }
 
 // @ts-expect-error
 function testNarrowedModel() {
-  const a1: GenericNarrowedModel<Model, NarrowedModelFields> = {} as NarrowedModel;
-  const a2: NarrowedModel = {} as GenericNarrowedModel<Model, NarrowedModelFields>;
+  testType.equal<GenericNarrowedModel<Model, NarrowedModelFields>, NarrowedModel>(true);
 
   // Narrowing the never type should yield never
-  const b: Equals<GenericNarrowedModel<never, never>, never> = "pass";
-  const c: Equals<GenericNarrowedModel<never, any>, never> = "pass";
-  const d: Equals<GenericNarrowedModel<never, string>, never> = "pass";
-  const e: Equals<GenericNarrowedModel<never, NarrowedModelFields>, never> = "pass";
+  testType.equal<GenericNarrowedModel<never, never>, never>(true);
+  testType.equal<GenericNarrowedModel<never, any>, never>(true);
+  testType.equal<GenericNarrowedModel<never, string>, never>(true);
+  testType.equal<GenericNarrowedModel<never, NarrowedModelFields>, never>(true);
   // Narrowing the object type should yield object
-  const f: Equals<GenericNarrowedModel<object, never>, object> = "pass";
-  const g: Equals<GenericNarrowedModel<object, any>, object> = "pass";
-  const h: Equals<GenericNarrowedModel<object, string>, object> = "pass";
-  const i: Equals<GenericNarrowedModel<object, NarrowedModelFields>, object> = "pass";
+  testType.equal<GenericNarrowedModel<object, never>, object>(true);
+  testType.equal<GenericNarrowedModel<object, any>, object>(true);
+  testType.equal<GenericNarrowedModel<object, string>, object>(true);
+  testType.equal<GenericNarrowedModel<object, NarrowedModelFields>, object>(true);
   // Narrowing a model with never fields implies an empty array was used to select fields,
   // so either never or an empty object are sensible. We're rolling with never since that behavior
   // is less likely to break if we find a convincing reason to change it.
-  const j: Equals<GenericNarrowedModel<Model, never>, never> = "pass";
+  testType.equal<GenericNarrowedModel<Model, never>, never>(true);
 
   // Narrowing a model with any fields should yield the model itself
-  const k: Equals<GenericNarrowedModel<Model, any>, Model> = "pass";
+  testType.equal<GenericNarrowedModel<Model, any>, Model>(true);
 
-  const l1: SuggestNarrowedModel<Model, NarrowedModelFields> = {} as NarrowedModel;
-  const l2: NarrowedModel = {} as SuggestNarrowedModel<Model, NarrowedModelFields>;
+  testType.equal<SuggestNarrowedModel<Model, NarrowedModelFields>, NarrowedModel>(true);
 
-  const m: Equals<SuggestNarrowedModel<never, never>, never> = "pass";
-  const n: Equals<SuggestNarrowedModel<never, any>, never> = "pass";
+  testType.equal<SuggestNarrowedModel<never, never>, never>(true);
+  testType.equal<SuggestNarrowedModel<never, any>, never>(true);
 
-  const o: Equals<SuggestNarrowedModel<never, string>, never> = "pass";
-  const p: Equals<SuggestNarrowedModel<never, NarrowedModelFields>, never> = "pass";
-  const q: Equals<SuggestNarrowedModel<object, never>, object> = "pass";
-  const r: Equals<SuggestNarrowedModel<object, any>, object> = "pass";
-  const s: Equals<SuggestNarrowedModel<object, string>, object> = "pass";
-  const t: Equals<SuggestNarrowedModel<object, NarrowedModelFields>, object> = "pass";
+  testType.equal<SuggestNarrowedModel<never, string>, never>(true);
+  testType.equal<SuggestNarrowedModel<never, NarrowedModelFields>, never>(true);
+  testType.equal<SuggestNarrowedModel<object, never>, object>(true);
+  testType.equal<SuggestNarrowedModel<object, any>, object>(true);
+  testType.equal<SuggestNarrowedModel<object, string>, object>(true);
+  testType.equal<SuggestNarrowedModel<object, NarrowedModelFields>, object>(true);
   // SuggestNarrowedModel is the same story as above, but this never case corresponds to the
   // default behavior of the service, which is to return only the document key. To this end,
   // SuggestNarrowedModel with never fields yields an interface with only the non-null properties
   // of the model.
-  const u: Equals<SuggestNarrowedModel<Model, never>, { key?: string }> = "pass";
-  const v: Equals<SuggestNarrowedModel<Model, any>, Model> = "pass";
+  testType.equal<SuggestNarrowedModel<Model, never>, { key?: string }>(true);
+  testType.equal<SuggestNarrowedModel<Model, any>, Model>(true);
 
   // Passing unknown or string as fields are type errors
   // @ts-expect-error
-  const w: Equals<GenericNarrowedModel<object, unknown>, object> = "fail";
+  type A = GenericNarrowedModel<object, unknown>;
   // @ts-expect-error
-  const x: Equals<GenericNarrowedModel<never, unknown>, never> = "fail";
+  type B = GenericNarrowedModel<never, unknown>;
   // @ts-expect-error
-  const y: Equals<GenericNarrowedModel<Model, unknown>, Model> = "fail";
+  type C = GenericNarrowedModel<Model, unknown>;
   // @ts-expect-error
-  const z: Equals<GenericNarrowedModel<Model, string>, Model> = "fail";
+  type D = GenericNarrowedModel<Model, string>;
 
   // @ts-expect-error
-  const aa: Equals<SuggestNarrowedModel<never, unknown>, never> = "fail";
+  type E = SuggestNarrowedModel<never, unknown>;
   // @ts-expect-error
-  const ab: Equals<SuggestNarrowedModel<object, unknown>, object> = "fail";
+  type F = SuggestNarrowedModel<object, unknown>;
   // @ts-expect-error
-  const ac: Equals<SuggestNarrowedModel<Model, unknown>, Model> = "fail";
+  type G = SuggestNarrowedModel<Model, unknown>;
   // @ts-expect-error
-  const ad: Equals<SuggestNarrowedModel<Model, string>, Model> = "fail";
-
-  return [
-    a1,
-    a2,
-    b,
-    c,
-    d,
-    e,
-    f,
-    g,
-    h,
-    i,
-    j,
-    k,
-    l1,
-    l2,
-    m,
-    n,
-    o,
-    p,
-    q,
-    r,
-    s,
-    t,
-    u,
-    v,
-    w,
-    x,
-    y,
-    z,
-    aa,
-    ab,
-    ac,
-    ad,
-  ];
+  type H = SuggestNarrowedModel<Model, string>;
 }
 
 // @ts-expect-error
 function testSelectArray() {
-  const a: Equals<SelectArray<never>, readonly string[]> = "pass";
-  const b: Equals<SelectArray<"field1">, readonly "field1"[]> = "pass";
-  const c: Equals<SelectArray<"field1" | "field2">, readonly ("field1" | "field2")[]> = "pass";
+  testType.equal<SelectArray<never>, readonly string[]>(true);
+  testType.equal<SelectArray<"field1">, readonly "field1"[]>(true);
+  testType.equal<SelectArray<"field1" | "field2">, readonly ("field1" | "field2")[]>(true);
 
-  // @ts-expect-error
-  const d: Equals<SelectArray<any>, readonly string[]> = "fail";
-  // @ts-expect-error
-  const e: Equals<SelectArray<unknown>, readonly string[]> = "fail";
-  return [a, b, c, d, e];
+  testType.equal<SelectArray<any>, readonly string[]>(false);
+  testType.equal<SelectArray<unknown>, readonly string[]>(false);
 }
 
 // @ts-expect-error
 function testSearchFieldArray() {
-  const a: Equals<SearchFieldArray<object>, readonly string[]> = "pass";
-  const b: Equals<SearchFieldArray<Model>, readonly ModelFields[]> = "pass";
-  const c: Equals<SearchFieldArray<never>, readonly string[]> = "pass";
-  const d: Equals<SearchFieldArray<any>, readonly string[]> = "pass";
+  testType.equal<SearchFieldArray<object>, readonly string[]>(true);
+  testType.equal<SearchFieldArray<Model>, readonly ModelFields[]>(true);
+  testType.equal<SearchFieldArray<never>, readonly string[]>(true);
+  testType.equal<SearchFieldArray<any>, readonly string[]>(true);
 
   // @ts-expect-error
-  const e: Equals<SearchFieldArray<unknown>, readonly string[]> = "pass";
-
-  return [a, b, c, d, e];
+  type T = SearchFieldArray<unknown>;
 }
 
 // @ts-expect-error
@@ -233,29 +182,26 @@ function testNarrowedClient() {
   async () => {
     const suggest = await client.suggest("", "", {});
     for await (const result of suggest.results) {
-      const a: Equals<
-        (typeof result)["document"],
-        {
-          key?: string;
-        }
-      > = "pass";
-      // @ts-expect-error
-      const b = result.document.a;
-      return [a, b];
+      testType.equal<(typeof result)["document"], { key?: string }>(true);
+      return;
     }
     return;
   };
 
   async () => {
-    type VectorFields = NonNullable<
-      NonNullable<
-        NonNullable<
-          NonNullable<Parameters<(typeof client)["search"]>[1]>["vectorSearchOptions"]
-        >["queries"]
-      >[number]["fields"]
-    >;
-    const a: Equals<VectorFields, readonly ModelFields[]> = "pass";
-    return a;
+    const suggest = await client.suggest("", "", { select: selectNarrowed });
+    for await (const result of suggest.results) {
+      testType.equal<(typeof result)["document"], NarrowedModel>(true);
+      return;
+    }
+    return;
+  };
+
+  async () => {
+    const searchOptions = {} as Parameters<(typeof client)["search"]>[1];
+    const vectorFields = searchOptions?.vectorSearchOptions?.queries[0].fields;
+    type VectorFields = NonNullable<typeof vectorFields>;
+    testType.equal<VectorFields, readonly ModelFields[]>(true);
   };
 
   async () => {
@@ -269,33 +215,15 @@ function testNarrowedClient() {
       select: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], Model> = "pass";
-      const b = result.document.c;
-      suppressUnusedWarning.push(a);
-      suppressUnusedWarning.push(b);
+      testType.equal<(typeof result)["document"], Model>(true);
     }
     for await (const result of select2.results) {
-      const a1: (typeof result)["document"] = {} as NarrowedModel;
-      const a2: NarrowedModel = {} as (typeof result)["document"];
-      // @ts-expect-error
-      const b = result.document.c;
-      suppressUnusedWarning.push(a1);
-      suppressUnusedWarning.push(a2);
-      suppressUnusedWarning.push(b);
+      testType.equal<(typeof result)["document"], NarrowedModel>(true);
     }
     for await (const result of select3.results) {
-      const a1: (typeof result)["document"] = {} as NarrowedModel;
-      const a2: NarrowedModel = {} as (typeof result)["document"];
-      // @ts-expect-error
-      const b = result.document.c;
-      suppressUnusedWarning.push(a1);
-      suppressUnusedWarning.push(a2);
-      suppressUnusedWarning.push(b);
+      testType.equal<(typeof result)["document"], NarrowedModel>(true);
     }
-    return suppressUnusedWarning;
   };
   async () => {
     const select1 = await client.search("New", {
@@ -308,21 +236,15 @@ function testNarrowedClient() {
       searchFields: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], Model> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], Model>(true);
     }
     for await (const result of select2.results) {
-      const a: Equals<(typeof result)["document"], Model> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], Model>(true);
     }
     for await (const result of select3.results) {
-      const a: Equals<(typeof result)["document"], Model> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], Model>(true);
     }
-    return suppressUnusedWarning;
   };
   async () => {
     const select1 = await client.search("New", {
@@ -338,31 +260,15 @@ function testNarrowedClient() {
       searchFields: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], Model> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], Model>(true);
     }
     for await (const result of select2.results) {
-      const a1: (typeof result)["document"] = {} as NarrowedModel;
-      const a2: NarrowedModel = {} as (typeof result)["document"];
-      // @ts-expect-error
-      const b = result.document.c;
-      suppressUnusedWarning.push(a1);
-      suppressUnusedWarning.push(a2);
-      suppressUnusedWarning.push(b);
+      testType.equal<(typeof result)["document"], NarrowedModel>(true);
     }
     for await (const result of select3.results) {
-      const a1: (typeof result)["document"] = {} as NarrowedModel;
-      const a2: NarrowedModel = {} as (typeof result)["document"];
-      // @ts-expect-error
-      const b = result.document.c;
-      suppressUnusedWarning.push(a1);
-      suppressUnusedWarning.push(a2);
-      suppressUnusedWarning.push(b);
+      testType.equal<(typeof result)["document"], NarrowedModel>(true);
     }
-    return suppressUnusedWarning;
   };
 }
 
@@ -376,21 +282,24 @@ function testWideClient() {
   async () => {
     const suggest = await client.suggest("", "", {});
     for await (const result of suggest.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      return a;
+      testType.equal<(typeof result)["document"], object>(true);
     }
   };
 
   async () => {
-    type VectorFields = NonNullable<
-      NonNullable<
-        NonNullable<
-          NonNullable<Parameters<(typeof client)["search"]>[1]>["vectorSearchOptions"]
-        >["queries"]
-      >[number]["fields"]
-    >;
-    const a: Equals<VectorFields, readonly string[]> = "pass";
-    return a;
+    const suggest = await client.suggest("", "", { select: selectNarrowed });
+    for await (const result of suggest.results) {
+      testType.equal<(typeof result)["document"], object>(true);
+      return;
+    }
+    return;
+  };
+
+  async () => {
+    const searchOptions = {} as Parameters<(typeof client)["search"]>[1];
+    const vectorFields = searchOptions?.vectorSearchOptions?.queries[0].fields;
+    type VectorFields = NonNullable<typeof vectorFields>;
+    testType.equal<VectorFields, readonly string[]>(true);
   };
 
   async () => {
@@ -404,19 +313,14 @@ function testWideClient() {
       select: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select2.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select3.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
   };
   async () => {
@@ -430,21 +334,15 @@ function testWideClient() {
       searchFields: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select2.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select3.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
-    return suppressUnusedWarning;
   };
   async () => {
     const select1 = await client.search("New", {
@@ -460,20 +358,14 @@ function testWideClient() {
       searchFields: ["key", "a", "b/a", "d/b"],
     });
 
-    const suppressUnusedWarning: any[] = [];
-
     for await (const result of select1.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select2.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
     for await (const result of select3.results) {
-      const a: Equals<(typeof result)["document"], object> = "pass";
-      suppressUnusedWarning.push(a);
+      testType.equal<(typeof result)["document"], object>(true);
     }
-    return suppressUnusedWarning;
   };
 }

--- a/sdk/search/search-documents/test/narrowedTypes.ts
+++ b/sdk/search/search-documents/test/narrowedTypes.ts
@@ -180,7 +180,7 @@ function testNarrowedClient() {
   const selectNarrowed = ["key", "a", "b/a", "d/b"] as const;
 
   async () => {
-    const suggest = await client.suggest("", "", {});
+    const suggest = await client.suggest("", "");
     for await (const result of suggest.results) {
       testType.equal<(typeof result)["document"], { key?: string }>(true);
       return;


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Issues associated with this PR

#27942

### Describe the problem that is addressed by this PR

The type responsible for narrowing the result document type for suggest queries failed to account for a distributed type. This PR fixes that bug. 

Also, the regression tests had covered this scenario, but the current method for assessing type equality was inadequate (mutual assignability isn't sufficient to catch real user cases.) This PR adds a dependency to a library with robust type utilities. It may be a good idea to vendor this package.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
