### PR TITLE
[EngSys] unpin NodeTestVersion of 21.2.0

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -20,7 +20,7 @@
     "NodeTestVersion": [
       "18.x",
       "20.x",
-      "21.2.0"
+      "21.x"
     ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"


### PR DESCRIPTION
now that a fix to `fs.writeFileSync` has been released.

Revert "Temporarily pin NodeTestVersion of v21 to 21.2.0 (#27951)"

This reverts commit b1a31b3d36e1fd5b0c3e0062567f5ea07c977369.

### Issues associated with this PR
#27957 
