### PR TITLE
[Storage]Change to check both header 'x-ms-error-code' and error code in response body

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Changed ContainerClient.createIfNotExists, ContainerClient.deleteIfExists, BlobClient.exists, BlobClient.deleteIfExists, AppendBlobClient.createIfNotExists and PageBlobClient.createIfNotExists to check both header 'x-ms-error-code' and error code in response body. Fixed issue [27913](https://github.com/Azure/azure-sdk-for-js/issues/27913).
+
 ### Other Changes
 
 ## 12.17.0 (2023-11-09)

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -815,6 +815,11 @@ export class ContainerClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-container
    * Naming rules: @see https://learn.microsoft.com/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options -
    */
   public async createIfNotExists(
@@ -829,7 +834,8 @@ export class ContainerClient extends StorageClient {
         _response: res._response, // _response is made non-enumerable
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "ContainerAlreadyExists") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ContainerAlreadyExists") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message:
@@ -1009,6 +1015,11 @@ export class ContainerClient extends StorageClient {
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-container
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options - Options to Container Delete operation.
    */
   public async deleteIfExists(
@@ -1024,7 +1035,8 @@ export class ContainerClient extends StorageClient {
         _response: res._response, // _response is made non-enumerable
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "ContainerNotFound") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ContainerNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a container only if it exists.",

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Changed Path.createIfNotExists and Path.deleteIfExists to check both header 'x-ms-error-code' and error code in response body. Fixed issue [27913](https://github.com/Azure/azure-sdk-for-js/issues/27913).
+
 ### Other Changes
 
 ## 12.16.0 (2023-11-09)

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -377,6 +377,11 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param resourceType - Resource type, "directory" or "file".
    * @param options -
    */
@@ -397,7 +402,8 @@ export class DataLakePathClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "PathAlreadyExists") {
+      const errorCode = e.details?.errorCode ?? e.details?.error?.code;
+      if (errorCode === "PathAlreadyExists") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when creating a blob only if it does not already exist.",
@@ -503,6 +509,11 @@ export class DataLakePathClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param recursive - Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
    * @param options -
    */
@@ -519,7 +530,8 @@ export class DataLakePathClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "PathNotFound") {
+      const errorCode = e.details?.errorCode ?? e.details?.error?.code;
+      if (errorCode === "PathNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a directory or file only if it exists.",

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Changed ShareClient.createIfNotExists, ShareClient.deleteIfExists, ShareFileClient.createIfNotExists, ShareDirectoryClient.deleteIfExists and ShareFileClient.deleteIfExists to check both header 'x-ms-error-code' and error code in response body. Fixed issue [27913](https://github.com/Azure/azure-sdk-for-js/issues/27913).
+
 ### Other Changes
 
 ## 12.17.0 (2023-11-09)

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -710,6 +710,11 @@ export class ShareClient extends StorageClient {
    * the same name already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-share
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set the account's CORS rules
+   * to expose header 'x-ms-error-code' to help the function to tell whether
+   * the error is expected.
+   *
    * @param options -
    */
   public async createIfNotExists(
@@ -723,7 +728,8 @@ export class ShareClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "ShareAlreadyExists") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ShareAlreadyExists") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when creating a share only if it doesn't already exist.",
@@ -1009,6 +1015,10 @@ export class ShareClient extends StorageClient {
    * Marks the specified share for deletion if it exists. The share and any directories or files
    * contained within it are later deleted during garbage collection.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-share
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
    *
    * @param options -
    */
@@ -1023,7 +1033,8 @@ export class ShareClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "ShareNotFound") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ShareNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a share only if it exists.",
@@ -1830,6 +1841,11 @@ export class ShareDirectoryClient extends StorageClient {
    * If the directory already exists, it is not modified.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options -
    */
   public async createIfNotExists(
@@ -1843,7 +1859,8 @@ export class ShareDirectoryClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "ResourceAlreadyExists") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ResourceAlreadyExists") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message:
@@ -2189,6 +2206,11 @@ export class ShareDirectoryClient extends StorageClient {
    * deleted.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options -
    */
   public async deleteIfExists(
@@ -2202,10 +2224,8 @@ export class ShareDirectoryClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (
-        e.details?.errorCode === "ResourceNotFound" ||
-        e.details?.errorCode === "ParentNotFound"
-      ) {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ResourceNotFound" || errorCode === "ParentNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a directory only if it exists.",
@@ -4162,6 +4182,11 @@ export class ShareFileClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *
+   * Please be noted: function logic relies on header 'x-ms-error-code'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.   *
+   *
    * @param options -
    */
   public async deleteIfExists(
@@ -4175,10 +4200,8 @@ export class ShareFileClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (
-        e.details?.errorCode === "ResourceNotFound" ||
-        e.details?.errorCode === "ParentNotFound"
-      ) {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "ResourceNotFound" || errorCode === "ParentNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a file only if it exists.",

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Changed QueueClient.createIfNotExists and QueueClient.deleteIfExists to check both header 'x-ms-error-code' and error code in response body. Fixed issue [27913](https://github.com/Azure/azure-sdk-for-js/issues/27913).
+
 ### Other Changes
 
 ## 12.16.0 (2023-11-09)

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -648,6 +648,11 @@ export class QueueClient extends StorageClient {
    * If the queue already exists, it is not changed.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4
    *
+   * Please be noted: function logic relies on header 'x-ms-errorcode'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options -
    */
   public async createIfNotExists(
@@ -671,7 +676,8 @@ export class QueueClient extends StorageClient {
         ...response,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "QueueAlreadyExists") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "QueueAlreadyExists") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when creating a queue only if it does not already exist.",
@@ -697,6 +703,11 @@ export class QueueClient extends StorageClient {
    * Deletes the specified queue permanently if it exists.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3
    *
+   * Please be noted: function logic relies on header 'x-ms-errorcode'.
+   * If you invoke the function in a browser environment, it's recommanded to set
+   * the account's CORS rules to expose header 'x-ms-error-code' to help the
+   * function to tell whether the error is expected.
+   *
    * @param options -
    */
   public async deleteIfExists(
@@ -710,7 +721,8 @@ export class QueueClient extends StorageClient {
         ...res,
       };
     } catch (e: any) {
-      if (e.details?.errorCode === "QueueNotFound") {
+      const errorCode = e.details?.errorCode ?? e.details?.code;
+      if (errorCode === "QueueNotFound") {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Expected exception when deleting a queue only if it exists.",


### PR DESCRIPTION
Fixed issue [27913](https://github.com/Azure/azure-sdk-for-js/issues/27913).


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
