### PR TITLE
[OpenAI] Fix sub-path export for models

### DIFF
--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -21,8 +21,8 @@
       "import": "./dist-esm/src/api/index.js"
     },
     "./models": {
-      "types": "./types/src/api/models.d.ts",
-      "import": "./dist-esm/src/api/models.js"
+      "types": "./types/src/models.d.ts",
+      "import": "./dist-esm/src/models.js"
     },
     "./rest": {
       "types": "./types/src/rest/index.d.ts",

--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -21,8 +21,8 @@
       "import": "./dist-esm/src/api/index.js"
     },
     "./models": {
-      "types": "./types/src/models.d.ts",
-      "import": "./dist-esm/src/models.js"
+      "types": "./types/src/models/index.d.ts",
+      "import": "./dist-esm/src/models/index.js"
     },
     "./rest": {
       "types": "./types/src/rest/index.d.ts",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/28034

### Describe the problem that is addressed by this PR
Sub-path export for models was broken after the changes for the 2023-12-01-preview API.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
