### PR TITLE
[EngSys][Test] Pin NodeTestVersion to 21.2.0 again

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -20,7 +20,7 @@
     "NodeTestVersion": [
       "18.x",
       "20.x",
-      "21.x"
+      "21.2.0"
     ],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"


### PR DESCRIPTION
Because of a regression in v21.4.0, running our tests with `esm` package is broken.

https://github.com/nodejs/node/issues/51081

Revert "[EngSys] unpin NodeTestVersion of 21.2.0 (#27999)"

This reverts commit 884d750c2fc130fba6e5501b1a2fd8fef51fcbe9.
