### PR TITLE
[core-util] Add reshape helper

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Created new "reshape" helper for serialization/deserialization operations on JS objects.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -21,7 +23,7 @@
 ### Features Added
 
 - Add support for hex encoding to `uint8ArrayToString` and `stringToUint8Array`
-- Fix bug when `uint8ArrayToString` with Base64 encoding would not decode binary data 
+- Fix bug when `uint8ArrayToString` with Base64 encoding would not decode binary data
   containing bytes which are not valid ISO/IEC 8859-1 (latin1) characters.
 
 ### Bugs Fixed

--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -89,6 +89,24 @@ export function objectHasProperty<Thing, PropertyName extends string>(thing: Thi
 export function randomUUID(): string;
 
 // @public
+export function reshape(object: unknown, selector: string, newPropertyName: string): unknown;
+
+// @public
+export function reshape(object: unknown, selector: string, mapFunction: (value: unknown) => unknown): unknown;
+
+// @public
+export function reshape(object: unknown, selector: string, newPropertyName: string, mapFunction: (value: unknown) => unknown): unknown;
+
+// @public
+export function reshape(object: unknown, selector: string, options: ReshapeOptions): unknown;
+
+// @public
+export interface ReshapeOptions {
+    mapFunction?: (value: unknown) => unknown;
+    newPropertyName?: string;
+}
+
+// @public
 export function stringToUint8Array(value: string, format: EncodingType): Uint8Array;
 
 // @public

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -19,3 +19,4 @@ export { isDefined, isObjectWithProperties, objectHasProperty } from "./typeGuar
 export { randomUUID } from "./uuidUtils";
 export { isBrowser, isBun, isNode, isDeno, isReactNative, isWebWorker } from "./checkEnvironment";
 export { uint8ArrayToString, stringToUint8Array, type EncodingType } from "./bytesEncoding";
+export { reshape, type ReshapeOptions } from "./reshape";

--- a/sdk/core/core-util/src/reshape.ts
+++ b/sdk/core/core-util/src/reshape.ts
@@ -210,16 +210,22 @@ export function reshape(
           if (newPropertyName) {
             throw new Error("cannot rename array indices");
           }
-          if (mapFunction && targetProp) {
-            parent[targetProp] = value.map(mapFunction);
+          if (mapFunction) {
+            value = value.map(mapFunction);
           }
-        } else if (targetProp) {
-          parent[targetProp] = value.map((arrayItem) => {
+        } else {
+          value = value.map((arrayItem) => {
             return reshape(arrayItem, part.remainingSelector, {
               newPropertyName,
               mapFunction,
             });
           });
+        }
+
+        if (parent && targetProp) {
+          parent[targetProp] = value;
+        } else {
+          return value;
         }
       }
       return object;
@@ -237,9 +243,10 @@ export function reshape(
     targetProp = newPropertyName;
   }
 
-  if (targetProp) {
+  if (parent && targetProp) {
     parent[targetProp] = value;
+    return object;
+  } else {
+    return value;
   }
-
-  return object;
 }

--- a/sdk/core/core-util/src/reshape.ts
+++ b/sdk/core/core-util/src/reshape.ts
@@ -1,0 +1,245 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+interface SelectorPropertyName {
+  type: "propertyName";
+  value: string;
+}
+
+interface SelectorArrayIterator {
+  type: "arrayIterator";
+  remainingSelector: string;
+}
+
+type SelectorPart = SelectorArrayIterator | SelectorPropertyName;
+
+function* selectorParts(selector: string): Iterable<SelectorPart> {
+  let partialResult: string[] = [];
+  let backSlashFound = false;
+  let openBracketFound = false;
+  let rollingUpSelector = false;
+  for (const char of selector) {
+    if (rollingUpSelector) {
+      partialResult.push(char);
+      continue;
+    }
+    if (backSlashFound) {
+      partialResult.push(char);
+      backSlashFound = false;
+      continue;
+    }
+    if (openBracketFound && char === "]") {
+      openBracketFound = false;
+      if (partialResult.length) {
+        yield { type: "propertyName", value: partialResult.join("") };
+        partialResult = [];
+      }
+      rollingUpSelector = true;
+      continue;
+    }
+    switch (char) {
+      case ".":
+        yield { type: "propertyName", value: partialResult.join("") };
+        partialResult = [];
+        break;
+      case "\\":
+        backSlashFound = true;
+        break;
+      case "[":
+        openBracketFound = true;
+        break;
+      default:
+        partialResult.push(char);
+    }
+  }
+
+  if (rollingUpSelector) {
+    yield { type: "arrayIterator", remainingSelector: partialResult.join("") };
+  } else if (partialResult.length) {
+    yield { type: "propertyName", value: partialResult.join("") };
+  }
+}
+
+/**
+ * Options for configuring a selected property.
+ */
+export interface ReshapeOptions {
+  /**
+   * The new property name for the selected property.
+   */
+  newPropertyName?: string;
+  /**
+   * A function that maps the current property value to a new one.
+   */
+  mapFunction?: (value: unknown) => unknown;
+}
+
+/**
+ * A simple helper method that allows you to modify a JS object.
+ * The original argument is mutated in place, but also returned
+ * in order to make casting to the final type easier.
+ *
+ * Example usage:
+ * ```ts
+ * // changes input to look like `{b: 1}`
+ * reshape({a: 1}, "a", "b");
+ *
+ * ```
+ * @param object - The object to modify.
+ * @param selector - The selector for the property to modify.
+ * Separate property names with `.`,
+ * iterate over arrays with `[]`,
+ * and escape these characters with `\`.
+ * @param newPropertyName - The new property name for the selected property.
+ */
+export function reshape(object: unknown, selector: string, newPropertyName: string): unknown;
+/**
+ * A simple helper method that allows you to modify a JS object.
+ * The original argument is mutated in place, but also returned
+ * in order to make casting to the final type easier.
+ *
+ * Example usage:
+ * ```ts
+ * // changes input to look like `{a: "hello 1"}`
+ * reshape({a: 1}, "a", (value) => `hello ${value}`);
+ *
+ * ```
+ * @param object - The object to modify.
+ * @param selector - The selector for the property to modify.
+ * Separate property names with `.`,
+ * iterate over arrays with `[]`,
+ * and escape these characters with `\`.
+ * @param mapFunction - A function that maps the current property value to a new one.
+ */
+export function reshape(
+  object: unknown,
+  selector: string,
+  mapFunction: (value: unknown) => unknown
+): unknown;
+/**
+ * A simple helper method that allows you to modify a JS object.
+ * The original argument is mutated in place, but also returned
+ * in order to make casting to the final type easier.
+ *
+ * Example usage:
+ * ```ts
+ * // changes input to look like `{b: "hello 1"}`
+ * reshape({a: 1}, "a", "b", (value) => `hello ${value}`);
+ *
+ * ```
+ * @param object - The object to modify.
+ * @param selector - The selector for the property to modify.
+ * Separate property names with `.`,
+ * iterate over arrays with `[]`,
+ * and escape these characters with `\`.
+ * @param newPropertyName - The new property name for the selected property.
+ * @param mapFunction - A function that maps the current property value to a new one.
+ */
+export function reshape(
+  object: unknown,
+  selector: string,
+  newPropertyName: string,
+  mapFunction: (value: unknown) => unknown
+): unknown;
+/**
+ * A simple helper method that allows you to modify a JS object.
+ * The original argument is mutated in place, but also returned
+ * in order to make casting to the final type easier.
+ *
+ * Example usage:
+ * ```ts
+ * // changes input to look like `{b: "hello 1"}`
+ * reshape({a: 1}, "a", { newPropertyName: "b", mapFunction: (value) => `hello ${value}`});
+ * ```
+ * @param object - The object to modify.
+ * @param selector - The selector for the property to modify.
+ * Separate property names with `.`,
+ * iterate over arrays with `[]`,
+ * and escape these characters with `\`.
+ * @param options - Options for modifying the selected property.
+ */
+export function reshape(object: unknown, selector: string, options: ReshapeOptions): unknown;
+export function reshape(
+  object: unknown,
+  selector: string,
+  nameOrMapOrOptions: string | ((value: unknown) => unknown) | ReshapeOptions,
+  mapFunctionOrNothing?: (value: unknown) => unknown
+): unknown {
+  if (object === null || object === undefined) {
+    return object;
+  }
+  let newPropertyName: string | undefined;
+  let mapFunction: undefined | ((value: unknown) => unknown);
+
+  if (typeof nameOrMapOrOptions === "string") {
+    newPropertyName = nameOrMapOrOptions;
+    if (mapFunctionOrNothing) {
+      mapFunction = mapFunctionOrNothing;
+    }
+  } else if (typeof nameOrMapOrOptions === "function") {
+    mapFunction = nameOrMapOrOptions;
+  } else if (typeof nameOrMapOrOptions === "object") {
+    const options = nameOrMapOrOptions as ReshapeOptions | undefined | null;
+    newPropertyName = options?.newPropertyName;
+    mapFunction = options?.mapFunction;
+  } else {
+    throw new RangeError("misconfigured options to reshape");
+  }
+
+  if (!newPropertyName && !mapFunction) {
+    return object;
+  }
+
+  let value: any = object;
+  let parent: any;
+  let targetProp: string | undefined;
+
+  for (const part of selectorParts(selector)) {
+    if (part.type === "propertyName") {
+      const prop = part.value;
+      if (typeof value[prop] !== "undefined") {
+        targetProp = prop;
+        parent = value;
+        value = value[prop];
+      } else {
+        return object;
+      }
+    } else if (part.type === "arrayIterator") {
+      if (Array.isArray(value)) {
+        if (!part.remainingSelector) {
+          if (newPropertyName) {
+            throw new Error("cannot rename array indices");
+          }
+          if (mapFunction && targetProp) {
+            parent[targetProp] = value.map(mapFunction);
+          }
+        } else if (targetProp) {
+          parent[targetProp] = value.map((arrayItem) => {
+            return reshape(arrayItem, part.remainingSelector, {
+              newPropertyName,
+              mapFunction,
+            });
+          });
+        }
+      }
+      return object;
+    }
+  }
+
+  if (mapFunction) {
+    value = mapFunction(value);
+  }
+
+  if (newPropertyName) {
+    if (targetProp) {
+      delete parent[targetProp];
+    }
+    targetProp = newPropertyName;
+  }
+
+  if (targetProp) {
+    parent[targetProp] = value;
+  }
+
+  return object;
+}

--- a/sdk/core/core-util/test/public/reshape.spec.ts
+++ b/sdk/core/core-util/test/public/reshape.spec.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, it, assert, expect } from "vitest";
+import { reshape } from "../../src/reshape";
+
+describe("reshape", function () {
+  it("renames a simple property", function () {
+    const input = { a: 1, b: 2 };
+    const actual = reshape(input, "a", "c");
+    const expected = { c: 1, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("maps a simple property", function () {
+    const input = { a: 1, b: 2 };
+    const actual = reshape(input, "a", String);
+    const expected = { a: "1", b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("renames and maps a simple property", function () {
+    const input = { a: 1, b: 2 };
+    const actual = reshape(input, "a", "c", String);
+    const expected = { c: "1", b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("renames a nested property", function () {
+    const input = { a: { c: { e: 4 }, d: 3 }, b: 2 };
+    const actual = reshape(input, "a.c.e", "f");
+    const expected = { a: { c: { f: 4 }, d: 3 }, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("can map elements of an array", function () {
+    const input = { a: { b: [1, 2, 3] } };
+    const actual = reshape(input, "a.b[]", String);
+    const expected = { a: { b: ["1", "2", "3"] } };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("renaming array elements is an error", function () {
+    const input = { a: { b: [1, 2, 3] } };
+    expect(() => reshape(input, "a.b[]", "oops")).toThrowError("cannot rename array indices");
+  });
+
+  it("can rename properties of elements of an array", function () {
+    const input = {
+      a: {
+        b: [
+          { c: 1, d: 2 },
+          { c: 3, d: 4 },
+        ],
+      },
+    };
+    const actual = reshape(input, "a.b[]c", "e");
+    const expected = {
+      a: {
+        b: [
+          { e: 1, d: 2 },
+          { e: 3, d: 4 },
+        ],
+      },
+    };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("selecting a property that doesn't exist does nothing", function () {
+    const input = { a: 1, b: 2 };
+    const actual = reshape(input, "c", "d");
+    const expected = { a: 1, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("selecting a property as an array that is not an array does nothing", function () {
+    const input = { a: 1, b: 2 };
+    const actual = reshape(input, "a[]", String);
+    const expected = { a: 1, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("property with a dot in the name can be selected", function () {
+    const input = { a: { ".c.": { e: 4 }, d: 3 }, b: 2 };
+    const actual = reshape(input, String.raw`a.\.c\..e`, "f");
+    const expected = { a: { ".c.": { f: 4 }, d: 3 }, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("property with a backslash in the name can be selected", function () {
+    const input = { a: { "\\c\\": { e: 4 }, d: 3 }, b: 2 };
+    const actual = reshape(input, String.raw`a.\\c\\.e`, "f");
+    const expected = { a: { "\\c\\": { f: 4 }, d: 3 }, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+});

--- a/sdk/core/core-util/test/public/reshape.spec.ts
+++ b/sdk/core/core-util/test/public/reshape.spec.ts
@@ -100,6 +100,13 @@ describe("reshape", function () {
     assert.deepEqual(actual, expected);
   });
 
+  it("property with a backslash and dot in the name can be selected", function () {
+    const input = { a: { "odata\\.c": { e: 4 }, d: 3 }, b: 2, odata: { c: 5 } };
+    const actual = reshape(input, String.raw`a.odata\\\.c`, "z");
+    const expected = { a: { z: { e: 4 }, d: 3 }, b: 2, odata: { c: 5 } };
+    assert.deepEqual(actual, expected);
+  });
+
   it("can handle nested arrays", function () {
     const input = {
       a: [
@@ -114,6 +121,13 @@ describe("reshape", function () {
         ["3", "4"],
       ],
     };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("can handle arrays as the initial input", function () {
+    const input = [1, 2, 3];
+    const actual = reshape(input, "[]", String);
+    const expected = ["1", "2", "3"];
     assert.deepEqual(actual, expected);
   });
 });

--- a/sdk/core/core-util/test/public/reshape.spec.ts
+++ b/sdk/core/core-util/test/public/reshape.spec.ts
@@ -12,6 +12,12 @@ describe("reshape", function () {
     assert.deepEqual(actual, expected);
   });
 
+  it("can remap the root object", function () {
+    const actual = reshape({ properties: { a: 1, b: 2 } }, "", (input: any) => input.properties);
+    const expected = { a: 1, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
   it("maps a simple property", function () {
     const input = { a: 1, b: 2 };
     const actual = reshape(input, "a", String);
@@ -91,6 +97,23 @@ describe("reshape", function () {
     const input = { a: { "\\c\\": { e: 4 }, d: 3 }, b: 2 };
     const actual = reshape(input, String.raw`a.\\c\\.e`, "f");
     const expected = { a: { "\\c\\": { f: 4 }, d: 3 }, b: 2 };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("can handle nested arrays", function () {
+    const input = {
+      a: [
+        [1, 2],
+        [3, 4],
+      ],
+    };
+    const actual = reshape(input, "a[][]", String);
+    const expected = {
+      a: [
+        ["1", "2"],
+        ["3", "4"],
+      ],
+    };
     assert.deepEqual(actual, expected);
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-util`

### Describe the problem that is addressed by this PR

When trying to serialize/deserialize object payloads, we often have to recurse into them in order to rename properties and stringify/destringify values. This helper allows for applying these kinds of operations to an object where there is a known path to the property being modified. In the event the property does not exist, no mutation occurs.

```ts
// changes input to look like `{b: 1}`
reshape({a: 1}, "a", "b");

// changes input to look like `{a: "hello 1"}`
reshape({a: 1}, "a", (value) => `hello ${value}`);

// changes input to look like `{b: "hello 1"}`
reshape({a: 1}, "a", "b", (value) => `hello ${value}`);

// arrays are also supported, output looks like `["1", 2", "3"]`
reshape({a: [1, 2, 3]}, "a[]", String);
```

The only thing I don't currently handle is repeated selection, e.g. if you have a potential cycle in the path to a property and want to try recursing as deeply as you can.

### Are there test cases added in this PR? _(If not, why?)_

Yes!

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
