### PR TITLE
api-management-custom-widgets-scaffolder displayNameToName fnc with prefix

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- added a prefix to result of "displayNameToName" function to prevent conflicts in name with existing, build-in widgets
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/execute.js
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/bin/execute.js
@@ -27,10 +27,11 @@ const OVERRIDE_DEFAULT_PORT = 3000;
 const TECHNOLOGIES = ["typescript", "react", "vue"];
 /**
  * Converts user defined name of a custom widget to a unique ID, which is in context of Dev Portal known as "name".
+ * Prefix "cw-" to avoid conflicts with existing widgets.
  *
  * @param displayName - User defined name of the custom widget.
  */
-const displayNameToName = (displayName) => encodeURIComponent(displayName
+const displayNameToName = (displayName) => encodeURIComponent(("cw-" + displayName)
     .normalize("NFD")
     .toLowerCase()
     .replace(/[\u0300-\u036f]/g, "")

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/scaffolding.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/scaffolding.ts
@@ -50,12 +50,13 @@ export type Configs = WidgetConfig | ServiceInformation | Options;
 
 /**
  * Converts user defined name of a custom widget to a unique ID, which is in context of Dev Portal known as "name".
+ * Prefix "cw-" to avoid conflicts with existing widgets.
  *
  * @param displayName - User defined name of the custom widget.
  */
 export const displayNameToName = (displayName: string): string =>
   encodeURIComponent(
-    displayName
+    ("cw-" + displayName)
       .normalize("NFD")
       .toLowerCase()
       .replace(/[\u0300-\u036f]/g, "")


### PR DESCRIPTION
### Packages impacted by this PR
api-management-custom-widgets-scaffolder

### Issues associated with this PR
https://dev.azure.com/msazure/One/_workitems/edit/25953312

### Describe the problem that is addressed by this PR
conflicting names of custom and build-in widgets

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
