### PR TITLE
[core-lro] Option 1 - new lro in shared folder with existing ones

### DIFF
--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -24,6 +24,9 @@ export interface CreateHttpPollerOptions<TResult, TState> {
 }
 
 // @public
+export function createHttpPromisePoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): PromisePollerLike<TState, TResult>;
+
+// @public
 export interface LongRunningOperation<T = unknown> {
     requestMethod?: string;
     requestPath?: string;
@@ -149,6 +152,24 @@ export interface PollOperationState<TResult> {
 
 // @public
 export type PollProgressCallback<TState> = (state: TState) => void;
+
+// @public (undocumented)
+export interface PromisePollerLike<TState extends OperationState<TResult>, TResult> extends Promise<TResult> {
+    readonly isDone: boolean;
+    readonly isStopped: boolean;
+    onProgress(callback: (state?: TState) => void): CancelOnProgress;
+    readonly operationState: TState | undefined;
+    poll(options?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<TState>;
+    pollUntilDone(pollOptions?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<TResult>;
+    readonly result: TResult | undefined;
+    serialize(): Promise<string>;
+    // (undocumented)
+    submitted(): Promise<void>;
+}
 
 // @public
 export interface RawResponse {

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -100,7 +100,7 @@ export interface CreateHttpPollerOptions<TResult, TState> {
   /**
    * A function to process the result of the LRO.
    */
-  processResult?: (result: unknown, state: TState) => TResult;
+  processResult?: (result: unknown, state: TState) => TResult | Promise<TResult>;
   /**
    * A function to process the state of the LRO.
    */

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -93,6 +93,8 @@ function createHttpPollerOrPromisePoller<TResult, TState extends OperationState<
           response,
           operationLocation: config?.operationLocation,
           resourceLocation: config?.resourceLocation,
+          initialUrl: lro.requestPath,
+          requestMethod: lro.requestMethod,
           ...(config?.mode ? { metadata: { mode: config.mode } } : {}),
         };
       },

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createHttpPoller } from "./http/poller";
+export { createHttpPoller, createHttpPromisePoller } from "./http/poller";
 export {
   CancelOnProgress,
   OperationState,
   OperationStatus,
   SimplePollerLike,
+  PromisePollerLike
 } from "./poller/models";
 export { CreateHttpPollerOptions } from "./http/models";
 export {

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -62,7 +62,7 @@ export interface CreatePollerOptions<TResponse, TResult, TState> {
   /**
    * A function to process the result of the LRO.
    */
-  processResult?: (result: TResponse, state: TState) => TResult;
+  processResult?: (result: TResponse, state: TState) => TResult | Promise<TResult>;
   /**
    * A function to process the state of the LRO.
    */

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -220,6 +220,56 @@ export interface SimplePollerLike<TState extends OperationState<TResult>, TResul
   toString(): string;
 }
 
+export interface PromisePollerLike<TState extends OperationState<TResult>, TResult> extends Promise<TResult> {
+  /**
+   * Returns true if the poller has finished polling.
+   */
+  isDone: boolean;
+  /**
+   * Returns true if the poller is stopped.
+   */
+  isStopped: boolean;
+  /**
+   * Returns the state of the operation.
+   */
+  operationState: TState | undefined;
+  /**
+   * Returns the result value of the operation,
+   * regardless of the state of the poller.
+   * It can return undefined or an incomplete form of the final TResult value
+   * depending on the implementation.
+   */
+  result: TResult | undefined;
+  /**
+   * Returns a promise that will resolve once a single polling request finishes.
+   * It does this by calling the update method of the Poller's operation.
+   */
+  poll(options?: { abortSignal?: AbortSignalLike }): Promise<TState>;
+  /**
+   * Returns a promise that will resolve once the underlying operation is completed.
+   */
+  pollUntilDone(pollOptions?: { abortSignal?: AbortSignalLike }): Promise<TResult>;
+  /**
+   * Invokes the provided callback after each polling is completed,
+   * sending the current state of the poller's operation.
+   *
+   * It returns a method that can be used to stop receiving updates on the given callback function.
+   */
+  onProgress(callback: (state?: TState) => void): CancelOnProgress;
+
+  /**
+   * Returns a serialized version of the poller's operation
+   * by invoking the operation's toString method.
+   */
+  serialize(): Promise<string>;
+
+  /**
+   * 
+   */
+  submitted(): Promise<void>;
+}
+
+
 /**
  * A state proxy that allows poller implementation to abstract away the operation
  * state. This is useful to implement `lroEngine` and `createPoller` in a modular

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -12,6 +12,10 @@ export interface OperationConfig {
   operationLocation?: string;
   /** The resource location */
   resourceLocation?: string;
+  /** The initial Url  */
+  initialUrl?: string;
+  /** The request method */
+  requestMethod?: string;
   /** metadata about the operation */
   metadata?: Record<string, string>;
 }

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -224,22 +224,22 @@ export interface PromisePollerLike<TState extends OperationState<TResult>, TResu
   /**
    * Returns true if the poller has finished polling.
    */
-  isDone: boolean;
+  readonly isDone: boolean;
   /**
    * Returns true if the poller is stopped.
    */
-  isStopped: boolean;
+  readonly isStopped: boolean;
   /**
    * Returns the state of the operation.
    */
-  operationState: TState | undefined;
+  readonly operationState: TState | undefined;
   /**
    * Returns the result value of the operation,
    * regardless of the state of the poller.
    * It can return undefined or an incomplete form of the final TResult value
    * depending on the implementation.
    */
-  result: TResult | undefined;
+  readonly result: TResult | undefined;
   /**
    * Returns a promise that will resolve once a single polling request finishes.
    * It does this by calling the update method of the Poller's operation.

--- a/sdk/core/core-lro/src/poller/operation.ts
+++ b/sdk/core/core-lro/src/poller/operation.ts
@@ -149,12 +149,14 @@ export async function initOperation<TResponse, TResult, TState>(inputs: {
     withOperationLocation,
     setErrorAsResult,
   } = inputs;
-  const { operationLocation, resourceLocation, metadata, response } = await init();
+  const { operationLocation, resourceLocation, initialUrl, requestMethod, metadata, response } = await init();
   if (operationLocation) withOperationLocation?.(operationLocation, false);
   const config = {
     metadata,
     operationLocation,
     resourceLocation,
+    initialUrl,
+    requestMethod,
   };
   logger.verbose(`LRO: Operation description:`, config);
   const state = stateProxy.initState(config);
@@ -201,10 +203,8 @@ async function pollOperationHelper<TResponse, TState, TResult, TOptions>(inputs:
   );
   const status = getOperationStatus(response, state);
   logger.verbose(
-    `LRO: Status:\n\tPolling from: ${
-      state.config.operationLocation
-    }\n\tOperation status: ${status}\n\tPolling status: ${
-      terminalStates.includes(status) ? "Stopped" : "Running"
+    `LRO: Status:\n\tPolling from: ${state.config.operationLocation
+    }\n\tOperation status: ${status}\n\tPolling status: ${terminalStates.includes(status) ? "Stopped" : "Running"
     }`
   );
   if (status === "succeeded") {

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -209,7 +209,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
 }
 
 /**
- * Returns a poller&promise factory.
+ * Returns a promise poller factory.
  */
 export function buildCreatePromisePoller<TResponse, TResult, TState extends OperationState<TResult>>(
   inputs: BuildCreatePollerOptions<TResponse, TState>
@@ -274,10 +274,18 @@ export function buildCreatePromisePoller<TResponse, TResult, TState extends Oper
     let currentPollIntervalInMs = intervalInMs;
 
     const poller: PromisePollerLike<TState, TResult> = {
-      operationState: state,
-      result: state?.result,
-      isDone: ["succeeded", "failed", "canceled"].includes(state?.status ?? ""),
-      isStopped: resultPromise === undefined,
+      get operationState(): TState | undefined {
+        return state;
+      },
+      get result(): TResult | undefined {
+        return state?.result;
+      },
+      get isDone(): boolean {
+        return ["succeeded", "failed", "canceled"].includes(state?.status ?? "");
+      },
+      get isStopped(): boolean {
+        return resultPromise === undefined;
+      },
       onProgress: (callback: (state?: TState) => void) => {
         const s = Symbol();
         handlers.set(s, callback);

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -7,6 +7,7 @@ import {
   CreatePollerOptions,
   Operation,
   OperationState,
+  PromisePollerLike,
   RestorableOperationState,
   SimplePollerLike,
   StateProxy,
@@ -73,24 +74,24 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     const stateProxy = createStateProxy<TResult, TState>();
     const withOperationLocation = withOperationLocationCallback
       ? (() => {
-          let called = false;
-          return (operationLocation: string, isUpdated: boolean) => {
-            if (isUpdated) withOperationLocationCallback(operationLocation);
-            else if (!called) withOperationLocationCallback(operationLocation);
-            called = true;
-          };
-        })()
+        let called = false;
+        return (operationLocation: string, isUpdated: boolean) => {
+          if (isUpdated) withOperationLocationCallback(operationLocation);
+          else if (!called) withOperationLocationCallback(operationLocation);
+          called = true;
+        };
+      })()
       : undefined;
     const state: RestorableOperationState<TState> = restoreFrom
       ? deserializeState(restoreFrom)
       : await initOperation({
-          init,
-          stateProxy,
-          processResult,
-          getOperationStatus: getStatusFromInitialResponse,
-          withOperationLocation,
-          setErrorAsResult: !resolveOnUnsuccessful,
-        });
+        init,
+        stateProxy,
+        processResult,
+        getOperationStatus: getStatusFromInitialResponse,
+        withOperationLocation,
+        setErrorAsResult: !resolveOnUnsuccessful,
+      });
     let resultPromise: Promise<TResult> | undefined;
     const abortController = new AbortController();
     // Progress handlers
@@ -118,48 +119,48 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
         return () => handlers.delete(s);
       },
       pollUntilDone: (pollOptions?: { abortSignal?: AbortSignalLike }) =>
-        (resultPromise ??= (async () => {
-          const { abortSignal: inputAbortSignal } = pollOptions || {};
-          // In the future we can use AbortSignal.any() instead
-          function abortListener(): void {
-            abortController.abort();
-          }
-          const abortSignal = abortController.signal;
-          if (inputAbortSignal?.aborted) {
-            abortController.abort();
-          } else if (!abortSignal.aborted) {
-            inputAbortSignal?.addEventListener("abort", abortListener, { once: true });
-          }
+      (resultPromise ??= (async () => {
+        const { abortSignal: inputAbortSignal } = pollOptions || {};
+        // In the future we can use AbortSignal.any() instead
+        function abortListener(): void {
+          abortController.abort();
+        }
+        const abortSignal = abortController.signal;
+        if (inputAbortSignal?.aborted) {
+          abortController.abort();
+        } else if (!abortSignal.aborted) {
+          inputAbortSignal?.addEventListener("abort", abortListener, { once: true });
+        }
 
-          try {
-            if (!poller.isDone()) {
+        try {
+          if (!poller.isDone()) {
+            await poller.poll({ abortSignal });
+            while (!poller.isDone()) {
+              await delay(currentPollIntervalInMs, { abortSignal });
               await poller.poll({ abortSignal });
-              while (!poller.isDone()) {
-                await delay(currentPollIntervalInMs, { abortSignal });
-                await poller.poll({ abortSignal });
-              }
-            }
-          } finally {
-            inputAbortSignal?.removeEventListener("abort", abortListener);
-          }
-          if (resolveOnUnsuccessful) {
-            return poller.getResult() as TResult;
-          } else {
-            switch (state.status) {
-              case "succeeded":
-                return poller.getResult() as TResult;
-              case "canceled":
-                throw new Error(cancelErrMsg);
-              case "failed":
-                throw state.error;
-              case "notStarted":
-              case "running":
-                throw new Error(`Polling completed without succeeding or failing`);
             }
           }
-        })().finally(() => {
-          resultPromise = undefined;
-        })),
+        } finally {
+          inputAbortSignal?.removeEventListener("abort", abortListener);
+        }
+        if (resolveOnUnsuccessful) {
+          return poller.getResult() as TResult;
+        } else {
+          switch (state.status) {
+            case "succeeded":
+              return poller.getResult() as TResult;
+            case "canceled":
+              throw new Error(cancelErrMsg);
+            case "failed":
+              throw state.error;
+            case "notStarted":
+            case "running":
+              throw new Error(`Polling completed without succeeding or failing`);
+          }
+        }
+      })().finally(() => {
+        resultPromise = undefined;
+      })),
       async poll(pollOptions?: { abortSignal?: AbortSignalLike }): Promise<void> {
         if (resolveOnUnsuccessful) {
           if (poller.isDone()) return;
@@ -202,6 +203,195 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
           }
         }
       },
+    };
+    return poller;
+  };
+}
+
+export function buildCreatePromisePoller<TResponse, TResult, TState extends OperationState<TResult>>(
+  inputs: BuildCreatePollerOptions<TResponse, TState>
+): (
+  lro: Operation<TResponse, { abortSignal?: AbortSignalLike }>,
+  options?: CreatePollerOptions<TResponse, TResult, TState>
+) => PromisePollerLike<TState, TResult> {
+  const {
+    getOperationLocation,
+    getStatusFromInitialResponse,
+    getStatusFromPollResponse,
+    isOperationError,
+    getResourceLocation,
+    getPollingInterval,
+    getError,
+    resolveOnUnsuccessful,
+  } = inputs;
+  return (
+    { init, poll }: Operation<TResponse, { abortSignal?: AbortSignalLike }>,
+    options?: CreatePollerOptions<TResponse, TResult, TState>
+  ) => {
+    const {
+      processResult,
+      updateState,
+      withOperationLocation: withOperationLocationCallback,
+      intervalInMs = POLL_INTERVAL_IN_MS,
+      restoreFrom,
+    } = options || {};
+    const stateProxy = createStateProxy<TResult, TState>();
+    const withOperationLocation = withOperationLocationCallback
+      ? (() => {
+        let called = false;
+        return (operationLocation: string, isUpdated: boolean) => {
+          if (isUpdated) withOperationLocationCallback(operationLocation);
+          else if (!called) withOperationLocationCallback(operationLocation);
+          called = true;
+        };
+      })()
+      : undefined;
+    let statePromise: Promise<TState>;
+    let state: RestorableOperationState<TState> | undefined = undefined;
+    if (restoreFrom) {
+      state = deserializeState(restoreFrom);
+      statePromise = Promise.resolve(state);
+    } else {
+      statePromise = initOperation({
+        init,
+        stateProxy,
+        processResult,
+        getOperationStatus: getStatusFromInitialResponse,
+        withOperationLocation,
+        setErrorAsResult: !resolveOnUnsuccessful,
+      });
+    }
+    let resultPromise: Promise<TResult> | undefined;
+    const abortController = new AbortController();
+    // Progress handlers
+    type Handler = (state?: TState) => void;
+    const handlers = new Map<symbol, Handler>();
+    const handleProgressEvents = async (): Promise<void> => handlers.forEach((h) => h(state));
+    const cancelErrMsg = "Operation was canceled";
+    let currentPollIntervalInMs = intervalInMs;
+
+    const poller: PromisePollerLike<TState, TResult> = {
+      operationState: state,
+      result: state?.result,
+      isDone: ["succeeded", "failed", "canceled"].includes(state?.status ?? ""),
+      isStopped: resultPromise === undefined,
+      onProgress: (callback: (state?: TState) => void) => {
+        const s = Symbol();
+        handlers.set(s, callback);
+        return () => handlers.delete(s);
+      },
+      serialize: async () => {
+        await statePromise;
+        return JSON.stringify({
+          state,
+        });
+      },
+      submitted: async () => {
+        await statePromise;
+      },
+      pollUntilDone: async (pollOptions?: { abortSignal?: AbortSignalLike }) => {
+        resultPromise ??= (async () => {
+          await statePromise;
+          const { abortSignal: inputAbortSignal } = pollOptions || {};
+          // In the future we can use AbortSignal.any() instead
+          function abortListener(): void {
+            abortController.abort();
+          }
+          const abortSignal = abortController.signal;
+          if (inputAbortSignal?.aborted) {
+            abortController.abort();
+          } else if (!abortSignal.aborted) {
+            inputAbortSignal?.addEventListener("abort", abortListener, { once: true });
+          }
+
+          try {
+            if (!poller.isDone) {
+              await poller.poll({ abortSignal });
+              while (!poller.isDone) {
+                await delay(currentPollIntervalInMs, { abortSignal });
+                await poller.poll({ abortSignal });
+              }
+            }
+          } finally {
+            inputAbortSignal?.removeEventListener("abort", abortListener);
+          }
+          if (resolveOnUnsuccessful) {
+            return poller.result as TResult;
+          } else {
+            switch (state!.status) {
+              case "succeeded":
+                return poller.result as TResult;
+              case "canceled":
+                throw new Error(cancelErrMsg);
+              case "failed":
+                throw state!.error;
+              case "notStarted":
+              case "running":
+                throw new Error(`Polling completed without succeeding or failing`);
+            }
+          }
+        })().finally(() => { resultPromise = undefined; });
+        return resultPromise;
+      },
+      async poll(pollOptions?: { abortSignal?: AbortSignalLike }): Promise<TState> {
+        await statePromise;
+        if (resolveOnUnsuccessful) {
+          if (poller.isDone) return state!;
+        } else {
+          switch (state!.status) {
+            case "succeeded":
+              return state!;
+            case "canceled":
+              throw new Error(cancelErrMsg);
+            case "failed":
+              throw state!.error;
+          }
+        }
+        await pollOperation({
+          poll,
+          state: state!,
+          stateProxy,
+          getOperationLocation,
+          isOperationError,
+          withOperationLocation,
+          getPollingInterval,
+          getOperationStatus: getStatusFromPollResponse,
+          getResourceLocation,
+          processResult,
+          getError,
+          updateState,
+          options: pollOptions,
+          setDelay: (pollIntervalInMs) => {
+            currentPollIntervalInMs = pollIntervalInMs;
+          },
+          setErrorAsResult: !resolveOnUnsuccessful,
+        });
+        await handleProgressEvents();
+        if (!resolveOnUnsuccessful) {
+          switch (state!.status) {
+            case "canceled":
+              throw new Error(cancelErrMsg);
+            case "failed":
+              throw state!.error;
+          }
+        }
+
+        return state!;
+      },
+      then<TResult1 = TResult, TResult2 = never>(
+        onfulfilled?: ((value: TResult) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+      ): Promise<TResult1 | TResult2> {
+        return poller.pollUntilDone().then(onfulfilled, onrejected);
+      },
+      catch<TResult2 = never>(onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult | TResult2> {
+        return poller.pollUntilDone().catch(onrejected);
+      },
+      finally(onfinally?: (() => void) | undefined | null): Promise<TResult> {
+        return poller.pollUntilDone().finally(onfinally);
+      },
+      [Symbol.toStringTag]: "LRO Promise Poller"
+
     };
     return poller;
   };

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -208,6 +208,9 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
   };
 }
 
+/**
+ * Returns a poller&promise factory.
+ */
 export function buildCreatePromisePoller<TResponse, TResult, TState extends OperationState<TResult>>(
   inputs: BuildCreatePollerOptions<TResponse, TState>
 ): (
@@ -247,7 +250,7 @@ export function buildCreatePromisePoller<TResponse, TResult, TState extends Oper
       })()
       : undefined;
     let statePromise: Promise<TState>;
-    let state: RestorableOperationState<TState> | undefined = undefined;
+    let state: RestorableOperationState<TState> | undefined;
     if (restoreFrom) {
       state = deserializeState(restoreFrom);
       statePromise = Promise.resolve(state);
@@ -259,7 +262,7 @@ export function buildCreatePromisePoller<TResponse, TResult, TState extends Oper
         getOperationStatus: getStatusFromInitialResponse,
         withOperationLocation,
         setErrorAsResult: !resolveOnUnsuccessful,
-      });
+      }).then((s) => state = s);
     }
     let resultPromise: Promise<TResult> | undefined;
     const abortController = new AbortController();


### PR DESCRIPTION
fix https://github.com/Azure/azure-sdk-for-js/issues/28051 and see experimental code in codegen pr: https://github.com/Azure/autorest.typescript/pull/2181

The changes would be mixed in src folder and the usage would be like:
- restorePoller
```typescript
import { OperationState, PromisePollerLike } from "@azure/core-lro";
export function restorePoller<TResponse extends HttpResponse, TResult = void>(
  client: StandardContext | StandardClient,
   sourceOperation: (
      ...args: any[]
    ) => PromisePollerLike<OperationState<TResult>, TResult>,
  serializedState: string,
  options?: RestorePollerOptions<TResult>
): PromisePollerLike<OperationState<TResult>, TResult>
```

- getLongRunningPoller
```typescript
import {
  LongRunningOperation,
  LroResourceLocationConfig,
  LroResponse,
  OperationState,
  PromisePollerLike,
  createHttpPromisePoller
} from "@azure/core-lro";
export function getLongRunningPoller<
  TResponse extends HttpResponse,
  TResult = void
>(
  client: Client,
  getInitialResponse: () => PromiseLike<TResponse>,
  processResponseBody: (result: TResponse) => TResult,
  options: GetLongRunningPollerOptions
): PromisePollerLike<OperationState<TResult>, TResult> 
```
