### PR TITLE
[storage-blob] remove unused dev dependency `@types/node-fetch`

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -149,7 +149,6 @@
     "@types/chai": "^4.1.6",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
-    "@types/node-fetch": "^2.5.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
It may be useful in perf testing before but no more as we move perf tests out and migrated to Core v2.
