### PR TITLE
[dev-tool] change dev dependency `@types/semver` version to `^7.5.6`

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -76,7 +76,7 @@
     "@types/minimist": "^1.2.5",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
-    "@types/semver": "~7.5.6",
+    "@types/semver": "^7.5.6",
     "autorest": "^3.5.1",
     "builtin-modules": "^3.1.0",
     "c8": "^8.0.1",


### PR DESCRIPTION
With caret version we can get upgrades from automated weekly run. Also for its main packaeg `semver` we depend on caret version too (`^7.5.4`)

Resolves #25838 
