### PR TITLE
[OpenAI & Core] Fix whisper responseFormat behavior

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Guard against unrecognized value types in the form data policy.
+
 ### Other Changes
 
 ## 1.13.0 (2023-12-07)

--- a/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
@@ -75,6 +75,10 @@ async function prepareFormData(formData: FormDataMap, request: PipelineRequest):
           }),
           body: stringToUint8Array(value, "utf-8"),
         });
+      } else if (value === undefined || value === null || typeof value !== "object") {
+        throw new Error(
+          `Unexpected value for key ${fieldName}: ${value}. Value should be serialized to string first.`,
+        );
       } else {
         // using || instead of ?? here since if value.name is empty we should create a file name
         const fileName = (value as File).name || "blob";

--- a/sdk/openai/openai/CHANGELOG.md
+++ b/sdk/openai/openai/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.10 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.10 (2024-01-03)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix `responseFormat` behavior in `getAudioTranscription` and `getAudioTranslation` methods where request wasn't properly formed if it wasn't specified.
 
 ## 1.0.0-beta.9 (2024-01-02)
 

--- a/sdk/openai/openai/assets.json
+++ b/sdk/openai/openai/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/openai/openai",
-  "Tag": "js/openai/openai_8cdce605bc"
+  "Tag": "js/openai/openai_94d151367d"
 }

--- a/sdk/openai/openai/sources/customizations/api/client/openAIClient/index.ts
+++ b/sdk/openai/openai/sources/customizations/api/client/openAIClient/index.ts
@@ -244,9 +244,9 @@ export async function getAudioTranslation<Format extends AudioResultFormat>(
       }),
       contentType: "multipart/form-data",
       body: {
-        file: createFile(fileContent, "placeholder.wav"),
-        response_format,
         ...snakeCaseKeys(rest),
+        file: createFile(fileContent, "placeholder.wav"),
+        ...(response_format ? { response_format } : {}),
       },
     });
   if (status !== "200") {
@@ -310,9 +310,9 @@ export async function getAudioTranscription<Format extends AudioResultFormat>(
       }),
       contentType: "multipart/form-data",
       body: {
-        file: createFile(fileContent, "placeholder.wav"),
-        response_format,
         ...snakeCaseKeys(rest),
+        file: createFile(fileContent, "placeholder.wav"),
+        ...(response_format ? { response_format } : {}),
       },
     });
   if (status !== "200") {

--- a/sdk/openai/openai/src/api/client/openAIClient/index.ts
+++ b/sdk/openai/openai/src/api/client/openAIClient/index.ts
@@ -618,7 +618,7 @@ export async function getAudioTranslation<Format extends AudioResultFormat>(
       body: {
         ...snakeCaseKeys(rest),
         file: createFile(fileContent, "placeholder.wav"),
-        response_format,
+        ...(response_format ? { response_format } : {}),
       },
     });
   if (status !== "200") {
@@ -684,7 +684,7 @@ export async function getAudioTranscription<Format extends AudioResultFormat>(
       body: {
         ...snakeCaseKeys(rest),
         file: createFile(fileContent, "placeholder.wav"),
-        response_format,
+        ...(response_format ? { response_format } : {}),
       },
     });
   if (status !== "200") {

--- a/sdk/openai/openai/test/public/node/whisper.spec.ts
+++ b/sdk/openai/openai/test/public/node/whisper.spec.ts
@@ -32,6 +32,22 @@ describe("OpenAI", function () {
         }
       });
 
+      describe("getAudioTranscription", function () {
+        it(`returns json transcription if responseFormat wasn't specified`, async function () {
+          const file = await fs.readFile(`./assets/audio/countdown.mp3`);
+          const res = await client.getAudioTranscription(getModel(authMethod), file);
+          assertAudioResult("json", res);
+        });
+      });
+
+      describe("getAudioTranslation", function () {
+        it(`returns json translation if responseFormat wasn't specified`, async function () {
+          const file = await fs.readFile(`./assets/audio/countdown.mp3`);
+          const res = await client.getAudioTranslation(getModel(authMethod), file);
+          assertAudioResult("json", res);
+        });
+      });
+
       matrix(
         [
           ["json", "verbose_json", "srt", "vtt", "text"],


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai & @azure/core-rest-pipeline

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/28145

### Describe the problem that is addressed by this PR

The `responseFormat` parameter is included in a form data request. If the customer does not specify it, the parameter is added to the form data request with a value of undefined. However, the form data policy attempts to treat this value as a File object.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

To avoid sending an incorrect parameter, the fix is to not send it if it is not set by the customer. Additionally, the core should verify that the form data value is defined and is an object before proceeding to treat it as such.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
