### PR TITLE
fix spelling error in AccountSASPermissions.yml

### DIFF
--- a/sdk/storage/storage-blob/src/sas/AccountSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASPermissions.ts
@@ -129,7 +129,7 @@ export class AccountSASPermissions {
   public write: boolean = false;
 
   /**
-   * Permission to create blobs and files granted.
+   * Permission to delete blobs and files granted.
    */
   public delete: boolean = false;
 


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

spelling error for docs

### Checklists
- [ ] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** https://github.com/Azure/autorest.typescript/issues/2190
- [ ] Added a changelog (if necessary)
