### PR TITLE
[core-tracing] Remove unnecessary ESLint rule overrides

### DIFF
--- a/sdk/core/core-tracing/.eslintrc.json
+++ b/sdk/core/core-tracing/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "@azure/azure-sdk/ts-no-const-enums": "off",
-    "@azure/azure-sdk/ts-versioning-semver": "warn"
-  }
-}


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-tracing 

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR

As a way to ensure I have the correct roles and credentials set up to commit code, I wanted to make a quick non-impactful change to the repo.

Specifically, two eslint rule overrides can be removed from core-tracing:

- ts-no-const-enums: we no longer export const enums
- ts-versioning-semver: this package now follows proper semver 

With those two overrides removed, we can just remove the eslintrc file entirely and rely on the base config.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_

No source code changes


### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
