### PR TITLE
[core] Default to `application/octet-stream` content type for multipart blobs

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Guard against unrecognized value types in the form data policy.
+- Form file uploads now have content type `application/octet-stream` if no other content type was specified.
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
@@ -87,9 +87,9 @@ async function prepareFormData(formData: FormDataMap, request: PipelineRequest):
           "Content-Disposition",
           `form-data; name="${fieldName}"; filename="${fileName}"`,
         );
-        if (value.type) {
-          headers.set("Content-Type", value.type);
-        }
+
+        // again, || is used since an empty value.type means the content type is unset
+        headers.set("Content-Type", value.type || "application/octet-stream");
 
         parts.push({
           headers,

--- a/sdk/core/core-rest-pipeline/test/formDataPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/formDataPolicy.spec.ts
@@ -189,7 +189,8 @@ describe("formDataPolicy", function () {
         assert.deepEqual(
           parts[0].headers,
           createHttpHeaders({
-            // Content-Type should not be inferred
+            // Content-Type should default to 'application/octet-stream' for binary content (lack of content type is reserved for text content)
+            "Content-Type": "application/octet-stream",
             "Content-Disposition": `form-data; name="file"; filename="blob"`,
           }),
         );


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-rest-pipeline`

### Issues associated with this PR

- Fixes #28081

### Describe the problem that is addressed by this PR

According to the `multipart/form-data` specification, binary content should have a default Content-Type of `application/octet-stream` if none is provided. Not supplying a `Content-Type` value implies that the content is text-based with a default encoding.

This PR corrects behavior so that form fields with values of type `Blob` and `File` have their content type set to `application/octet-stream` in the multipart request if no other content type is specified.

### Are there test cases added in this PR? _(If not, why?)_

Fixed existing test to conform to corrected behavior.
