### PR TITLE
[tool] fix linting of vite-plugin-browser-test-map

### DIFF
--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -30,7 +30,7 @@
     "clean": "rimraf dist/",
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint --no-eslintrc -c ../../../sdk/.eslintrc.internal.json src --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "integration-test:browser": "echo skipped",

--- a/common/tools/vite-plugin-browser-test-map/src/index.ts
+++ b/common/tools/vite-plugin-browser-test-map/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-function hasPackageCache<T extends {}>(
+function hasPackageCache<T extends Record<string, unknown>>(
   obj: T
 ): obj is T & { packageCache: Map<string, { data: any }> } {
   return "packageCache" in obj;
@@ -17,7 +17,7 @@ export default function browserTestMap() {
   return {
     name: "browser-test-config",
     enforce: "pre",
-    configResolved: (config: {}) => {
+    configResolved: (config: Record<string, unknown>) => {
       if (hasPackageCache(config)) {
         for (const { data } of config.packageCache.values()) {
           if (data.browser) {


### PR DESCRIPTION
Fix following errors when running "npm run lint"

```
> eslint src --ext .ts


Oops! Something went wrong! :(

ESLint: 8.56.0

ESLint couldn't find a configuration file. To set up a configuration file for this project, please run:

    npm init @eslint/config

ESLint looked for configuration files in /home/meng/git/jssdk/common/tools/vite-plugin-browser-test-map/src and its ancestors. If it found none, it then looked in your home directory.
```

and

```
   4:36  error    Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `object` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types
   6:51  warning  Unexpected any. Specify a different type                                                                                                                                                                                                                                                                                             @typescript-eslint/no-explicit-any
  20:30  error    Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `object` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types
```