### PR TITLE
[Identity] potentially fix min-max tests

### DIFF
--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -44,14 +44,23 @@ export enum AzureAuthorityHosts {
 }
 
 /**
+ * @internal
  * The default authority host.
  */
 export const DefaultAuthorityHost = AzureAuthorityHosts.AzurePublicCloud;
 
 /**
+ * @internal
  * Allow acquiring tokens for any tenant for multi-tentant auth.
  */
 export const ALL_TENANTS: string[] = ["*"];
 
+/**
+ * @internal
+ */
 export const CACHE_CAE_SUFFIX = ".cae";
+
+/**
+ * @internal
+ */
 export const CACHE_NON_CAE_SUFFIX = ".nocae";

--- a/sdk/identity/identity/test/authTestUtils.ts
+++ b/sdk/identity/identity/test/authTestUtils.ts
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AuthenticationError } from "../src";
-import { DefaultAuthorityHost } from "../src/constants";
+import { AuthenticationError, AzureAuthorityHosts } from "../src";
 import { assert } from "chai";
 
+/**
+ * @internal
+ * The default authority host.
+ */
+export const DefaultAuthorityHost = AzureAuthorityHosts.AzurePublicCloud;
 /**
  * Waits for the given promise to resolve, then returns the resulted error.
  * Throws an exception if the promise doesn't reject.


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
- None documented

### Describe the problem that is addressed by this PR
- Fix min-max tests in live test pipeline. The failures occur due to references to non-public constants of the sdk code through the public tests. So fixing these references will potentially solve the pipeline failures.

### Checklists
- [x] Added impacted package name to the issue description