### PR TITLE
[engsys] Update default TypeScript compilerOptions for data plane packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "module": "es6",
     "lib": [],
     "declaration": true,


### PR DESCRIPTION
### Packages impacted by this PR

All data-plane packages that inherit from our global tsconfig.

### Describe the problem that is addressed by this PR

Noticed our default emit target was es2017, but es2020 has been [fully supported in Node since 16.5](https://node.green/). As our minimum runtime is now Node 18, it feels safe to bump up the minimum here. This will also let us use things like BigInt and String.prototype.matchAll.