### PR TITLE
[core] Enforce ordering of formData and multipart policies

### DIFF
--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -6,6 +6,7 @@ import { Pipeline, createEmptyPipeline } from "./pipeline";
 import { PipelineRetryOptions, TlsSettings } from "./interfaces";
 import { RedirectPolicyOptions, redirectPolicy } from "./policies/redirectPolicy";
 import { UserAgentPolicyOptions, userAgentPolicy } from "./policies/userAgentPolicy";
+import { multipartPolicy, multipartPolicyName } from "./policies/multipartPolicy";
 
 import { ProxySettings } from ".";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
@@ -16,7 +17,6 @@ import { proxyPolicy } from "./policies/proxyPolicy";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy";
 import { tlsPolicy } from "./policies/tlsPolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
-import { multipartPolicy } from "./policies/multipartPolicy";
 
 /**
  * Defines options that are used to configure the HTTP pipeline for
@@ -88,7 +88,7 @@ export function createPipelineFromOptions(options: InternalPipelineOptions): Pip
     pipeline.addPolicy(decompressResponsePolicy());
   }
 
-  pipeline.addPolicy(formDataPolicy());
+  pipeline.addPolicy(formDataPolicy(), { beforePolicies: [multipartPolicyName] });
   pipeline.addPolicy(userAgentPolicy(options.userAgentOptions));
   pipeline.addPolicy(setClientRequestIdPolicy(options.telemetryOptions?.clientRequestIdHeaderName));
   // The multipart policy is added after policies with no phase, so that

--- a/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
@@ -97,7 +97,7 @@ async function prepareFormData(formData: FormDataMap, request: PipelineRequest):
         });
       }
     }
-
-    request.multipartBody = { parts };
   }
+
+  request.multipartBody = { parts };
 }

--- a/sdk/core/ts-http-runtime/src/createPipelineFromOptions.ts
+++ b/sdk/core/ts-http-runtime/src/createPipelineFromOptions.ts
@@ -6,6 +6,7 @@ import { Pipeline, createEmptyPipeline } from "./pipeline";
 import { PipelineRetryOptions, TlsSettings } from "./interfaces";
 import { RedirectPolicyOptions, redirectPolicy } from "./policies/redirectPolicy";
 import { UserAgentPolicyOptions, userAgentPolicy } from "./policies/userAgentPolicy";
+import { multipartPolicy, multipartPolicyName } from "./policies/multipartPolicy";
 
 import { ProxySettings } from ".";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy";
@@ -15,7 +16,6 @@ import { isNode } from "./util/checkEnvironment";
 import { proxyPolicy } from "./policies/proxyPolicy";
 import { tlsPolicy } from "./policies/tlsPolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
-import { multipartPolicy } from "./policies/multipartPolicy";
 
 /**
  * Defines options that are used to configure the HTTP pipeline for
@@ -87,7 +87,7 @@ export function createPipelineFromOptions(options: InternalPipelineOptions): Pip
     pipeline.addPolicy(decompressResponsePolicy());
   }
 
-  pipeline.addPolicy(formDataPolicy());
+  pipeline.addPolicy(formDataPolicy(), { beforePolicies: [multipartPolicyName] });
   pipeline.addPolicy(userAgentPolicy(options.userAgentOptions));
   // The multipart policy is added after policies with no phase, so that
   // policies can be added between it and formDataPolicy to modify

--- a/sdk/core/ts-http-runtime/src/policies/formDataPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/formDataPolicy.ts
@@ -93,7 +93,7 @@ async function prepareFormData(formData: FormDataMap, request: PipelineRequest):
         });
       }
     }
-
-    request.multipartBody = { parts };
   }
+
+  request.multipartBody = { parts };
 }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-rest-pipeline
@azure/ts-http-runtime

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

This PR makes two minor changes to the core packages, neither should result in
behavior change at runtime.

- Moves setting the requests' multipartBody outside the loop to avoid setting it
repeatedly. The end result is the same, since we return early if there is no form data.
- Explicitly declares an ordering between multipartPolicy and formDataPolicy to
ensure the two are always sequenced correctly. This happens implicitly today but
will now be enforced.

Both of these changes were spin-offs of changes in #28083

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A 

### Are there test cases added in this PR? _(If not, why?)_

There are no behavior changes to test - these should be considered pure refactors

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-js/pull/28083/

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
