### PR TITLE
Fix baseUri Deprecation Error in monitor/opentelemetry

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
@@ -45,7 +45,7 @@ export class ApplicationInsightsClient extends coreClient.ServiceClient {
       userAgentOptions: {
         userAgentPrefix
       },
-      baseUri: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
+      endpoint: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
     };
     super(optionsWithDefaults);
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
@@ -45,7 +45,7 @@ export class ApplicationInsightsClient extends coreClient.ServiceClient {
       userAgentOptions: {
         userAgentPrefix
       },
-      endpoint: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
+      // endpoint: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
     };
     super(optionsWithDefaults);
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/generated/applicationInsightsClient.ts
@@ -45,7 +45,7 @@ export class ApplicationInsightsClient extends coreClient.ServiceClient {
       userAgentOptions: {
         userAgentPrefix
       },
-      // endpoint: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
+      endpoint: options.endpoint ?? options.baseUri ?? "{Host}/v2.1"
     };
     super(optionsWithDefaults);
 


### PR DESCRIPTION
### Packages impacted by this PR
@monitor/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Setting the `baseUri` value is throwing errors due to the deprecation of the value in the core-utils package.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
