### PR TITLE
[EngSys] fix "rush lint:fix"

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -84,12 +84,6 @@
     },
     {
       "commandKind": "bulk",
-      "name": "lint:fix",
-      "summary": "Fix linting errors for projects",
-      "enableParallelism": true
-    },
-    {
-      "commandKind": "bulk",
       "name": "lint",
       "summary": "Lint projects",
       "enableParallelism": true
@@ -160,6 +154,13 @@
       "commandKind": "bulk",
       "name": "extract-api",
       "summary": "Run API Extractor on projects",
+      "enableParallelism": true,
+      "ignoreMissingScript": true
+    },
+    {
+      "commandKind": "bulk",
+      "name": "lint:fix",
+      "summary": "Fix linting errors for projects",
       "enableParallelism": true,
       "ignoreMissingScript": true
     },

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -44,6 +44,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "lint": "eslint src tests --ext .ts",
+    "lint:fix": "eslint src tests --ext .ts --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "integration-test:browser": "echo skipped",

--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -31,6 +31,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"./**/*.{ts,json,md}\"",
     "lint": "eslint --no-eslintrc -c ../../../sdk/.eslintrc.internal.json src --ext .ts",
+    "lint:fix": "eslint --no-eslintrc -c ../../../sdk/.eslintrc.internal.json src --ext .ts --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "integration-test:browser": "echo skipped",

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -25,7 +25,7 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint --no-eslintrc -c ../../eslintrc.internal.json package.json src --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint:fix": "eslint --no-eslintrc -c ../../.eslintrc.internal.json package.json src --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint --no-eslintrc -c ../../.eslintrc.internal.json package.json src --ext .ts",
     "pack": "npm pack 2>&1",
     "test": "echo \"No tests implemented\"",


### PR DESCRIPTION
- make the command optional, as some generated packages don't have this command
- add "lint:fix" to eslint-plugin-azure-sdk and vite-plugin-browser-test-map
- fix typo in mock-hub's "lint:fix" command
