### PR TITLE
[engsys] pin vitest and @vitest/browser version to 1.1.3

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -196,7 +196,7 @@
       "name": "install-test-browsers",
       "summary": "Ensure supported browsers are preinstalled before running playwright based tests",
       "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "node common/scripts/install-run.js playwright playwright install"
+      "shellCommand": "node common/scripts/install-run.js playwright@1.40.1 playwright install"
     }
   ],
   /**

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,7 +16,9 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "chai": "4.3.10"
+    "chai": "4.3.10",
+    "vitest": "1.1.0",
+    "@vitest/browser": "1.1.0"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -17,8 +17,8 @@
      */
     // "some-library": "1.2.3"
     "chai": "4.3.10",
-    "vitest": "1.1.0",
-    "@vitest/browser": "1.1.0"
+    "vitest": "1.1.3",
+    "@vitest/browser": "1.1.3"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1125,14 +1125,14 @@ dependencies:
     specifier: file:./projects/web-pubsub-express.tgz
     version: file:projects/web-pubsub-express.tgz
   '@vitest/browser':
-    specifier: 1.1.0
-    version: 1.1.0(playwright@1.40.1)(vitest@1.1.0)
+    specifier: 1.1.3
+    version: 1.1.3(playwright@1.40.1)(vitest@1.1.3)
   chai:
     specifier: 4.3.10
     version: 4.3.10
   vitest:
-    specifier: 1.1.0
-    version: 1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0)
+    specifier: 1.1.3
+    version: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
 
 packages:
 
@@ -3712,8 +3712,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: false
 
-  /@vitest/browser@1.1.0(playwright@1.40.1)(vitest@1.1.0):
-    resolution: {integrity: sha512-59Uwoiw/zAQPmqgIKrzev8HNfeNlD8Q/nDyP9Xqg1D3kaM0tcOT/wk5RnZFW5f0JdguK0c1+vSeOPUSrOja1hQ==}
+  /@vitest/browser@1.1.3(playwright@1.40.1)(vitest@1.1.3):
+    resolution: {integrity: sha512-ksI0V8YqonFYfjVYMPTvDR84i7ix7QPL2Sc8G2mHirVGAf4jJS3uC/CsifRLe5/E2r8QUhHbAdZQpvMCqBJV5w==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
@@ -3727,47 +3727,48 @@ packages:
       webdriverio:
         optional: true
     dependencies:
-      estree-walker: 3.0.3
+      '@vitest/utils': 1.1.3
       magic-string: 0.30.5
       playwright: 1.40.1
       sirv: 2.0.4
-      vitest: 1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0)
+      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
     dev: false
 
-  /@vitest/expect@1.1.0:
-    resolution: {integrity: sha512-9IE2WWkcJo2BR9eqtY5MIo3TPmS50Pnwpm66A6neb2hvk/QSLfPXBz2qdiwUOQkwyFuuXEUj5380CbwfzW4+/w==}
+  /@vitest/expect@1.1.3:
+    resolution: {integrity: sha512-MnJqsKc1Ko04lksF9XoRJza0bGGwTtqfbyrsYv5on4rcEkdo+QgUdITenBQBUltKzdxW7K3rWh+nXRULwsdaVg==}
     dependencies:
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/spy': 1.1.3
+      '@vitest/utils': 1.1.3
       chai: 4.3.10
     dev: false
 
-  /@vitest/runner@1.1.0:
-    resolution: {integrity: sha512-zdNLJ00pm5z/uhbWF6aeIJCGMSyTyWImy3Fcp9piRGvueERFlQFbUwCpzVce79OLm2UHk9iwaMSOaU9jVHgNVw==}
+  /@vitest/runner@1.1.3:
+    resolution: {integrity: sha512-Va2XbWMnhSdDEh/OFxyUltgQuuDRxnarK1hW5QNN4URpQrqq6jtt8cfww/pQQ4i0LjoYxh/3bYWvDFlR9tU73g==}
     dependencies:
-      '@vitest/utils': 1.1.0
+      '@vitest/utils': 1.1.3
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: false
 
-  /@vitest/snapshot@1.1.0:
-    resolution: {integrity: sha512-5O/wyZg09V5qmNmAlUgCBqflvn2ylgsWJRRuPrnHEfDNT6tQpQ8O1isNGgo+VxofISHqz961SG3iVvt3SPK/QQ==}
+  /@vitest/snapshot@1.1.3:
+    resolution: {integrity: sha512-U0r8pRXsLAdxSVAyGNcqOU2H3Z4Y2dAAGGelL50O0QRMdi1WWeYHdrH/QWpN1e8juWfVKsb8B+pyJwTC+4Gy9w==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: false
 
-  /@vitest/spy@1.1.0:
-    resolution: {integrity: sha512-sNOVSU/GE+7+P76qYo+VXdXhXffzWZcYIPQfmkiRxaNCSPiLANvQx5Mx6ZURJ/ndtEkUJEpvKLXqAYTKEY+lTg==}
+  /@vitest/spy@1.1.3:
+    resolution: {integrity: sha512-Ec0qWyGS5LhATFQtldvChPTAHv08yHIOZfiNcjwRQbFPHpkih0md9KAbs7TfeIfL7OFKoe7B/6ukBTqByubXkQ==}
     dependencies:
       tinyspy: 2.2.0
     dev: false
 
-  /@vitest/utils@1.1.0:
-    resolution: {integrity: sha512-z+s510fKmYz4Y41XhNs3vcuFTFhcij2YF7F8VQfMEYAAUfqQh0Zfg7+w9xdgFGhPf3tX3TicAe+8BDITk6ampQ==}
+  /@vitest/utils@1.1.3:
+    resolution: {integrity: sha512-Dyt3UMcdElTll2H75vhxfpZu03uFpXRCHxWnzcrFjZxT1kTbq8ALUYIeBgGolo1gldVdI0YSlQRacsqxTwNqwg==}
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: false
@@ -9924,8 +9925,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite-node@1.1.0(@types/node@18.19.3):
-    resolution: {integrity: sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==}
+  /vite-node@1.1.3(@types/node@18.19.3):
+    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -9981,8 +9982,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitest@1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0):
-    resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
+  /vitest@1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3):
+    resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -10007,12 +10008,12 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.19.3
-      '@vitest/browser': 1.1.0(playwright@1.40.1)(vitest@1.1.0)
-      '@vitest/expect': 1.1.0
-      '@vitest/runner': 1.1.0
-      '@vitest/snapshot': 1.1.0
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
+      '@vitest/expect': 1.1.3
+      '@vitest/runner': 1.1.3
+      '@vitest/snapshot': 1.1.3
+      '@vitest/spy': 1.1.3
+      '@vitest/utils': 1.1.3
       acorn-walk: 8.3.1
       cac: 6.7.14
       chai: 4.3.10
@@ -10027,7 +10028,7 @@ packages:
       tinybench: 2.5.1
       tinypool: 0.8.1
       vite: 5.0.10(@types/node@18.19.3)
-      vite-node: 1.1.0(@types/node@18.19.3)
+      vite-node: 1.1.3(@types/node@18.19.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -18117,7 +18118,7 @@ packages:
       '@types/mocha': 10.0.6
       '@types/node': 18.19.3
       '@types/sinon': 17.0.2
-      '@vitest/browser': 1.1.0(playwright@1.40.1)(vitest@1.1.0)
+      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
       chai: 4.3.10
       chai-as-promised: 7.1.1(chai@4.3.10)
       cross-env: 7.0.3
@@ -18146,7 +18147,7 @@ packages:
       tslib: 2.6.2
       typescript: 5.2.2
       util: 0.12.5
-      vitest: 1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0)
+      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/node'
@@ -18253,7 +18254,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.39.0(@types/node@18.19.3)
       '@types/node': 18.19.3
-      '@vitest/browser': 1.1.0(playwright@1.40.1)(vitest@1.1.0)
+      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
       eslint: 8.56.0
@@ -18263,7 +18264,7 @@ packages:
       rimraf: 3.0.2
       tslib: 2.6.2
       typescript: 5.2.2
-      vitest: 1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0)
+      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1124,9 +1124,15 @@ dependencies:
   '@rush-temp/web-pubsub-express':
     specifier: file:./projects/web-pubsub-express.tgz
     version: file:projects/web-pubsub-express.tgz
+  '@vitest/browser':
+    specifier: 1.1.0
+    version: 1.1.0(playwright@1.40.1)(vitest@1.1.0)
   chai:
     specifier: 4.3.10
     version: 4.3.10
+  vitest:
+    specifier: 1.1.0
+    version: 1.1.0(@types/node@18.19.3)(@vitest/browser@1.1.0)
 
 packages:
 
@@ -19698,7 +19704,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-HHcWrfhkbE57G4dEI3OnTRgXTsGMaJiUNik2pnk+IjBDWThENnxzUMucuNOSWrB9UIYUlgXRFPFkxTiuKpRFXw==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-y7F6JQX5LiZAO+lonRHtUTq4bLmZRloU6c5o9Hot1TUD2mtuuF+6zZJd+WIB05GYiTwYkdszzHF4AOOH7aqP3Q==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
as core-util browser testing is broken by 1.2.0 with the following error

https://github.com/vitest-dev/vitest/issues/4984

```
 FAIL  test/public/aborterUtils.spec.ts > createAbortablePromise > should resolve if not aborted nor rejected
ReferenceError: process is not defined
 ❯ test/public/aborterUtils.spec.ts:30:21
     28|
     29|   it("should resolve if not aborted nor rejected", async function () {
     30|     const clock = vi.useFakeTimers();
       |                     ^
     31|     const promise = createPromise();
     32|     await clock.advanceTimersToNextTimerAsync();
```
