### PR TITLE
[engsys] remove unused dev dependency `mocha-junit-reporter`

### DIFF
--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -47,7 +47,6 @@
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "mocha": "^10.0.0",
-    "mocha-junit-reporter": "^2.0.0",
     "moment": "^2.29.1",
     "c8": "^8.0.0",
     "puppeteer": "^10.1.0",

--- a/sdk/vision/ai-vision-image-analysis-rest/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/package.json
@@ -87,7 +87,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",


### PR DESCRIPTION
We have moved to use Mocha's builtin XUnit reporter

Resolves #28242
