### PR TITLE
[ServiceBus] bump runtime dependency core-amqp version to ^4.1.1

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^4.1.0",
+    "@azure/core-amqp": "^4.1.1",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",


### PR DESCRIPTION
This ensures we can use the newly added constants `maxUint32Value`
