### PR TITLE
[engsys] revert compilerOptions back to target ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2017",
     "module": "es6",
     "lib": [],
     "declaration": true,


### PR DESCRIPTION
as we still rely on `esm` to run dist-esm/**/*.spec.js tests, and newer syntaxes are not supported.

Revert "[engsys] Update default TypeScript compilerOptions for data plane packages (#28223)"

This reverts commit 209ce9c84d1bf5162dfa4dbb5e1fa09174965331.
