### PR TITLE
[core-rest-pipeline] add back dev dependency of `@types/node`

### DIFF
--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -98,6 +98,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
+    "@types/node": "^18.0.0",
     "@vitest/browser": "^1.1.0",
     "eslint": "^8.0.0",
     "playwright": "^1.39.0",


### PR DESCRIPTION
which was accidentally removed.

