### PR TITLE
[identity] Remove MsalBaseUtils class

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -94,6 +94,7 @@
     "mkdirp",
     "mongodb",
     "MPNS",
+    "msal",
     "MSRC",
     "nise",
     "northcentralus",

--- a/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
@@ -8,7 +8,6 @@ import {
   defaultLoggerCallback,
   getMSALLogLevel,
   handleMsalError,
-  handleMsalResult,
   msalToPublic,
   publicToMsal,
 } from "../utils";
@@ -205,7 +204,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       this.logger.info("Attempting to acquire token silently");
       const app = await this.getApp();
       const response = await app.acquireTokenSilent(parameters);
-      return handleMsalResult(scopes, response);
+      return this.handleResult(scopes, response);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }
@@ -246,7 +245,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         await app.acquireTokenRedirect(parameters);
         return { token: "", expiresOnTimestamp: 0 };
       case "popup":
-        return handleMsalResult(scopes, await app.acquireTokenPopup(parameters));
+        return this.handleResult(scopes, await app.acquireTokenPopup(parameters));
     }
   }
 }

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -2,21 +2,24 @@
 // Licensed under the MIT license.
 
 import * as msalBrowser from "@azure/msal-browser";
+
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../../errors";
-import { MsalBaseUtilities, getAuthority, getKnownAuthorities } from "../utils";
 import { MsalFlow, MsalFlowOptions } from "../flows";
+import { getAuthority, getKnownAuthorities } from "../utils";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
   resolveTenantId,
 } from "../../util/tenantIdUtils";
+
 import { AccessToken } from "@azure/core-auth";
 import { AuthenticationRecord } from "../types";
 import { BrowserLoginStyle } from "../../credentials/interactiveBrowserCredentialOptions";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { CredentialLogger } from "../../util/logging";
 import { DefaultTenantId } from "../../constants";
-import { MultiTenantTokenCredentialOptions } from "../../credentials/multiTenantTokenCredentialOptions";
 import { LogPolicyOptions } from "@azure/core-rest-pipeline";
+import { MultiTenantTokenCredentialOptions } from "../../credentials/multiTenantTokenCredentialOptions";
 
 /**
  * Union of the constructor parameters that all MSAL flow types take.
@@ -82,7 +85,7 @@ export function defaultBrowserMsalConfig(
  *
  * @internal
  */
-export abstract class MsalBrowser extends MsalBaseUtilities implements MsalBrowserFlow {
+export abstract class MsalBrowser implements MsalBrowserFlow {
   protected loginStyle: BrowserLoginStyle;
   protected clientId: string;
   protected tenantId: string;
@@ -92,9 +95,9 @@ export abstract class MsalBrowser extends MsalBaseUtilities implements MsalBrows
   protected msalConfig: msalBrowser.Configuration;
   protected disableAutomaticAuthentication?: boolean;
   protected app?: msalBrowser.IPublicClientApplication;
+  protected logger: CredentialLogger;
 
   constructor(options: MsalBrowserFlowOptions) {
-    super(options);
     this.logger = options.logger;
     this.loginStyle = options.loginStyle;
     if (!options.clientId) {

--- a/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { credentialLogger } from "../../util/logging";
@@ -62,9 +64,9 @@ export class MsalAuthorizationCode extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: any) {
-      throw this.handleError(scopes, err, options);
+      throw handleMsalError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalAuthorizationCode.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { credentialLogger } from "../../util/logging";
+import { handleMsalError } from "../utils";
 
 /**
  * Options that can be passed to configure MSAL to handle authentication through opening a browser window.
@@ -64,7 +64,7 @@ export class MsalAuthorizationCode extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientAssertion.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientAssertion.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { isError } from "@azure/core-util";
@@ -48,7 +50,7 @@ export class MsalClientAssertion extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: unknown) {
       let err2 = err;
       if (err === null || err === undefined) {
@@ -56,7 +58,7 @@ export class MsalClientAssertion extends MsalNode {
       } else {
         err2 = isError(err) ? err : new Error(String(err));
       }
-      throw this.handleError(scopes, err2 as Error, options);
+      throw handleMsalError(scopes, err2 as Error, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientAssertion.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientAssertion.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { handleMsalError } from "../utils";
 import { isError } from "@azure/core-util";
 
 /**
@@ -50,7 +50,7 @@ export class MsalClientAssertion extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: unknown) {
       let err2 = err;
       if (err === null || err === undefined) {

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
@@ -8,12 +8,12 @@ import {
 } from "../../credentials/clientCertificateCredential";
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
 import { createHash, createPrivateKey } from "crypto";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { ClientCredentialRequest } from "@azure/msal-node";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { formatError } from "../../util/logging";
+import { handleMsalError } from "../utils";
 import { promisify } from "util";
 import { readFile } from "fs";
 
@@ -172,7 +172,7 @@ export class MsalClientCertificate extends MsalNode {
       // Even though we're providing the same default in memory persistence cache that we use for DeviceCodeCredential,
       // The Client Credential flow does not return the account information from the authentication service,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientCertificate.ts
@@ -8,6 +8,8 @@ import {
 } from "../../credentials/clientCertificateCredential";
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
 import { createHash, createPrivateKey } from "crypto";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { ClientCredentialRequest } from "@azure/msal-node";
 import { CredentialFlowGetTokenOptions } from "../credentials";
@@ -170,9 +172,9 @@ export class MsalClientCertificate extends MsalNode {
       // Even though we're providing the same default in memory persistence cache that we use for DeviceCodeCredential,
       // The Client Credential flow does not return the account information from the authentication service,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: any) {
-      throw this.handleError(scopes, err, options);
+      throw handleMsalError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { handleMsalError } from "../utils";
 
 /**
  * Options that can be passed to configure MSAL to handle client secrets.
@@ -46,7 +46,7 @@ export class MsalClientSecret extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClientSecret.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 
@@ -44,9 +46,9 @@ export class MsalClientSecret extends MsalNode {
       });
       // The Client Credential flow does not return an account,
       // so each time getToken gets called, we will have to acquire a new token through the service.
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: any) {
-      throw this.handleError(scopes, err, options);
+      throw handleMsalError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import * as msalNode from "@azure/msal-node";
+
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { DeviceCodePromptCallback } from "../../credentials/deviceCodeCredentialOptions";
@@ -46,9 +49,9 @@ export class MsalDeviceCode extends MsalNode {
       const deviceResponse = await this.withCancellation(promise, options?.abortSignal, () => {
         requestOptions.cancel = true;
       });
-      return this.handleResult(scopes, this.clientId, deviceResponse || undefined);
+      return handleMsalResult(scopes, deviceResponse || undefined);
     } catch (error: any) {
-      throw this.handleError(scopes, error, options);
+      throw handleMsalError(scopes, error, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalDeviceCode.ts
@@ -4,11 +4,11 @@
 import * as msalNode from "@azure/msal-node";
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { DeviceCodePromptCallback } from "../../credentials/deviceCodeCredentialOptions";
+import { handleMsalError } from "../utils";
 
 /**
  * Options that can be passed to configure MSAL to handle authentication through device codes.
@@ -49,7 +49,7 @@ export class MsalDeviceCode extends MsalNode {
       const deviceResponse = await this.withCancellation(promise, options?.abortSignal, () => {
         requestOptions.cancel = true;
       });
-      return handleMsalResult(scopes, deviceResponse || undefined);
+      return this.handleResult(scopes, deviceResponse || undefined);
     } catch (error: any) {
       throw handleMsalError(scopes, error, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { formatError } from "../../util/logging";
@@ -86,9 +88,9 @@ export class MsalOnBehalfOf extends MsalNode {
         claims: options.claims,
         oboAssertion: this.userAssertionToken,
       });
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: any) {
-      throw this.handleError(scopes, err, options);
+      throw handleMsalError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOnBehalfOf.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { formatError } from "../../util/logging";
+import { handleMsalError } from "../utils";
 import { parseCertificate } from "./msalClientCertificate";
 
 /**
@@ -88,7 +88,7 @@ export class MsalOnBehalfOf extends MsalNode {
         claims: options.claims,
         oboAssertion: this.userAssertionToken,
       });
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT license.
 
 import * as msalNode from "@azure/msal-node";
+
 import { MsalNode, MsalNodeOptions, hasNativeBroker } from "./msalNodeCommon";
-import { credentialLogger } from "../../util/logging";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { credentialLogger } from "../../util/logging";
 import open from "open";
 
 /**
@@ -91,9 +94,9 @@ export class MsalOpenBrowser extends MsalNode {
       if (result.fromNativeBroker) {
         this.logger.verbose(`This result is returned from native broker`);
       }
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (err: any) {
-      throw this.handleError(scopes, err, options);
+      throw handleMsalError(scopes, err, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -4,11 +4,11 @@
 import * as msalNode from "@azure/msal-node";
 
 import { MsalNode, MsalNodeOptions, hasNativeBroker } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { credentialLogger } from "../../util/logging";
+import { handleMsalError } from "../utils";
 import open from "open";
 
 /**
@@ -94,7 +94,7 @@ export class MsalOpenBrowser extends MsalNode {
       if (result.fromNativeBroker) {
         this.logger.verbose(`This result is returned from native broker`);
       }
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (err: any) {
       throw handleMsalError(scopes, err, options);
     }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import * as msalNode from "@azure/msal-node";
+
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
+import { handleMsalError, handleMsalResult } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 
@@ -45,9 +48,9 @@ export class MsalUsernamePassword extends MsalNode {
       const result = await this.getApp("public", options?.enableCae).acquireTokenByUsernamePassword(
         requestOptions,
       );
-      return this.handleResult(scopes, this.clientId, result || undefined);
+      return handleMsalResult(scopes, result || undefined);
     } catch (error: any) {
-      throw this.handleError(scopes, error, options);
+      throw handleMsalError(scopes, error, options);
     }
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalUsernamePassword.ts
@@ -4,10 +4,10 @@
 import * as msalNode from "@azure/msal-node";
 
 import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
-import { handleMsalError, handleMsalResult } from "../utils";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
+import { handleMsalError } from "../utils";
 
 /**
  * Options that can be passed to configure MSAL to handle authentication through username and password.
@@ -48,7 +48,7 @@ export class MsalUsernamePassword extends MsalNode {
       const result = await this.getApp("public", options?.enableCae).acquireTokenByUsernamePassword(
         requestOptions,
       );
-      return handleMsalResult(scopes, result || undefined);
+      return this.handleResult(scopes, result || undefined);
     } catch (error: any) {
       throw handleMsalError(scopes, error, options);
     }

--- a/sdk/identity/identity/src/msal/utils.browser.ts
+++ b/sdk/identity/identity/src/msal/utils.browser.ts
@@ -3,14 +3,14 @@
 
 import * as msalCommon from "@azure/msal-browser";
 
-import { AccessToken, GetTokenOptions } from "@azure/core-auth";
-import { AuthenticationRecord, MsalAccountInfo, MsalResult, MsalToken } from "./types";
+import { AuthenticationRecord, MsalAccountInfo, MsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
-import { CredentialLogger, credentialLogger, formatError, formatSuccess } from "../util/logging";
+import { CredentialLogger, credentialLogger, formatError } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
 
 import { AbortError } from "@azure/abort-controller";
 import { AzureLogLevel } from "@azure/logger";
+import { GetTokenOptions } from "@azure/core-auth";
 import { isNode } from "@azure/core-util";
 
 export interface ILoggerCallback {
@@ -139,24 +139,6 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
       // default msal logging level should be Info
       return msalCommon.LogLevel.Info;
   }
-}
-
-/**
- * Handles the MSAL authentication result.
- * If the result has an account, we update the local account reference.
- * If the token received is invalid, an error will be thrown depending on what's missing.
- */
-export function handleMsalResult(
-  scopes: string | string[],
-  result?: MsalResult,
-  getTokenOptions?: GetTokenOptions,
-): AccessToken {
-  ensureValidMsalToken(scopes, result, getTokenOptions);
-  logger.getToken.info(formatSuccess(scopes));
-  return {
-    token: result!.accessToken!,
-    expiresOnTimestamp: result!.expiresOn!.getTime(),
-  };
 }
 
 /**

--- a/sdk/identity/identity/src/msal/utils.browser.ts
+++ b/sdk/identity/identity/src/msal/utils.browser.ts
@@ -2,19 +2,25 @@
 // Licensed under the MIT license.
 
 import * as msalCommon from "@azure/msal-browser";
+
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
 import { AuthenticationRecord, MsalAccountInfo, MsalResult, MsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
-import { CredentialLogger, formatError, formatSuccess } from "../util/logging";
+import { CredentialLogger, credentialLogger, formatError, formatSuccess } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
+
 import { AbortError } from "@azure/abort-controller";
-import { MsalFlowOptions } from "./flows";
-import { isNode, randomUUID } from "@azure/core-util";
 import { AzureLogLevel } from "@azure/logger";
+import { isNode } from "@azure/core-util";
 
 export interface ILoggerCallback {
   (level: msalCommon.LogLevel, message: string, containsPii: boolean): void;
 }
+
+/**
+ * @internal
+ */
+const logger = credentialLogger("IdentityUtils");
 
 /**
  * Latest AuthenticationRecord version
@@ -28,7 +34,6 @@ const LatestAuthenticationRecordVersion = "1.0";
  */
 export function ensureValidMsalToken(
   scopes: string | string[],
-  logger: CredentialLogger,
   msalToken?: MsalToken,
   getTokenOptions?: GetTokenOptions,
 ): void {
@@ -89,30 +94,30 @@ export function getKnownAuthorities(
 
 /**
  * Generates a logger that can be passed to the MSAL clients.
- * @param logger - The logger of the credential.
+ * @param credLogger - The logger of the credential.
  * @internal
  */
 export const defaultLoggerCallback: (
   logger: CredentialLogger,
   platform?: "Node" | "Browser",
 ) => msalCommon.ILoggerCallback =
-  (logger: CredentialLogger, platform: "Node" | "Browser" = isNode ? "Node" : "Browser") =>
+  (credLogger: CredentialLogger, platform: "Node" | "Browser" = isNode ? "Node" : "Browser") =>
   (level, message, containsPii): void => {
     if (containsPii) {
       return;
     }
     switch (level) {
       case msalCommon.LogLevel.Error:
-        logger.info(`MSAL ${platform} V2 error: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 error: ${message}`);
         return;
       case msalCommon.LogLevel.Info:
-        logger.info(`MSAL ${platform} V2 info message: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 info message: ${message}`);
         return;
       case msalCommon.LogLevel.Verbose:
-        logger.info(`MSAL ${platform} V2 verbose message: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 verbose message: ${message}`);
         return;
       case msalCommon.LogLevel.Warning:
-        logger.info(`MSAL ${platform} V2 warning: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 warning: ${message}`);
         return;
     }
   };
@@ -137,88 +142,63 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
 }
 
 /**
- * The common utility functions for the MSAL clients.
- * Defined as a class so that the classes extending this one can have access to its methods and protected properties.
- *
- * It keeps track of a logger and an in-memory copy of the AuthenticationRecord.
- *
- * @internal
+ * Handles the MSAL authentication result.
+ * If the result has an account, we update the local account reference.
+ * If the token received is invalid, an error will be thrown depending on what's missing.
  */
-export class MsalBaseUtilities {
-  protected logger: CredentialLogger;
-  protected account: AuthenticationRecord | undefined;
+export function handleMsalResult(
+  scopes: string | string[],
+  result?: MsalResult,
+  getTokenOptions?: GetTokenOptions,
+): AccessToken {
+  ensureValidMsalToken(scopes, result, getTokenOptions);
+  logger.getToken.info(formatSuccess(scopes));
+  return {
+    token: result!.accessToken!,
+    expiresOnTimestamp: result!.expiresOn!.getTime(),
+  };
+}
 
-  constructor(options: MsalFlowOptions) {
-    this.logger = options.logger;
-    this.account = options.authenticationRecord;
-  }
-
-  /**
-   * Generates a UUID
-   */
-  generateUuid(): string {
-    return randomUUID();
-  }
-
-  /**
-   * Handles the MSAL authentication result.
-   * If the result has an account, we update the local account reference.
-   * If the token received is invalid, an error will be thrown depending on what's missing.
-   */
-  protected handleResult(
-    scopes: string | string[],
-    clientId: string,
-    result?: MsalResult,
-    getTokenOptions?: GetTokenOptions,
-  ): AccessToken {
-    if (result?.account) {
-      this.account = msalToPublic(clientId, result.account);
+/**
+ * Handles MSAL errors.
+ */
+export function handleMsalError(
+  scopes: string[],
+  error: Error,
+  getTokenOptions?: GetTokenOptions,
+): Error {
+  if (
+    error.name === "AuthError" ||
+    error.name === "ClientAuthError" ||
+    error.name === "BrowserAuthError"
+  ) {
+    const msalError = error as msalCommon.AuthError;
+    switch (msalError.errorCode) {
+      case "endpoints_resolution_error":
+        logger.info(formatError(scopes, error.message));
+        return new CredentialUnavailableError(error.message);
+      case "device_code_polling_cancelled":
+        return new AbortError("The authentication has been aborted by the caller.");
+      case "consent_required":
+      case "interaction_required":
+      case "login_required":
+        logger.info(
+          formatError(scopes, `Authentication returned errorCode ${msalError.errorCode}`),
+        );
+        break;
+      default:
+        logger.info(formatError(scopes, `Failed to acquire token: ${error.message}`));
+        break;
     }
-    ensureValidMsalToken(scopes, this.logger, result, getTokenOptions);
-    this.logger.getToken.info(formatSuccess(scopes));
-    return {
-      token: result!.accessToken!,
-      expiresOnTimestamp: result!.expiresOn!.getTime(),
-    };
   }
-
-  /**
-   * Handles MSAL errors.
-   */
-  protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    if (
-      error.name === "AuthError" ||
-      error.name === "ClientAuthError" ||
-      error.name === "BrowserAuthError"
-    ) {
-      const msalError = error as msalCommon.AuthError;
-      switch (msalError.errorCode) {
-        case "endpoints_resolution_error":
-          this.logger.info(formatError(scopes, error.message));
-          return new CredentialUnavailableError(error.message);
-        case "device_code_polling_cancelled":
-          return new AbortError("The authentication has been aborted by the caller.");
-        case "consent_required":
-        case "interaction_required":
-        case "login_required":
-          this.logger.info(
-            formatError(scopes, `Authentication returned errorCode ${msalError.errorCode}`),
-          );
-          break;
-        default:
-          this.logger.info(formatError(scopes, `Failed to acquire token: ${error.message}`));
-          break;
-      }
-    }
-    if (
-      error.name === "ClientConfigurationError" ||
-      error.name === "BrowserConfigurationAuthError" ||
-      error.name === "AbortError"
-    ) {
-      return error;
-    }
-    return new AuthenticationRequiredError({ scopes, getTokenOptions, message: error.message });
+  if (
+    error.name === "ClientConfigurationError" ||
+    error.name === "BrowserConfigurationAuthError" ||
+    error.name === "AbortError"
+  ) {
+    return error;
   }
+  return new AuthenticationRequiredError({ scopes, getTokenOptions, message: error.message });
 }
 
 // transformations.ts

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -3,14 +3,14 @@
 
 import * as msalCommon from "@azure/msal-node";
 
-import { AccessToken, GetTokenOptions } from "@azure/core-auth";
-import { AuthenticationRecord, MsalAccountInfo, MsalResult, MsalToken } from "./types";
+import { AuthenticationRecord, MsalAccountInfo, MsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
-import { CredentialLogger, credentialLogger, formatError, formatSuccess } from "../util/logging";
+import { CredentialLogger, credentialLogger, formatError } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
 
 import { AbortError } from "@azure/abort-controller";
 import { AzureLogLevel } from "@azure/logger";
+import { GetTokenOptions } from "@azure/core-auth";
 import { isNode } from "@azure/core-util";
 
 export interface ILoggerCallback {
@@ -139,24 +139,6 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
       // default msal logging level should be Info
       return msalCommon.LogLevel.Info;
   }
-}
-
-/**
- * Handles the MSAL authentication result.
- * If the result has an account, we update the local account reference.
- * If the token received is invalid, an error will be thrown depending on what's missing.
- */
-export function handleMsalResult(
-  scopes: string | string[],
-  result?: MsalResult,
-  getTokenOptions?: GetTokenOptions,
-): AccessToken {
-  ensureValidMsalToken(scopes, result, getTokenOptions);
-  logger.getToken.info(formatSuccess(scopes));
-  return {
-    token: result!.accessToken!,
-    expiresOnTimestamp: result!.expiresOn!.getTime(),
-  };
 }
 
 /**

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -2,19 +2,25 @@
 // Licensed under the MIT license.
 
 import * as msalCommon from "@azure/msal-node";
+
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
 import { AuthenticationRecord, MsalAccountInfo, MsalResult, MsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
-import { CredentialLogger, formatError, formatSuccess } from "../util/logging";
+import { CredentialLogger, credentialLogger, formatError, formatSuccess } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
+
 import { AbortError } from "@azure/abort-controller";
-import { MsalFlowOptions } from "./flows";
-import { isNode, randomUUID } from "@azure/core-util";
 import { AzureLogLevel } from "@azure/logger";
+import { isNode } from "@azure/core-util";
 
 export interface ILoggerCallback {
   (level: msalCommon.LogLevel, message: string, containsPii: boolean): void;
 }
+
+/**
+ * @internal
+ */
+const logger = credentialLogger("IdentityUtils");
 
 /**
  * Latest AuthenticationRecord version
@@ -28,7 +34,6 @@ const LatestAuthenticationRecordVersion = "1.0";
  */
 export function ensureValidMsalToken(
   scopes: string | string[],
-  logger: CredentialLogger,
   msalToken?: MsalToken,
   getTokenOptions?: GetTokenOptions,
 ): void {
@@ -89,30 +94,30 @@ export function getKnownAuthorities(
 
 /**
  * Generates a logger that can be passed to the MSAL clients.
- * @param logger - The logger of the credential.
+ * @param credLogger - The logger of the credential.
  * @internal
  */
 export const defaultLoggerCallback: (
   logger: CredentialLogger,
   platform?: "Node" | "Browser",
 ) => ILoggerCallback =
-  (logger: CredentialLogger, platform: "Node" | "Browser" = isNode ? "Node" : "Browser") =>
+  (credLogger: CredentialLogger, platform: "Node" | "Browser" = isNode ? "Node" : "Browser") =>
   (level, message, containsPii): void => {
     if (containsPii) {
       return;
     }
     switch (level) {
       case msalCommon.LogLevel.Error:
-        logger.info(`MSAL ${platform} V2 error: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 error: ${message}`);
         return;
       case msalCommon.LogLevel.Info:
-        logger.info(`MSAL ${platform} V2 info message: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 info message: ${message}`);
         return;
       case msalCommon.LogLevel.Verbose:
-        logger.info(`MSAL ${platform} V2 verbose message: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 verbose message: ${message}`);
         return;
       case msalCommon.LogLevel.Warning:
-        logger.info(`MSAL ${platform} V2 warning: ${message}`);
+        credLogger.info(`MSAL ${platform} V2 warning: ${message}`);
         return;
     }
   };
@@ -137,99 +142,74 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
 }
 
 /**
- * The common utility functions for the MSAL clients.
- * Defined as a class so that the classes extending this one can have access to its methods and protected properties.
- *
- * It keeps track of a logger and an in-memory copy of the AuthenticationRecord.
- *
- * @internal
+ * Handles the MSAL authentication result.
+ * If the result has an account, we update the local account reference.
+ * If the token received is invalid, an error will be thrown depending on what's missing.
  */
-export class MsalBaseUtilities {
-  protected logger: CredentialLogger;
-  protected account: AuthenticationRecord | undefined;
+export function handleMsalResult(
+  scopes: string | string[],
+  result?: MsalResult,
+  getTokenOptions?: GetTokenOptions,
+): AccessToken {
+  ensureValidMsalToken(scopes, result, getTokenOptions);
+  logger.getToken.info(formatSuccess(scopes));
+  return {
+    token: result!.accessToken!,
+    expiresOnTimestamp: result!.expiresOn!.getTime(),
+  };
+}
 
-  constructor(options: MsalFlowOptions) {
-    this.logger = options.logger;
-    this.account = options.authenticationRecord;
-  }
-
-  /**
-   * Generates a UUID
-   */
-  generateUuid(): string {
-    return randomUUID();
-  }
-
-  /**
-   * Handles the MSAL authentication result.
-   * If the result has an account, we update the local account reference.
-   * If the token received is invalid, an error will be thrown depending on what's missing.
-   */
-  protected handleResult(
-    scopes: string | string[],
-    clientId: string,
-    result?: MsalResult,
-    getTokenOptions?: GetTokenOptions,
-  ): AccessToken {
-    if (result?.account) {
-      this.account = msalToPublic(clientId, result.account);
+/**
+ * Handles MSAL errors.
+ */
+export function handleMsalError(
+  scopes: string[],
+  error: Error,
+  getTokenOptions?: GetTokenOptions,
+): Error {
+  if (
+    error.name === "AuthError" ||
+    error.name === "ClientAuthError" ||
+    error.name === "BrowserAuthError"
+  ) {
+    const msalError = error as msalCommon.AuthError;
+    switch (msalError.errorCode) {
+      case "endpoints_resolution_error":
+        logger.info(formatError(scopes, error.message));
+        return new CredentialUnavailableError(error.message);
+      case "device_code_polling_cancelled":
+        return new AbortError("The authentication has been aborted by the caller.");
+      case "consent_required":
+      case "interaction_required":
+      case "login_required":
+        logger.info(
+          formatError(scopes, `Authentication returned errorCode ${msalError.errorCode}`),
+        );
+        break;
+      default:
+        logger.info(formatError(scopes, `Failed to acquire token: ${error.message}`));
+        break;
     }
-    ensureValidMsalToken(scopes, this.logger, result, getTokenOptions);
-    this.logger.getToken.info(formatSuccess(scopes));
-    return {
-      token: result!.accessToken!,
-      expiresOnTimestamp: result!.expiresOn!.getTime(),
-    };
   }
-
-  /**
-   * Handles MSAL errors.
-   */
-  protected handleError(scopes: string[], error: Error, getTokenOptions?: GetTokenOptions): Error {
-    if (
-      error.name === "AuthError" ||
-      error.name === "ClientAuthError" ||
-      error.name === "BrowserAuthError"
-    ) {
-      const msalError = error as msalCommon.AuthError;
-      switch (msalError.errorCode) {
-        case "endpoints_resolution_error":
-          this.logger.info(formatError(scopes, error.message));
-          return new CredentialUnavailableError(error.message);
-        case "device_code_polling_cancelled":
-          return new AbortError("The authentication has been aborted by the caller.");
-        case "consent_required":
-        case "interaction_required":
-        case "login_required":
-          this.logger.info(
-            formatError(scopes, `Authentication returned errorCode ${msalError.errorCode}`),
-          );
-          break;
-        default:
-          this.logger.info(formatError(scopes, `Failed to acquire token: ${error.message}`));
-          break;
-      }
-    }
-    if (
-      error.name === "ClientConfigurationError" ||
-      error.name === "BrowserConfigurationAuthError" ||
-      error.name === "AbortError"
-    ) {
-      return error;
-    }
-    if (error.name === "NativeAuthError") {
-      this.logger.info(
-        formatError(
-          scopes,
-          `Error from the native broker: ${error.message} with status code: ${
-            (error as any).statusCode
-          }`,
-        ),
-      );
-      return error;
-    }
-    return new AuthenticationRequiredError({ scopes, getTokenOptions, message: error.message });
+  if (
+    error.name === "ClientConfigurationError" ||
+    error.name === "BrowserConfigurationAuthError" ||
+    error.name === "AbortError"
+  ) {
+    return error;
   }
+  if (error.name === "NativeAuthError") {
+    logger.info(
+      formatError(
+        scopes,
+        `Error from the native broker: ${error.message} with status code: ${
+          (error as any).statusCode
+        }`,
+      ),
+    );
+    return error;
+  }
+  return new AuthenticationRequiredError({ scopes, getTokenOptions, message: error.message });
 }
 
 // transformations.ts

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import Sinon, { createSandbox } from "sinon";
-import { MsalBaseUtilities } from "../../src/msal/utils";
-import { Recorder } from "@azure-tools/test-recorder";
+import * as coreUtil from "@azure/core-util";
+
 import {
   AuthenticationResult,
   ConfidentialClientApplication,
   PublicClientApplication,
 } from "@azure/msal-node";
+import Sinon, { createSandbox } from "sinon";
+
 import { PlaybackTenantId } from "../msalTestUtils";
+import { Recorder } from "@azure-tools/test-recorder";
 import { Test } from "mocha";
 
 export type MsalTestCleanup = () => Promise<void>;
@@ -44,7 +46,7 @@ export async function msalNodeTestSetup(
 
   const sandbox = createSandbox();
 
-  const stub = sandbox.stub(MsalBaseUtilities.prototype, "generateUuid");
+  const stub = sandbox.stub(coreUtil, "randomUUID");
   stub.returns(playbackValues.correlationId);
 
   if (testContextOrStubbedToken instanceof Test || testContextOrStubbedToken === undefined) {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A 

### Describe the problem that is addressed by this PR

As we start to cleanup and refactor Identity, one of the low hanging fruits we can remove right now is the MsalBaseUtils class
which all the MsalFlows inherit from. By standardizing here we can start to peel away some of the inheritance based indirection
and move towards composition of smaller building blocks.

I tried to minimize the number of changes and make this a pure refactor, as 1:1 to the existing behavior as possible while we 
work out the larger refactor of the Msal inheritance based flows. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

This is a pure refactor

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
