### PR TITLE
[core] Upgrade vitest to 1.2.1

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -190,13 +190,6 @@
       "summary": "Unlink dependencies and purge downloaded node_modules",
       "safeForSimultaneousRushProcesses": true,
       "shellCommand": "rush unlink && rush purge"
-    },
-    {
-      "commandKind": "global",
-      "name": "install-test-browsers",
-      "summary": "Ensure supported browsers are preinstalled before running playwright based tests",
-      "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "node common/scripts/install-run.js playwright playwright install"
     }
   ],
   /**

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -196,7 +196,7 @@
       "name": "install-test-browsers",
       "summary": "Ensure supported browsers are preinstalled before running playwright based tests",
       "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "node common/scripts/install-run.js playwright@1.40.1 playwright install"
+      "shellCommand": "node common/scripts/install-run.js playwright playwright install"
     }
   ],
   /**

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,9 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "chai": "4.3.10",
-    "vitest": "1.1.3",
-    "@vitest/browser": "1.1.3"
+    "chai": "4.3.10"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1124,15 +1124,9 @@ dependencies:
   '@rush-temp/web-pubsub-express':
     specifier: file:./projects/web-pubsub-express.tgz
     version: file:projects/web-pubsub-express.tgz
-  '@vitest/browser':
-    specifier: 1.1.3
-    version: 1.1.3(playwright@1.40.1)(vitest@1.1.3)
   chai:
     specifier: 4.3.10
     version: 4.3.10
-  vitest:
-    specifier: 1.1.3
-    version: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
 
 packages:
 
@@ -3732,8 +3726,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: false
 
-  /@vitest/browser@1.1.3(playwright@1.40.1)(vitest@1.1.3):
-    resolution: {integrity: sha512-ksI0V8YqonFYfjVYMPTvDR84i7ix7QPL2Sc8G2mHirVGAf4jJS3uC/CsifRLe5/E2r8QUhHbAdZQpvMCqBJV5w==}
+  /@vitest/browser@1.2.1(playwright@1.40.1)(vitest@1.2.1):
+    resolution: {integrity: sha512-jhaQ15zWYAwz8anXgmLW0yAVLCXdT8RFv7LeW9bg7sMlvGJaTCTIHaHWFvCdADF/i62+22tnrzgiiqSnApjXtA==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
@@ -3747,45 +3741,45 @@ packages:
       webdriverio:
         optional: true
     dependencies:
-      '@vitest/utils': 1.1.3
+      '@vitest/utils': 1.2.1
       magic-string: 0.30.5
       playwright: 1.40.1
       sirv: 2.0.4
-      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
+      vitest: 1.2.1(@types/node@18.19.3)(@vitest/browser@1.2.1)
     dev: false
 
-  /@vitest/expect@1.1.3:
-    resolution: {integrity: sha512-MnJqsKc1Ko04lksF9XoRJza0bGGwTtqfbyrsYv5on4rcEkdo+QgUdITenBQBUltKzdxW7K3rWh+nXRULwsdaVg==}
+  /@vitest/expect@1.2.1:
+    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
     dependencies:
-      '@vitest/spy': 1.1.3
-      '@vitest/utils': 1.1.3
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
       chai: 4.3.10
     dev: false
 
-  /@vitest/runner@1.1.3:
-    resolution: {integrity: sha512-Va2XbWMnhSdDEh/OFxyUltgQuuDRxnarK1hW5QNN4URpQrqq6jtt8cfww/pQQ4i0LjoYxh/3bYWvDFlR9tU73g==}
+  /@vitest/runner@1.2.1:
+    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
     dependencies:
-      '@vitest/utils': 1.1.3
+      '@vitest/utils': 1.2.1
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: false
 
-  /@vitest/snapshot@1.1.3:
-    resolution: {integrity: sha512-U0r8pRXsLAdxSVAyGNcqOU2H3Z4Y2dAAGGelL50O0QRMdi1WWeYHdrH/QWpN1e8juWfVKsb8B+pyJwTC+4Gy9w==}
+  /@vitest/snapshot@1.2.1:
+    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: false
 
-  /@vitest/spy@1.1.3:
-    resolution: {integrity: sha512-Ec0qWyGS5LhATFQtldvChPTAHv08yHIOZfiNcjwRQbFPHpkih0md9KAbs7TfeIfL7OFKoe7B/6ukBTqByubXkQ==}
+  /@vitest/spy@1.2.1:
+    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
     dependencies:
       tinyspy: 2.2.0
     dev: false
 
-  /@vitest/utils@1.1.3:
-    resolution: {integrity: sha512-Dyt3UMcdElTll2H75vhxfpZu03uFpXRCHxWnzcrFjZxT1kTbq8ALUYIeBgGolo1gldVdI0YSlQRacsqxTwNqwg==}
+  /@vitest/utils@1.2.1:
+    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -3819,6 +3813,11 @@ packages:
 
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
     dev: false
 
@@ -9945,8 +9944,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite-node@1.1.3(@types/node@18.19.3):
-    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
+  /vite-node@1.2.1(@types/node@18.19.3):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -10002,8 +10001,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitest@1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3):
-    resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
+  /vitest@1.2.1(@types/node@18.19.3)(@vitest/browser@1.2.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -10028,13 +10027,13 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.19.3
-      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
-      '@vitest/expect': 1.1.3
-      '@vitest/runner': 1.1.3
-      '@vitest/snapshot': 1.1.3
-      '@vitest/spy': 1.1.3
-      '@vitest/utils': 1.1.3
-      acorn-walk: 8.3.1
+      '@vitest/browser': 1.2.1(playwright@1.40.1)(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4(supports-color@8.1.1)
@@ -10048,7 +10047,7 @@ packages:
       tinybench: 2.5.1
       tinypool: 0.8.1
       vite: 5.0.10(@types/node@18.19.3)
-      vite-node: 1.1.3(@types/node@18.19.3)
+      vite-node: 1.2.1(@types/node@18.19.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -18127,18 +18126,18 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-3sRTVyJoahTdQVBhee6Iu2rc4wf55ICfgE3NCzckBZVSOVNrQAGjfV+PZlV0xTLzBXISQrep04MVX3M+T5zJBQ==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-ysSAhwT+CS9nQDDS0GqsTFtCKLBeBcAUfjaviFfFMcc+mpISso3SVc6ju21sbFDxMGsxToWlPhE2IPO5BBmg0Q==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.39.0(@types/node@16.18.68)
+      '@microsoft/api-extractor': 7.39.0(@types/node@18.19.3)
       '@opentelemetry/api': 1.7.0
       '@types/chai': 4.3.11
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.6
       '@types/node': 18.19.3
       '@types/sinon': 17.0.2
-      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
+      '@vitest/browser': 1.2.1(playwright@1.40.1)(vitest@1.2.1)
       chai: 4.3.10
       chai-as-promised: 7.1.1(chai@4.3.10)
       cross-env: 7.0.3
@@ -18167,10 +18166,9 @@ packages:
       tslib: 2.6.2
       typescript: 5.2.2
       util: 0.12.5
-      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
+      vitest: 1.2.1(@types/node@18.19.3)(@vitest/browser@1.2.1)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
-      - '@types/node'
       - '@vitest/ui'
       - happy-dom
       - jsdom
@@ -18268,13 +18266,13 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-FCZx8EbYPrvEquAPZEd6zx69Ku6fuLAtBQOL9dcvoooa2Z6fj/rHGlnhhCR5wRGwXvhtqxLWRCv8taKnmKKJYg==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-EDcqbIiv3WcLHXXC61CRqyaYNEiPFFPWKyxrLJqcmHD9KjI0eMG6zrlEuH22w1DKzqdD+sFuEsgqs9gPMkBE3A==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
       '@microsoft/api-extractor': 7.39.0(@types/node@18.19.3)
       '@types/node': 18.19.3
-      '@vitest/browser': 1.1.3(playwright@1.40.1)(vitest@1.1.3)
+      '@vitest/browser': 1.2.1(playwright@1.40.1)(vitest@1.2.1)
       cross-env: 7.0.3
       downlevel-dts: 0.10.1
       eslint: 8.56.0
@@ -18284,7 +18282,7 @@ packages:
       rimraf: 3.0.2
       tslib: 2.6.2
       typescript: 5.2.2
-      vitest: 1.1.3(@types/node@18.19.3)(@vitest/browser@1.1.3)
+      vitest: 1.2.1(@types/node@18.19.3)(@vitest/browser@1.2.1)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19970,7 +19968,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-dNC826Z6E331JOFpXiarBtZmYHm0Ow8fkxL+SUy0WW1rr2SHQPkQuOlV7Nl+PrVGxDQOsEaOe0AJ/JrAS0x1EA==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-ZZ8+i4YtTU6gh5gI37qF1UHWhaZF85RDPTCUbbTnFImmhrIh5tBp1nTrm8n4UzDe7BtKTr5l13sRIWXWkktQhw==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:

--- a/rush.json
+++ b/rush.json
@@ -185,7 +185,7 @@
     /**
      * The list of shell commands to run after the Rush installation finishes
      */
-    "postRushInstall": ["rush install-test-browsers"],
+    "postRushInstall": [],
     /**
      * The list of shell commands to run before the Rush build command starts
      */

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -38,7 +38,7 @@
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run unit-test:node && npm run integration-test:node",
     "test": "npm run test:node && npm run test:browser",
-    "unit-test:browser": "vitest -c vitest.browser.config.mts",
+    "unit-test:browser": "playwright install && vitest -c vitest.browser.config.mts",
     "unit-test:node": "vitest",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -99,11 +99,11 @@
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/node": "^18.0.0",
-    "@vitest/browser": "^1.1.0",
+    "@vitest/browser": "^1.2.1",
     "eslint": "^8.0.0",
     "playwright": "^1.39.0",
     "rimraf": "^3.0.0",
     "typescript": "~5.2.0",
-    "vitest": "^1.1.0"
+    "vitest": "^1.2.1"
   }
 }

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -33,7 +33,7 @@
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run unit-test:node && npm run integration-test:node",
     "test": "npm run test:node && npm run test:browser",
-    "unit-test:browser": "vitest -c vitest.browser.config.mts",
+    "unit-test:browser": "playwright install && vitest -c vitest.browser.config.mts",
     "unit-test:node": "vitest",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -70,12 +70,12 @@
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/node": "^18.0.0",
-    "@vitest/browser": "^1.1.0",
+    "@vitest/browser": "^1.2.1",
     "eslint": "^8.0.0",
     "playwright": "^1.39.0",
     "rimraf": "^3.0.0",
     "typescript": "~5.2.0",
-    "vitest": "^1.1.0"
+    "vitest": "^1.2.1"
   },
   "//metadata": {
     "migrationDate": "2023-03-08T18:36:03.000Z"


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-util
@azure/core-rest-pipeline

### Issues associated with this PR

#28256

### Describe the problem that is addressed by this PR

We discovered a bug in [vitest 1.2.0](https://github.com/vitest-dev/vitest/issues/4984) 
which has now been fixed. Given that release 1.2.1 includes this bug fix, we can
remove our workaround of pinning vitest.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).

Fixes #28256 