### PR TITLE
[Identity] Initialize public client application before API calls for msal-browser - IBC

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.1 (2023-01-18)
+## 4.0.1 (2024-01-18)
 
 ### Bugs Fixed
 - Initialize Public Client Application in the Interactive Browser Credential, as required by @azure/msal-browser v3 fixed in [#28292](https://github.com/Azure/azure-sdk-for-js/pull/28292). 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 4.0.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.0.1 (2023-01-18)
 
 ### Bugs Fixed
-
-### Other Changes
+- Initialize Public Client Application in the Interactive Browser Credential, as required by @azure/msal-browser v3 fixed in [#28292](https://github.com/Azure/azure-sdk-for-js/pull/28292). 
 
 ## 3.4.1 (2023-11-13)
 

--- a/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
@@ -124,9 +124,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
    */
   public async handleRedirect(): Promise<AuthenticationRecord | undefined> {
     const app = await this.getApp();
-    return this.handleBrowserResult(
-      (await app.handleRedirectPromise(redirectHash)) || undefined
-    );
+    return this.handleBrowserResult((await app.handleRedirectPromise(redirectHash)) || undefined);
   }
 
   /**
@@ -154,7 +152,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
    */
   public async getActiveAccount(): Promise<AuthenticationRecord | undefined> {
     const app = await this.getApp();
-    const account =  app.getActiveAccount();
+    const account = app.getActiveAccount();
     if (!account) {
       return;
     }
@@ -228,14 +226,11 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         // This will go out of the page.
         // Once the InteractiveBrowserCredential is initialized again,
         // we'll load the MSAL account in the constructor.
+
         await app.acquireTokenRedirect(parameters);
         return { token: "", expiresOnTimestamp: 0 };
       case "popup":
-        return this.handleResult(
-          scopes,
-          this.clientId,
-          await app.acquireTokenPopup(parameters)
-        );
+        return this.handleResult(scopes, this.clientId, await app.acquireTokenPopup(parameters));
     }
   }
 }

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -91,7 +91,7 @@ export abstract class MsalBrowser extends MsalBaseUtilities implements MsalBrows
   protected account: AuthenticationRecord | undefined;
   protected msalConfig: msalBrowser.Configuration;
   protected disableAutomaticAuthentication?: boolean;
-  protected app?: msalBrowser.PublicClientApplication;
+  protected app?: msalBrowser.IPublicClientApplication;
 
   constructor(options: MsalBrowserFlowOptions) {
     super(options);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/28215

### Describe the problem that is addressed by this PR
- The public client application needs to be initialized explicitly with the new version of msal-browser. This affects the browser-side's Interactive Browser Credential which throws the `unitialized_public_client` error from @azure/msal-browser when trying to authenticate with the getToken() call.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
- We can either call the initialize() method on the public application's instance OR we can call the `createPublicClientApplication()` method for initializing the public client application, like we are doing in this PR

### Are there test cases added in this PR? _(If not, why?)_
- No, will open a separate PR for test cases and samples for IBC credentials. As this focuses on ONLY the changes needed for the bug fix.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
