### PR TITLE
Added pipeline to validate spec location

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -44,6 +44,11 @@ stages:
                         PackageName: ${{artifact.name}}
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
+                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceDirectory: ${{parameters.ServiceDirectory}}
+                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
                     - pwsh: |
                         Get-ChildItem -Recurse ${{parameters.ArtifactName}}/${{artifact.name}}
                       workingDirectory: $(Pipeline.Workspace)


### PR DESCRIPTION
### Purpose of this PR
The purpose is to gate on the REST API specifications used to release SDK are from the main branch of [Azure/azure-rest-api-spec](https://github.com/Azure/azure-rest-api-specs).

### Packages impacted by this PR
All the data plane GA packages to be released.

I scanned through this JS repo and identified 11 data plane services that have released GA packages but their configuration file either `tsp-location.yaml` or `swagger\README.md` reference the REST API specs from a non-main branch of Azure spec repo.
Please refer to [this spreadsheet](https://microsoftapc-my.sharepoint.com/:x:/g/personal/raychen_microsoft_com/ETMHnmWSA6VKmGouTjAITwEBqSavTLQkOcd2Ykx2eEE8_g?e=oalb1N) to get the details of all the violated packages.

After this PR is merged, the next GA release for these packages will be blocked. They need to correct the spec path before releasing GA packages.

### Describe the problem that is addressed by this PR
Added a pipeline from common template to release pipeline to validate the REST API specification location is from the main branch of [Azure/azure-rest-api-spec](https://github.com/Azure/azure-rest-api-specs). 

This validation will be skipped if the package to be released is non-GA package. 

### Provide a list of related PRs
The common script and pipeline were merged by another PR.
https://github.com/Azure/azure-sdk-tools/pull/7451

FYI - The same change has been added to other language repos' release pipelines.
https://github.com/Azure/azure-sdk-for-net/pull/40783
https://github.com/Azure/azure-sdk-for-java/pull/38332


