### PR TITLE
Revert "Added pipeline to validate spec location"

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -44,11 +44,6 @@ stages:
                         PackageName: ${{artifact.name}}
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
-                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceDirectory: ${{parameters.ServiceDirectory}}
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
                     - pwsh: |
                         Get-ChildItem -Recurse ${{parameters.ArtifactName}}/${{artifact.name}}
                       workingDirectory: $(Pipeline.Workspace)


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-js#28303

There is an incorrect assumption at https://github.com/Azure/azure-sdk-for-js/blob/main/eng/common/scripts/Verify-RestApiSpecLocation.ps1#L235 for the JS repo which doesn't have the package name in the path like other languages. 