### PR TITLE
[Identity] Initialize public client application before API calls for msal-browser

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.4.2 (2024-01-25)
+
+### Bugs Fixed
+
+- Initialize Public Client Application in the Interactive Browser Credential, as required by @azure/msal-browser v3 fixed in [#28292](https://github.com/Azure/azure-sdk-for-js/pull/28292).
+
 ## 3.4.1 (2023-11-13)
 
 ### Bugs Fixed

--- a/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalAuthCode.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 
 import * as msalBrowser from "@azure/msal-browser";
+
 import { MsalBrowser, MsalBrowserFlowOptions } from "./msalBrowserCommon";
-import { defaultLoggerCallback, msalToPublic, publicToMsal, getMSALLogLevel } from "../utils";
+import { defaultLoggerCallback, getMSALLogLevel, msalToPublic, publicToMsal } from "../utils";
+
 import { AccessToken } from "@azure/core-auth";
 import { AuthenticationRecord } from "../types";
 import { AuthenticationRequiredError } from "../../errors";
@@ -19,7 +21,7 @@ const redirectHash = self.location.hash;
  * @internal
  */
 export class MSALAuthCode extends MsalBrowser {
-  protected app: msalBrowser.PublicClientApplication;
+  protected app?: msalBrowser.IPublicClientApplication;
   private loginHint?: string;
 
   /**
@@ -43,14 +45,22 @@ export class MSALAuthCode extends MsalBrowser {
         piiLoggingEnabled: options.loggingOptions?.enableUnsafeSupportLogging,
       },
     };
+  }
 
-    // Preparing the MSAL application.
-    this.app = new msalBrowser.PublicClientApplication(
-      this.msalConfig as msalBrowser.Configuration
-    );
-    if (this.account) {
-      this.app.setActiveAccount(publicToMsal(this.account));
+  private async getApp(): Promise<msalBrowser.IPublicClientApplication> {
+    if (!this.app) {
+      // Prepare the MSAL application
+      this.app = await msalBrowser.PublicClientApplication.createPublicClientApplication(
+        this.msalConfig as msalBrowser.Configuration
+      );
+
+      // setting the account right after the app is created.
+      if (this.account) {
+        this.app.setActiveAccount(publicToMsal(this.account));
+      }
     }
+
+    return this.app;
   }
 
   /**
@@ -62,9 +72,10 @@ export class MSALAuthCode extends MsalBrowser {
     result?: msalBrowser.AuthenticationResult
   ): Promise<AuthenticationRecord | undefined> {
     try {
+      const app = await this.getApp();
       if (result && result.account) {
         this.logger.info(`MSAL Browser V2 authentication successful.`);
-        this.app.setActiveAccount(result.account);
+        app.setActiveAccount(result.account);
         return msalToPublic(this.clientId, result.account);
       }
 
@@ -75,7 +86,7 @@ export class MSALAuthCode extends MsalBrowser {
       }
 
       // If we don't have an active account, we try to activate it from all the already loaded accounts.
-      const accounts = this.app.getAllAccounts();
+      const accounts = app.getAllAccounts();
       if (accounts.length > 1) {
         // If there's more than one account in memory, we force the user to authenticate again.
         // At this point we can't identify which account should this credential work with,
@@ -91,7 +102,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         // To safely trigger a new login, we're also ensuring the local cache is cleared up for this MSAL object.
         // However, we want to avoid kicking the user out of their authentication on the Azure side.
         // We do this by calling to logout while specifying a `onRedirectNavigate` that returns false.
-        await this.app.logout({
+        await app.logout({
           onRedirectNavigate: () => false,
         });
         return;
@@ -100,7 +111,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       // If there's only one account for this MSAL object, we can safely activate it.
       if (accounts.length === 1) {
         const account = accounts[0];
-        this.app.setActiveAccount(account);
+        app.setActiveAccount(account);
         return msalToPublic(this.clientId, account);
       }
 
@@ -115,9 +126,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
    * Uses MSAL to handle the redirect.
    */
   public async handleRedirect(): Promise<AuthenticationRecord | undefined> {
-    return this.handleBrowserResult(
-      (await this.app.handleRedirectPromise(redirectHash)) || undefined
-    );
+    const app = await this.getApp();
+    return this.handleBrowserResult((await app.handleRedirectPromise(redirectHash)) || undefined);
   }
 
   /**
@@ -129,13 +139,14 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       scopes: arrayScopes,
       loginHint: this.loginHint,
     };
+    const app = await this.getApp();
     switch (this.loginStyle) {
       case "redirect": {
-        await this.app.loginRedirect(loginRequest);
+        await app.loginRedirect(loginRequest);
         return;
       }
       case "popup":
-        return this.handleBrowserResult(await this.app.loginPopup(loginRequest));
+        return this.handleBrowserResult(await app.loginPopup(loginRequest));
     }
   }
 
@@ -143,7 +154,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
    * Uses MSAL to retrieve the active account.
    */
   public async getActiveAccount(): Promise<AuthenticationRecord | undefined> {
-    const account = this.app.getActiveAccount();
+    const app = await this.getApp();
+    const account = app.getActiveAccount();
     if (!account) {
       return;
     }
@@ -178,7 +190,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
 
     try {
       this.logger.info("Attempting to acquire token silently");
-      const response = await this.app.acquireTokenSilent(parameters);
+      const app = await this.getApp();
+      const response = await app.acquireTokenSilent(parameters);
       return this.handleResult(scopes, this.clientId, response);
     } catch (err: any) {
       throw this.handleError(scopes, err, options);
@@ -210,20 +223,17 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       loginHint: this.loginHint,
       scopes,
     };
-
+    const app = await this.getApp();
     switch (this.loginStyle) {
       case "redirect":
         // This will go out of the page.
         // Once the InteractiveBrowserCredential is initialized again,
         // we'll load the MSAL account in the constructor.
-        await this.app.acquireTokenRedirect(parameters);
+
+        await app.acquireTokenRedirect(parameters);
         return { token: "", expiresOnTimestamp: 0 };
       case "popup":
-        return this.handleResult(
-          scopes,
-          this.clientId,
-          await this.app.acquireTokenPopup(parameters)
-        );
+        return this.handleResult(scopes, this.clientId, await app.acquireTokenPopup(parameters));
     }
   }
 }

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -91,7 +91,7 @@ export abstract class MsalBrowser extends MsalBaseUtilities implements MsalBrows
   protected account: AuthenticationRecord | undefined;
   protected msalConfig: msalBrowser.Configuration;
   protected disableAutomaticAuthentication?: boolean;
-  protected app?: msalBrowser.PublicClientApplication;
+  protected app?: msalBrowser.IPublicClientApplication;
 
   constructor(options: MsalBrowserFlowOptions) {
     super(options);


### PR DESCRIPTION
@azure/identity,  (cherry picked from commit c1da174cc574dbe29586bf9f4f7f950752142d96)

https://github.com/Azure/azure-sdk-for-js/issues/28215

- The public client application needs to be initialized explicitly with the new version of msal-browser. This affects the browser-side's Interactive Browser Credential which throws the
`unitialized_public_client` error from @azure/msal-browser when trying to authenticate with the getToken() call.

there are more than one possible design, why was the one in this PR chosen?
- We can either call the initialize() method on the public application's instance OR we can call the `createPublicClientApplication()` method for initializing the public client application, like we are doing in this PR

- No, will open a separate PR for test cases and samples for IBC credentials. As this focuses on ONLY the changes needed for the bug fix.

- [x] Added impacted package name to the issue description
- [ ] Added a changelog (if necessary)

(cherry picked from commit c1da174cc574dbe29586bf9f4f7f950752142d96)


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
