### PR TITLE
[OpenAI] Adjust the toolChoice model to the one that is expected by OpenAI API

### DIFF
--- a/sdk/openai/openai/src/models/models.ts
+++ b/sdk/openai/openai/src/models/models.ts
@@ -631,8 +631,11 @@ export type ChatCompletionsNamedToolSelection =
 export interface ChatCompletionsNamedFunctionToolSelection {
   /** The object type, which is always 'function'. */
   type: "function";
-  /** The name of the function that should be called. */
-  name: string;
+  /** Specifies a tool the model should use. Used to force the model to call a specific function. */
+  function: {
+    /** The name of the function that should be called. */
+    name: string;
+  }
 }
 
 /** A representation of a chat message as received in a response. */


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR
[28325](https://github.com/Azure/azure-sdk-for-js/issues/28325)

### Describe the problem that is addressed by this PR
There's a mismatch between `toolChoice` type in sdk and [a model for tool_choice expected in OpenAI API](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
API breaking change, if some users mitigated the error by, for instance, ignoring sdk's typings or by casting to `any` or forcing type by `as unknown as ...`

### Are there test cases added in this PR? _(If not, why?)_
It's a easy change, I just built sdk locally for the first time and I can add the test cases for it later if you ask me to do so

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
