### PR TITLE
[monitor-opentelemetry] Compare between the published version and the src 

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/perf.yml
+++ b/sdk/monitor/monitor-opentelemetry/perf.yml
@@ -10,7 +10,7 @@ parameters:
 - name: PackageVersions
   displayName: PackageVersions (regex of package versions to run)
   type: string
-  default: '1.1.2|source'
+  default: '1.1.1|source'
 - name: Tests
   displayName: Tests (regex of tests to run)
   type: string


### PR DESCRIPTION
Perf tests.. switching from 1.1.2 to 1.1.1, since 1.1.2 is not published yet