### PR TITLE
[test-recorder] Support test context from vitest

### DIFF
--- a/sdk/test-utils/recorder/src/index.ts
+++ b/sdk/test-utils/recorder/src/index.ts
@@ -16,3 +16,4 @@ export {
 export { env } from "./utils/env";
 export { delay } from "./utils/delay";
 export { CustomMatcherOptions } from "./matcher";
+export { TestInfo, MochaTest, VitestTestContext } from "./testInfo";

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -20,7 +20,7 @@ import {
   RecorderStartOptions,
   RecordingStateManager,
 } from "./utils/utils";
-import { Test } from "mocha";
+import { Test as MochaTest } from "mocha";
 import { assetsJsonPath, sessionFilePath } from "./utils/sessionFilePath";
 import { SanitizerOptions } from "./utils/utils";
 import { paths } from "./utils/paths";
@@ -35,6 +35,11 @@ import { isNode } from "@azure/core-util";
 import { env } from "./utils/env";
 import { decodeBase64 } from "./utils/encoding";
 import { AdditionalPolicyConfig } from "@azure/core-client";
+
+
+interface VitestContext {
+  currentTestName?: string;
+}
 
 /**
  * This client manages the recorder life cycle and interacts with the proxy-tool to do the recording,
@@ -53,19 +58,58 @@ export class Recorder {
   private assetsJson?: string;
   private variables: Record<string, string>;
 
-  constructor(private testContext?: Test | undefined) {
+  constructor(
+    private testContext?:
+      | MochaTest
+      | VitestContext
+      | undefined,
+  ) {
+    if (!this.testContext) {
+      throw new Error(
+        "Unable to determine the recording file path, testContext provided is not defined.",
+      );
+    }
+
     logger.info(`[Recorder#constructor] Creating a recorder instance in ${getTestMode()} mode`);
     if (isRecordMode() || isPlaybackMode()) {
       if (this.testContext) {
-        this.sessionFile = sessionFilePath(this.testContext);
+        let context:
+          | MochaTest
+          | {
+              suiteTitle: string;
+              testTitle: string;
+            };
+        if (this.testContext instanceof MochaTest) {
+          if (!this.testContext.parent) {
+            throw new RecorderError(
+              `Test ${this.testContext.title} is not inside a describe block, so a file path for its recording could not be generated. Please place the test inside a describe block.`,
+            );
+          }
+          context = {
+            suiteTitle: this.testContext.parent.fullTitle(),
+            testTitle: this.testContext.title,
+          };
+        } else {
+          if (!this.testContext.currentTestName) {
+            throw new RecorderError(`Unable to determine the recording file path. Unexpected empty Vitest context`);
+          }
+          // vitest format:
+          //   ""fileName.ts > suite title [> nested suite title ]* > test title""
+          const parts = this.testContext.currentTestName.split(" > ");
+          if (parts.length < 3) {
+            throw new RecorderError(`Unable to determine the recording file path. Unexpected Vitest currentTestname`);
+          }
+          context = {
+            suiteTitle: parts.slice(1, parts.length - 1).join("_").trim(),
+            testTitle: parts[parts.length - 1].trim(),
+          };
+        }
+
+        this.sessionFile = sessionFilePath(context);
         this.assetsJson = assetsJsonPath();
 
         logger.info(`[Recorder#constructor] Using a session file located at ${this.sessionFile}`);
         this.httpClient = createDefaultHttpClient();
-      } else {
-        throw new Error(
-          "Unable to determine the recording file path, testContext provided is not defined.",
-        );
       }
     }
     this.variables = {};

--- a/sdk/test-utils/recorder/src/testInfo.ts
+++ b/sdk/test-utils/recorder/src/testInfo.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Represents a Test.
+ */
+export type TestInfo = MochaTest | VitestTestContext;
+
+/**
+ * Represents a Mocha Test.
+ */
+export interface MochaTest {
+  /**
+   * The title of the test.
+   */
+  title: string;
+  /**
+   * The parent of the Mocha Test Suite.
+   */
+  parent?: MochaTestSuite;
+}
+
+/**
+ * Represents a Mocha Test Suite.
+ */
+export interface MochaTestSuite {
+  fullTitle(): string;
+}
+
+/**
+ * Represents a Vitest Test Context
+ */
+export interface VitestTestContext {
+  /**
+   * The Vitest Context Task.
+   */
+  task: VitestTask;
+}
+
+/**
+ * Represents a Vitest Test Context Task
+ */
+export interface VitestTask {
+  /**
+   * The Vitest Context Task Name.
+   */
+  name: string;
+  /**
+   * The Vitest Context Task Suite.
+   */
+  suite: VitestSuite;
+}
+
+/**
+ * Represents a Vitest Test Suite.
+ */
+export interface VitestSuite {
+  /**
+   * The Vitest Context Task Suite Name.
+   */
+  name: string;
+}
+
+/**
+ * Determines whether the given test is a Mocha Test.
+ * @param test - The test to check.
+ * @returns true if the given test is a Mocha Test.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function isMochaTest(test: any): test is MochaTest {
+  return test && typeof test.title === "string";
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function isVitestTestContext(test: any): test is VitestTestContext {
+  return test && typeof test.task === "object" && typeof test.task.name === "string";
+}

--- a/sdk/test-utils/recorder/src/testInfo.ts
+++ b/sdk/test-utils/recorder/src/testInfo.ts
@@ -71,12 +71,16 @@ export interface VitestSuite extends VitestTaskBase {
  * @param test - The test to check.
  * @returns true if the given test is a Mocha Test.
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function isMochaTest(test: any): test is MochaTest {
-  return test && typeof test.title === "string";
+export function isMochaTest(test: unknown): test is MochaTest {
+  return typeof test === "object" && test != null && "title" in test;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function isVitestTestContext(test: any): test is VitestTestContext {
-  return test && typeof test.task === "object" && typeof test.task.name === "string";
+/**
+ * Determines whether the given test is a Vitest Test.
+ * @param test - The test to check.
+ * @returns true if the given test is a Vitest Test.
+ */
+export function isVitestTestContext(test: unknown): test is VitestTestContext {
+  return typeof test == "function" && "task" in test &&
+    typeof test.task === "object" && test.task != null && "name" in test.task;
 }

--- a/sdk/test-utils/recorder/src/testInfo.ts
+++ b/sdk/test-utils/recorder/src/testInfo.ts
@@ -81,6 +81,11 @@ export function isMochaTest(test: unknown): test is MochaTest {
  * @returns true if the given test is a Vitest Test.
  */
 export function isVitestTestContext(test: unknown): test is VitestTestContext {
-  return typeof test == "function" && "task" in test &&
-    typeof test.task === "object" && test.task != null && "name" in test.task;
+  return (
+    typeof test == "function" &&
+    "task" in test &&
+    typeof test.task === "object" &&
+    test.task != null &&
+    "name" in test.task
+  );
 }

--- a/sdk/test-utils/recorder/src/testInfo.ts
+++ b/sdk/test-utils/recorder/src/testInfo.ts
@@ -37,10 +37,15 @@ export interface VitestTestContext {
   task: VitestTask;
 }
 
+export interface VitestTaskBase {
+  name: string;
+  suite?: VitestSuite;
+}
+
 /**
  * Represents a Vitest Test Context Task
  */
-export interface VitestTask {
+export interface VitestTask extends VitestTaskBase {
   /**
    * The Vitest Context Task Name.
    */
@@ -54,7 +59,7 @@ export interface VitestTask {
 /**
  * Represents a Vitest Test Suite.
  */
-export interface VitestSuite {
+export interface VitestSuite extends VitestTaskBase {
   /**
    * The Vitest Context Task Suite Name.
    */

--- a/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
+++ b/sdk/test-utils/recorder/src/utils/sessionFilePath.ts
@@ -4,9 +4,13 @@
 import { isNode } from "@azure/core-util";
 import { generateTestRecordingFilePath } from "./filePathGenerator";
 import { relativeRecordingsPath } from "./relativePathCalculator";
-import { RecorderError } from "./utils";
 
-export function sessionFilePath(testContext: Mocha.Test): string {
+export interface TestContext {
+  suiteTitle: string; // describe(suiteTitle, () => {})
+  testTitle: string; // it(testTitle, () => {})
+}
+
+export function sessionFilePath(testContext: TestContext): string {
   // sdk/service/project/recordings/{node|browsers}/<describe-block-title>/recording_<test-title>.json
   return `${relativeRecordingsPath()}/${recordingFilePath(testContext)}`;
 }
@@ -16,17 +20,11 @@ export function sessionFilePath(testContext: Mocha.Test): string {
  *
  *  `{node|browsers}/<describe-block-title>/recording_<test-title>.json`
  */
-export function recordingFilePath(testContext: Mocha.Test): string {
-  if (!testContext.parent) {
-    throw new RecorderError(
-      `Test ${testContext.title} is not inside a describe block, so a file path for its recording could not be generated. Please place the test inside a describe block.`,
-    );
-  }
-
+export function recordingFilePath(testContext: TestContext): string {
   return generateTestRecordingFilePath(
     isNode ? "node" : "browsers",
-    testContext.parent.fullTitle(),
-    testContext.title,
+    testContext.suiteTitle,
+    testContext.testTitle,
   );
 }
 

--- a/sdk/test-utils/recorder/test/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/recorder.spec.ts
@@ -22,16 +22,17 @@ describe("Recorder file paths", () => {
   });
 
   it("calculates paths for a vitest test", () => {
-    const vitestTest = {
-      task: {
-        name: "vitest test title",
-        suite: {
-          name: "vitest suite title",
-        },
+    const vitestTest = () => {
+      /* no-op */
+    };
+    (vitestTest as any).task = {
+      name: "vitest test title",
+      suite: {
+        name: "vitest suite title",
       },
     };
 
-    const context = calculatePaths(vitestTest);
+    const context = calculatePaths(vitestTest as any);
     expect(context).to.eql({
       suiteTitle: "vitest suite title",
       testTitle: "vitest test title",
@@ -39,19 +40,20 @@ describe("Recorder file paths", () => {
   });
 
   it("calculates paths for a vitest test with nested suites", () => {
-    const vitestTest = {
-      task: {
-        name: "vitest test title",
+    const vitestTest = () => {
+      /* no-op */
+    };
+    (vitestTest as any).task = {
+      name: "vitest test title",
+      suite: {
+        name: "vitest suite title",
         suite: {
-          name: "vitest suite title",
-          suite: {
-            name: "toplevel suite",
-          },
+          name: "toplevel suite",
         },
       },
     };
 
-    const context = calculatePaths(vitestTest);
+    const context = calculatePaths(vitestTest as any);
     expect(context).to.eql({
       suiteTitle: "toplevel suite_vitest suite title",
       testTitle: "vitest test title",

--- a/sdk/test-utils/recorder/test/recorder.spec.ts
+++ b/sdk/test-utils/recorder/test/recorder.spec.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+
+import { calculatePaths } from "../src/recorder";
+
+describe("Recorder file paths", () => {
+  it("calculates paths for a Mocha test", () => {
+    const mochaTest = {
+      title: "mocha test title",
+      parent: {
+        fullTitle: () => "mocha suite title",
+      },
+    };
+    const context = calculatePaths(mochaTest);
+
+    expect(context).to.eql({
+      suiteTitle: "mocha suite title",
+      testTitle: "mocha test title",
+    });
+  });
+
+  it("calculates paths for a vitest test", () => {
+    const vitestTest = {
+      task: {
+        name: "vitest test title",
+        suite: {
+          name: "vitest suite title",
+        },
+      },
+    };
+
+    const context = calculatePaths(vitestTest);
+    expect(context).to.eql({
+      suiteTitle: "vitest suite title",
+      testTitle: "vitest test title",
+    });
+  });
+
+  it("calculates paths for a vitest test with nested suites", () => {
+    const vitestTest = {
+      task: {
+        name: "vitest test title",
+        suite: {
+          name: "vitest suite title",
+          suite: {
+            name: "toplevel suite",
+          },
+        },
+      },
+    };
+
+    const context = calculatePaths(vitestTest);
+    expect(context).to.eql({
+      suiteTitle: "toplevel suite_vitest suite title",
+      testTitle: "vitest test title",
+    });
+  });
+});


### PR DESCRIPTION
Currently we just need suite title and test title to generate recording file names. `vitest` provides the info via `context` of the callback function.

This PR adds vitest support to recorder. Call site would look like

```ts
   //...
  beforeEach(async (context) => {
    recorder = new Recorder(context);
```
