### PR TITLE
Use "License" instead of "Licence" in file header

### DIFF
--- a/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples-dev/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Use AAD token credentials when sending a SMS message.

--- a/sdk/communication/communication-sms/samples/v1/javascript/usingAadAuth.js
+++ b/sdk/communication/communication-sms/samples/v1/javascript/usingAadAuth.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Use AAD token credentials when sending a SMS message.

--- a/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
+++ b/sdk/communication/communication-sms/samples/v1/typescript/src/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Use AAD token credentials when sending a SMS message.

--- a/sdk/eventhub/event-hubs/samples-browser/src/configuration.js
+++ b/sdk/eventhub/event-hubs/samples-browser/src/configuration.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This file contains the configuration settings needed to authenticate and connect

--- a/sdk/eventhub/event-hubs/samples-browser/src/index.js
+++ b/sdk/eventhub/event-hubs/samples-browser/src/index.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This file hooks up the "Send" and "Receive" buttons on the web page to the

--- a/sdk/eventhub/event-hubs/samples-browser/src/receiveEvents.js
+++ b/sdk/eventhub/event-hubs/samples-browser/src/receiveEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /*
   This sample demonstrates how to use the EventHubConsumerClient to process events from all partitions

--- a/sdk/eventhub/event-hubs/samples-browser/src/sendEvents.js
+++ b/sdk/eventhub/event-hubs/samples-browser/src/sendEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /*
   This sample demonstrates how the send() function can be used to send events to Event Hubs.

--- a/sdk/eventhub/event-hubs/samples-dev/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/iothubConnectionString.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint.

--- a/sdk/eventhub/event-hubs/samples-dev/iothubConnectionStringWebsockets.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/iothubConnectionStringWebsockets.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint using WebSockets.

--- a/sdk/eventhub/event-hubs/samples-dev/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/receiveEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to process events from all partitions of a consumer group in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples-dev/sendBufferedEvents.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/sendBufferedEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  @summary Demonstrates how to send events to an Event Hub using the `EventHubBufferedProducerClient`.

--- a/sdk/eventhub/event-hubs/samples-dev/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/sendEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to an Event Hub.

--- a/sdk/eventhub/event-hubs/samples-dev/sendEventsToSpecificPartition.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/sendEventsToSpecificPartition.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to a specific partition in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples-dev/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/useWithIotHub.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to receive messages from an IoT Hub.

--- a/sdk/eventhub/event-hubs/samples-dev/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to instantiate EventHubsClient using AAD token credentials obtained from using service principal secrets.

--- a/sdk/eventhub/event-hubs/samples-dev/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples-dev/websockets.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to connect to Azure Event Hubs over websockets to work over an HTTP proxy.

--- a/sdk/eventhub/event-hubs/samples-express/src/asyncBatchingProducer.ts
+++ b/sdk/eventhub/event-hubs/samples-express/src/asyncBatchingProducer.ts
@@ -1,6 +1,6 @@
 /**
   Copyright (c) Microsoft Corporation.
-  Licensed under the MIT Licence.  
+  Licensed under the MIT License.  
   
   This sample demonstrates a strategy for creating and sending
   batches of events to Event Hubs.

--- a/sdk/eventhub/event-hubs/samples-express/src/index.ts
+++ b/sdk/eventhub/event-hubs/samples-express/src/index.ts
@@ -1,6 +1,6 @@
 /*
   Copyright (c) Microsoft Corporation.
-  Licensed under the MIT Licence.
+  Licensed under the MIT License.
 
   This sample demonstrates how to send events to Event Hubs
   from an express service. The service will take the HTTP body of

--- a/sdk/eventhub/event-hubs/samples/v5/browser/src/configuration.js
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/src/configuration.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This file contains the configuration settings needed to authenticate and connect

--- a/sdk/eventhub/event-hubs/samples/v5/browser/src/index.js
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/src/index.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This file hooks up the "Send" and "Receive" buttons on the web page to the

--- a/sdk/eventhub/event-hubs/samples/v5/browser/src/receiveEvents.js
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/src/receiveEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /*
   This sample demonstrates how to use the EventHubConsumerClient to process events from all partitions

--- a/sdk/eventhub/event-hubs/samples/v5/browser/src/sendEvents.js
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/src/sendEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /*
   This sample demonstrates how the send() function can be used to send events to Event Hubs.

--- a/sdk/eventhub/event-hubs/samples/v5/express/src/asyncBatchingProducer.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/express/src/asyncBatchingProducer.ts
@@ -1,6 +1,6 @@
 /**
   Copyright (c) Microsoft Corporation.
-  Licensed under the MIT Licence.  
+  Licensed under the MIT License.  
   
   This sample demonstrates a strategy for creating and sending
   batches of events to Event Hubs.

--- a/sdk/eventhub/event-hubs/samples/v5/express/src/index.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/express/src/index.ts
@@ -1,6 +1,6 @@
 /*
   Copyright (c) Microsoft Corporation.
-  Licensed under the MIT Licence.
+  Licensed under the MIT License.
 
   This sample demonstrates how to send events to Event Hubs
   from an express service. The service will take the HTTP body of

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/iothubConnectionString.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/iothubConnectionString.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/iothubConnectionStringWebsockets.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/iothubConnectionStringWebsockets.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint using WebSockets.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/receiveEvents.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/receiveEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to process events from all partitions of a consumer group in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/sendBufferedEvents.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/sendBufferedEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  *

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/sendEvents.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/sendEvents.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/sendEventsToSpecificPartition.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/sendEventsToSpecificPartition.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to a specific partition in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/useWithIotHub.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/useWithIotHub.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to receive messages from an IoT Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/usingAadAuth.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/usingAadAuth.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to instantiate EventHubsClient using AAD token credentials obtained from using service principal secrets.

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/websockets.js
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/websockets.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to connect to Azure Event Hubs over websockets to work over an HTTP proxy.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionString.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionString.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionStringWebsockets.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/iothubConnectionStringWebsockets.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to convert an IoT Hub connection string to an Event Hubs connection string that points to the built-in messaging endpoint using WebSockets.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/receiveEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to process events from all partitions of a consumer group in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendBufferedEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendBufferedEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  *

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendEventsToSpecificPartition.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/sendEventsToSpecificPartition.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to send events to a specific partition in an Event Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/useWithIotHub.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to use the EventHubConsumerClient to receive messages from an IoT Hub.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to instantiate EventHubsClient using AAD token credentials obtained from using service principal secrets.

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/src/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/src/websockets.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary Demonstrates how to connect to Azure Event Hubs over websockets to work over an HTTP proxy.

--- a/sdk/servicebus/service-bus/samples-dev/advanced/administrationClient.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/administrationClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to manage the resources of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples-dev/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/deferral.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the deferMessage() function can be used to defer a message for later processing.

--- a/sdk/servicebus/service-bus/samples-dev/advanced/listingEntities.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/listingEntities.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to list the entities of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples-dev/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/movingMessagesToDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to

--- a/sdk/servicebus/service-bus/samples-dev/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/processMessageFromDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates retrieving a message from a dead letter queue, editing it and

--- a/sdk/servicebus/service-bus/samples-dev/advanced/ruleManager.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/ruleManager.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to use RuleManager to create, list, and delete subscription-level rules.

--- a/sdk/servicebus/service-bus/samples-dev/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/sessionRoundRobin.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how you can continually read through all the available

--- a/sdk/servicebus/service-bus/samples-dev/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples-dev/advanced/sessionState.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates usage of SessionState.

--- a/sdk/servicebus/service-bus/samples-dev/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples-dev/browseMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.

--- a/sdk/servicebus/service-bus/samples-dev/exceedMaxDeliveryCount.ts
+++ b/sdk/servicebus/service-bus/samples-dev/exceedMaxDeliveryCount.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates exceeding the max delivery count for a service bus queue so that

--- a/sdk/servicebus/service-bus/samples-dev/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples-dev/receiveMessagesLoop.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receiveMessages() function can be used to receive Service Bus

--- a/sdk/servicebus/service-bus/samples-dev/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples-dev/receiveMessagesStreaming.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receive() function can be used to receive Service Bus messages

--- a/sdk/servicebus/service-bus/samples-dev/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples-dev/scheduledMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the scheduleMessages() function can be used to schedule messages to

--- a/sdk/servicebus/service-bus/samples-dev/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples-dev/sendMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus

--- a/sdk/servicebus/service-bus/samples-dev/session.ts
+++ b/sdk/servicebus/service-bus/samples-dev/session.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions

--- a/sdk/servicebus/service-bus/samples-dev/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples-dev/useProxy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to create a ServiceBusClient meant to be used in an environment

--- a/sdk/servicebus/service-bus/samples-dev/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples-dev/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to create a namespace using AAD token credentials

--- a/sdk/servicebus/service-bus/samples-dev/usingNamedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/samples-dev/usingNamedKeyCredential.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to authenticate using AzureNamedKeyCredential

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/administrationClient.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/administrationClient.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to manage the resources of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/deferral.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the deferMessage() function can be used to defer a message for later processing.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/listingEntities.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/listingEntities.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to list the entities of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/movingMessagesToDLQ.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/processMessageFromDLQ.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates retrieving a message from a dead letter queue, editing it and

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/ruleManager.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/ruleManager.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to use RuleManager to create, list, and delete subscription-level rules.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/sessionRoundRobin.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how you can continually read through all the available

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/advanced/sessionState.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates usage of SessionState.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/browseMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/exceedMaxDeliveryCount.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/exceedMaxDeliveryCount.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates exceeding the max delivery count for a service bus queue so that

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/receiveMessagesLoop.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receiveMessages() function can be used to receive Service Bus

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/receiveMessagesStreaming.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receive() function can be used to receive Service Bus messages

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/scheduledMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the scheduleMessages() function can be used to schedule messages to

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/sendMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/session.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/useProxy.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to create a ServiceBusClient meant to be used in an environment

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/usingAadAuth.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to create a namespace using AAD token credentials

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/administrationClient.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/administrationClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to manage the resources of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/deferral.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the deferMessage() function can be used to defer a message for later processing.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/listingEntities.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/listingEntities.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to list the entities of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/processMessageFromDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates retrieving a message from a dead letter queue, editing it and

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/ruleManager.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/ruleManager.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to use RuleManager to create, list, and delete subscription-level rules.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/sessionRoundRobin.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how you can continually read through all the available

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/advanced/sessionState.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates usage of SessionState.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/browseMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/exceedMaxDeliveryCount.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/exceedMaxDeliveryCount.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates exceeding the max delivery count for a service bus queue so that

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/receiveMessagesLoop.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receiveMessages() function can be used to receive Service Bus

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/receiveMessagesStreaming.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receive() function can be used to receive Service Bus messages

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/scheduledMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the scheduleMessages() function can be used to schedule messages to

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/sendMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/session.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/useProxy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to create a ServiceBusClient meant to be used in an environment

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/src/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to create a namespace using AAD token credentials

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/administrationClient.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/administrationClient.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to manage the resources of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/deferral.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the deferMessage() function can be used to defer a message for later processing.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/listingEntities.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/listingEntities.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to list the entities of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/movingMessagesToDLQ.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/processMessageFromDLQ.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates retrieving a message from a dead letter queue, editing it and

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/ruleManager.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/ruleManager.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to use RuleManager to create, list, and delete subscription-level rules.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionRoundRobin.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how you can continually read through all the available

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionState.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates usage of SessionState.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/browseMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.

--- a/sdk/servicebus/service-bus/samples/v7/javascript/exceedMaxDeliveryCount.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/exceedMaxDeliveryCount.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates exceeding the max delivery count for a service bus queue so that

--- a/sdk/servicebus/service-bus/samples/v7/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/receiveMessagesLoop.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receiveMessages() function can be used to receive Service Bus

--- a/sdk/servicebus/service-bus/samples/v7/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/receiveMessagesStreaming.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receive() function can be used to receive Service Bus messages

--- a/sdk/servicebus/service-bus/samples/v7/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/scheduledMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the scheduleMessages() function can be used to schedule messages to

--- a/sdk/servicebus/service-bus/samples/v7/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/sendMessages.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus

--- a/sdk/servicebus/service-bus/samples/v7/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/session.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions

--- a/sdk/servicebus/service-bus/samples/v7/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/useProxy.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to create a ServiceBusClient meant to be used in an environment

--- a/sdk/servicebus/service-bus/samples/v7/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/usingAadAuth.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to create a namespace using AAD token credentials

--- a/sdk/servicebus/service-bus/samples/v7/javascript/usingNamedKeyCredential.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/usingNamedKeyCredential.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to authenticate using AzureNamedKeyCredential

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/administrationClient.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/administrationClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to manage the resources of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/deferral.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the deferMessage() function can be used to defer a message for later processing.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/listingEntities.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/listingEntities.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the ServiceBusAdministrationClient can be used to list the entities of a service bus namespace.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/processMessageFromDLQ.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates retrieving a message from a dead letter queue, editing it and

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/ruleManager.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/ruleManager.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to use RuleManager to create, list, and delete subscription-level rules.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how you can continually read through all the available

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionState.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates usage of SessionState.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/browseMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/exceedMaxDeliveryCount.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/exceedMaxDeliveryCount.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates exceeding the max delivery count for a service bus queue so that

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/receiveMessagesLoop.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receiveMessages() function can be used to receive Service Bus

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/receiveMessagesStreaming.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the receive() function can be used to receive Service Bus messages

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/scheduledMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the scheduleMessages() function can be used to schedule messages to

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/sendMessages.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how the sendMessages() method can be used to send messages to Service Bus

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/session.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/useProxy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to create a ServiceBusClient meant to be used in an environment

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/usingAadAuth.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * This sample demonstrates how to create a namespace using AAD token credentials

--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/usingNamedKeyCredential.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/usingNamedKeyCredential.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * @summary This sample demonstrates how to authenticate using AzureNamedKeyCredential

--- a/sdk/storage/storage-blob/samples-browser/largeFileUploads.js
+++ b/sdk/storage/storage-blob/samples-browser/largeFileUploads.js
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT Licence.
+// Licensed under the MIT License.
 
 /**
  * Here we demonstrate how to inject new SAS for an ongoing upload.


### PR DESCRIPTION
Though both are correct (US version and non-US version), our repo mostly uses "License". This PR updates the occurrance of "Licence" with "License" to be consistent and make our linter happy.

