### PR TITLE
Added spec location validation pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -44,6 +44,11 @@ stages:
                         PackageName: ${{artifact.name}}
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
+                    - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceDirectory: ${{parameters.ServiceDirectory}}
+                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
                     - pwsh: |
                         Get-ChildItem -Recurse ${{parameters.ArtifactName}}/${{artifact.name}}
                       workingDirectory: $(Pipeline.Workspace)


### PR DESCRIPTION

This PR is to add back the spec location validation back to the release pipeline.
Here is the original PR which was reverted by an issue of the JS package path.
https://github.com/Azure/azure-sdk-for-js/pull/28303

Here is the PR of the fix of common script that has been merged:
https://github.com/Azure/azure-sdk-tools/pull/7569

This is the [test run result](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3433518&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=7abbbe6b-d005-5c95-feb6-99ffe4e699e1) in JS repo.

@weshaggard @jeremymeng , please review.