### PR TITLE
[dev-tool] add reporter options to vitest command line

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -44,13 +44,15 @@ export default leafCommand(commandInfo, async (options) => {
     await playwrightInstall();
   }
 
+  const reporterArgs =
+    `--reporter=verbose --reporter=junit --outputFile=test-results${options["browser"] ? ".browser" : ""}.xml`;
   const args = options["browser"] ? "-c vitest.browser.config.mts" : "";
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
   );
   const vitestArgs = updatedArgs?.length ? updatedArgs.join(" ") : "";
   const command = {
-    command: `vitest ${args} ${vitestArgs}`,
+    command: `vitest ${reporterArgs} ${args} ${vitestArgs}`,
     name: "vitest",
   };
 


### PR DESCRIPTION
- verbose reporter allows us to see all passing and failing tests

- junit reporter writes result files for devops pipeline to upload to associated builds

