### PR TITLE
[identity] Clean up remaining recordings

### DIFF
--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_a9e6170327"
+  "Tag": "js/identity/identity_f2b0fdb60f"
 }

--- a/sdk/identity/identity/recordings/node/clientcertificatecredential_internal_parsecertificate/recording_includes_the_x5c_value_when_sendcertificatechain_is_true.json
+++ b/sdk/identity/identity/recordings/node/clientcertificatecredential_internal_parsecertificate/recording_includes_the_x5c_value_when_sendcertificatechain_is_true.json
@@ -1,4 +1,0 @@
-{
-  "Entries": [],
-  "Variables": {}
-}

--- a/sdk/identity/identity/recordings/node/clientcertificatecredential_internal_parsecertificate/recording_omits_the_x5c_value_when_sendcertificatechain_is_false.json
+++ b/sdk/identity/identity/recordings/node/clientcertificatecredential_internal_parsecertificate/recording_omits_the_x5c_value_when_sendcertificatechain_is_false.json
@@ -1,4 +1,0 @@
-{
-  "Entries": [],
-  "Variables": {}
-}


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Describe the problem that is addressed by this PR

An order-of-operations when merging #28391 and #28361 means that two recordings
still need to be migrated over. 

This PR addresses that, moving the last two recordings to the assets repo

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
