### PR TITLE
Update RequestHandler.ts

### DIFF
--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -127,7 +127,7 @@ async function httpRequest(
   );
 
   if (response.status >= 400) {
-    const errorResponse: ErrorResponse = new ErrorResponse(result.message);
+    const errorResponse: ErrorResponse = new ErrorResponse(result?.message);
     logger.warning(
       response.status +
         " " +


### PR DESCRIPTION
Avoid error RequestHandler.ts:130
    const errorResponse: ErrorResponse = new ErrorResponse(result.message);
                                                                  ^
TypeError: Cannot read properties of null (reading 'message')


### Packages impacted by this PR

cosmosDB
### Issues associated with this PR


### Describe the problem that is addressed by this PR
When query fails the result comes without message and this is crashing the message handler

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
