### PR TITLE
[core] Prepare for Feb 2024 releases

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 4.1.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.2.0 (2024-02-01)
 
 ### Bugs Fixed
 
 - Correct timeToLive calculation to use absolute expiry time.
 
 ### Other Changes
+
+- Upgrade dependency `@azure/abort-controller` version to `^2.0.0`.
 
 ## 4.1.0 (2023-11-07)
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.2.0 (Unreleased)
+## 1.2.0 (2024-02-01)
 
 ### Features Added
 
 - Add a new property endpoint in ClientOptions and mark the baseUri as deprecated to encourage people to use endpoint.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add a new property endpoint in ClientOptions and mark the baseUri as deprecated to encourage people to use endpoint.
 
+### Bugs Fixed
+- Fixed an issue where `multipart/form-data` requests with an array of files as a parameter would not work if any of the files were supplied as a `Uint8Array`.
+
 ### Other Changes
 
 - Upgrade dependency `@azure/abort-controller` to `^2.0.0`.

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a new property endpoint in ClientOptions and mark the baseUri as deprecated to encourage people to use endpoint.
 
 ### Bugs Fixed
+
 - Fixed an issue where `multipart/form-data` requests with an array of files as a parameter would not work if any of the files were supplied as a `Uint8Array`.
 
 ### Other Changes

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 1.7.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.8.0 (2024-02-01)
 
 ### Bugs Fixed
 
 - Fix an error when serializing browser ReadableStream [PR #27052](https://github.com/Azure/azure-sdk-for-js/pull/27052)
 
 ### Other Changes
+
+- Upgrade dependency `@azure/abort-controller` version to `^2.0.0`.
 
 ## 1.7.3 (2023-06-01)
 

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-client",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "Core library for interfacing with AutoRest generated code",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Release History
 
-## 2.5.5 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 2.6.0 (2024-02-01)
 
 ### Other Changes
 
 - Search for the `resourceLocation` property in the raw response body if it cannot be found in the parsed response body.
+- Upgrade dependency `@azure/abort-controller` version to `^2.0.0`.
 
 ## 2.5.4 (2023-07-24)
 

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/core-lro",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "2.5.5",
+  "version": "2.6.0",
   "description": "Isomorphic client library for supporting long-running operations in node.js and browser.",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 1.13.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.14.0 (2024-02-01)
 
 ### Bugs Fixed
 
@@ -13,6 +9,8 @@
 - Form file uploads now have content type `application/octet-stream` if no other content type was specified.
 
 ### Other Changes
+
+- Upgrade dependency `@azure/abort-controller` version to `^2.0.0`.
 
 ## 1.13.0 (2023-12-07)
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.13.1";
+export const SDK_VERSION: string = "1.14.0";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.6.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.7.0 (2024-02-01)
 
 ### Other Changes
+
+- Upgrade dependency `@azure/abort-controller` version to `^2.0.0`.
 
 ## 1.6.1 (2023-11-07)
 
@@ -21,7 +17,7 @@
 ### Features Added
 
 - Add support for hex encoding to `uint8ArrayToString` and `stringToUint8Array`
-- Fix bug when `uint8ArrayToString` with Base64 encoding would not decode binary data 
+- Fix bug when `uint8ArrayToString` with Base64 encoding would not decode binary data
   containing bytes which are not valid ISO/IEC 8859-1 (latin1) characters.
 
 ### Bugs Fixed

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-util",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Core library for shared utility methods",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
- bump minor versions for @azure/abort-controller dependency version upgrade
- update CHANGELOG
