### PR TITLE
[identity] Fix tests for msal-node 2.6.2

### DIFF
--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -31,7 +31,9 @@ describe("IdentityClient", function () {
   it("throws an exception if the credential is not available (can't resolve discovery endpoint)", async () => {
     const { error } = await testContext.sendCredentialRequests({
       scopes: ["scope"],
-      credential: new ClientSecretCredential(PlaybackTenantId, "client", "secret"),
+      credential: new ClientSecretCredential(PlaybackTenantId, "client", "secret", {
+        authorityHost: "https://unreachable-host.com",
+      }),
       secureResponses: [
         createResponse(400, {
           error: "test_error",

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -181,7 +181,7 @@ describe("IdentityClient", function () {
       (msg: string) => msg.indexOf("azure:identity:") >= 0,
     );
 
-    assert.equal(expectedMessages.length, logMessages.length);
+    assert.equal(logMessages.length, expectedMessages.length);
 
     for (let i = 0; i < logMessages.length; i++) {
       assert.ok(logMessages[i].match(expectedMessages[i]), `Checking[${i}] ${logMessages[i]}`);

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -32,6 +32,7 @@ describe("IdentityClient", function () {
     const { error } = await testContext.sendCredentialRequests({
       scopes: ["scope"],
       credential: new ClientSecretCredential(PlaybackTenantId, "client", "secret", {
+        // createResponse below will simulate a 400 error when trying to resolve the authority
         authorityHost: "https://unreachable-host.com",
       }),
       secureResponses: [
@@ -54,7 +55,11 @@ describe("IdentityClient", function () {
   it("throws an exception when an authentication request fails", async () => {
     const { error } = await testContext.sendCredentialRequests({
       scopes: ["https://test/.default"],
-      credential: new ClientSecretCredential("adfs", "client", "secret"),
+      credential: new ClientSecretCredential("adfs", "client", "secret", {
+        // createResponse below will simulate a 200 when trying to resolve the authority,
+        // then the 400 error when trying to get the token
+        authorityHost: "https://valid-authority.com",
+      }),
       secureResponses: [
         ...prepareMSALResponses(),
         createResponse(400, {

--- a/sdk/identity/identity/test/internal/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/identityClient.spec.ts
@@ -33,7 +33,7 @@ describe("IdentityClient", function () {
       scopes: ["scope"],
       credential: new ClientSecretCredential(PlaybackTenantId, "client", "secret", {
         // createResponse below will simulate a 400 error when trying to resolve the authority
-        authorityHost: "https://unreachable-host.com",
+        authorityHost: "https://fake-authority.com",
       }),
       secureResponses: [
         createResponse(400, {
@@ -58,7 +58,7 @@ describe("IdentityClient", function () {
       credential: new ClientSecretCredential("adfs", "client", "secret", {
         // createResponse below will simulate a 200 when trying to resolve the authority,
         // then the 400 error when trying to get the token
-        authorityHost: "https://valid-authority.com",
+        authorityHost: "https://fake-authority.com",
       }),
       secureResponses: [
         ...prepareMSALResponses(),

--- a/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/onBehalfOfCredential.spec.ts
@@ -27,6 +27,7 @@ describe("OnBehalfOfCredential", function () {
       clientId: "client",
       clientSecret: "secret",
       userAssertionToken: "user-assertion",
+      authorityHost: "https://fake-authority.com",
     });
 
     const newMSALClientLogs = (): number =>
@@ -60,6 +61,7 @@ describe("OnBehalfOfCredential", function () {
       clientId: "client",
       certificatePath,
       userAssertionToken: "user-assertion",
+      authorityHost: "https://fake-authority.com",
     });
 
     const newMSALClientLogs = (): number =>

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -74,6 +74,7 @@ describe("ClientCertificateCredential", function () {
       env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!,
       certificatePath,
       recorder.configureClientOptions({
+        authorityHost: "https://fake-authority.com",
         httpClient: {
           async sendRequest(): Promise<PipelineResponse> {
             await delay(100);

--- a/sdk/identity/identity/test/public/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientSecretCredential.spec.ts
@@ -5,6 +5,7 @@
 
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
 import { Recorder, delay, env, isRecordMode } from "@azure-tools/test-recorder";
+
 import { AbortController } from "@azure/abort-controller";
 import { ClientSecretCredential } from "../../../src";
 import { Context } from "mocha";
@@ -55,7 +56,9 @@ describe("ClientSecretCredential", function () {
       env.AZURE_TENANT_ID!,
       env.AZURE_CLIENT_ID!,
       env.AZURE_CLIENT_SECRET!,
-      recorder.configureClientOptions({}),
+      recorder.configureClientOptions({
+        authorityHost: "https://fake-authority.com",
+      }),
     );
 
     const controller = new AbortController();

--- a/sdk/identity/identity/test/public/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/usernamePasswordCredential.spec.ts
@@ -5,6 +5,7 @@
 
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
 import { Recorder, delay, env, isLiveMode } from "@azure-tools/test-recorder";
+
 import { AbortController } from "@azure/abort-controller";
 import { Context } from "mocha";
 import { UsernamePasswordCredential } from "../../../src";
@@ -54,6 +55,9 @@ describe("UsernamePasswordCredential", function () {
       clientId,
       env.AZURE_IDENTITY_TEST_USERNAME || env.AZURE_USERNAME!,
       env.AZURE_IDENTITY_TEST_PASSWORD || env.AZURE_PASSWORD!,
+      recorder.configureClientOptions({
+        authorityHost: "https://fake-authority.com",
+      }),
     );
 
     const controller = new AbortController();


### PR DESCRIPTION
- fix unreachable host test
- fix second test
- put expected and actual in the right place
- [identity] Fix tests due to MSAL behavior change

<!-- Give your Pull Request a brief description, and answer the following questions. This helps us find the best reviewers for the PR. -->

### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28413 

### Describe the problem that is addressed by this PR

in 2.6.2, @azure/msal-node made some changes to their implementation which impacted our tests. Additional details can be found [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/6859). I'll save you a click:

>  In 2.6.2 we fixed a bug affecting how we resolve endpoints. MSAL.js ships with hardcoded endpoints for Microsoft authorities and the bug prevented these from being used, resulting in making a network request to resolve these endpoints.

Adding insult to injury, our integration tests still pull in MSAL 1.x as 2.x is not compatible with our ESM package 😠 whatever
changes we make here need to be compatible with both, even test changes...

By passing our own authority host we bring back the behavior our mocks are set to rely on. It's not great, and I plan to tackle these tests in the near future. This PR unblocks the upgrade run by `rush update --full` so that we can keep up
with changes.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_



### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
