### PR TITLE
[identity] prepare for core's ESM migration

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -17,6 +17,7 @@ import {
   handleMsalError,
   msalToPublic,
   publicToMsal,
+  randomUUID,
 } from "../utils";
 import {
   processMultiTenantRequest,
@@ -35,7 +36,6 @@ import { NativeBrokerPluginControl } from "../../plugins/provider";
 import { RegionalAuthority } from "../../regionalAuthority";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
 import { getLogLevel } from "@azure/logger";
-import { randomUUID } from "@azure/core-util";
 
 /**
  * Union of the constructor parameters that all MSAL flow types for Node.

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -142,7 +142,7 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
 }
 
 /**
- * Wraps core-util's {@link randomUUID} in order to allow for mocking in tests.
+ * Wraps core-util's randomUUID in order to allow for mocking in tests.
  * This prepares the library for the upcoming core-util update to ESM.
  *
  * @internal

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -7,11 +7,11 @@ import { AuthenticationRecord, MsalAccountInfo, MsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
 import { CredentialLogger, credentialLogger, formatError } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
+import { randomUUID as coreRandomUUID, isNode } from "@azure/core-util";
 
 import { AbortError } from "@azure/abort-controller";
 import { AzureLogLevel } from "@azure/logger";
 import { GetTokenOptions } from "@azure/core-auth";
-import { isNode } from "@azure/core-util";
 
 export interface ILoggerCallback {
   (level: msalCommon.LogLevel, message: string, containsPii: boolean): void;
@@ -139,6 +139,17 @@ export function getMSALLogLevel(logLevel: AzureLogLevel | undefined): msalCommon
       // default msal logging level should be Info
       return msalCommon.LogLevel.Info;
   }
+}
+
+/**
+ * Wraps core-util's {@link randomUUID} in order to allow for mocking in tests.
+ * This prepares the library for the upcoming core-util update to ESM.
+ *
+ * @internal
+ * @returns A string containing a random UUID
+ */
+export function randomUUID(): string {
+  return coreRandomUUID();
 }
 
 /**

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as coreUtil from "@azure/core-util";
+import * as util from "../../src/msal/utils";
 
 import {
   AuthenticationResult,
@@ -46,7 +46,7 @@ export async function msalNodeTestSetup(
 
   const sandbox = createSandbox();
 
-  const stub = sandbox.stub(coreUtil, "randomUUID");
+  const stub = sandbox.stub(util, "randomUUID");
   stub.returns(playbackValues.correlationId);
 
   if (testContextOrStubbedToken instanceof Test || testContextOrStubbedToken === undefined) {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A - prepares Identity for #26238

### Describe the problem that is addressed by this PR

When core moves to ESM, we can no longer directly stub out core-util's
randomUUID as (as far as I understand it) ESM modules are immutable.

In the future, vitest's import maps (IIRC) would help alleviate this pain, but
this should be a reasonable solution to unblock core's migration to ESM.

### Provide a list of related PRs _(if any)_

#26238

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
