### PR TITLE
Domain-specific changes to fix docindex

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -4,7 +4,6 @@ $LanguageDisplayName = "JavaScript"
 $PackageRepository = "NPM"
 $packagePattern = "*.tgz"
 $MetadataUri = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/js-packages.csv"
-$BlobStorageUrl = "https://azuresdkdocs.blob.core.windows.net/%24web?restype=container&comp=list&prefix=javascript%2F&delimiter=%2F"
 $GithubUri = "https://github.com/Azure/azure-sdk-for-js"
 $PackageRepositoryUri = "https://www.npmjs.com/package"
 
@@ -194,7 +193,13 @@ function Get-javascript-GithubIoDocIndex() {
   # Fetch out all package metadata from csv file.
   $metadata = Get-CSVMetadata -MetadataUri $MetadataUri
   # Get the artifacts name from blob storage
-  $artifacts = Get-BlobStorage-Artifacts -blobStorageUrl $BlobStorageUrl -blobDirectoryRegex "^javascript/([a-z]*)-(.*)/$" -blobArtifactsReplacement "@`${1}/`${2}"
+  $artifacts = Get-BlobStorage-Artifacts `
+    -blobDirectoryRegex "^javascript/([a-z]*)-(.*)/$" `
+    -blobArtifactsReplacement "@`${1}/`${2}" `
+    -storageAccountName 'azuresdkdocs' `
+    -storageContainerName '$web' `
+    -storagePrefix 'javascript/'
+
   # Build up the artifact to service name mapping for GithubIo toc.
   $tocContent = Get-TocMapping -metadata $metadata -artifacts $artifacts
   # Generate yml/md toc files and build site.


### PR DESCRIPTION
Needed for https://github.com/Azure/azure-sdk-tools/pull/7629 to work

Example pipeline working: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3467799&view=logs&j=5e8cddd4-765d-5046-f31f-2d7d6b215293&t=5e8cddd4-765d-5046-f31f-2d7d6b215293 (note CreateDocIndex works) 