### PR TITLE
[Azure Monitor OpenTelemetry] Allow spanProcessors and logRecordProcessors to be passed as options.

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry.api.md
+++ b/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry.api.md
@@ -6,7 +6,9 @@
 
 import { AzureMonitorExporterOptions } from '@azure/monitor-opentelemetry-exporter';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { Resource } from '@opentelemetry/resources';
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 // @public
 export interface AzureMonitorOpenTelemetryOptions {
@@ -15,8 +17,10 @@ export interface AzureMonitorOpenTelemetryOptions {
     enableLiveMetrics?: boolean;
     enableStandardMetrics?: boolean;
     instrumentationOptions?: InstrumentationOptions;
+    logRecordProcessors?: [LogRecordProcessor];
     resource?: Resource;
     samplingRatio?: number;
+    spanProcessors?: [SpanProcessor];
 }
 
 // @public

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { metrics, trace } from "@opentelemetry/api";
+import { ProxyTracerProvider, metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import { NodeSDK, NodeSDKConfiguration } from "@opentelemetry/sdk-node";
 import { InternalConfig } from "./shared/config";
@@ -17,6 +17,9 @@ import {
   StatsbeatInstrumentation,
 } from "./types";
 import { BrowserSdkLoader } from "./browserSdkLoader/browserSdkLoader";
+import { SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { LogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 export {
   AzureMonitorOpenTelemetryOptions,
@@ -57,19 +60,51 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions) {
   // Initialize OpenTelemetry SDK
   const sdkConfig: Partial<NodeSDKConfiguration> = {
     autoDetectResources: true,
-    logRecordProcessor: logHandler.getLogRecordProcessor(),
     metricReader: metricHandler.getMetricReader(),
     views: metricHandler.getViews(),
     instrumentations: instrumentations,
     resource: config.resource,
     sampler: traceHandler.getSampler(),
-    spanProcessor: traceHandler.getSpanProcessor(),
   };
   sdk = new NodeSDK(sdkConfig);
   sdk.start();
+
+  // TODO: Send processors as NodeSDK config once arrays are supported
+  // https://github.com/open-telemetry/opentelemetry-js/issues/4451
+
   // Add extra SpanProcessors, MetricReaders and LogRecordProcessors
-  traceHandler.start();
-  logHandler.start();
+  let spanProcessors: SpanProcessor[] = options?.spanProcessors || [];
+  spanProcessors.push(traceHandler.getAzureMonitorSpanProcessor());
+  // Add batch processor as the last one
+  spanProcessors.push(traceHandler.getBatchSpanProcessor());
+
+  // Add extra SpanProcessors, MetricReaders and LogRecordProcessors
+  let logRecordProcessors: LogRecordProcessor[] = options?.logRecordProcessors || [];
+  logRecordProcessors.push(logHandler.getBAzureLogRecordProcessor());
+  // Add batch processor as the last one
+  logRecordProcessors.push(logHandler.getBatchLogRecordProcessor());
+
+  try {
+    const tracerProvider = (
+      trace.getTracerProvider() as ProxyTracerProvider
+    ).getDelegate() as NodeTracerProvider;
+    spanProcessors.forEach((spanProcessor) => {
+      tracerProvider.addSpanProcessor(spanProcessor);
+    });
+  } catch (error) {
+    InternalLogger.getInstance().error("Failed to add SpanProcessors to TracerProvider.", error);
+  }
+  try {
+    const logProvider = logs.getLoggerProvider() as LoggerProvider;
+    logRecordProcessors.forEach((logRecordProcessor) => {
+      logProvider.addLogRecordProcessor(logRecordProcessor);
+    });
+  } catch (error) {
+    InternalLogger.getInstance().error(
+      "Failed to add LogRecordProcessors to LoggerProvider.",
+      error,
+    );
+  }
 }
 
 /**

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 
 import { AzureMonitorLogExporter } from "@azure/monitor-opentelemetry-exporter";
-import { logs } from "@opentelemetry/api-logs";
 import { Instrumentation } from "@opentelemetry/instrumentation";
 import { BunyanInstrumentation } from "@opentelemetry/instrumentation-bunyan";
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import { InternalConfig } from "../shared/config";
 import { MetricHandler } from "../metrics/handler";
 import { AzureLogRecordProcessor } from "./logRecordProcessor";
@@ -15,7 +14,8 @@ import { AzureLogRecordProcessor } from "./logRecordProcessor";
  */
 export class LogHandler {
   private _azureExporter: AzureMonitorLogExporter;
-  private _logRecordProcessor: BatchLogRecordProcessor;
+  private _azureLogRecordProcessor: AzureLogRecordProcessor;
+  private _batchLogRecordProcessor: BatchLogRecordProcessor;
   private _metricHandler: MetricHandler;
   private _config: InternalConfig;
   private _instrumentations: Instrumentation[];
@@ -29,20 +29,18 @@ export class LogHandler {
     this._config = config;
     this._metricHandler = metricHandler;
     this._azureExporter = new AzureMonitorLogExporter(config.azureMonitorExporterOptions);
-    this._logRecordProcessor = new BatchLogRecordProcessor(this._azureExporter);
+    this._batchLogRecordProcessor = new BatchLogRecordProcessor(this._azureExporter);
+    this._azureLogRecordProcessor = new AzureLogRecordProcessor(this._metricHandler);
     this._instrumentations = [];
     this._initializeInstrumentations();
   }
 
-  public start(): void {
-    try {
-      const azureLogProccessor = new AzureLogRecordProcessor(this._metricHandler);
-      (logs.getLoggerProvider() as LoggerProvider).addLogRecordProcessor(azureLogProccessor);
-    } catch (error) {}
+  public getBAzureLogRecordProcessor(): AzureLogRecordProcessor {
+    return this._azureLogRecordProcessor;
   }
 
-  public getLogRecordProcessor(): BatchLogRecordProcessor {
-    return this._logRecordProcessor;
+  public getBatchLogRecordProcessor(): BatchLogRecordProcessor {
+    return this._batchLogRecordProcessor;
   }
 
   public getInstrumentations(): Instrumentation[] {

--- a/sdk/monitor/monitor-opentelemetry/src/shared/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/types.ts
@@ -4,6 +4,8 @@
 import { AzureMonitorExporterOptions } from "@azure/monitor-opentelemetry-exporter";
 import { InstrumentationConfig } from "@opentelemetry/instrumentation";
 import { Resource } from "@opentelemetry/resources";
+import { LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { SpanProcessor } from "@opentelemetry/sdk-trace-base";
 
 /**
  * Azure Monitor OpenTelemetry Options
@@ -19,14 +21,14 @@ export interface AzureMonitorOpenTelemetryOptions {
   enableLiveMetrics?: boolean;
   /** Enable Standard Metrics feature */
   enableStandardMetrics?: boolean;
-  /**
-   * OpenTelemetry Instrumentations options included as part of Azure Monitor (azureSdk, http, mongoDb, mySql, postgreSql, redis, redis4)
-   */
+  /** OpenTelemetry Instrumentations options included as part of Azure Monitor (azureSdk, http, mongoDb, mySql, postgreSql, redis, redis4) */
   instrumentationOptions?: InstrumentationOptions;
-  /**
-   * Application Insights Web Instrumentation options (enabled, connectionString, src, config)
-   */
+  /** Application Insights Web Instrumentation options (enabled, connectionString, src, config)*/
   browserSdkLoaderOptions?: BrowserSdkLoaderOptions;
+  /** An array of log record processors to register to the logger provider.*/
+  logRecordProcessors?: [LogRecordProcessor];
+  /** An array of span processors to register to the tracer provider.*/
+  spanProcessors?: [SpanProcessor];
 }
 
 /**

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -38,9 +38,9 @@ describe("LogHandler", () => {
         }),
     );
     const loggerProvider: LoggerProvider = new LoggerProvider();
-    loggerProvider.addLogRecordProcessor(handler.getLogRecordProcessor());
+    loggerProvider.addLogRecordProcessor(handler.getBatchLogRecordProcessor());
+    loggerProvider.addLogRecordProcessor(handler.getBAzureLogRecordProcessor());
     logs.setGlobalLoggerProvider(loggerProvider);
-    handler.start();
 
     const tracerProvider = new NodeTracerProvider();
     tracerProvider.register();

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -58,9 +58,9 @@ describe("Library/TraceHandler", () => {
         }),
     );
     const tracerProvider = new NodeTracerProvider();
-    tracerProvider.addSpanProcessor(handler.getSpanProcessor());
+    tracerProvider.addSpanProcessor(handler.getAzureMonitorSpanProcessor());
+    tracerProvider.addSpanProcessor(handler.getBatchSpanProcessor());
     trace.setGlobalTracerProvider(tracerProvider);
-    handler.start();
 
     // Load Http modules, HTTP instrumentation hook will be created in OpenTelemetry
     http = require("http") as any;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
Fixes #28415 

