### PR TITLE
[core-util] Add utility type for JSON Merge Patch

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9306,6 +9306,14 @@ packages:
       streamx: 2.15.6
     dev: false
 
+  /tersify@3.12.1:
+    resolution: {integrity: sha512-VwzXGHZSOB4T27s4uvh9v8FYrNXyfVz0nBQi28TDwrZoQwT8ZJUp1W2Ff73ekN07stJSb0D+pr6iXeNeFqTI6Q==}
+    dependencies:
+      acorn: 8.11.3
+      is-buffer: 2.0.5
+      unpartial: 1.0.5
+    dev: false
+
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -9583,6 +9591,13 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /type-plus@7.6.0:
+    resolution: {integrity: sha512-ijsLw2QQDynAMpANnCc4jWUfeo65EGDHXeiqUaUKxq6bxuoTvcXHJGbOihGQMhHjxE4159pkWiTLP1xu/6xdhA==}
+    dependencies:
+      tersify: 3.12.1
+      unpartial: 1.0.5
+    dev: false
+
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
@@ -9711,6 +9726,11 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /unpartial@1.0.5:
+    resolution: {integrity: sha512-yAqaXcachjgZUnM2yIkf+4KJhmyuoj7stBvlnlZpB15OYVbKnLhgJfmLW7qkpzLHCdsm1bEFvhyN9hCmlZ3uuw==}
+    engines: {node: '>=6'}
     dev: false
 
   /unpipe@1.0.0:
@@ -10273,7 +10293,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-2/wrw99JB2E8EA/YOzTM6XFxWrQ3iZ6Tx/mTbs4rqv/VVAhE+HWlk0NfSWACrrnhO8eDVhij7n38NDae5aFHFQ==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-Svy9M0FMqKjG+/dp40NjOggL4xnATYP3XS0gR+YKpuDM6yc+pmhGA3ryAE3WFsO6Bb5ZxEmk+NzFc/y9n//nFA==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -10309,7 +10329,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-A9Ai6fGqmepgJx5thrYJ1AOlYXVpxeXSV9JcwkpUvKUvRQLA9iH37BBi4fUl8U3zly28BL/yTziaNWOlHOCrvA==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-nCaZjmdxRSbOqEIbYfAHTabsRImLd1Cet6HA1JZTsRtYUflxlO3f9MkjYF9A/on/qasfvIkzGna1NYoELiotTw==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -10353,7 +10373,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-nNhC4B1+ST1AmWAEyBJg0qB6dFjF+fS0TEFf/cHGG7d6kqQLTmuwUf12oOjyJCVfq2yYDbWd8ySXbAfzBIef6g==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-anH/cH8keDOm7eWYdk80cWMSWvlhhdov7WYzpJu3CSGO69WBO44/63U566TTtcJWRTu1rIEHSmRQNb0CCYt0xw==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -10397,7 +10417,7 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-UTR4KtCHvBav83lyWKCJ/qIc+0se2ZVyc+wUSJZsG8HNfT8gD6FoBMugQXR+tP1O4EBLUHGhTtB9tlhVK7hj/Q==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-wNOkfpwL/KnTiFueyGIAPKcadgSIgppMWF7o2a4bu78gxQGgLKohAPFjb6l17dTbr+BFh/KUkiHeUkOGpmhLuA==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
@@ -10440,7 +10460,7 @@ packages:
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-dtzzrZ2Ybyh2+h5Z0pE1baeCIcZMbekcGla2ckd20ACncPW/DDLY3Py8XC8V73TDF9JqTdF09kArGobCdpQuLg==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-fVhkQz/DSK0wnxuq44JIBa9kbvWW7A89h0XcwWUI4jtc/07mmhRk9ES9mblyW69OEbfMy7XbQUOi+EP1j0KM3g==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
@@ -10484,7 +10504,7 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-PqTQtcNp1ZYMx4Cx0uHKlAUipEgxRDLQlXy60iXo4/ukgNlCZlorF7qdEa5hmvHrxHq4oO7YQ5WnACDbmIpERg==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-Bg3ykXJuItueECE6so/VrsmMSxfstdWrYH+QVZGaVuziV0Nh0XvQtTel1tPv+Hzm6ywPsUTqmAMkUqBCXQ1qCA==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
@@ -10527,7 +10547,7 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-lP38hmJdhXqE53J9IjwrwnRBK8lXYCswqm3n0C6pswzPqcKdQjEktenlWb/qExrAFdsxlSppheuV0Ogmp2FeUg==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-9jrBf0XfnSFVRWY1AUJWSA3+3AyDPVLu3rD+9LsfhZWNdxs6DnwnKrm1ABoGnRbo9M+hH7Wrd3rMGa+nhZgVlg==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -10574,7 +10594,7 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-1T2CpJBRUttCEJ+qxK00M6WcFob7nmjLl07MdUdzEzj00uVsmNIvG+4BqUD2SYvhto0MWoEeSBJ48NZBOlSizg==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-8gWbUXgadrmh3/V29ggl6oi9lJ3QDojIS8ELGjU7Xz1+ivdg9L2hsfs7fgE0/2TpbOD12WzZkp9Mbumf6rs2bQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -10622,7 +10642,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-WynK+CHRIJjzQoT6INoqOsD6l/sfZ4lFFjHY650tL9df8xSu3Rele3XMIJDGA+cy0AfQb05hSsoTtq4tfdle9w==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-v/7HQHq7y7VEEBrxILujBK2eCt4YXaJPH1NNTcJTE8A7btrtDgVcITjOVcIMIFJuMYlr0TmpTXud6XILPKSPPg==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -10669,7 +10689,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-S8+TjZpf7ciwEziKXjMTlzy1egeqqv5bFRngKe5TabKFYnT9ecNx2Mu3z0h0Ge/EkzmGm4sdLBoeLRyJk1XYFg==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-7SCZl6GcnMU3EmqaoblJd3Mp9UwjSNda1nq7doEXit/BsFIWlkBH0/T5e3FcACidrED4X9QvITClG6qTE4HY3w==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -10693,7 +10713,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-/AExn5Tm5BfPKQl8tNPZfFXeMAY5ARWOaPUAKDKU0IpfhYye/pYSq/57/Kth11Ul3PZsMOYVxQZLpkZ4ho6Gow==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-WBtDAoamNoKEbFTT4WaVYltkTbs6spYXoVSU8fxqr5IrL0KOa0sffCG75+2Cqw+/Ka6Osg6q62cGmE6qc9iNDw==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -10736,7 +10756,7 @@ packages:
     dev: false
 
   file:projects/ai-personalizer.tgz:
-    resolution: {integrity: sha512-Gs6YyJBhMhOzw8D4NysNzyoRqzFHaTYVX0MrKpAYRmPKg2PeoZm2MUHwA4Ax3+F+UV4RsKRPkl6OpdVlYdVDqA==, tarball: file:projects/ai-personalizer.tgz}
+    resolution: {integrity: sha512-J9tv2nEF7Dcpk6hnx6lBjDXMhES+10Gsc08vOVYyzz7HSUS0FliJD4ddMskeq1MVS+PFL9yq0uLtw72WGE3Uxw==, tarball: file:projects/ai-personalizer.tgz}
     name: '@rush-temp/ai-personalizer'
     version: 0.0.0
     dependencies:
@@ -10778,7 +10798,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-apuV/ZeR0Co9HlCTYgERvAzTo0LkhzrV5S92KyNXd/yI7yfvkRsb0EXt67Z4ga89ugvj+UDFcWZ4OUkwck8gQQ==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-nLdMhaE37As2oD/NUJrU2apWy7MjDvc7i4Y6ezQW05/+S+Czxif2svfoRCwQxGua/TDZ+ODAcr3Nw7rxesukVQ==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -10824,7 +10844,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-Y/kArDrx4cOEEp6sfgAlA1BftCvX5md0BNDKJp+PDMCyoxF/xK/zLvXwSMxqiAjt9N8BiV9LTHTZksgcRyyKOw==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-ROEq4btnu3J6tq1wK466wvL5DWdPVXnLOCyRgcygD5YQE8OiEiITbBt8iha73I2FeqLmK2D17AA672v1ZEJ9Ng==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
@@ -10867,7 +10887,7 @@ packages:
     dev: false
 
   file:projects/ai-vision-image-analysis.tgz:
-    resolution: {integrity: sha512-F3GP/xUm8HCUwpSjucJIwVele5rheX6lntfR5AH7kCpx4x4T+9gWwR/afo7Keyxrsz8vr0Cl+2ux5USdR+3evw==, tarball: file:projects/ai-vision-image-analysis.tgz}
+    resolution: {integrity: sha512-HvcVKC4rIhZo7sqGiWgi0Rb2Vig4ZHgMgJQaddJVq6kr3AJYvDPyvmms91aD8iPLEFYRtzJgmN+bbvn+KFJvYg==, tarball: file:projects/ai-vision-image-analysis.tgz}
     name: '@rush-temp/ai-vision-image-analysis'
     version: 0.0.0
     dependencies:
@@ -10910,7 +10930,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-Dxj2Dly3rHpNIYmqc/xZ/mprYmXMDFfuoRkvy5tuyoLg4A7xbrCENaV5MgUgbE0XfwaRXUGy3ynx9Z30QzFZ+A==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-kdfblFYi/3HptZsKwl5sDuXba8odq6gt8GD3V8msFIsdx/I3PEv/ZIhDoJDRl/TllA/85DcfMIaazU2ghSaqsg==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -10952,7 +10972,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-xS3kcWPfOtefSlxaMFofngMervbsqAjGgWWiIMN04hghp7w3PTaoNdB37SFQruDU4vRli5vHbOvluUCCWU9MQg==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-lg6lKiK4+zPSKsJElpQveUkrAvvN+nxwMgL5zVs4+HvHrV4FMaAiaIkxyP6nlOtXzPbRaihBFGUM4Z2G1xYcCw==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -11003,7 +11023,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-8rKdwXE2pX+sBmp10d3QrufPGtjSnkQou6GbhzzRQ+vlLb5wihvFyRTHxNx+wO/RSeLAjazAZFAUXX+fDAkZhw==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-POrAGwyZ0EQD0DUwNPc9BZPMcAVdBRVRThynUlUSw9hki80INARnNoHtA05VD/8/2icOzS12WAgxS7vrGiK1qg==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -11048,7 +11068,7 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-H8ScUgcJ/PLRGO/3jAO14SaUWy9kePN6zqZEbqwT9iSuIsrc1ZfvsaylvbACMyEUmPJp+AmhTIq3gHosYk0Iyw==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-aL6H0VxQsjLuJy2o+zIhoSCFl/woFTcQP3+hLOm9DUNHImTrs3uDqkq0T4hIm1GUOt25ppEjIVCNWhou6rI70w==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -11073,7 +11093,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-8Pie58GBztruxL9THYTEULHidIdLeNSNSJsTznCTL+LtvAN+AqgaO7QKBW40i3miT3hsJcjhUNMozY3aujLG6Q==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-jvXSBleMUf15bQNOZ7izbJApJiWREFMpiD7IRw2SqywCsieAEhhn00pYRr3kHQ7B2doeNHblTB2FqRZSFOzaew==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -11098,7 +11118,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-7W+0/d8yb077/x2KPcRf/KBmi8HTfEsF/bxJUwrB1z0VOgJdkUp5C7Wpvr8nwwuuZ41xsOfZoNx9w/oP1TFayA==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-MH/QaiVpOgsOj9V+job3BHgUbMxx+eC3e38sZD8JAE3tpTMfzS9iFy9gcuh0bK4heccquHxIXHhaBo3k+/znUw==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -11123,7 +11143,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-Af20AMSxVNA5tdXQe/6kbjJFqaZTG57QuW+fC84mn5s/nZlo6mdUbET+G6RhUMKn/K5mN49Qn6s22b0FasN/9Q==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-Ruj7pqgF3Zm51EKFDTpNkRakE+YlNt3TyKGn3ryIDCp7sPFKUe2ifkTypL/zt5Lpv17uJC9fcqcRkZza30jxIg==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -11145,7 +11165,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-JA0XCnF6/CoglwhoiN+W7MEASmKvelszkL6tZYymWbqkNdURpVGJaZA1QEXVA9E01jEa2XfcQfLoq4QzKnSuBg==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-PhBl4FAXf2H/6+jkNb2H1uMbg3dYnlFtw4PEYtnO4/e1JCGGxvbH9gyv0PhIEzeyi+SR1MVu5ndKn+IMYC4Eww==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -11171,7 +11191,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-58ytwOdmbzwBqNhlOv9JXbBQuJPh3AV/6mHbTDo0Ns7DyFrJwUF7J5xWBk1K9oQOfTJtdJaqmhd/XcSumT5RcA==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-KRGoXxLWDqu/VQBGmlBjvjX44rfOCtxd5znSUfGLGbQnnlUzSPhjgsGZLF9x4qEa4Wl1aL7A4yQYNeETtN2t0Q==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -11196,7 +11216,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-z3ySh7wY+XpQYqOd7qQ3Ylj/N+0+TwqrGjYPZbsq+tC3F8enhmTVNxIFOz5QTdTD3xg+UGkZJVefz9XeMLR0Ig==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-6B5qlq0WoIsABt9IzyAz/NKJMGMPeGP8OP4DuKZ2px/hzB0Cravn0ZS5eao7hpUssiXfQTRjLiIF9twS0JoRKA==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -11222,7 +11242,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-dYaUWOBiVhPo4WCdemTIkNbrtlMGcqOMaHDXX3wxcgLxgEff2g404cQbQtYjGvr0+570r4nYRFzRNoSHJ1Vhhg==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-qcgsbjcEFN/i26M8fIdNdopVEkpedk5YVhaw8bK/oeNGqChJPxjXF8BtBPSTxPbY+/COyQZ1qEFA4unU3QaXOQ==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -11248,7 +11268,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-Ynq/OzzFAq0qzSDgk5gXUp5VnKBQzufzU6hXdLvRnmqrv322sjAwUDgDilVirpTAcdg9Tucfkinb3jd7eIB30w==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-JUAf5XLDVrYhyjMjBmPaCW//QAmn6sESAUsKfv488zy1XRO8SEbpAVqiANPObm4Rj3jvqBSMEs67Ff2nO2SU3A==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -11272,7 +11292,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-TKIcyurbmgUkcoaMRkTV9yUKo1zHSbn+M63SJ90U0ZKuWIAHNZXTA9qcJP7CdOwaw6Acop/vIHqxuXu42yE8SQ==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-j1ELvbMaVNdQSgMPC2s1tNMmyBWHFVIlqLk8ziGzQioXVS2mSharU0OLA9RFQ5Gc6e2O3NP4IBNBqUcY+qcDQA==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -11300,7 +11320,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-H7+xCzynoaXKx/uU8Pd/MEIZL2y0kj9Ly7+LPCLylbdVDjzdTI6aDMvH40dqVppKx6RI3QHLm9kcxTKhKhmsgw==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-9qP7AvKz+t5w/dGdMJTM1UloK13xYE3BUBrz9EwEbBw8eKEBXby1XuvrBvBpDIuu3McoikIg3m4gZdf3lXbQZw==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -11328,7 +11348,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-VwGRJ8CmytyWpU6FqePvH10tE2PYaUqlIjDOrloL8P51d4IEwxkza5FH2tEwD45Nh9QwBBZkJ+3RT6or2NkQmA==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-hp/RAat2StUP+ouYMIXhOBg8RUHVO015W9GS+GFZc8zv7SdTYolBo9K4bVEDRz5EfMYj6qWlglLUjSdRSaOyJg==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11354,7 +11374,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-zFQ9p4qosftq7SFtlaE/WjiYqn7T1NjB0B4oVgPxQ6Z+hnuhzHurk5pr5sbV6Eyz63kA03ybH+G/YMeAidRhdw==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-TURNxgWQeFzokDtNhIEn7ueCtOslXdVQQcO24UH4Wa4HQAIW9a+yebxHOdddWnCq4tzTi4ukVjYZwxungmf4nw==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -11396,7 +11416,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-oZTNBIiHdrBD1tTaFDhN8g9LSTSIDXEBPeYyH4qOWqIi+TAkcLbr7RKvBB97SVAZ/P3syLRbsCaq4uDeAdM1sg==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-0IAWC/TIdDIPQNusckYi7WZj9vTgw8tdSnGVqyKNpB8nqPufBTTpx/wNfWtYoxpzfJKqZG2NMxw0uFMKYlliUA==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -11420,7 +11440,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-p8uidlJ8B1HypJK8r+PybhN5wgiqRcX35QLlbc1iigDyAT1Hso+Ijs6zjbcN4PineVT5TtBi6qfZmdJjL8ojLQ==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Fvw1nfYSZ23Kn+5nnBeC9oAktA2xCEOF6drex5jUqh6GAKWQy+JHbmLMsqwyMr0Tpdb3po9TO+OYop2DLXOlqg==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11445,7 +11465,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-tgWxM0AIFP2N9tUuDPssC0nKw2YHokkn3+DvaFTjBx1f5lIkFo68O8R/2V3sgHgnYmOIdTbwwBuQDo15j5hSEA==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-EDabaLGmxgc+kAty/9i4gsCiAJs+IVUh1ph+W4EmWc6qStzSFmsHM8+N9w3Kdl6A6KS7zkIEhyeDyQr9n/8vlA==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -11471,7 +11491,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-sqRsdxi+meceK2KxdhfHzeSJGHbtju4Js/VpBXtdlDe4+wGOKMu6dYCYdjy9F9LDQ5bCxYcD/ld1Y0J9hRA2xg==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-f3FYJ6c7DcZNbke382COAnr5zfB9emAWfsJaR8fVAbTLWm5SHmfBgcmmvRg+MI8l3QE++zB/1+nnnUiQa6fFdg==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -11496,7 +11516,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-8bQI/Jdoq+voXirnOgbjTkWLGW6Jc3vUEE3jOpCaDJzes0i7mVluYcwrbZJLFgmj4Ss8wgIekmJPIuPN3qIRcA==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-eHjSoe/U6vvQOZVwV+Gtv2mwPmA5HY/6d5yePLA6sngsWLqg0eiZAOWSGDtflv3V4IzJupK4IeMT9PAJDspJxg==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -11522,7 +11542,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-R/ZqwuZFLihicRRzxEoFZ9Rp2vcRM6h2XZaqAL3qpsTDwXxwbTeZjXe2tboXhcuV5aviHE9RJ+DW1xXpf8F9rA==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-ZnN3iJzZZSel1a0YnVpa3QIS+0duk6bVoegYfseb0xzyh+fRZCftY8vrGmwm5Iw5S7LnE+hUGqbMRwAj/lN1Rg==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -11548,7 +11568,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-AyyNOq5v8JY/+CpvRgTiqrH0FA6VQo1XJr/CAWZzCiY658rRp7VI75SZTgO7Kh+bP1tcUSsVSyssTE+Uj2DWBw==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-QMnRfjUf1wQL69YWRsZfkMkNat6ilDXNIL20LFJ7dOE56YuCUsywqKM0VMF0hpF4mSF38kfvfumsBR66kHVhgA==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -11573,7 +11593,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-djqdv23szVeMtL2YXWBKC5YB9NjJPov6Xoh2+19cUzCu/nKI3tDzbKBMAiqC6xsZzdaIDGtqfFuUI1fLcJDRBg==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-/zCR97Z4bbUuypIzZSkmo8Y9dwDS3NA1aoEa1tVGPaWNn/MDdFOso37sH5BDRS7x+WvJV6XDG6YMPxnqijdhZQ==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -11597,7 +11617,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-wXEOHzdJPE1mo3ZElAjRI+3L407vycweQsojmyrxm1tg0BziSeYI7Za0Ak/Z3Zp6zfMWmTV+tkbq+yGMZpvl+Q==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-nPwc5eJzM4Bf015yC9KXJpCi+tAQ60Sb1Jeeo8aiVp+LgwYg1dEf9GoToZAgLFLtWFafDVpAF6MsjZeC8sk9Sg==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -11623,7 +11643,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-WdKxnP1TfkEy6EuErTpgyyeVkLaejIAQGyFzO/zjBQ93orHp7sfrCQ/6xmaxuJiwnu26oqTmD3MGziSve5p/Fw==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-fMXPEFOog3NHo4LGbeTGVSjGAdVEoBVd6yY9xtwjd9v3+mYNNbeSp6xrng8CZVw948bm0d90Sd39eVmp4ajulA==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -11651,7 +11671,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-vyiBWQNMdBTo07MRCZIUHr0+yj0IXfNIOjwuzGAu9gRcScETu3exdm3o/hzQoq/dRD+8AHKjHkAQYaw000Mdcg==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-QylzujO6riBfozJAmTOpwwFmz/vQK8njxAi2ddeCC0hhF87N4kcSGLGRokHrak7ANfYUanfJKRubsYI4qFS/jA==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -11679,7 +11699,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-/9Jh2PEZvSr5gcc5rv9V2qb14IFKl6XZx2HV3SOEOOcyOuL1FHY0CxTpS6+IMCahP5nqXEsdho/2iCLkYFumEw==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-rXIRGjuAzlRIOhnDOvM7Aet4A41ElO/RBITPo7v1uIB6AMwWAgIcXZEJWfHrsGPpE0QXxnG1K5a8YP50Z1wQag==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -11704,7 +11724,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-Bsh1puWkxZK2dr1G9mbGVmJ5QDoEi7Yhc3aGfbFSxBxRL8IZAEsUjPNvDPvtX72xx2iGeCjQdZJFFq9GybqSvg==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-otkryeVicA5iCG/hZGF9wK6K0xL+HJlvc7c6fmQbIeTNZHJDQSaeuQphgONLKrdDMG+lqi9B+253w/3kbt94eQ==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -11729,7 +11749,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-PunaoIsC9xQwbr9FhvPdSJkGIjEl6psDF7VwPEFy/I85L86kydXdiCSOqIinpnCF3jZElG7Wi1BJnh1sxEKqzw==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-JP+tp2pXr/XgamYwgPGjYSubrzKwAc1yElWOAQYdntaeahtf6QD1TXTXdAxqYtB/K12DGwB/oWzcdfSCPzYbLg==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -11755,7 +11775,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-E8/QnXWjYTkL0NW/6aGuXlE2Sq6nW1W7c19EGLh88lOpbhe1ZFrAgJVtFmvdOwRGEB79SgAI4kx+CZfnprejFQ==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-qkU0bD6vfjpfIoayQHUJ5/QB/Y3+cVK0sceivRHkN9M5W8/bYlfNwhOJa4euc0/5g1FcuyxZdncL0Mfn85YkoA==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -11781,7 +11801,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-d4M47LNhld0J0669RmBgJlqjbZbAFZ/FLY9vrqNgPiDvrXyhjNiZKTHza9vdXyL9psDMv7dIk4X/MLQKrrj5Xg==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-/aKCbDsxY5JyFL3UA5Tai9lVJ2HTLDeN5Wm92ivCnrxeLafuPCvc/ZzaDJrWfmH1/VaoKDqmhhw13xbu1b819A==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -11805,7 +11825,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-zPi8+e65nL/Hncla3utOY4XB7hEuyZArcaGN9G/qeHpgYNlRyxWTv8NR0vcNz7etzXXSvhfTDG4fjmMNXkz0ZA==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-CRWk3xzdl9rSmIXJUjmRcTq5qRP3PMZTdq2MR0CRuVobM3zUyqWDHVrrEX+Gx7WbnWe1KKnjaTSkFfY0rOoGnA==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -11829,7 +11849,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-zXwQnRB2qDpdKzABD8oVAJNodzV79wtSBTkHe3CsBovqlZGPb7E2Cqk5asMKI2Q0mk6E6QKQv9ObyUsYRgJbZQ==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-z+ovW5OliCzSdVeeRTpWYEpmZ5+kBvrA3u1pDU5sln/GYsiUA+oF8OYupD7+htwd988e3hhetjkhwAnuNLSOKg==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -11858,7 +11878,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-SWFA2qPke3qzQzfoBneQ3t2nB4yMD7FQnw9Cf09Nh5vnFennPxFZvWpveH0AMOI1+NvJHEQ1FNQAHzIw2K3DbQ==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-V6SZ01gKgQ4GIq2xZ8FKL3MrjN0vS6yvfkcsyiMB1KFemx18z9LoYYkcifCZcUTn30UllwoKSkRA1QvorFRs0w==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -11884,7 +11904,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-c+n4sHVDhL+nSR5/SzFP2CJ2Zvb+Ul/9GPOeB0P9RLANv+Qf/MvUeFPPH4010c0id52s9oK7VpGTmtiV271a6Q==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-wxwMQYtX1EGFjstthMk7ZM4wPe0PYOUz4n3C4CLitrKqEksjAVOeelum3/CAlrNiylg1lmELpKswMxYS5tw7BA==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11909,7 +11929,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-aShbJbDZWZGlctvCciTYLExJUjWp9nnvd34SQD97CTqABmDBNDv1OtUCUR7jV4sJoN2Yhp//aP0chyXBrNtc7A==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-cuFM9XfSvznKxNVHNrObPYmHHSQfoCeGj4R1OxK0vIcbSPfmige1UcJ6BcF2m4A1mwE+BcDF/d3NIk69xP6lyw==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -11933,7 +11953,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-PqGK1ek/kHuaTx6w6Gu8+JAoXtRDXGrn/GQYY0/g3XwuleQTEEuK23jS9uuSlsc8D5S68nb91SdZzBFyeSIjuA==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-1/gvVbpVnhWfswragle6PhmV4RobRSN75ffcld2a9ENM/LDaNWxP2BwBaiFnIP+GECqwhqDWxd5S/2LplQ/Ezw==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -11957,7 +11977,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-gpmGTMpy5YZgYCYSI3qpAVKcvmm53P+ycYNwYyEvYDXeCUlEwZfcghv8yeXFCH16BPbN6plD8b52/GyfzDWlng==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-GseNtkgrNsu2ZC/AenvcIviMVCZ5uu1VcDubT45uljM1KG3PzgRrX+KXhs2g2X/ltmmcsJd5WatT00/wjudseg==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -11985,7 +12005,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-+OaeNWuRDQ5aO3Tj2gL0KJDuWcMUOFmLJOoY/K+uie4t84Zo0AxPIMLJGOjshYjBtPtWKqqwuZMZtMVRB6VLXA==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-riNnLidCm0qTLe9IXRGW4fcUlYdKY61TaEjoaUocU0cumoAe8ZH4Rw39MOP3YI3hVbjwk+xC7zHfQGlsDcGwUw==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -12014,7 +12034,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-jHKzdEZgkFnv+JL8Ap6WkgHgeJ0qMgLMeZEtSndFO1PH228K6WkPXUDtJ8ok0JymEYeGkEWvFt0D6OpnKEM58g==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-dh+oermVN8Gg9daS95PCpJPTPMnWgjTQk/UrT6Sbe8gynXp/DQuh5TqePRPUvnMFOD4ppvv2TfvOHF5l+4YsmQ==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12040,7 +12060,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-k631gfp8UUpLGBgm+GdGa6DcA3hnSkj0AKVaUHNgr4oTAjWY7C6fDbppEr36yHynmI/LF/dOHHJZm6KXmNwcRg==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-8SLQaHM9cFx1lfdqHc5apBu7U6af1FnCQELMArMGbhF95iyp13qSlrf9r3FS2bjVRdtpTiPDYeiTmOdcYlk61Q==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -12083,7 +12103,7 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-WpjcNm9JXAWAiwmKwoklfR+X7XxPUMuNZMhk9zey8kjdpsBA6/uBePvAGl5+EKlfhqmNtvPtYXceCIOLpbhJZQ==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-LdZ4ljmmCDWvHdnyblkeS4wf/aA9QHwN583IF2vckKAMt/EX5QTXAX6//qiZbrip1/ReE5tIRiDqEXX3nU5BqQ==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -12109,7 +12129,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-ewU6jnOEAEsM66GN+ZCUjkUK12Gp7LUF/PkE4oWjJe5yUx43dRHNzspPkxjTnmeafVS0gLwVpdr2mFu7ZdGxRQ==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-DbNBw/Ioo84nKu5R6UZAp/oJ9elX26EFzQO/GcijmlU9CCCp5uMMxpmw1d6jqR7H+JzEz5viNIsF/rXv1cmQ7A==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -12137,7 +12157,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-s3mR2J/JlONYXfVF64Pkr0KV9aoKj2X2TZVahXZFCVFZjdrxhqaAN29UyV0YB4BxIcfITQOA/P/BT0Qk3z3dxg==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-boz5mN4lQ9AQ0wDBcNG/2j0izBvqZmaHR4QjuLpwpizYJbD5pAueKUhiwoe6eZgiJlqWU1G3zsQfaQrRgyqbMg==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -12163,7 +12183,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-HTzsms/itgg5kF67rutTyQiqkJJ+nfovxUCebHiATcX44TAvENmaeh4dTOXqAcuA6mmEUKvL3cY5QHWWSL2Gig==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-EGbklpXc3JAQYlUYQePEgQzgIjHYjPnOWz9DgPlNFzMWMixmuOOo/YBmIauYmUBo98b6xs3qLWbW1PIhyTBMZA==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -12188,7 +12208,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-/cSkJq1ULwX2T8VXjEyVWHmsZEYgZ12eHfX1tsmL7aAaxQmDvuMFiv2u885/HpBLgnR7E0MII2IW6vzvtwUBLA==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-Fnc3fbQlYn/dJ3W3Kpd68QYfeW+9EMf8ON111CyZ/LuwEGfz9m0eQ2e3N/8dUfkqAZaCSAFvBDP1NpzWJTa9Ig==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -12214,7 +12234,7 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-QTlCGAcVg8AC8ukrSFjFNSbxe1XC+j5bn4GOVwKI66JWlYKpvjQzPwDnXdHZFdnt5+aZjocKvCPLHFueA9zbFQ==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-7BxumsP3MqRlvCwvI4dWszBWyj76ti/PtNf0sTLhclR1a62cshKmoBVfxIlWn/lfWE/AgluETdOM+vgKhQPxQg==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -12242,7 +12262,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-vgXncbiD2eOnB27FP0qR2itJPgfBduUBV8AxKbC4yTvqB7OdHkz2WXh5X94zKmmlJYcsdsF6twhPme4GFT+5aw==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-yoSs/EtC7G8DYsbTSOngt90PdK+nJ+mNkWd19M1a7d9sz/T3dmFUn2JzKzIwAH/itLS6t75ovE0FopByYC4eqw==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -12270,7 +12290,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-c9f/twhyMA2lkFw7rX5JDjltqKxX+HQmcZRTgR7UG/LxxmJ8w2uDYvH7+YOvw6OlFhWAWL4bmpQDD/wvAyvpmA==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-2U9/01Fj9IHhSgmS1LrRN+9hEzhTqLYLICakIH5eDzA+dNmyEfOdjLvUV6xhsxB2zJ0fGXKEGI9NA762+ZhbYA==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -12312,7 +12332,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-rT0qC/QNLE+bj0lvde8Xnj/mQCJh23yAvxKASn6Mdr58Z0HKGwnfswZDnTKWd4rCX7ZLDqr4YcuP6RSZPCJ+oA==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-HAkUIPY+l1ZaRvFBKsBPzbO05ntT4LRzwR6Vyq8+kjJyghBPVfuJ/SJ2DEx0AiIF0/xB2PaNHdK1LUS9opbdtA==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -12340,7 +12360,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-t9ZReKis2F1wSuzev2f71EDb11vE0FHxGVTer3zIKmNwDv9MbFNxTrxt0tsEx3BXg6KnYAXvcMQv9df+7NJZwQ==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-cQZL5WIOuLTwXqj/HZNlTo3gCuZ9GWqbcVHhkpCipN4zlF+VFds4p9MSjxPPQw2YVNaWlvMayKAo/ghIzd8ZuQ==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -12368,7 +12388,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-j1zbhDxRRF7ITIwhrViaaH4I7+SQc4wbbeemlzfZQOxBfhdnymItfXt6R/UkltfGEpSphG1Twycwhthy3pdwZw==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-i7JxuQlF46RFewoFfUHV73rl71Yyw3eMIMS+1arRWzZpGyvww7TBKoe9APicdSJyRYQBKIXo0Q7fjZLaqceveg==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -12394,7 +12414,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-ojo5GxPihuZ3Z+AXBb9HKSdWNJ0Z6a4CiSjn+MZwiqMEpRWGnAL42+OEnQBq38UQMHDnxjzIQiBPAmgOSQxVEA==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-pvIqeyM5IqwZiJKi+R9IC+YDVrhk5L3aFMmnWxRIdp5ANwThO8sA8IG7A8NaRsepecXvTUquQYklXci8SFkoig==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -12421,7 +12441,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-2GBbJuW02z1M2UO+z7Q9xz6f5gd3Bi+ugNLjFZ5tgXZN757o9JPpv5zucfgRe3lGPsBjlnxVqGXeef/dUYuSMA==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-bLZ6VP/4JAWtAoccX8ax6PlA5p1eh0yRPKYjrIfAWC03/9j2lJIT0qMIm7mdqFQPiOUmTWbVGazJx8Q1eIVw1w==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -12446,7 +12466,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-KdxmsfJUUp/4Yv3lr/oWitazctYLY6LV8uGaLi1460Js87BmeeRdq2zrujnEVsI5tGnU4dY+Im3+BkRGN+FunA==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-cQ/vE462ixNT9/TFgQANjagl3qge4wQi9fE73xrmRHu7hW1P+ISPBmZtkTtIC1bf3xWcqbsVbviEvirjjfLNPg==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -12474,7 +12494,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-fgsGuFAo+DFcOOrQNR9O3aBjDRO1KfI1Qj5N2OCk/XdkKZQymyStafFRo/tdhkaxzfdwjP/J4c8BxRjtJ6I9qw==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-VzhtaRdwEBfrBUr351J913a2JEyeGNt6a9pntY776N2lvMyfvx/fYvGFTRPoI+QWwQE7aM11UBjorxeGuLwgEQ==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -12500,7 +12520,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-wGJJx1w8LSFywDQNKgJM7DpuLX1SGlvvPoNcsMcJ9ZNCVodpowJ2y0G+OEM68sFlU2pUovY6bSUJCTbAIu1V6w==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-EpVdUeDD2YPDEKjyp2rsj9xW7c0lg+LMl7VoioZR4CFEikavuK+pxAPmhqvPU8enmW06BD+b+YLluMsaDbkEgQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12526,7 +12546,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-SXcYoI+heUhm9UJi1w9lPeDGPwr2V+bU/m2H/OrYODjF/QWX/VC0qP0hLE9wideSX/FY5o5IImAZoJIPBnbIpg==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-5zW9fLYsxlGdohgq2xVWa/C18IwHEystB5D6TZx28UabEAAYSC/wS/8eRFLEHKLZ+8yfhNvwj3JZTPlzBqEOQw==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -12551,7 +12571,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-/G6+xdtBe3y7pOzY4fMyCOJmbkcVCEWcvlf0Q73n0auP/Vy2yH8/9HZwW9fdihINZHFdPB2DjVqYo2gunPDgMA==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-Ac2M5xvIctX9OpKa/OOMBEm0pUPvM0HPP5pldW6qydnkvpEw8djILxZht1hVy5qDPBpW99FYSWr0IwqzdZvGQw==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -12579,7 +12599,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-vORrWtrmi71FX0n9cOyHZe0Iq/7WxqMeAiRlZLoSs1bRV76TJ18WNnM4nI/VOG1yTDZOkxfEKFY7Ezf0ha4lWw==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-2GXHI5Gx5tclFRiBXyEWvBnraByiFvHUIOLkprQKS5GUD97Lz8GuR2IA0Lf6VZSFdbH7lUOAOCWPApP0dlF70g==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -12604,7 +12624,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-NGrA68p/jCilv/EApvzJ/aceroY+PIir6egmuyDpFNCpc9chcmGnh6/Hgf/NiO+h6mSQ2SqDORNI/SduWqrlaw==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-XUQrA8q6SwV7XGHqTAZuKbdXNtYE5Rz+uAIHUTsJ2wUjHAvTPwHhuKf1NloMREScA3gOTh8wfyz8p0TPjcfhYA==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -12632,7 +12652,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-wgpCGG7aIKEtOMGXNXfqaJKexFtyMzhoDZik958KBAthJ7KcJaZ57u05OlC+JlC7K3+CiaQMVDNwYYezm1i7JQ==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-n/e+HolmZ3/H33JSP2fJaIwdEzilzJn8le5NqY7S9f3l2jhFmIvvZ+klLt/kOoZyhEv3I2ddkptMfLF1BFCXbg==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -12660,7 +12680,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-BBKdxNoXHyRJoBQaUtGCYFZAQaq19RMG0kX80m4GCV7O4HZWxTOCofjH/3QwwkFg/oSnPMKkefGKPHZnzJiBTA==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-zK5W2/qpGgiXL7E10AK1nCqjnJV8klb7yOoIqg2KtuwGwKZpSl+OzSZQJZcJMHjnaKrQCXzGiqseRY32xlzaPA==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -12685,7 +12705,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-2YZBWBA7TSWgsncXp6u6TonASJ5TNCaUyTXAiz7ldVaBNvggS5fWxz9oytkGEXWhzAh+gzWDJX9rH4tmdxdpKQ==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-h+kYTRElXiytQ93xukEL8D7yTWQgnMSuhCZMYgxUwBKwLj6AmFUOU9+YljVCkBQoGvS0IwlbkTkhoewgnqOGUQ==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -12710,7 +12730,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-7XuviBGy86DqZm4hchFOgs2g2nuElQ4rK66kOBEA1ifsWtOmkBayi4vI0lfBAHkxg+PrV+hLKAqS8DFEwLCWgQ==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-B4TYKJeSI5GQbkuwoIvLq2/QcljL0c8pNb9yv1ElTnVZsP03+9kkhkA4AQpnELk1q8JndP8B/025sh2znmx6qQ==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -12738,7 +12758,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-2V4zBx8VCesoHUBX6ZFNmhzlZ5Dm2LOAs1gTE+dyoF2mGcpt9jBeIHi3BXqulpVuG3EnJcGi1ZAP1fCh6YibDA==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-OKslbZIQQO/gysjnXmXbbD/n3NA1D3ZxFLFEDmuOTsCqm54I3A6tvFycMJv94uXpcbyDSih1MLkOludXofnbFA==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -12764,7 +12784,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-LQPxjPtL9iiY++XGiLTYOIK4lB0yRST1j07mW4hd7vOBlMvOoM7JfwcDrnDp4BLHa64+t4g1TmRtYeeOd1tt8g==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-kF0/hJrXJb7r/NxvYqQQ7AlKAjB7Vhlgm13D1E9SPTN+LgHoHYlNhTXlDoM8LDBmMK/oyCBCIRt+/e/VBeBAMg==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -12789,7 +12809,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-nTBpr3wCMvH0FGgtMbk786yJ1yMXVQsThoQ8eZJ4yP9YIdhkxQZttS2y7iqEFvKTsDNhpsbAAmQFsNBFVjDpHA==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-2k+z1Cr5hqzxufmrK5aRKmrultjAEKJ7fwkkvBHT47ugjdrH1kaqMaPeglZOc8rv3dz8m3S0S8VFqEl5bQM1Qg==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -12814,7 +12834,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-S0rI1jj1OtAT5UWDB4VrUt+AYPllYmxHNuPwb+ei1GqCdZgu3zAHHi4k+zItYa5nxCX4kawBcw/oFPpjN0MS2w==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-5/TLSlXd9qBGSQwHJmGadjQ4IuY/+YFK2qAC0ugdE/ubtr2SEv4Lp/QkO/FVj/ovcHdWA5WkfNQd6OGk54usgw==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -12840,7 +12860,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-A8QXDD9n2tUfbJh16qfXpXkd69T4VYbMGaN+QhLy1ieepSnLBNntAReKPNZ99XTfEOS1JCamExLVxYIBQxU9/w==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-SGYNUv+Bf8Ql/3BybEGZYucvQq8q082q3tkIbCeL+85cwZ3UiGBsJPKR6CvRvPqB8iyOA3RApnuOwUkw0bRjFg==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -12865,7 +12885,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-b9PwHG/l/9/MdYNXHy9HoYGXwkp51fZRhf5bsBzBek4f56jYEahUSiMfB0gGtffq+J0G6xZnHmIu/3XYI1Ul+w==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-DKlO9h+U0IJW6aBQBLpcjwUt9pGKB5Hjhg1+73qodi9biHur1kzBQbkt24fxyj221TlfGWGQLFu4zLe6gn5HNQ==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -12891,7 +12911,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-1i06q09d6Mqd1cpPn9vNdSkR0Wi1qVMwaCQGxOedyJAunpXJYzkwTjago7eMoVNE2WzAiQ2gPV4zRvIRX58IzA==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-fbKhPaL1OBQYsv+vNNMhm7FgiO9XEwAY5JEDyN+DPA4LEVZTcKI+igVDj0O+M06vPILxgiXMvtxl8zu2uEg0bQ==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -12919,7 +12939,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-VTkILgpeFPT5Ikenf0XoXHxjicS7EvsfDr7a/APJsW3RJ0HVFcP/y8IbaE8iEhZi/xcsRNEO/cNFSbSTJ7JWgg==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-uIu7AMlGAIRvCYnR9UhpUDyim/Dbym5pHkIr5EuGgSTyeDdC8CtauRPNSxLPm02ytnZj0pEBEmmW6nobXJB3gg==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -12944,7 +12964,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-oeD3CltmHLXpOx6BPfsoETD7T1tSEzBtBFS1anNE1LoH8RFI9E9xtywpZlasKsd4/yX7Qp6shXx7HSVlT2RZ1Q==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-Xa0mQJ7TWVKbuoOZ35e1MI69IgLvfw7e+L+6oQWN2+Wzg//8wbPPEXPnIf9hCu8VNL+7o/2Zwr6ucoF9sc3TjA==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -12969,7 +12989,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-ANACzGzb28R1SavTXwrI2Cz/tKiRDXIFNlxspsINDPx2TP6tzmYnE6Djr0vsbe5xjL/+n6qVMZlsvF5yS0FPlw==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-cy61JiinDhi+oMsT44xwd4yG66q5cnI2gzeslsLaSeXfxu5cqA3M+pH08j1xlydaGKRyJ2ZCnzIbvHxtlsp6yQ==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -12995,7 +13015,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Hl/7OSWXnooo6p5W8cVIh4Kak19G/kaOS8snkk6wG8PgPRrKR08OMVz5IUUKLeAlkylS8FpBRSX6A9xNk5vzow==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-4sb1ebTRsh2yWm3WRhIY1xcnMXPyzNf8SVFqifXSk46TykelyS41PhJCdHAH/Kws+bEPbPQYY4FNDGnZc9cFSA==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13021,7 +13041,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-6OSSBNwP7o9WOrZoaMg0pXi3c0m0kln7Ka33JcQlWdc/RvPXX+QYP3GB7JCugstKfT88TjyxW0Gqfq5Z8uN/7A==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-iPSaQOmOlRMI/57fcNuvkC5AHzXFbiVQ//vjCvZ8fnhnaxxNAUhyDISOE8NmkWVIhfGxNnb/xZa2XARPv9uvOg==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -13046,7 +13066,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-zntNp0BekAxQBbVw8wX59yC72S/s5a9ViuOvhLQGvH7qUEENRjCblCSCT0AMb0kmsLaHkEagpYH/pZMy81LHqA==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-gOBysTjMrxGSClroAdpGwTHbtgzHtSi1/nPL5vR344kH6oXrEOO8ZSzxTe4/c9R8DpisEk9yo8O1jnSflXM7vA==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -13072,7 +13092,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-DGakE0rD3qWGynszqUKbntKeP+7nx3AeqKo3sNLd7L/N0JR+X3n7C5V1orBUz/BpixpZeA9dQF3cTI9X8Ib53Q==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-/FZh/ZlwXDjqEVN+XiTlNc5JP5wB3SbdVkq0hl++MGbxxMjCb2Ej6xzdGPNCLvejXwEzA7st50dhdTXoAjpm6A==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -13097,7 +13117,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-tYj51jqPy3pmFOozD+5jSSz5JnV5OJHV3bDuBHWLr2zOgagFxbQ8/lclrm9NQahlADEe5kLxX6nj/7AYZ9ojKQ==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-Xt61BqQZ/2s9GhiCoBIavTOrsizzIL7zy8HC8trTIHP4+kimZdbP38m4LhXNhUdv9S3UX1yO5Af6RmQWLarHTQ==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -13123,7 +13143,7 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-JcfD3AWhQWLx794LyahmAHohmaKEwu+RcUOPcQ2Kyos9ei4j20/m/kRDoTkQX/Rf39vabW+8a9+xzj3+sUqbJA==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-F78CFFeLwnl1LZm9OyyZHy9Tk70TA6K2mJQp9mfreGhuEP09+dILKUbTFQTfqbbS+xTP7oczqeXdcXED55NWJA==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -13148,7 +13168,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-MYXznzGSlYDxDKQVWpXoRxX5ZbOrmLa4mMgYH4RDGWSLHB0hzPvVBEI7nh3/KAaM2gWxEs/tSNtZT+pdRXAi6w==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-Kd+ymBPARdoHqgu1N/dFHZzddPP+yoZjl9LMr1BmV2WFpKS2+oYnx624ud0oZfJ9SMC/RahGao6r2TkaYX1XLg==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -13174,7 +13194,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-axwEmuwZW+IBARjD23HJZxU6/uYmBK/qd9/DRq/FPMK6Kz2+aZ4ZI/C+WLNELsLQE9L1C6ygatgq+uJJypP+Yw==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-J7HMN21JDnYKiT6ft1ILlWFHeWGxHWmDLTxCrQ2jesxEjyu6prrcoFyBp+zoytDdYYOtC/ssDxfyakSk6t+9Hw==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -13202,7 +13222,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-HFu+I7zIwF9vUEn0XCmVEcbaQzbpiHpNwvvGslE0bZSrZNYWnbt5PlDplC9KcGOVf1sgWKnGizeDnYxHlSUQDQ==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-KydFvXg8uMedqlG/KKFFLNuOdsunP8ZnIJ//zRVtGyq1KP607cRSkGRbB67J75LMTXXsOT/5n7BJ5nEhRbKcjg==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -13230,7 +13250,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-WYuDNHJzp3si9AplgotIvQtx9kkN4uK11YxBCR30QreXJ9T091SBB+li0kZvPGYVqFEUhGcJQ37w9mU2lQ0aQQ==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-X7HcLq2nzlk81tGXkVvKgz0Fx46UHQoqtV0FlpLG2BScGhcbWi+tUqJ0l9TujKPHP49xlTL+GLLFYwp1KOS1Yg==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13256,7 +13276,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-4vXRXIavPgqDW9ZdhCbWsQxKTCtgwx1csW1MSIBX3lJko2gPSyxSEiHJs3CF8YkXk5iF5ol5PMvzhIhRz8RXFA==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-Vygp+DUXBKrorf/1m1HxOpFPT9kJVxQz++2DB99DSI2jsBZKXCQZhcJjKT0j/kCG92wUAilb7gHLyq9U1vU81w==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -13283,7 +13303,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-D8U8+JMsH4tRHqF9x7tlFMRR5+Y81k1xbKhIhDAcWRk362rweS96Fp+NPZPdFz+9j+dxP5tPKmzci1Ksw0J7cA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-DlzL1wVJ5Z6+wJ9L8rxaCdOAUrvXJ8WJrEWWdtTt4RJ66BNQMmiEaSxrkATXc5gwm9MHdbBLF5FrKDvxB84/gQ==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -13309,7 +13329,7 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-ePQFuevBWdp2C2a8xwdBlQ/2/+CEUVq0EryCXvRxTBKhSoKHVjpufG2qp/4TF68n+4SkgeJ+kXRp146+H7SH6A==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-bGCgl7pbtZQRUTT1f1wLurtE0t+rOiZSc6mgQ7L3FJIkdq7JdxX7t3xXI5oOGICfOloaa7nGzU7D//4QwamCKg==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -13333,7 +13353,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-oCw3Z615kxm2cgAzd3qtFmsTFSHy3e+AxSE9WMmMSfvqAZ8twVVb8MIeXKxodE2BoQ5efDkI1KT4z/yIOj4PvA==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-WjzAu0SayTjGWC8gcCEAgUOnpzGvghPT/vq2Wdiv95j3175TmfJuCI5v5tO1moYrC824ltkVxEVjrD9r4VuSYA==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -13358,7 +13378,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-8Q2DTKcqTziZ9LIzlQ5ycyqAl+dXdlsRdRPDqaWO3JkhSH+SM17j2tdkrY9hh8rpcK03Q5rG0lxYcfa0LXr1Bw==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-AI24nVu19DajOypXCOekIm68TmPLRagZQtmsr0krPsWuOGMEmgRebGHm0YoapxwXwoAdQuX4fUlqL7A8dTMcww==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -13384,7 +13404,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-oKWN6Bq+OGsuYM1Pxsle7C82cCtZ65Ts3FezPecZgKJ1wXU1hDQXdpnhGoaV4ZRC+2lof0dqWfq/pe9JRF1ViA==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-oPMXWu8zLFzLa4aMSOYXBcQNyOg3wqIljRU69HGAiBiVHkf0QUTEh1xBhV+cHFkiLDAwhNaOyg2zkaFjX8pmQA==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -13410,7 +13430,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-DtqpRn3dxck3ZcVCfmaf1tsL/a6knllrB201mUrJqQap5iodbQ0MJBmPaB2qimsdB1g/WediQwttxYOf/2hd2g==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-m6Gubj9K9dr3/Jy8CrN55409OxekBCP3AaVZe4pv6GH85SppXiGH50F+7V5a9VinQWDCs1HL/M43fy21DBduYg==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -13435,7 +13455,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-5PXG6jNP7r9/a2Kamki6uSLy4Lim87CWz/QxwKCDT2okc2tmTGQTlY4hdXGN5eIL1Wb3bmajhGk4xvsXw8AJUA==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-ZaEaDxy6vAgujp6DNyO87DBmOv9NuSEPX1kpFdgyiDCLUAfHRAil2FzZ6d7vY06kkmxeAtOiMwmc/+O/b1Y3JA==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -13463,7 +13483,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-rFSATajnKiUhPk+jmTM/4K09SAsJLOrd4sw7svNJ2QeDxXPgye9gkaCuQpKGc/sHxeVK3tOuH4I07dRaMB/Jog==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-Beny3h4rd1WN3dp+C2harxlIw6EXASPNr0Ck0YdYz5W0o1Ps7Hdi386+b8oHxx1DC6thoQdsrPrn/Hn+HjW9xQ==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -13489,7 +13509,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-tBfBSxGa8+P0sapqUQhH/7VYTrX/J8Dyk74veS6T1OSLBT7bdnvAZDfeDHzSipjK8OMMmWIcUAELarINFMYCZA==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-FiG4Rn03MXXR/IYGIZb5kyv/Ou3c1lXKGQRJI4NeaMEkMk7bxrA7y7O81I/6mRLsZSj2XBBSAe3Kv/AhBJLjdw==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -13515,7 +13535,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-mBlsPFbV1e6Q2evtFsaQAK8NRyFOqYIW5H/SMQMBbUYI6D48i182P3rASKX60cjMDBWgnTzZttS0TAQQ6tJ9Ig==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-WcgPteMVGAfkpZYTJ8aFIUvHV6cPFedZ0f3Je1P0kFo250U06PBj4A+SvqCjwXyebSiwvtZOsbYEKj7J7FwfKw==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -13540,7 +13560,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-qmTgRy9u0CC5DWJozhPvit0slc6zsI6HjCdoljAgrwko6AP/81HiK5IUFhxRUKRSbcKPR/AaYK9HL07Mq01EXw==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-N8s+NPvlg1g3f1cWjZFDmBM2rMUn33xrxAgWVEzp+UaGvzEPQniePv/R48pxLHoecKSmD6fGXv/PvS57BGeAWQ==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -13568,7 +13588,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-7plbqeHkq4xq4/H4yZZMX2IyPs2TZoBA/xNoEHPOKLhVsUI7lyXUjJ/ynwgMBYCOJm6TtdnnCHLOb4rZhYWOAw==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-CJ1MIsG6a6EHbY3ox+fqeTl1p1/jVAas/hW/Cdm8WG0/1PjzHusK7xle4cKvYhOTGVsK2IEmWjYV2LfTR25yVw==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -13596,7 +13616,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-DoRts1bOV92yiUeH9RrUW8eEnd1C17MKKhNRMhp6ALJzYrqh3ZXgJb7Zn8zX9KB6vdYGMIhzxTMH5ibbeQjC4Q==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-R9rGG9vrE26wtfyZKEX7T9rSxZe5eX2Ag85ulH1zmSC/nPA8TlHZNMdWxFdZYbOF3XHSLpful4pFIKeiQ4FZcQ==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -13621,7 +13641,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-dESebxa5UtA454LniHaYY1iaFPSpp8lEqHS2FoBsROqTOc12xc5hR3swx1LSpHsflore2wUd+BwgMKAuAW/KSQ==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-XdQEyeCULkHgzaFFtdlsrFSDd7rw/G0IkyiNtefdo95wvBl3DPEb6UdVdnD3qXNcpqUM82+PynzRKFtxoRrNIg==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -13649,7 +13669,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-hbsH4uMM0VU8/vQfNmPx6YML75S/tomajqTB5k+hdUP5Ey/aEbqRhsxEdZQVXgTA6mWBO+T2CcpTSS6ka3c4kw==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-yUvnAgXw+hP5KeFAzhZRYikS0vhc7acQDE9rPicF6hoPDu2rn987TbectbiMthu2fRmQoIiLeLY9S7n4ffD/7w==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -13674,7 +13694,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridnetwork.tgz:
-    resolution: {integrity: sha512-Fb3Tg/vEl6RyTxm7TUVI+lWqae00hiCbzxLnZxD0JP8qvgwMDo9xJY9nwkuvQHAg19mocGn3I4fGpzSKvGDUgA==, tarball: file:projects/arm-hybridnetwork.tgz}
+    resolution: {integrity: sha512-bSt4NzAIWfSqIcuKFK6o12X88NOBslQiRkfkFNZG5i5Y5ZfxO26HQwHtNmRy5uGe0/jowr1sqTuUYc6Ba8gtbw==, tarball: file:projects/arm-hybridnetwork.tgz}
     name: '@rush-temp/arm-hybridnetwork'
     version: 0.0.0
     dependencies:
@@ -13702,7 +13722,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-ejF/JWys9bv4/TO8IzGFBq4p2tRcJI0Gee5pgCf2RElsFxJGwaSdykmmVBO++NYCl4IT6qOLRTlMohWvJn09fA==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-e7GbkR2YSOJlOdFco0fdII0SSIdYj+nwIyWcC4Y2KskCHkkTJtL5WwAtqFS2TiDRc551k6N0tVYcy3/jrd2pYQ==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -13730,7 +13750,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-/C+Sq+GdVvQFiGu4KxirY1tE07wWqdFL/uMiilAGZLkPFdCMrLIgnTi/h2u9g+/rsf/jJ9FgOTDL30x+VvptWw==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-Aj8NrNyp7Ge2gE3My6MKZAqv+GEbA/jStr3WIjAx+KPO3g+TvRg1hT5TmNIi+geqYOCduGjgHtvrKnntxN0wFA==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -13755,7 +13775,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-g2chgBhbYaNguAU98q+7kJapxKHieI/aRPRuVUt8bPenQRiFidCxKkcER4wXEHpkB4+3F1tz3k+biC5QTuJR8Q==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-858fLbDvtPQXSy8SRRa00rRHzLsVmnQzRCNxX1nfuAPLCMAsQW7pq/8KTJUVyxmXB8FpBQ0WbceY57ymOg0MdQ==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -13780,7 +13800,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-k+3HsyGI8ew0cfwXXenLedX10WBYj9iAutNElhbDIdUv3HIgp5gGtAF/jR1znnXS2I/T+aNv1cFfAsjR7QA+Nw==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-zN9pwM7hMDnYM6/GxTRq6eYntTfbrV+BgbK+D/+VjAiWkP5qdAHq/x1MZgvniDuY2S9ipILOxXZcTh2gCNpYeg==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13806,7 +13826,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-0lGR5L/VvzAaFuWFI0D7qvcqxgh6L5HKsQfWMFpMwEwn85MnYPyKbH2XnhVRi2N/LlcP9z8zdT+AfSmvCYvPmw==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-4k5fEd9l1YixK07lMQkY8uf/hKyC95oN8I3as1jtnoX6m5Pa86DUXpYKDoNIg0n58jDDjLtzFIJxSVfx9ZfZPg==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -13832,7 +13852,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-zLHdnV5jkbgw0LOoXMHu1HND4KTQojpIHtBiYveRI9MWcczot/js9h9PJUDyB3eJ9DsIlBq5z13S59sOINldQA==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-7EaaFDMYUQ0y668O/vQfj2k/smzIJO3vINiKai7cD9ktCFuJMpDatZxzClbcTrUaFLhQVbDvHmRhvB0uH/aJKg==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13858,7 +13878,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-aJByelU87hrheznrcCYxT+he/bK0W1+g3dU2U3ptq7n9b0NqNeHQViHPHI4Yh94tKpOyXb3A7vkq8O247/tWjQ==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-Qc9POMYoOpkecO3o7+1oDos6vXWSkpT5b1gphTmgTRdZjLAczsjV8tiHT+f+beolARLQ5zFdBxmx+BjfpcxPhw==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -13886,7 +13906,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-kfWj2IJslf5tsHZRFustYozveHwrp998PHiQ9kOVr8kZECwxVjsH5kH4XfH+YrWUjBpBCAvgjXo+Bx71Y7ij9Q==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-4Jj71hyFkdeVK2JIsOtuDCgwCScBKTQrpdVv3+bdTYiownyei9TrF9VABohBvTUKkf22oSJCjEV4dzqiVheT6g==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -13912,7 +13932,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-WOYXJgGHUZMtPmFpo5invZnDYUGU+R1eY9ZZiL2D3jFh0JQWT4s0EGfkrL43cj5FIHkFg31gOoOIs6T4DP3aRg==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-QmZn+rYEILiTLzw01YY074BEomKvtvbKANd0GThfSim0AyKjns0f3Z1h30k4PGK4as9G9icGGzhl062L7+NDQQ==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -13938,7 +13958,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-wPDB/VqgzWJFl1sQICvG0lKRHni4Ik4KU3k5TA4WcsdO/QKVbrxumZagqFcx+/DkR7nMbeGqvJq3rLfoOuCg4w==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-cHMT/OTCS98sWisidUdrmKCHypoZ5dLOoDHHo9Odn79epZGSMa3bO5w1PbtQDL7gaMGmJ7DS3VRSfruPwAW4DQ==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -13964,7 +13984,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-iO+KMEN6URMBVFq3M4wPDBXbxsxL54jif9D60+7yCRISnpQ1EM+fcEhY5sfJEygXmfR6pAAvYbfC027XxjUmNw==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-iNtONSuE08Hwhgu4ZPz/pKdFSBXEUlNJDoFjY5YI7OnTUvjYtY6PWbjhiY+IEpHFO5DaszkUcBJ4SgD/als4WQ==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -13989,7 +14009,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-Zu2hFqTnKLvOsT6pBSFhKAH397z378fLN5lKDqWtl7m+H2y39Ms/hSa7Jk3eW/r1hf+9fwkQp8lnH368+h6Waw==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-FYZPx83R81/DuDk6K/xILizEy2C+l0KM6OH8jCbr3WD96vJ9r7WrojJRAddaPmaHtkXNMMDZdF0ATfgJT+BgxQ==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -14015,7 +14035,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-q6GwoDiJYMfgSV7b+QHUb1xpE28ErFP6dru2gwBvosCIPE2w80IXKHxymFfCboL3t23cQegyf4NVRJfIhffk7A==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-gQZ/dUEOVKBZsBLOIsdpevlCk/eafWwKZgyXbUvUotSydKD4F2nAbWBUDSMuEYnYWwBihvKofcloZL0rf044Gw==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14040,7 +14060,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-Gk6JuSwUHHYJyRqfJMtRGtkfXF4w+PZ6e6wjBrWuuFXnabzQtojqQ/h7RnRhfupCbHki6EO3EWobkTVs61tGUQ==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-Bj0Who/LrO61WZ4rnEH3EE3CCyVWo3CfhDpmDWg8zsgxDdDjUheWQZJ6UWYZtWx0wUh3ZMfNoqbmwD0bop/DUw==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -14064,7 +14084,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-PSzdDpIUkayJuoc3dygVBV8eGQdmtqSC6mhiPU8f7ViYzplJStyq7UarqPxLpDi7WII2msjBzSWbtBGd3svqBg==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-NgsntKbKQFR73zA9+wor4qEo/QbzyVtkshwzczysQY/tUtyPvplv4bEP3wOk1RqlOm2MRXNgNwSDJCvBGDI/+Q==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -14090,7 +14110,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-9m7RSg42v9eT54DDy90ZkXtl0eHzj5oAU8MIY+gORZ6k23oKO5zwotLfaTfMuwn84cuDcgKt+/e/ejY5ccHFEA==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-GEmoHAIJBhuUeC2GfBWEcG9AXhjQ1hh/CHJ5uwM/4fiTpRgxr4Sui0YO60TFHSjHWIH+NGjAebD8f2A/aTs/Ug==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -14115,7 +14135,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-8hN0Q7DdCwPrQprO65Tnrfwrt+vbnB7gVE7XSQHK+KO3L9wJPIQmHlLlA4HXLRnHaeOxLuZo6O+D91HUSoIgTA==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-Z73ZZ11IJh1/gPssNnBWYuPYPoASu7BzERzcadCN6yVNMoW3WXjntY5ixAMsdLn/LbdcWfVb2GEk7umyT058SQ==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -14140,7 +14160,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-90d06Y8TyxsJAMYsWHO2CkJ49DQdF9SV3iprjk0YV0jvq+h6TyU0fYOuWL5pcHyBJgLLbAhwgyLuPW/d9IDbrw==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-SgA1RaCjuV63dfEnecEY+OBU39ffmBgfLXBpaYAnCBFmOYTFY/+vDplW0Sppgez2Sa4CenUxll4XQz+SRr85DA==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -14165,7 +14185,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-bGdFY179VFFhGsC5KbiRxmvlDGLM9v57q0//Y+COeuQTJJJzwvYXvTH7xnmAEkU+vkLk5rkkiXb00JhUXtc7JQ==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-XH4DVvRNlEgZwMyPnpwt8xBcS1O9wLDAN6SJeHKkFeVP0WfBgf7fB6rNPgim39LAme3vC//XVf7p7CBg+3xgsg==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -14187,7 +14207,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-gSbXyHL0GCHJtdBb23oqFrJl0VJmY01SEA/oqVKWwNl93fbgFTfAXblQBF0/B7EK0kjoaNS9KF0pwxAJ0uFWHA==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-m9dc6TIIn/Ao5CG5OwmmZvxUlQJ08/hm36ZxgB0PTfOeu4AfVL/BA2rkjh0fRjBUsWZUSACDQsXcPjGMIYSWAg==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -14213,7 +14233,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-l1a6sy/WOr3jybyeRGxz+5WCV/Bjtwyw5UXf4/DEZBtaboucYEgbYDas6kMU2WEIzgx/kvHmpzB+//VfGtjazA==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-mFpul9q/rQN5nbevZU3XZb+SZdcHFscbgD7UK48xde5Btj93O9kafWfldmEdca6zMa9QXxbSPnT/TnKbwsng1A==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -14239,7 +14259,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-9XyVt4aPr1OBOJAbi1Enf+/Awvv+E7nnikbUPy+SIxRC9YFE8jpe9tURRq+g7w1BbeohLGt/dlox7hg8230PCw==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-/pDbHiWxdsYEalmGMyM9cWaq5Dc4uMN20xUEv9gy8yQoP4nphmssh62FO+EX/1P693e5w5YEKILu4Fgm2zk3uQ==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -14264,7 +14284,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-uEJAKn7RDt1J5k3cWMLkETAFNjdcPKgwjzebETnJ3KNrB9upo9PFQMTpFmF1I6g+hulq+WIQKQ+JkU9Y3N59/g==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-RWoe2mWIHnAhRXc7BC6LEYhjbHEGCIZEXUjnnk1QSMGOU1PgeD/kLxONNyibSl3t6jUOshTVaK7T6ULV5jEZyA==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -14289,7 +14309,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-VcQbT6OVq5Izit0erGR0BMV8jHV+IYCudhxJ1/ostokfjMNomx0EBN5W0J/cDQIyGUzFmCuUsdvVpfnM9SzUUA==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-cuIlwFiOduEccxgb7D5STjVyGLr21fO1LWCi4O3CBL1fCVAqX7EJhqegNBDLtCesHC0c1SpEDq3U5+f1dFZ0zw==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -14314,7 +14334,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-G98EMgbKH93YuOxKIaZjXyTmzAydfqnPvkZASgGA/+maH6/XCXJPDwi1yUNtORe8dvJ4V5KBuVYIUDkAJpYXlQ==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-NYra/zL+afBCsePrVh4BCPiHJajmdqm6mnMtEHJR164oMg94zjNYBSB/TUKWt9YyAtZHkjdMbjvHvRh1z2zShQ==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -14339,7 +14359,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-y4UNliM1f6/uZtmAzxhR+3p+B2R97PbnsGqwP828aIgeDPCvH/TbgEPnoAYxzbGk1xn2gv2UCFzoBWG82sAdKw==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-o0gPbHWTo3Uxp7RBvK62LBuoFa2ppwY1nQCcl/mxsrgw1opZVgtaJ2AdBmEPFYxYTRc57opI9L4cJg5AV2rCQg==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -14364,7 +14384,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-4+jyby6u2Lx4IOjiOETjLoDwgABklEPwlfxAw62Ry3paiyDrx3cHYb99q3zOeEVg41K93LEA3gjjigdIJ7JfUw==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-we5oiXpzCZM4G9EVZkywUTQeTfh1KzNLEEcBVcday/JhOtPERShqTxS9tOkAE6zMdxYqo6JhRUtBxZcBqSWQiA==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -14390,7 +14410,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-Upo/7hdVFZmnrFqIRfSTx8KCG5n5rvUFinu3ihKVO9dy2Y1HQLCa9mFC0W8lgtz/PuZa4BbUNX1KMEbRdt5tbA==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-xWhRPzBwBQjESCe9Xf8JGf96lCcgGTzpL+Vo4PSnfsv52l8vJ3xoCfGD/8Go0rWqhYrrxYXlUv02R5I7b3JNVA==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -14415,7 +14435,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-X9MiGtBBoBuSxeOr5Ycpb5R/4y2kPP4P2uJqAPmn5akuGZzO6dgDFC3YcGl83siah3gJwe7deoo6Ob57WdoURg==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-gvRdqOGmf6Lgwu6F3MAzEPdWDsfZjtUFgp94KWicqMgjNTa0FnMeT1G/G28mbMPYjk5RPDrV8hHyf93sHqVsVw==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -14439,7 +14459,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-s+UWcIBSBAEBgB4Ahce7/IiV3vXW/xVCj8J2CrvmT52ojBCJVwAxKUK7mOVW0KHJmhkBdTG3uJrLQMzANPLshQ==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-oyZ075vri6ziDSNjqFA/xjsfXsn4vjNNiuIz1ImmDieA4kQNIg5yoJVj7+S8uLg9zECseBNVWP9H23WpMVPJtQ==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -14467,7 +14487,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-IYL3WDCU/pwRdgaiTcrR3SdsDYfVk0jFEjoLGABHJDCJrlZrF61OFCa5ARLH29wP3fAyiC3ef4aaHWXLsKBpEQ==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-2qjEum1GexqNsDhY46oMT8FbTwYv0rJme1eUyMfr5u+xrMDXo7K1zf+LQ8KJoyBdRUA1fiwUKqfN0FqtNgvdwA==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14492,7 +14512,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-Y+b6ckM0YUnkUS+k8g+XALyerKTgTAQS2KCRxObck53gv24dCw5J2q0BV8xxXW6ygnBhYVo/9Ej8roDm0o9GoQ==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-RDSHN+RUCsfA7toKB826NCCWHBexULo0PDky2TQGuhlYMUJYqQIzpcFk4rOuKYXP+JtArTVWj8uxWGfPoCar+A==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -14518,7 +14538,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-+yENDrRuAz9Gm8N5zzN1J/Bvnq3CjDodyRLLwoK1XQJn5ZBuRO9gp4oTpYrWTuoaXdyHy+qLC6EOQ0ZOngJ57w==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-1eQrNzbAlQIUJrxg7213u2lVxWjRz0lAWEpmUAYNKN96vBVXF8c+3E99gIZvWP9YQ/eenannT6EPCy2eLw8zoQ==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -14543,7 +14563,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-E3+ueORV7yERXbQQ9mkuxIVnZsB5Up8pOvA2qAx5wPxgABUVO809ACj/zPAoq5uykPRV7WT4ImfCbEDxC0NE9w==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-wnID+sKcTzoQ3HmFlz++53h3+d5eBv3gPcJTz4I7XiSYO8Dob2pWnlAU0lEfQtBWceTckNLIiJydD62kjx83OA==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -14569,7 +14589,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-/HVl5dxlaZSBzlRdAYvcwO4UnGLrsOu4aFOscgqzUItsZlGtcsMK+33rjQbd6IT0i1FN9V5hvb7liGwctJgXQw==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-JM1Qkk5KMuzgNxDWoJU1reYlvY16AmwphaNGyOXGYUQI3bvl6c1MRw80Nl0pUMvq6cwsAFVYP9819lZv4FRmdw==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -14594,7 +14614,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-8G4nzEO92tEi/hyypn6z1SA4mhnyMERFor/PGMHinxiiPGD1QuJ03MEm6i4MGm9w6QuHXlm7OmE1cZ1mMbx3wQ==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-//WXow/OLpTQPqpWoDj/y9kcaXNtWvkdTF9Gy3ylbBHO2P0n6uv2tIS3u7kgaRihIMV4hhy3D2puVacvMQFzyA==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -14622,7 +14642,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-FGcjcU6JnaXmfiynY8v8Np5F5L9KG2XNjXqfKb0Q7RZdng90vwd3U0qhCoh4yUww/wqoWcNIOLZ1F8tZ978IfQ==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-TjyTXmX/0KsHwsqM8u4j0y1LLLvr7C7rLxd9kOPiYI8MpmursJGFrFMnJxYEHvHxQ2OiJpPCFWmW7X3IaOiMdA==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -14650,7 +14670,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-aP6XEztrRwtcMOzIsHK3fSD+HxJ7N7y+CX2ELaqK9CfIu8zGmfkSZsTZAhar0antkFeBwOeZoeAjs29geU3dhg==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-YUOVSMkTt8z/jN4kIUH5Z/OqGjkbHKxaz+pPcqryHBFYdSw1uOf9dlP6u6omr0nhjJIndMGvlW1twIKvIYOohA==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14676,7 +14696,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-yYVQb/cbneHOBrxNROFIUi4ysfVt+0ObaBEUgdACFqYPkJmk5JZKcjXEpGEgbsrGeBgR0RGaSlrCE3bP6+8bSg==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-SUkmdMRq5XkgJc1ZKDrqonkdv4prdmZWyyYvpTBV/USGGFYJ7eZVkVD+7Lz+GMHKUxj4kK9QjCmiIrMmDhE6SQ==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -14718,7 +14738,7 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-mk+yFayOE9gMXFFOFyEEIyvLHzVxV+KGLOUnNk+I7RjcHEyAPMz2Bog4XunMFjVbZIH2k7JOTEOCKBqFSRMncw==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-hdUBbkh2AWhdKLhCjRAjGviEMFvm6JueIxxfvloLmHnd3IQHv+wyBr2pxmbWezhfmhgTEPU0BVTulfmvbztsiw==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
@@ -14746,7 +14766,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-tZVwbrHux6GWmksyye1EoBsIucMWikIG7Xvpmpis6kCSdkoQI7eBJRBdv2RmcVUAqiunkKN3d+6DswwpR1CBqA==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-DBisz0pF2pM5ObEwaBkjzvfibZFqqdik9sevl/WXluQcigMybv8z64ikKja/kd/+5LgM1HNUCAnS2+zWDgUCEQ==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -14772,7 +14792,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-yFjZifEwNshRb7bdjoWN7kdj+WqVY18n49cC9J//vZ765L2Rzp1BlkOStVr3Qq+lnr1G2SGN4OvvmHmPIQt1SA==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-Firc/+i5Bh7E9/5PzOzIGRULdDQ1rAsppfjLz9BTccrlh4yQaPIgr7ypzyv03oK7Q9Vf2HeGDpWXWP3WvtX9NQ==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -14797,7 +14817,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-3a1c+3YdUXbjCaNfDxicfnSRP7XAYBLSyugUyQo6g4z6pik1PBWyHJGGFkjdiejRTYVRuvRfwA6ZYcT41ZbloQ==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-J8rwjVRXpM8dekA0G2BcK6f+i4bct6EUlPYOHuwh90hz6L6wm4C4379FHLX0WkcGt1x5rpiaEgxo0GFC36vUmg==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -14823,7 +14843,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-a0w08AaZLRdobGyoFYUYM5RtDHMRfQqWEQmHMlcT3Im3EKX5FC6jsELzeEKZXrSF3onQDAXZXLEIIFB2Q9KLPA==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-3LTjWBr83oqQ7hU6wgqdslJGhhbUpWxqT7WNEsMlwWQLZl0o16FJ7R1x7uXqvzDUNshoc45gL5uNTWAlonEI5Q==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -14851,7 +14871,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-LjQ5gJbcjwbj/n1fguRJoMlRCeEWWfLslwSiDAfwYAnZD65XCj5EhVcLYi1BkDG2B6NvXWrzn7QDMXD/5nOk3w==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-HZ/ji1x0usrynh2ki5izi601K9mSLv1gtgO0WFiRyU5KpHcZX9p2dKa8Ukb3o+9MthYfUNtNDTITM6hZNZCYBA==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -14876,7 +14896,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-+MQF+njv1o4fwlmWTdoHZ8RB05LBLt9t2rwS8lcm2NymhzH7lyJvGsqCNgN8cJn4Ja2ar36uirEJD8NHfOb2GA==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-6NvmF9X1F8dGSqfbYVsO0f8on6csbZS10Fxi9NPUyG6mJrk6ArdxUcXuuedDaj2vxSe224PDdNwPXqHvYW5TOw==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -14901,7 +14921,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-ul3xc6Uu2qKiQJ6nRT+wFY8RT2BTg6LLHH6JOMek8qI1xLrbX4c31toxnFb1tBIZMYK1yr4OWL8eavBTWpQZgw==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-ZcawGg4xeLENW+3M+5mymz2uBD4oo+leQRKb5uPhazSPRrD+2fxLkk/HPSM8iLLPCpanGdkz9mCUzYzfPbrgLw==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -14927,7 +14947,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-gjdrlgix7UShdm43M12fZheRDqDb7191OasomY6+Q/DDEc5WEEjbjZ7xnnebXVqJOjLh91Vpc8Fb/En60xYEHg==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-rKEhnv/hqP6U8uaI9KRmJhQ3rVkQNGDm89y8Gh3R0/FRQ7d06oAEhKM++ZQWbNpWEFMYXXdA9NZTYnl4l604XA==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -14952,7 +14972,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-fsv3wrsMJwCTdp5y//5IO41X90ikdRpdpJzwevlQkucnsucVY7HO0DV25sCDFQWNV9brvxe6BkwsjSPmNP4epQ==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-OWpHYj1etX0KxJpBjK21Ad9xM+RcYofVm/Jts0455ux4G+tNSvjVqEfMTEMGtbLvuxWsxgawEj1IGUHT2KRY+A==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -14978,7 +14998,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-SRNoSlLUX51y6DzfMjgPNV5KMB26Nfdh+tTD5zKl3KWavFtEbcO7vg1KPoth+m/SWDNEHkMjWYp6c/AJ6R+WuQ==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-jO+tyV0atiJUmuvqyGpvyTeO9CLykB/ufnI8JPCh9m2zZ2KE/ADjG8SlZwECXOlPZTibux/f5qoRYZkJes7PTQ==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -15006,7 +15026,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-uIJuch2e3+XekfSJgX7A6jFiUm0iD0Ze/5iVuSqUOUJJ/KXNcLcc4eMPeZ91oi2U+ZEvwCDytlnVvffI3QRyMA==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-QTZD5OinHMZAz6Wx1GbyrCp6i+cqd9vqE4oLk6o8PeqxAT2s0rcy/LbNN4iza0kZWnLQuwGhMOeYTbUmQQ4jQg==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -15030,7 +15050,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-qzLf4MKJ+CBVtq1S42784cipFCBaAXDhZaoEDpDfeF7aRiZRaDxXGIE1u6b0PyGLgydUXjc/oOPtzScKVSScoA==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-rYJMTReaDsrbPgG9r7g0ga7cQ7gQGrhv5+RKTskQhSUcbsm4Rg3XHKXA9YZSQL/epmXRXOkouz99jrUYebRHZw==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -15056,7 +15076,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-JYSmP5oozSdX+tywETuoPsnhoVZjvxum4safQ893nsPhxeJPJ4JikUoRhoTpcvUdgtIlA2PCYw2JmT6YQ+m5Ig==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-wzFUtSADoHV9Or4DsGjjNiH+PeN1WPCpwH5ShDCKWsMD4cPPbBwBv1eeXmjoacJy7LB5DRKN/ISqWzSCdFjf4w==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15081,7 +15101,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-uFACqQPunXhzaFbjhkKzvZJaoeOvvY0hMFsUuEPMuJ7RVVopLR7AhDddGf8tGmSI+avDfAWq/q1SKPyW8C+Vvg==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-iGTYr5+bappDNnZbiu1Q0fjunaqlqhBOc2gv2E3rMfdvLfmy3aAXzzWVZTswHm7eB/RZP/a5w7Evg//qvrQ7bQ==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -15106,7 +15126,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-Usb2EfNyEb9Se/0EerDMlYOGQEHIWqLvp2fGSGo4qu0gt/n8IA0pTlBTFuvk+JHdO5PQV2X8ClFoA6MGYm9UPw==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-h/zPGqudlckh/7gEWBFXNv45NfTr0UHsjfZ5Q/gRYqlyJhOkhKeSO+J8j9ks/hkAHIYAoM2WrXifxGY2c7hOgg==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -15132,7 +15152,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-9H5RkFaVH+rRpXnau8Pr1JxXG4ArL9LBirLqONKBJS6BbCiV1OOVServ2yoP+SR85QMVg7L5fR6G+Fav2bQZSQ==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-lXYH1atCqQfsKOFm/CmtXmEDvXqw5w6v5r1vB9W/aICJ9sjz0Aeflex3r63qfqZemQj2C8SM+HkPS+8sAUkVvQ==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -15157,7 +15177,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-cxWNkyocOgMJpzaiieyI1XgycSzx6WTMmuQBBEHezvqoJO6CMHw9rbouUpX2h4GfodIwrmTOYzqpPKJ63NpBlg==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-E+yD8jgmieBlQ54qp1ZzNGBBXUXm3jM+gvCIIVy6Xbg4Mal6+OfzFIoe4+1rErUef7TXIJEHYx8EfId1wibkog==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -15185,7 +15205,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-Rr4/FkHtH/3PkZNj1Eyz3CWbxnGLUuWIMhcbRrbXxVDTzjNVlCx0cot92X/4biovMPmFfORJFIf9PtMyHGtNSQ==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-tW5YgQ7vbfo6rReiBBN7DfevLEgg4MIcZXaqLdklG+gQAzaHbsdvbS2fo3ZwnLIgHWv4OhBuMQSEBwuPaeIx4A==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -15210,7 +15230,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-Uek/THu3jG6Yc9VdJthXRk7dOiys5boCk7N2XUV5vulqqvwZpUc0NQusNJw+1JDXZ1tlMOqN9bb1BnfCpGcwHw==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-6TdIwaUI/LeKSxGx9yp+R/WZvNh/3/0j/0AZjoTH3KYZJa9W+0yOiPsZvEb45GmsCAJLRpgJ8kb0Cl3C4jpsaA==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -15236,7 +15256,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-Ysz4zd0MIj6HKeOI/S9aPdErgQDJHle1XPQYAU1XE2LpEscApBEA4hQpAcQW4W24HlgwW2YQcITjB9g2aQiw2w==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-li1HBN/Wtz9lOQjTH2IooS00sWtzwuJWvgzMIwMdVVEc2bcycWxN37ERCciG3PYJgQxPDHuMOe13NIrTdml0Pg==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -15261,7 +15281,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-go4zj7Ep+h9KM5lU+d26B8EalOz5gQKmIldO1StDRntuVopbRgvyXKBmKTlPBjcwcFTFCv35J0Wi5od9XLuOAQ==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-GJ846B1sc4JvUDKJ0nxijzfCvinLu2LKsaIK0JC9GkLy1PjsiYtswnOhXKx06zq+DxbZVwUNuTMdOdwPPAlU4Q==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -15287,7 +15307,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-PqvBCgR0mOWv25ezPsjWsW2BWniEuZ2GQhJ05CCu0Tuik93SiUUrs3KJ8oojbR1Ac3FI+JDrzQzlg0HExEKcYQ==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-NaH+x2bdopnEJ7wfPIdHzWri07U5v52tY6xiPn8eZXW+eqOrxziOiBCgqj+ReH4NoqFJ7UPjgb3KBTtnzFx2kg==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -15312,7 +15332,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-/OlfdrygT4hE0ipX6TjO/rTHcVZ4Svj5QasTrgyEDHbXWM8fuHqh+/zD8iojHFRKu9esUFLjf02V8nyxJdyvoQ==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-twvU8DfnMgQGCiOBhVTvM7sYxTo4jgZ+FuAKUHPTMqNdXuGlX4UgMDIwi5ZfxKmmMu7aCLKLelCkEWHa39yXRw==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -15338,7 +15358,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-KBo6ddvCcU2+Fca+pInbxAaw/NbMptFYgafyQFuq/+W40i3mz5RWW0QivVyAmkZ3iQ0IlV14AGeo0cZ3qOjcDQ==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-/WVi9lUNV5B8iHEVRh5l0nq79W8lrhnskY/RjFTCbtPZ+xRdtDIR7gZxGvvi+i07Bkmn86DJjoewlPOoclrVIg==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -15364,7 +15384,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-OLsuozoTLNHAMhEo+g7RYMFn72HcYk5TYO/YjmZCm1SWBiIMXt5P3s7N3CWmCUZaSxodtUHvRUfS+9E72pmooA==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-JrEbdu45W3++LEw10DartFbyEbS9HYi9yKBE+7GPAqunS9L+MUpiGyesPAAvZ2zHlf5LL3dsfxzTG5/yVpGtkg==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -15392,7 +15412,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-YayAaoNYLEAeREoZhWid34DpCcTL+REsg27lCjyR8PWyTdk317JF1o8eWxl4uTk4y/iJZw/dfQwAMha/RqZhGw==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-1v5pRNZQPA9cQylz7V+V1juyeQyDN2IXf/XqxuBX4VexXu3sjdxif91Dxb6Bkm+b2lLL94UNQE+5J1Dp0wGh6w==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -15418,7 +15438,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-rzXVwRaABsftGZZyPXPfYti/UQa2BYLPzJ05PbBvVgY4rSGxnxzNr8yy5vWOfMTemz6aW6TQs74l3JbuFAc/aw==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-fKCwOJfSY/wItPvuvk6+hEeQZ6/vfyJmy5pw+IUyy00bWrLUFsXCqad4qcA49KxzPEIXYfNJGDZFMB5sM8RTxA==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -15444,7 +15464,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-0Ll7uvdZ0pLtsqh5qMQNL38mThrFCXIsvz0F+yXzLRR6OF8e6qZvhtdQm9pyeo7MvaSL3WITusZ7rL4p/x8ylg==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-/HN/eE53fOVpZ6F7wb9OkJlLXhQYCbiPJj0wOyv38MBEIijY/1MevOGaTWFxg2PxHz6HAYhM3QLYLVOgIMA1ew==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -15472,7 +15492,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-X91lp+uS2yVDbnS6ds2Htz3dKH+FSOSVgNeL148559atRdfFwRnQcnyE5kHTpmnFou8BNvEf1gKno9Io4h489g==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-LRcI0DD8CHWlbIDnhHKHA/zr87I3vphmgGwaiZfEc33OhqmjKtSrvgnl/r7E8y/YQh46tEvOE4x4dePGRYsEpg==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -15498,7 +15518,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-S5DSg8nwKSU7VUfbRBid4mgArOCLvO1qda5e/jT1hgurWCFzLPDG4yCqb53Or6trMNoylQwPEEh1A1HugAHO1A==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-DJdFKGf/AiB/ubKpcgcafg7Q1NPpYZvkqwKgqiJbnOXBeTPY6hkOYbn79L3wxe/mWBiNKqt5ABNQo1wdDWk7TQ==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -15525,7 +15545,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-/aDEFNF+IIe1WDA5O6yZaq/56lspBZounSndGdurSEyUg8otuzY2I+JtUwI9cHRTQCCAOiZ/RY6c4TledAZmkg==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-kvuHU5kZKbu5I5dievjH0JCKPR4gN8s0ayBA4kWja3vMBcAQBp55IE92bdaAgd38FkpuumaGR1R0MOVt4zddoA==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -15551,7 +15571,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-egRzAuAerECNYDLdakt0Rl6KNzuShB0//zJ/jx3zhQYdW6tjeF3jy6OThmfgAsAgh37XZcH3RpTSerKUYttucg==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-KIDKsR8CSh7VSFWdwLlCmw60tGWmPsO5bOFzROm2E7oObIOlCx8qeTPcZcrFGkVG7D0AGFGTpU+86CLuOyl1qA==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -15577,7 +15597,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-xubRrkT8E1daRC6MO5GjIvvjnA+FgR6TgnYlnFnbXfATzwewW1+IhaZ9oc4P2WGxj9OmpPOZmF3rbstHHKca6A==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-RdzOgDyFn6w/ExuSoxpI4DgCMHDeFGVzeWwnizOLlVPpikxDllVLuD1zf+/4T6bLWn+BhjrjBf2PvLReJvmpIA==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -15603,7 +15623,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-n8ugwg1RT9NW+sapyxvSLNnMEvInGh0DqP0eF8XJuIQ1P6Wx2Qz8WZ0p3CiW9b//D2r0U/cSMgsVcvR+typdFw==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-N4S9JCmafJeIl+gTDaILEHmjs4ojDf+WNoZ/htWf06QnTDusmTlxAY3BAti7YK9K5tMUAsW7u6st7GcMNkdIXA==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -15629,7 +15649,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-FOBE/K1ftIbc56QP4cz//0enx1IYRzKZGsvdeSSDg3zML/m2/x0PjQGyISjJ6zJCNSg6MzGPQsXili44qTo+sQ==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-AYd516ZXKpsgvy3GI5G6F0VJwGeNpRjM8nEb8Px/Gcbtjxzxdaq9UaVnZR4/363elpT6CqdWkYUWLrhrlXBzGw==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -15653,7 +15673,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-JrWoxSI+pSsJLqtMzK+YZ51Ef8LfCKENynGZfK9ySpkWy6OEFCDIdlKY+jFrVV6r5REkLR/gXxbxcTEcB+u+3g==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-T6QUGgIuRx01uJU009tIF7qSXQIlgGKzX0wim75Ry+pp4oHTJd2vKbG5giu1Sn1/aZ58Ege2YZN0hYKBpjiaCA==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -15678,7 +15698,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-kC6Qz4PKoU/GZqPhYjoES0ym7dQlFik7DUXoE9gQCacuD18eLBuvYnx8VX3s1n1LL8s/5n82FWjpvZYeVPP87g==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-qb1OfavxvVv35oqvCUL2qkpvSvOfbARP8T9SRobCtsLt1JVVVng0nNftPXmaqTcYowgeZbxvHnfaxEt1hlq4Ew==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -15704,7 +15724,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-JQRZ5EgXIYoSh6vTnaMeygBhbFwASKRgWZ7ctalG+GA/EOqFvzy1vJXkMBtlaGzDobM7J8T8pHk3o2v/VqC/Dg==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-9+6ZVaiUWW9LmdgOqJ+VTqLxQ3nplWECCW6452ApNuL5oqDwnKtTtaaENs1VBbUGnSz579gf822S3Ehe/jB7Mg==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15731,7 +15751,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-B/cPjPZWdE8zVv3IaYEoJn1SQY4k2+nQ8WGZynTZIas3v82/xTjZkz5/WWVxMj6ijD7THsPnUs2LZ3UDo/toDg==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-VHpC6LF062Ed3KInursxlyGmDfBTCJdwiBuwbYk6cMpkvIvhX8tsfSjpUSvWs5rcb3xRYAnUVeE3vq/6FEeogg==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -15756,7 +15776,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-CqBtCN7awgYs09a1Dw5iwbAAHbI1xNl6dan2MFXvRuGzASVwQ0aIw29cyeNms1x442r37djBmNubPA7rlLEcyQ==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-rnfaxcRRQCy5FyvbWdDG2Su2ukVXKWLJovsbDv/d6qipfoFq78umzl2fDWAazSZdg+HFelqfuqoZINwHRVO7hg==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -15783,7 +15803,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-UjK+KOiERaY1PIAyr1+wzLDWmI9ilSbg3Hn+Sqp1W3eRIiuFIgJ3tn1wi5VG1C5pky3aWCvvTtVoV/zQPxPiTg==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-q981wnu/bNjRORqVY/xmD4pBbucw7ugtKyHu61qVe294q5Dv8T3lJEGbAhotOHVJjGZEVp8N1DxTdKx40VUvYQ==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -15809,7 +15829,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-SpSW2edBY20MOZRUcTc6txOChSZ6RJ1IXZwXUm7B0mM+fcsgpzdXvnO3G9CKPqDboP51uf0hz50i4QgW1thcjw==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-BBQWzsCSLfJ7AAVogd5tIgyquvE4RSIHyoaMzUqNFMM/+MCTeAHATqEB1zenkhIy1z8g9Xb05g23qr6W6+Ne3A==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -15835,7 +15855,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-rncA4PSss8p7D9gFP6314Qy2xNHTogAHV3aw/fX1JXQbrZw+DS3bQaiHH7OQ7d2frxO2OnopAPVyIlXFrXcVRQ==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-5L8FkJCV7ggfVSYSLmIxGs0pta7Sx8YEQrhEORHkgEcYq7LXKu8WRk1AWJkW/kKkoQa5UEVYMZRK4F+0IbGmLg==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -15861,7 +15881,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-tWa9Pg85y9ENyj6tbglZ6N8HovxlKXRmNk0BJodVxvWZcgi/JBfIl2xjsuWsABP2RZSp7M4nJiydfYNwV9pusA==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-OyTn4VirU+0UIK1SArQXL5587Q6SGmVFgrgILvJn3vJfZlLsJipHW4a30Mih0Vn+vvBh8RMlnYtRKfRrP76/JQ==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -15887,7 +15907,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-AqIaDv21aCaVMrlslKINmJnQKXBOrcgjFGod2viJgC4OOlHQ1/ZkeDya2Nqllej6VfV/dwmUIhICGJjg5T0WMg==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-48kle8Hx8B1xfal/RXvWOU8hQMux7HJvUGgIcjWt1aI8k3O1wOx+Kcs/0H1sZX/saBJWAXfVL0IRs6srFu6Q4g==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -15913,7 +15933,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-BKNeAAZV8Y2sk27fTXNKwKn+3UU4TATWhu/BJkN1x3m90hfy+9Q1fsGHUpJpyezgSB/SWLjPmjf7RUtUC+401g==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-/dgZ+X9lyW1XvGPqhqUY/kYenpXk7fgdrV6u87cfRjdvaiS3Xr4fIos3fr2u6/4XX6YbTLy78XqlgpBJTJelzQ==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -15939,7 +15959,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-FJcLvy4aYWvPMnBieq8+tqIdyAjve+yztLDtjiCAOYfUQ05iz//ftSA/IbgoC9uiNjykbBL6bfFFD2HKESZ1Aw==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-KnsJ0J3Uf0l4IpU6CBNRTqKCRjzymef7ZXDf88OPDp+cGFKnf5quDzuvtd6IbwqAfdPwnfOHy6fochbMhr48Aw==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -15967,7 +15987,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-QM80As9AbnxIqlaxbqTTEOxZ4OgvsPRajPjT5ll6GpaAH/DvHzPh+DJZNKZAo46iCXXn4q98Z5fhBQK2/qDO8w==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-WnnbAMXOwiRz8hAzaCciL9bDZZkhy4s1JFdcvtL0+MsMLw7Empwwds4AYyOTYByKVX1qjWx5yK5ksBjoKkJ5Vg==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -15991,7 +16011,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-VAw/N13yQZx5W7O3Eny3oWdTT69yqW+UWI/8nnRbW94DTr6EvJM4ODwixkpSEKeivL5U5WGsb7vOKQjkOCSPBg==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-zmh7oEAh7qH6H3WW48CXN02M/6P50qR2ZM9KSxkQ5HjdXgYR5kx6nHlW1C8utH12DAwUqbAJAW7dXpK0mqYc5A==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -16017,7 +16037,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-HzjELsnKjiI5+wwfOLGvPbwgyu5602GpuKDqnELCINRoNsYGmawFSGe9gjMsqjWHr9EgqBei6Gatkl/2/eFQFg==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-me6ydgD85wovb2EtSWPSvzWKgJJranR19+CEI0QU/5zw4FZzL8e1lxDU4EZ3ppElTQ2/PjLk60oUi8FXsTvBUw==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -16045,7 +16065,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-8vg9CjXxkBEbFmdZKM0PgGXrU88A1QcrXBjfaCRvGUWk5C4R7lO4UDTy0ShAcj0nBvMxzsi1oc18taFr47Bq3w==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-YIVswoVdc32CNPrB7PwqJtxCUX9PA0uOti2uhDERn7eyCnDhr+D0R22QIqHjgJO5V4qJz6udWoWVElKW6fqPQA==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -16087,7 +16107,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-Xh11W+x3qo9c9/62XFqZqS4PXC59irKwPAN4SJ2TnJxA4udXUnt4g9pgrUnqpTmXMrm4zvpnJdIncIIu8ZQJQA==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-LG8Jxr7I9HacND8bgSB+39/xc2AHCbQSOFByxbLedQh6ZmmaZjOR7Zne/Aa2pLyN53gh6fzJrhmBgMzMVcIoeQ==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -16112,7 +16132,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-EQS+rLxIrRcM+kJV0Cyv5mHSzjMRK0HLKKookUi58H4KhQP9cDRqV+YiiTc3yOKm/Ov+ofzu9NgymE1lyutD9A==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-B7NdDbBcbbV+JQVAXK+9ozC1OBQPj5urL1+47uwoD+mF0CVYzvBGMmB8EYZmxQM7AiuYeRP1tkXniUUVhT6LSQ==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -16138,7 +16158,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-JCCswG6J0DinkboWkXFrqJ0DBDk9GyA3E7RCFKAnDhuUm0kOibi9s9ME0v8FIktuqvxbNJhCkqPOeQaHaLMX+w==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-jSMkAErWDk5ZjkNsOO1PH5xZDLlLGyw4QFVKfPmlEUMDxwBykhUjl4Wmn6j3Pv5kjLc5xuMNcXNrvT0/KjLDaw==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -16163,7 +16183,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-C9vutQ1CwCUluy0KJSA+Ut6QeuNckRwH0DkWbmniBKIrEsD3vCFrdY22ouReFouReKypKaYGDojt4Et/5543wQ==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-Ry9myGCAidDIXX2n83A9i63/HQmbkLCy2h6qBjyDhmS47dbyMmf071sHXhZJgH5Br95hr8J6YFd6yHUICbHGPA==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -16191,7 +16211,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-mbT1i5p0+o4hNro+1x1V7XzxBIs+JGz3Qgb/hME7oxzw9FGraYZrJ69EgjHAbbFbMqcx2U5ntlmFidYtbcL3fA==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-AU650A/3y4ziQ/rqFsSERucLmVfVBOaCVjBHP6OJpaCOKk7RX8JuJZ+x+eWgK4bSo+gUPOebDGgI+Q/MX+h/ow==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -16217,7 +16237,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-Tfpp+gIbZe1TsGpwMsa/aGVd5vdLITBJV08KfvKuSc/1i3m839bJbknB3vFC8qoDdJmNoK5zRYQGW85EYiN/vA==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-nhstvOKWNLbwUwi7DhXCrxT57ExMrXQ3f6CTL8aDFwSioI+IFSKQ6RLaKu3fFkwAELyOVDt9Uls4yhqzkvlUgA==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -16243,7 +16263,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-I83T4hrk/+AFsTHcmxA/lZcJz0PwNVbWKP4GDJHEEeInLnJRKGZZ5YFATQE0MhzpuXX+1dGf/HdiqTqpkcbjcg==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-xwfp2Ap5btsvfSgSuERclsDrBzWJxIaYbEv9Q5viB1E4KaRRZ2+vLDy3amPyzDOZNc4dv17D27cSFaXGaNDevA==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -16271,7 +16291,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-gXoxcFuVVWxtMzmQ900Lo0JxDDRiVgrTXWFmFdq7bvnw9smrueBvBtdYzWbvjQNkihyy+qi8qCr3jeZe3UyJfg==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-rtCPKc6KQDrUQ+fi9VSkiyDv1Oy51w19A59Ypp4oSwh3tALb2T0N2BUcLrrgus5GbIK/XtWKesRVUKNwctYjhg==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -16297,7 +16317,7 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-3mbEGrwKQRLvFCRjrN7xG1rTdwchxwNyvW7ccDaTwyFRiQTZXNsyufZ73EDLDSK77NjgCN1YOJZ/guzt+TjbLA==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-YPnUCzA5aSCvKYmaBkvxrEtUttXUqjXrhe3mXiQGtYMstLEAROTEwsBP+6ESI8p8LYh0ADi2zjZNp5aFI0iEZw==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16323,7 +16343,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-R6dRP6a53K9uWeESrGxove+ADHjWz/lkk8tCfPO6j2hYfu49y0utJto9g2yGZ8qGxHzIesPDTFH1NqNzIPWaUA==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-IguNRiF+57cisbNPxGnAanG1SLZ14m4hQi9PpwG6DWQDc1woLhS0pEGTqXbgDm7Lzq/avfZ2xf0PEe1o7T7aww==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -16349,7 +16369,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-UuclvCpptePzRKcAyQWKnFnQU7edaKuG12ku9PCfCbMLuZItRYqIJSM1H4aT31wW3JgUsZysxbmthcWespsolQ==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-LV0X1Sj820+EUNV5jLKemekAhRkyk/RKfBBucQeTYQd8SnY/o23wqqeGyq7L8eSdUq19FWZ2+N2sZhSf3UqvjA==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -16375,7 +16395,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-36ww40pZj8yUfccUwGGIHKJ5svxKBFAKWszS77MXmdTl5THVkOyAxSaKh3j4xSMCLs20tWc3ZE2H9YzefLOgNA==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-5gWhFkLcYi7GBJAaqJRnzlhmC7mmTguwuCd+FQjT4bV3k11nRGvwlkIPaReQEMJDukpYDhdTAiUWyD9iM+qSXg==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -16400,7 +16420,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-z2ngNs521+o3+YNg9ScofAa3SQT2lz9rz2/OrYRpOWHBBVAUwwvlvEJ+TFOTJwdfmMnwsYpkWghyGzotpLPrtQ==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-6Csyy7R3G0KlcmAA3zJ0aPSNgmEe6/hvhw+m6VnImoSqgwA1eXG4ON0tsnBytzowltYHLd+R6Lxh8XD1FUo9Tw==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -16426,7 +16446,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-0GESO8P2M/KIvBO5oFSTGQDXX520xrc6rhsj/yc1k54MRP+6JCCMNzeylXCDcr85OzJpNxmGOEFSnsMAwb2qiw==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-6rKIFvxB2D0S7jdC+2UBCTBFs4PfikHvgROS8bRS9oUmGbOEohuTdhE1qHtbeKj1C9nZVxo0/JPHCx3xMCkrrg==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -16451,7 +16471,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-CuS3AcyIg/JQ9oFIFJypWaIJOMLIYLWcffvrnZvRgVliEu8iK3lkogYsNxqtYkCoWcqWpwfV48mFcmsv+BnFtg==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-Y84gg1o+yk8zqlZrCLkxRPgc0Qp9Ce539Dz5wVJAzXvS7zrdtfBXJkEFej8YgC6NayIkKeQSq5wWsWvfec+zwg==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -16476,7 +16496,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-/P2PCIH/4hioRQMI8jmISmlYLbbPTxC5VQzsRWeSxOWRCrSJNXuYq1SdoAfczsWbwmyvLZzZVGN6cmNC6ZFsVA==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-UZneDROAd/r9gLnZopJ3lum925875/uv4NiFuALUyoBtiGCWPyoOHcDG2YDNFDruLkAmLBmf7qFKai0lg7ZVog==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -16501,7 +16521,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-NQUq4VWwVjuzUCNsR2UgoKVWjelQ/ReFSiCZipET1q5pjeoioDBj2AIzPaZcjxix+3/akBwUmcDVNW2uNKZQbA==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-tB2RkyvgTNKAQcuB1fljHMaD1F50HnYFHi5EkNx2py8C4Rk2w+3Os0icZ7Ykn01rkMCDJvSgo14WkAVS7rxZtQ==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -16526,7 +16546,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-wBTJs59c1ROzSY6FfDymLkvkDs23/FZmYKRQcaeO2IxnGRPV0CfnIqucDatxAv2/TMUx2LNgL6y7QhZgUndHpw==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-+U26ckNBw2MK3r8gwowy+bX7TFBCHdxgbfwAPbj4MqF3ra2cwrfzqSviVDA495TTykWeTht31cjJaJCYTISW1Q==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16551,7 +16571,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-FJ/YnvcZlM8syiLY24c4pyk9WrlCoWZCtEmu4PKHfgRXVBdIk6YZtZfVCu+cOkNKIu2oK5WOSqKPD60Ewrv/4g==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-uMZ87MKbKdxhSKNBkhtZM5qE1Vj4ZZE/dXSx2dtup/tQ7SRcvAiQLcRxVe/dlC5Zo0O+ofGgJ02IEl1ySicZlg==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -16576,7 +16596,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-zfyve2WxjrQSfzuiaea7TnbwAG9bovBCOnXlVqCyrtIDIBODGOglrZ6KArkhDqstWaESfBil8A0QRq8K9HqgHA==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-7/hVXfJ2gPKxIE9jmvLbC4IIO8KToPJr2eScg+Cufn1UNNFVqH0szHpJuEMafvmq5ot59DwXBoTUJWx6LBBR0Q==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -16602,7 +16622,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-RjyU3SFNTPflUz47xIZ6e3U6qSUOu/qKFi1nH0NWCS7AxuIVDBB3Lu52T/zbdCX2DUesCKsM5YafmTqEWRAkPw==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-TL2W19Zow7kMV4KS/O41FgQynJIZy4Qy0/Wl/4XygGiFRhU5s4YhE9Hqki0K3PE2M6C8Ubb6zbeWrpwMsMRgEA==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -16628,7 +16648,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-OUshlwDmFViAMuteL7GWlVPz7f5xGC/EFMoW+tMOXTSoZRLACssVtci8pt+vvcm7DT9w0Lhnc/sSMZ8zARHShA==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-bNaC7UNAvaoimzOx7ENnYKu3eSzSritq/Rn/tMrOqQT75zWru5TF5tNCyf7Wr8bWmu9cbfLsEo1TZICH5EZaiw==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -16652,7 +16672,7 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-hh7mdVXU8CQiCWp6Mx0gpGNFsT+WNPp4z8+4H/UzZLsEpVSxydQdbmnO5x1igV1Zkfo5vbTN2RbjCwSfXRFjdA==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-iCMpaYPg05rqticwrxrdFTMrwR4JjS5i8a04TGU1eyfw2PocJSNM/vDELIrFNY3YoCnQNfafti/WD+X+ISWu0w==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -16678,7 +16698,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-4Kj+1U4VB2J0rtu6hz73HELQl62p5E+ezHjT621h8Y6hxE64UUC960om2DBVvRkJont5J2EpB242PvjoIdTjnQ==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-51I/Wpifcym92BDEGLJ4m6/+kALK8xuLC13A2EysiRzb9KkBhnHkACJV7SI7d6429hllNVnaEA3+Pvm7dBzazw==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -16703,7 +16723,7 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-jKBoZ408JW6rPVcWvLp2BboNz4fk18Hi7pN+5py2r/J+0rt9jHKveHVJgFG5IVsGLzBuBxjSJzkm8c7LgFmZmw==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-NhwbB4MT8bKXoE/7NUxdzMFvmG5npKF6zbPBxSi+i1QHtouWfcKL8GlESXB/w9TrmaWmCNGPhg7gUlTPyj+m3Q==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -16728,7 +16748,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-NN86gaRK7kRwSZlf3OTq0DmI9sCAplKSRXW3XVtTXnjS5wJ8MFT9byrDY0iSYw0xdNZkTU1ZC0q690Fw4InbAw==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-pRi9qI/tnB3y/rAM4rAt8XbFrgpA3i62EZX4sKt9sOjRIcMLNR2JCRK+4wzqOEzM5Hn3oSeN37wyC1nytqPEDg==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -16754,7 +16774,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-h1HA74p/xvV5kWAYbGhWs5lwJwg6Pnw0w9Aewrgs5rRwaRm//37FVkhVvjxNC8WFH8ZFw4cz1ocfHP/OW8gybw==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-IW603hednrau1MM8W/1taGIg7w6DQtf04ouzpM2dHu1y7Ah2bRbEh7wHFaqQ+aB4BYh2yhQptEQedc0lbMAKjw==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -16780,7 +16800,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-Iv4x9Bfb5AS7/r47VoeMCULPTZob7WY92jAaJmKtbXfKxQnRkTFQrfh0tbNk6mubNSfE6NH7OE59hsrOVZyhbw==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-rsu69+VjCIJ5jaBQj8y55quc0bWbszuo6B31XcmU2uK5L+n4JjM0sQrUJ0pB62BMf5JZChClaqGnjgPGqYOHyw==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -16806,7 +16826,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-nX9vMIFmUXwj/AUc8incG7nikd0LMRvmv9CR3E3IRaivWQXVjDH+UkaIy9l47ZPytLpNwB0DnxNRD8SatuSzcQ==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-yXXceta7F9ntDGKHV26hzp7r4g2i2acwGv+SvxBSHOpahrE1tDABHR7nvbD6mI1iqgjqVwhH4A7YOHMY6oNODA==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -16831,7 +16851,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-8LuccInKY7oWwhyIs7XFvN/d/vsIBV+DC8MTJel6ps3IYHqxzAh49z5DDG9d30pU4ijfud4Nob/tPK9vD4IPvQ==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-gHYy31i91hQxHSawC/+xTpvC/dH4IVghcs929a7jbgT1G9Lb9+fFNzGv1RnvNINX+k6endh0SHvPyEaFzmCCUA==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -16857,7 +16877,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-k8AgoiZpObsn2sUH/+xVNJ5735feOuA3P3ct/SL6PpzdknOn3L9g9liPM2CYirwgwVF9QPbNa5s1pRMCqgCQ5Q==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-+KwSkET2AFZDyPBUeXcWEUxo1US0k0RpGzbHZ4jief9tutlz1bTHDmTo/lz0t1NGTKW1M11L+Qcjh+fIiRLJDA==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -16881,7 +16901,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-oZY/oUsMDWkmpfSZuA1uMc+sc10cbgcbADzIPIMjfZHfVQI3RMowPKhjA7vUR+XsihFUFHRJl2vGHaD0phLxGA==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-JEJk039suqfwRz+0GAqd+WzMiO4oHPnFSsxgqCRWReXx7uWjLA5G4KYG0Ywd8nTJDcny+OyIq34+inGaEbH/Aw==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -16931,7 +16951,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-7Ix8Ppj8z76E+JYdZvAgUKDPckj+0EzQOTRbh44V2xbshdu6hMDWcsRidsh6IqfQ/Nve4eGFeOL3lckVev8/aA==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-C2rl93kW7FLWWBNYnTE1/mA3cJngrQ/I8EsiqSzLfz1BmovQnWVlIMv4yVTp1wCv6xBfSKyJOsYpwW4Qk4m+dw==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -16974,7 +16994,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-oFyXQQUjUKegHE+xckE3SO2KlQoqTDzMzZMz10M9yWkfv/0LxGyX0+2+jPa0heAzkVR44/SPz4de2UyUwZowuw==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-Uqn0GBZBlPqAD38Fn50v9MKIEzs7gLOTDIfrkrnCxq25Dlxa2oDMgnVh+SXQfFFiIqjxrTaxMd7umMepOlViCw==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -17019,7 +17039,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-xxbkBTGkbfzMbqa65PMZXpC/mPQIAjb1qkFlv5zsq8xQi6SJIp9jcEaZU2O/QZXT/eVd5bU39jidLzkrcekYWQ==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-QX8FvwMnxn/+lyqCqWAWidadB1zNX8EitzVpxs7cPQJ54KYsHTrn9L1mGAwonD6xgksRG23OkcMgNH41SngXNA==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -17069,7 +17089,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-hipCtN8pRRzW1ZUyrzB7dbw7Zc510pbner+2tD806jh/M7bYFh8LhroWmMMjmeN4YP4m4iwoAR3TZqQk3M2/4Q==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-5x6ccZwMTbkgpF34g7iuuqKZ4Deu4ujRYnyRJPfeCgXx2BLumZxS8nvKgM1YC75Df9Tqqbips0ibQGzbLhgmMA==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -17116,7 +17136,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-/VZtpdF9kKmHyMm96o6BRUY4+RtVpJIqaI8ymZEmVpDiBYXJjixo/LlFlI5F77Ank+ANcQ6wfgv9fp3ahoVKGg==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-cwoPNZRFAJzD/FRU8YLyyDdahmQdyyue7R7F5wBhZ9bd1Pg1IY1JC6zkxHeGJUC1qRs6CjCLniTEJP2zX4t/MA==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -17156,7 +17176,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-CwRiWetlqJPzqvXiVTGXLQOIJScDWTABSfAOyeORpBsn3ZHAA2z54ONAGhiZ8fR20n+o0MMpw9bAssQAYUo3FA==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-PHK9rMXtTOcZSvdFcTdBGcYbnnnOnf+WBnlLR/xI4sVfbgTZytlCw3HUEMTKtnZ6DPyoPDD9tzphRn/2m6IM+Q==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -17202,7 +17222,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-nkAnEF2R6alqY4aZnFzN0A5j9oHO0ZZEhQhKvW3jt0j1JzmxYLvDszbYCjnFEx8BDIrEIYcdYR5kFYITsFbzGQ==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-Rl1aftlSevIKM/SAA0LdzKU8H5D3DZROSxRWPw+uUChDTuUa5UL4H9k4IRmjszJ4JJAK/f9QtLbm53x+M2ondw==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
@@ -17250,7 +17270,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-jihJvATojWRzElAt0SlSSVkhQe2To0qP0rgT7+U8dk1pfrqyaZ8y9bdrdEtpxcazwxMa0Crpv0xEiNLjyhnFxg==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-Qyzx0oDMpTR1DmLaXDranutjSitaeqDY3ma7iGs2PaLb9QkXukVDfzg6PTJiK/qM2YyLFA7U3PkV1Mhp5sfnBg==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -17291,7 +17311,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-8qahlgKaLi0OA/dr+JFN54Z2r3ExIz7GOnHkPOtjRkrgZIEfxJk7QrEoTmBT4qNyTd7AGUy1JM9JGA231N31hA==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-n87YnWnoGD35ZdZFPbtsz2dDHBUjAJoXsbrH44vyyuoQnoz4ieqGK3s/sjtDTkpyvmnn0PAGG6CQUUI3q9d9dA==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -17337,7 +17357,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-Lg96aJXOOPZQLBod0rIMStPmFeWwTFZMbTHlEXQ6J2KiiMrYNty0uQ4UcBB3Kwb3roiKOHJvLNe2Q4BG6E39ng==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-3W94PBl2jt8bLKAazsbaIsW5bLeLhwvbyWSnOhYABPMbVGT5aBdpHU6zzebAtooI/9imYRarVdmFPVZe1fAIhA==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -17381,7 +17401,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-Yz4XCt+lerp0Q+D23fxcfuQGBDYHw8GId62CzH72MpIeoXC/J3hh+X04C4ZdY3DxyJyQ1gFDKIQGoLKDDz8wDg==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-vKFllWvsspfP2K5sXf1GD2WihYd/FTUVW9T+zBjMm8RFekBS3GOZj+iFnRK7NLNxTp4oQ2gDBgsr4uG3D08V5Q==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -17427,7 +17447,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-iK+Yk222E6wOpeSjxzO848Dt2tURhHdWQVN+lhpD2uaNea371elui9UluepHSr9IDdMFKzGb80IVwL+CJbs0rw==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-onuaelLXjuFJICOK7SmapqZ11N3VylkRKwIlNHPRN5mtBVfXomRJNgTn+FzVxHQANYw06c3Sfe2mksVbrrkauA==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -17461,7 +17481,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-8JFSbPNo6ZaQXVVte11KWFlsFFPhVJsXX47+ZvKPOHOrwioDvzJTLj6lAZYmasp2Kcbb05YB8C+qfcTpppH0Mg==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-/pFhvgamqezBg/J7YXBdhIdGbxPExf1+Kx476kQjCo0yWXxIyftDyOqGjfdqyGHCuyXxYyq7nQuuWjuX552kRg==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -17507,7 +17527,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-F7HfeArRLr885zpZ7ozL4KmnaZbHekBi8zCj59PNUwtK0TEUsO7nTW6XROwa/4eg9C5lGJ/rbWclh9O0b8GCtw==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-lvYJI4a8MqO43Xy4bkF4zcQrx2pFlxld6vvsPKMB/pCU6jtSAq9h/BSZ4M+Ed186P+Q77z51JUUNJ8dLVMx5Wg==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -17552,7 +17572,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-X6xf9+LoF2R0TbBS5P5eMXtLmpWH9zO8O1RQRmHgTVJdkEhuO+KHqKeAKLMWrdJ5KpQUcR9PsxCKPDP9RL6UUQ==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-PlKPiWYFopnUrH/lNn4Q7955+f8kmzfvCf4LXfAW2S+XOi0N5CrI8446h7DNZ/BtG9U0REjO5Tb6GHj5TP9bWA==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -17598,7 +17618,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-z1tjFmBLEKnfXUG5NwyrmlTbhPlEBZDjeJ4R9MaCuicASL8wbaWa6q7CRpxsEawQdUn1Jbrj7/c3W9A63XVONg==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-k+3IpZ+nuzF9C0qbM+cLOwHdlp2cH4LA40AV1688D1FX78AkfubUEtU4BTXarEOmOWo94oDD0uvoo9B+cWGlBA==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
@@ -17641,7 +17661,7 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-D9cAdNxn548iqHP3Y1TQ+6jaEv4MWsQ20zWn6+nB0YPtj1NQLgqNw8iuvc4Frj9hD4F/tyqLOOmVIMeLr1UbUQ==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-8qhfYH0FgcoeaqyKXkOSIWJQg/QCic/WKqzw5jXyyOuS9UTcx6v2sUHVZlb+V/BxeN/+aQKKFPRKHZwj0ctbpQ==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
@@ -17669,7 +17689,7 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-HWt1CuVwHddZXYgWLRLsd7WvWXiJVk7RIletZFbwn0B1UxbDbigKlWaOgB1ODUqeXo84DNiDj6Ovz4ikdnEDbQ==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-y7W3jNlgnv851sv3AWjIa8EplkmjjH56UOkNi7bNN1kE1jgGqkG0C9lr23tKzz72fXKQ8guCk4z9ZE3SfX3/kQ==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -17713,7 +17733,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-6h6org7cGpL0umcPJGGijBodcBegawhjr+yoK3hUWbGV7NCTmOlRw7L/Yw/GWSjczugBO2ttOY11u4Km7db4vw==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-JrDYCnMV9A81Iz68jTZK2ElLbdSjU8IZQw87QIasft+dUDl34Q9v2F9qzIZiYLnx+vaQ21YIvnmS4qFyrt63eQ==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -17756,7 +17776,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-k/FlgP8O3N4bqcqcNbZa+t4hVg5HoslH/NxqS6bWMsWasCb8/lfqA2sq2IACPhM22I/UvBGdH+QO2DH0cDb0rg==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-jrlE1FLVjEVTdqLqmu6LKrauQg2ou6a0DQm14l2pWr6tUu7ceFcM4luWqwKgujggAMGp9awq54HDVH1mO9g1ag==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -17781,7 +17801,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-5TQtFVeFpawpIKY+PyO96TfzuLqTbmoRTVvi9/Vkth/1Qe2KX8thgPRckjEVxdwoHn1gvXOqLvUCpMvHoHgHSw==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-/U2yTsV36rcawD8Rhc6PwCDxLt+T5axYEWXQ/RwpOl/nlPIozlsQ9LQiz6AYZJaGwOTdmIu2K208gVf5LeYjDg==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -17821,7 +17841,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-Lh7qHNRNsty9gMlYMPXk9zz4Se9cbpo/CSmAGZzUWj7raLHhl9/ivwvHBDJ6QEIhUuS32W/6KY0qSTXUgGh7Yw==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-VKYLqxP9GhcoZ+Ny7UfGnuzDlGcmTFkmFihsvdVTzt9EOdHc0wL6bpseWAuq7Fa1o8WmGO3bcKMMM3GtYBbIpQ==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -17859,7 +17879,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-eMUMp93AGZ5GuIsAO9bLDKy60of4pVZJM9uADKuOVZaIgvDIr+V4Fv34e6NZPLDT/xtrTkcIGGIGNv+OdZckcQ==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-fczTPlBf9m1rXum1W1Oc5Sq9HDCoYoqRBN6apcxQp+Hu1xPGKXGoAQUz9uq223ZFjQrQa/yQ29deTKChajN6Tw==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -17878,7 +17898,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-UDSyDyJLwoP4Tkw4ZDWjK0JdSPukzcrwvhHroq/e9v36l2/IUOmycq3623dzJE9ZaycczU9TMO2dfSAOgQSZPA==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-c3Mf2+/ihH+I9FcF01RoEWxzDwZKq0CDFGatEL7A/ZT2CWGcHE/gt22GLzghGvoHq4wd8mFi74w5Ewhw/RwCfA==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -17912,7 +17932,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-NdCa3zq9kMdBrsNNE7yE2pFV84Lp8N09CKbZwf7+aVeutuxq98H4lkeWeP7OPdWIdjPriWlGik3+suBc4oalIA==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-SqxYLeWS7APdNsEhEOFKEBISprwOIzMNMzWHeaWDIoSE02ZnWmr3tuC1hiuHUeyLgSX5WxxkwydJG1cUw3abfw==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -17947,7 +17967,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-YgzdZvnjIYzOpSIQVjj0bCwoMHaETLnQcXy/hGJSwdHE1m2XXloR3P/lmAq/XomhgkSAmlWyt90ZMobVdSlTug==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-bXm7yzifjUwmxgJiJLLKYtJ5Tjzyk7ZNaDhNNem5+oWK6dwpLgky1B8ZqFo+SM9AREnA/VmxA1eyecg/tPIz4A==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -17979,7 +17999,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-j4eh8Jj3KRC2GMgP4EyMiKa/JtF0s5yTunmcKAnfXEcKSTha0nMDVE7iqf/+eKDeGEfQ1zc75jkNsiDGKvtpEw==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-HD0pELvvbuL/ADAvG2dKeZYB3GRCuHjYBFEjbgxuwMqNCM2hjlrDqc9i3XgbvhwpvhF47uKLMNjS7MlByLUJzQ==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -18020,7 +18040,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-NBH2ccsB+stxZdNlyyWx7pf1fW5Jx43oZbLRusWg8pRTGvhG7/Bd6sbbqBvyKZtOQNQPgkNMrPaKJuMiwA4LiA==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-tXMYTvlFLtaNTIr4HUb4t5M55sYtWqeNaxwBNOoeFdqz72acpzI0LooSZqeOgcEI+OR3kuQ/AdQhUhvpip84iw==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -18059,7 +18079,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-2tHqjTT6bvLqM8sxxZhFflAAxpiimTbqWceE8v0o1haQMH/dYj5htgkKIlpzv7m5hYTEM1+G0xqaeg/R+2f6oA==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-67Q4wo8DzWiJ+Lz5OweSPoqlpmFyiIRvusMaUltC2zIJHCpCEgJ8QaBEdPHv5fqnt2gJ0nWtCOdiaGlbTAgZKg==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -18070,6 +18090,7 @@ packages:
       playwright: 1.41.1
       rimraf: 3.0.2
       tslib: 2.6.2
+      type-plus: 7.6.0
       typescript: 5.3.3
       vitest: 1.2.2(@types/node@18.19.11)(@vitest/browser@1.2.2)
     transitivePeerDependencies:
@@ -18089,7 +18110,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-fplIoYvTiZo9RkFVzYIW0JqhC6i4SeqGewhLcJFruTbBgvpqrSt826S990Yx2O/sRFuqQJY9a1j7tsdtGOwQkA==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-UmpUiOpWabmSf6eZHuONUGEn/VmzasOPnqUj53FRY+dXiUboOueSP0fCtO4AMiSU74m6yQY85JFdeTYd2H4X8Q==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -18128,7 +18149,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-KlSbiGiAmf8s7W80m191fbR4pz7ezdoBoaZN7uJwREqp2KFAy3JSZTdr3T1ToAwROdEdqcHqWhiStDyf07DAvA==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-XoqiHRcf7JTjpDbPf4e+DqKJCUe8dGX6poFs74wc/wycgBJ+YgodSQGOFCTSJsG/LfNcoxFK5gud5l2a2jMp9A==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -18176,7 +18197,7 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-6KEBlrc0GF4qLPYRrM0vWDUTYkRQL6Zqzc3n+ogWtb2IqmlBpxNrQPoOWDEXFIE5Ux0zWks/W9w9Y3ZJi4k+wQ==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-4fhoHJVq9u3LRb+RHdq41Iu3b6lobcIRNlUIsi1bf18uVutsop8tgFRIztJV2cG/Wp6mICaEdxc5VBNZ6urPKw==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -18219,7 +18240,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-OJgN1t/0WCKXS8Twqyq27v/0rUDVrY9SLa0+e6MKqbP2OngKCkay5MdGHGR8U2gvoYhM8HWTKtnYsdHkDzN5bg==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-id8CAw+eOZLgK+TxY9x4lD1zsq/Ng9dW6lMrw10SLVi+LYEEiu1zQaVctzJk6YXqmzCj1HXeuwYLnItyGE7Qpw==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -18263,7 +18284,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-pAnv620f5vDpx/hnTauedeMe56yIKVUVeJLS7W0qzL66bzeB5erpr3XVDnJLPtwqZMBowwY8ACnAS3K+LGthNg==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-lUrjuNi0BdWFMHwwmpjTFvEusVbtKWIeUTW91Aw/bH70+R6Y91EcLDdCf07+gHyZ0eisKuSa/VzEEjAo0ILP2Q==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -18324,7 +18345,7 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-I86VTUERJuLZWpdbBLJO1eDWgHAoIDiy9s9EYJOcJhPo6g0g4bnx++Bn52zIwpMIfZLsss8BwoeW+CFBy+SPJg==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-DBz9A8dIj/Wtq7642S0igZy43x93cegJ3b68K6YtDp6aWst4hSr042BNgPzXDiKKMxP3VNGGYRMA2me8CARZHQ==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
@@ -18368,7 +18389,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-WMZyZXiRJiUP2/4XYBcaDbTNVGU9gkQWC0+QMNMVZxvtS6o9tKeT4ZY401lkF+FrISw4sG3ioIzCg0qvJZn/Hw==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-ssGxijFxgc2l5TVD2ip27NlgM492N/5IPjicnkTDNcvkEBCkHTkaVccFKFF6nO2CsrmXgVbXLDnP9EETKqRArg==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -18413,7 +18434,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-81LjcHURGDNhd99ICbhwWc+aJH10sWa3J7QjDxFc5WhdewTN9gCHQRLXUlXT5oxBl6VK/7cOt8+MHIZ9Ezq8Xg==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-c2p8g6bTDtMUiM6D02QH5VPifOavw3/sEXQRQhMooIM0SyRU82dZR2qtzOGw9ZGQ2oXOmPPpW7i/N8ifmjSw/A==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -18432,7 +18453,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-s3LNVS/9sokeZBxOF8BCe7Qdupa8j5xl6E24wxgwGik4+wuuJemIw9WSDywMSDtonbCxJ4AOS3zM3uvxCLL5gg==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-z83uGECKsUfV9JjZuOUPweb1PMwd3m75AibXjMSqeBGXNXbL8GfT/EOcAvWpf1BavT9Crhb5gL+1hfpeqRsSpg==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -18470,7 +18491,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-FAaP4hVWWIcOvHbklz38qKy4wQat4sUgdhjSyVNhgC56Bv+p4ahNPMeHSJpHDL4UUxTCRSS6REbr0HclO0Cesw==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-jn60gyAzl3U4N+uoXnidQUKE2gEEwspWgJHGeAYH5rSOWKuCb47sMZDABv54Zq+9TfYg1EFqfm07y+t6K/MlTQ==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -18531,7 +18552,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-oVy52Pb4eRPIF9CE2gJoGuTRpeezwDXjmS6pzm+CPbKHzRpqN/PMR9HXrgJW+PdArY/V03iu5HIQeoSLYBaKiA==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-PpCl3UfignubYNcrZEkpVgIYwtkT+7zMyaD26CNmP1fjJQ7tUX27wYhhCbNENL6h8jORX+GSZmKBiMdbPCYCAg==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -18576,7 +18597,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-swk60qoIblStP4Rt0xX8zciIVL1CAJQv82ae9flzxHBX/LyYrEmPjVNUow5CMHwp07D+jBdznN6q2h+IglqoaA==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-voCz1pr2cArzwsTdes0Nd0SKxp3YSKhEa19T29aWbhB6tqkB5fxryin+qao6K4QQiCEs4CSGP/K1Xc8XWWpRoQ==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -18626,7 +18647,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-INWlulbRgQf78gEGxUgaNfy9u4e1obPWxQd+5U1kdZ4nw40gQB7/i/3J/HjCXITOweF9KFaUB+QR9hT/3vTehA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-9i/AaeP/Jp7f7naf06lrEOaJakHUHhHSwFkMPvA/fMW4frJ7OZ+AeHTlpy/ljMbBZ+PMmnWwN1qGyRsVM7GOeA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -18673,7 +18694,7 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-cjKfwW0ee2CV2h6WE9j5wlIIQD9yDy9bgy1ce0eziev3i56GDxMilVcyIv0rIn+AU6JqgwPNF9+Nu4IEdka5pg==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-M0hwPC1LI5YpLCMwBvqPDdhiQJQqikjCXsT0L+1mqWXOex0oQzsMq/k7x3orGZjUivi958voDgyGylQyg/Dncg==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -18717,7 +18738,7 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-rgey2qJlM9lypN7m94Fh88ZyN+Bi4yWYaA9RLlJ3jqvqjfYCOeM8VBArXKMoCLktIVXylBtTElCYgOdwthZ2GA==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-YcOkb8XeQa3by8Ghc2eZDHdG/ttPEDD9KHPsEpABuTbZD2n0Q6dDQW9JLY97I1Mn0P3BvaC+7rBttM5YAWCbXg==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
@@ -18761,7 +18782,7 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-iXqKCZzWAoG8GDgIiwibWBLY0lK4PP6mliWTo3nmmgMdMawfljIV7MJ2BsyPmDS/5HUjaVjEpLRBOcXtcsTMhw==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-x9VzXqS/Tivms2RcbGop3ppMtA7t7cy4zsyVtpTlDTOZ4zhCbkntZsG0/JFi/ajPZnac9dfL3FMF7l/rw5f0Ow==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
@@ -18805,7 +18826,7 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-P6wlS8239MYWmqn9fWEBaBrHBBY9vXA/xP++qPLin1gdqDyUokikGWOB6FChxi8H7bFsYON2yX9BBtDQe6dz6Q==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-MziZZ/dBe3BdkA6VEW41x2LuPH3UaY/b/0Knf3ozeOfSL93xiR9v7E311ONh2dL4WtDPrtxJTKzK+2GNw7TQ3g==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
@@ -18835,7 +18856,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-/UGGBgB1OQ2YPdzQW6MldQKXoo1Hr/2obEd0feyy5rFF9kWGixPxRxXk7sPRnuy9qYh9ZJhI9iTOsbFgQBtksQ==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-u5JY4ANXYsPdPYCrPN2gTAsQg2yoJ640Auz1A57PdcPqY01GdqWWvEID/1JhlGMX8fRuX1HMLbvgH97LNR121w==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -18871,7 +18892,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-93i3wAAxogo5LM6+liEPwOlSNJWVCKcVXRQGCQ809Nsj5FV9jB5lVJtxLvmyvIHmpNrqw/3U6Hwx2PPkgwjYnA==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-GjYlf2sH1KlrPkuN4/wwClSONc29RS3TB/p4tXw7Am9CoiaDxLND1qmfIbZT/PJVIAj9ebFyXXE0qu2cxvjkdg==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -18906,7 +18927,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-21YXtQmhkzaqcI1I1kbedfdBNk/oLMhW/jA+UUctadUKR/JhgUbKKrCllcO862hDGxMg9crn02dWgglXMNvSkg==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-lnEO7rUHoQgXheJHsuagOHKrTOaiMLAssB8m0Hm1M7FbsUeUIi3EzqaIRvxHy/NMjg159vreAYi86d5LW1Ai3A==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -18964,7 +18985,7 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-fzninn0YL1sitB2dhc0RUI3nwBUFDylACvsLr5JjPhgsQl+hGiRLBB8orxDJMJIfN9i1iB9U++oa3uwaR55wig==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-a+ex2R0Rw4PM+Vv94qw4VfY0G0UFyzYtf9lhLsKJZRF6X5rMzMr6eOpu0ZAkecF+wTdgJC84QuFL1kb2uLgH8g==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -19009,7 +19030,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-3hG7hArCsr4WNKmSlT4hYtBEpdpwGDyt4+WfRUnYoOipTIY8soJl0aB3SgJ86cqY1Vz1Yu4/fjsQu1GVNxMnjA==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-1s10Pka97wVORu/7NvpZRA3VgTcEURe8yma2K+Ct1yKqewPN+s7E2B876as8XVawglPnmkjmplEt+TBV64yp6A==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -19053,7 +19074,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-E1DhOXZWaRpag+UqAwIBso7h/hZlAZjpZ9XILwxT9cVXO9/rpMYf98OvJZUVPZ0OnE2EW+KD1AaLrIBHHaYKGA==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-kM4KHlaC1zKHSZbxhW7CAKBIdAvwMCDIckqW/MonDF9buK1MC3WB5dtsh35ktWViTtua1hlaeF63dvl+1A05RQ==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -19085,7 +19106,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-YTdcXZMP5YXmRPivvLPbcXTgdfAHcvKiEgHbthiNYfS+hBHOQJ/MReZJow3acjuIaa+FuEXWZRXG0d5/1xIASg==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-A0liJrlWJSoz8A/1NseuMffz4DaYSHdx1Q3+AnB70oYEZvqduPjwVlUHmVW9P9IOSvxbGkCtKLRgX6CXpMF7Jg==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -19131,7 +19152,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-sk47+QOOa9xIcaEFAZMg2YrP1/3Uj04oVcml/pNcp/UVVplrD5qnwF/VyVXgAnOBh1NMtaPzUNvVIelqyVDqBg==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-QCp/m0Fv4FdPiScKlBv7TPZhg99RXjhvaAUd7mjifh/xRBuUFBnyuxLHGIkEXGk4lKnkQF2yw7o7532DPkmcMA==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -19160,7 +19181,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-6s9JFwrYyTjDS0qg8Pi6abcqocSAnWVYcH6suhmg5ESJds8Xaqlj7tXgVirPjgo0GaRCMyFqjwfe6bXMdrEXdg==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-/H95hrTlnOVR0HtJyFzzPE3NMUlgSfLkelbEloVlowYejF6TdJa3xxdbUrC60wCeH5N90LVpNl7KtOHt+KJZ4Q==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -19206,7 +19227,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-b2N+432yxXX5M00OgH9+SfhjOmtJHjSrulWUsabTaOArYpkQFy19OpkoF6E3jyfLNVo79D2mEDc//mGJh7NKIw==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-R2QZSJWhVT8TbyIud8WitmIMGs+gOY/MEIWf3pmpoz6FrxqLBOI+WvChay/Sj77OyZblmi3sPymP7Yi2pbsQlA==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -19249,7 +19270,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-wf4EtNAHndiBQN2NJNRLIO7ulreY4ZTllYaie7tCqb/1QvOdF9ft+d2PxqwQc6lzEQj0yf2gFTwtbqIolBgZGw==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-q1RbwDeBEh6FNKsDgyMiryxKe/4yjShipvSCmdRtnwNK/mAXj4Zo4+wmfgcJzZsax33YjpRQ2QxbC8qd2azlWg==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -19295,7 +19316,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-6AxCFQSQ8YmBbXTQJukFMnoqHkenOTaWnnDV3F0QfgNc4LlYafeuy4yxjcQSzeYdyKDJEuKGSXUSlkPUVVQMew==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-6QCgCv5HVqPeAwnnbO2cWLhY1jLo/x7f7CmqAj2Xz/K5ZOtiGr48wd32BcouTSl4MZDHjr4BdFQ8F5DsY2Zb/Q==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -19336,7 +19357,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-qiui1uasWTYd77rfpPKeAJ4SmPdLHQE86hl71zbxyq3lil+ZWGWX33dEw0R7zPjMdFDW1Qp3FNM39MkTVLT94g==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-x+/9I6/5Diyz/R/BFhp0Qvw84GzyP36ct7Gvc7KjeYmXc4U01eLYwhncXU/nLzenHwGbmtFaHAMOTPBXk72qqg==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -19354,7 +19375,7 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-9nTdKTlVT2btLa0cUH5F4x7xfQilCBvZIKkfL0kcXHEc4LRBPBsCdXM0HOpMlG9gA3zUSyZ0QNGPyGMtgYL9Sg==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-BJKLEL1HEPMUgX0LuAPfedsWbUrB44kVtLdSoNb31KY5hvsiVINfsOPqpiEIv09kA6jDq39auG3m14hVmXM9fA==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
@@ -19398,7 +19419,7 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-Y4n4je18Ga7s9sDBRjdAshm9+URnnhYGrX/SMnVsfohQM63iUuu5cJkE0y/VLUcp0qHGQeb5F3oj6pfKw+n37A==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-xIrkL26M5vC4EyIqiqpZYm/BJAsAYaO4N7BAeGyyTh5IXkwSZgUNf2AE8x8F8o/T/k5Dxaq7IOB/VAspPD6x0Q==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
@@ -19442,7 +19463,7 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-6C0n57bxy4VKQ2J7lqa5cTyHC+ApVmsc/BNFgAPiBCCbjWIQHURLNzxZIVAyBglljSbRXU+0yhaCY2OtFr5Q3w==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-/N25m1jJCltndhtEtLsG5nTgcUoICHt2FN+7Va8/b07VTdJq3dMD2trCaNrClqT5uuCZehyos7quDDRwE2T3GQ==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
@@ -19486,7 +19507,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-mKE2gouA8nMXnKDYyvYtsXuJgj3a4f3VojferrJ6n4u+XGhDL/2+nQC2Z4/WhHVxgNW1dFDOAX4Pv7Fx+93sww==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-+ffZ3Tc/4LwxGgc/J7JQxuXq0inOalQ+0ydVuG54Eh1SqfJr0JO9mZ/7UCVqB8If+Bq32zjLJYMFpLsBD40+YA==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
@@ -19530,7 +19551,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-4WwgtPIRxO9PdgLMETjkxmBBFMEDWbjyH7cEVlDgjKUzuGMM5SuW5FlGhmGEf5sRlJAOMgWQC+2IzOcR0v0Yig==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-yMIEVGrf+onWbq2eXKBPyoi2PeFUKuS69y2HjT+S9mTnwvV5yKmOWV707KhFPcrS98ODqCOGvDd+TApXMr7cyw==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -19572,7 +19593,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-KyGTRR7Bo7Q1mzCcB4LxVYpmSLJXynpmlC94KJZfaF0vYBChxI5xMmgS3IdAZrVi1bNg7CiyPZ+lexEyG4jPvw==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-7rOHwOBIF7ZFYbdLEecqfORS0V/CzUX951L/x/kf8n9NJ3Z2OgAFufT8kMU9FJD7j2IVvT3hcXcaUXei53xSzQ==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -19619,7 +19640,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-PH3e1D3wdc9xOuNsYmXxE5zVJx2da6RH6NVD4zUxAG6+DbpfMSWPudtAOL68ThXcAfcR6iFTQaf5yWWKFtN/Gw==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-f8T8GJAzfxLmlNnGEQ8b3O2W+hw8d/8wdZYaUDmFtxZW6pD16DDD7vTmD6kfAdK4QE5qfRIIlftFjsdbZ6812g==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -19639,7 +19660,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-da4RN342k6GTfeit2u9kBOHuZKqlqIld7cga93GJBU28NoQRTW/d5H1gpUopbtgJqkMzILyCx/p4GKOVNf7lKQ==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-SrBVAf2jVBZKr7jWDEOY7hah33Ri6yOAblJ9sKHDVCcWGtjeQvq1IYkhKaff49+cPP0WsQdMFszcjhlUSO9Mbw==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -19687,7 +19708,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-rcqCobUfZWys2WNN0gvsqT5ctw559nIbceLW4+mujmDPz3TV7aJu0ujspVyl+HL6Ro1+J7UahxWmoFcg9Jjl4w==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-fR80kWGbKwCMxk8b0fQX6lwjVdj7TYHQCmpQKcXSqPXPSQuPA3sDvKqvEBzT5Kn6KoT16bQJaQBKsAtE2DOMTg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -19725,7 +19746,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-jJAKV0xZtJJLGYQWKh491I84Og97NX2goKLq+z5ioxrIbIoC9z2XED2DpzVtFN90F+UOyTfNIA8niXTAfXbwZg==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-C9rZ9hkT9UNbghHczPbJlLcB+uRG7CIn0n6MR24xK05TPGKAMr6AH48ZyOScwFKmhny62AgudFTDGaQfj1ntaw==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -19773,7 +19794,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-y5PG2buxNe+jvEMOWPIkvGNmz4xS7QQu/qH+LwlJon9QS0xi1WSpB7CJ3gw1MsGUmf2IdtPdKe0EIzCRzC1w4Q==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-y0rzHjN3OrxRiu9UqHtkHynL4x+Y+A/UbO/5Iiqrf+gSTbbhIbW6SKsNkllMsxTV3Kq9pRMOxiAgEepgfvuFKw==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -19819,7 +19840,7 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-JddXXBc3Fzs+3i2BziZnS4wEXKEQyoAxanDZexhL4f02dLlr7a+ZqnshiL3a26ftU+P0qA418Mkc9k5uo873Dw==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-FSWbjeGxbmvq0XG52pw859XIj+/9LyiNiIs+pycQevphT5iSFqEss5i3pVYXgxY3gyMEQY5B6noh22QVjQu6Cw==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
@@ -19862,7 +19883,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-qJLH4brP89bJ1nfZOg4YxePycfOVkeQRO+n8KPJNnQyLZ0F6nWecfsbPR/jvB4HhJ4ekBnhmLEyb+bjg85+E4A==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-VVhPBRK2iqjVyYlxjbv/+iusa/nP20IZrtqvbKkkPCn0dPY1FrLjnErLmIRNYC0FWkgA64ifRimby1MQ0/JjMQ==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -19906,7 +19927,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-C+xIjNJ7I41EFe1RXj40DbTygg8+5QpjTL6NYzzj5ixPkLTvVlYNLUOKnqBUCAmwcqpGcEZaFs+F/xpxtM9DTQ==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-gLy/jIqo4M5KQDQ7dT6ticlAyuh4bUcZ2PV5/PzlXb5w1H5EQ5NAaIGvKDiA8w7+U72aFHIG4JgSnqB3c3EArg==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19953,7 +19974,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-Uzx9RffIdkBCAXP0wentqMlG5zfivRZoXVtXD5hmMtS4JnG3TZI8ua540zqVS5Xjsl29tYAA0OvqBUrX1/FGFg==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-pEjdCtqgoFpUalzeVr86GQr7QfLZIoZXVG3tFAr7561QJuSBocfk76DQ4+SIs+5sXeczcydncCTmWW++zNQTCg==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -19972,7 +19993,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-BhlaHYt/Ij/i8dM3DoKkZhvBnx/4NZR7pRW5rOeYjRIJ7mOzTGVchY3zl/73Cvs9GDG+aSELZbl4iD/EDVHI6Q==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-5J1GmfidT03RZ7ywuJibJNFCJhiXAN2uEB+1mW6tm8FxwV5KzlbfhrPerVlJx16iKaYLROVQ+I9kvHGi76Ad+g==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -19991,7 +20012,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-6PIwoLHtEcBDBvO2QBSgz6ow08Fq4Cjm4IQAqf3ehZ3YxkGr9Ur+iauQCKGKGuoQkvBKN+/tSE+eH31gXAwUPw==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-7fLdA56pxs/a82c2miyuPemJmCq1ncUI9mnTnewgpUsP38mXEv2KoWKA4Z3h7Mbdf3RtM3I32pTJ93gHoukWsQ==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -20009,7 +20030,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-zraFDkG9i/46nWwzzUb3lZwiUc6/ptb8GcAHr7G6Iov4UKKp5c5ZxpujMaSweNqhJE5MqsHOhiGGF68skFAlZg==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-M6s857XTATgivZNEd4ixdExBtxqv1bwHEBudREi2OfcnANorlm4pVCK22xeBXoPL4//e/iZsbFXbl4C7GuZLkA==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -20028,7 +20049,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-FTDK/qFntU+PkxtjuqpHYMmG8Kv2jD7HwugTTYtSkCT8EorHnszTBqCkZimr/LiXVLJid0L0RQFm6Q+p9oI3Lg==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-NUe1V0v0JejGrE1S3fRduV3PbRLWSdOr103L6UWyQOFKxZWf7BWhcMpWeEZhPHhiVzhKXbC6pkJRMMHg8lCPGw==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -20047,7 +20068,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-Dwsgma06weTLvZI61bM4bSzh3ODhcj/MshL4OyBT35KfJXoKJSQxNXyRIGwSWD7gLOaRMgXhhBmO3pbxt/BMIw==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-/7/MtTW0WsR8tZqMeUxrQ+NXABFm03tKI/ZpWrt2Sk9/7TbMEkDcx7kP73lhbPbLD5cdrxJEt6WHHtHppaMGpA==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -20065,7 +20086,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-FSxsbCaTZBDfL4/OyAawE3MC51c6eNb95XrhiC7iWLi16eC1wo78fUZm6PPHdm+1X8sWLi7zLoHOVOkGcUp7Cg==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-BTIv5j2xYZS38Lcu9/bR+Anbc9pQCzko8dy1jyMiGb6lW2ZepWB2N2xpaltzUB9lEkuvVEOpnOeaDAiTXWC86Q==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -20088,7 +20109,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-D5BIygZ4dlmhIwXEFvXbvHQ8vQP25oCwuMfqqj7omIGcBnjGd1ZctGccXb4IIn3stdDN9K0kWkbCL8LGk8KYow==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-Q11EkupOXDgOSsr5Pm4aaMlJoogBVNT0fBsz78eIuUavvP3dldUorxjpej5vOO/IEdrgE30cO3+9aG9ahA8VsA==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -20106,7 +20127,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-njm+4G2z3tEyAJiuSZai/v7Ky4eXABeSEc8WetP7HdgyjqMRNtzn1b967+QdcyhKr4MZB10kTBFB+jSCqwkAUg==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-cunjxtJLc/kvupBa3qV2hzsPbFdaY9B++94q8adhGce8A4+4t/U1nngYCTNcpshHrW19Shyfc0D9B2/nzcVs9g==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -20127,7 +20148,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-0xXr89bc9LRMZuQvO4ABTj+LFDXDpbcXGR2rJ+FWBni8HbjSSSsc+05tQbJhfZSOR9A+rdcb3KSh/WXKolSIpg==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-h8gWZGBXsCoIIwc6lN2WdyWDFrieXrWlOPLAba+683ogP9I+Fe7gblr7yg1VEL/3ZucWhdedY34J4iNaRDN5Og==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -20145,7 +20166,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-E9cyCLD94gPO7XEjAltrsgi/QfrsxvKlZRLN69ynjgR8YCKPiKxWhwA71dbOXR+6WdQGLziY5/ahRn1aw2wJCg==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-xbw3rJTKWhgQyZfQi3aeDhrrLQp9+vqyvUPnf22XBnHZdlPb8flgzkybTnJCcfDosfHkMcJ9FzfDwgz522m+FA==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -20165,7 +20186,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-q/BfrxIgVuicoY31xrb5OiZa8/qH/NSKcgfI0GhxI1DOdrmCoWkJ9QvNitX+4wY1r871UBavYxBi8eUDUiTWKg==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-aTmwY4DYjq2ojq5qoRLsWPNaPz/BhBFg5aaVWyRfEbp+y09meOTvxJX/SKyRIElJHL4VvEGhJmlJzaVlW5FSEw==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -20187,7 +20208,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-HIiso1r1nBMZeKvA1/eoOJ+dSK4IzGy5UOhhNRvqMgCVpTfUzEuZJwW8Yw5zi13eYRu+XRhl0SPQSAoT4A2uHg==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-gdPCJMlW63XPH9RjOMdewbs3oG5f32a2z9y6K2tsKezD3jLIfuVTdVupUC1FwXrWEamIB2Exr+EhGEgs5/9McQ==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -20209,7 +20230,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-aQ4EzEEfnovzniE9NML2Auuo/Me1y82fit9J3tWJZ85W9kY/5eUsBr+z7QxHH4ZhB42prfZox2LPGHntfKuTgQ==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-04/tWii88dOeGkomAPQBt+LetH06XSwStSEZZaIM8cSZAujhXLsycY0/8x0UklPGqdgVnQcfKDnsrq/Kcz2Y2A==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -20231,7 +20252,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-bU69h3UXFLxz6udNlPpwdYck4XvRczm+bGVzdenMNqq0DX9M8xXKQQ/Jew5Q2OMKZJZ1J+kPo5cv+QmPBlv0zA==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-+W8g3raSUGu474tyOcmFxhtKgRA25dM0PV7VZLc5UdmRKCC6HotP2I3pCJ5ddBfjuUoFT4gLoF2yt+8EoyT0+w==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -20250,7 +20271,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-m4miWyp+BhptAHW0KNafiP9ZLli5kRk7xQrFWlegcJbCA/JAaBWvYAw9oP9T1oCsgbeQPPT0vRneQDeS+0G7gg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-48AdhN8pnAFVSjXikBLk70J6sx1KGbC9hCOTqd9H0QHzw916F6R7IgVuQlAd1/jHi3iijcnfwKmEK4DsPt0Kbg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -20273,7 +20294,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-Jz6WyDQQRZFtPgcJHS86iySw53jFfRR9lrdx6fRKjByfcThT42g8xnxlRmjEm+WsojbwSPrB5K/IudllklmAoQ==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-cQLwordo4ZAz2VZazO16pBgb0I4vkXY0duiDVVNk8lhfR2xvP91zSgDNqGIXTUxpI3Heh88LV6/d+u+QgFPDcA==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -20292,7 +20313,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-wQwiTu5mH9IyYOvk97o8d7CuZv7DMykW9qmc0lt8lOqa14hFEsHF447eqfZ5uFwdoxFWOk2iHEnGe4ScmBaCOw==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-EytmQd33NT7pO4y0QSaaEi69QxIbXt1kpKFTkMxZFiB2OMWQy4YEb0ANXHayINJmS3bCXtFe58ofkKVE+NnwQA==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20311,7 +20332,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-l9zFEUo2T3dnR6Eiv+aPmtPIy53goj1fjlyNLubqq+UNFuVNtVqaZJdA9OL9JaftnIA6nLx+ei3TaBO3LFqgKg==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-6nAwJfgQEv6AncU2Njmc8sXfSurrU4P2Qp9PTNoL4RhGfViKUSoQGhlMaxRH6Z/RjjFZLmze/cax0yiePij7rg==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -20330,7 +20351,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-hAqWT8R94Txrv9RYDpZvh4uYVRU84VA4X1C8gKvdVrfk45ilzGswPdOlvCTftlKKhACq731PKRikFiFTKJgMHw==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-0Zskenv0s6R69K0M2hzGlKKovxBTDrCHILy1VSKoCKUY/g0Y5PG11CJWEYAddY8hQAQsp10uE6TPuez1ZJlGEA==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -20350,7 +20371,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-HtocnQRtcjxZIYCVWgy+FYUm4wZVIMigyPwBWpyMJD8djHmxgFoLeqK0yD7q1MhwH3b/5Zh61kFaZkhPrvoVuA==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-lzQzzmcAqWqUk1t/XrEnBwfeWoKfWTjydMYAtjJcCHKUJPJ/JELDLtMLS/A1NTVJ1Qo0XAIAmzqB8cXEwOX34w==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -20368,7 +20389,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-rZGNEcQFXYbFMW+hLZ+lym9qQYcBQlN3BzXqPBf8Q364LHlgzR9n/oeA0e550k5eumXZNSC6MD3CXm2DPwm6NQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-GqiplbAwkNlbf+sDzUbLmPoMFFvAvOi8Hbij7PwbHtUBObOIh70rQ94DChdOE0SeSCCkuxfjMnYS937uDy0vAQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -20388,7 +20409,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-iA9blZqJdybkcQLJlEwaBCeXPP3ONPiJv7Db3DBM9WWuDGe2Ez+VOWOIRUU9/nY09yiPrQP9CMxHyYIq1MUA/g==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-7KoGsDWUfrlq9JXgE5BC3h0dexd1f9BdQpJ4zZoDmv9c2pk5yXzK83bLxQL2s33caTfXwWuxoRzQxMZLDQ1H+Q==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -20408,7 +20429,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-KV/wLyJb9qzdI8iz0TwgjQvcJH8nPaUYKdU19iBjDmx6YtFlO/vX2zzmVV+9a4aGAWXy3NRlbB2Fmt35MMVq8Q==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-lZJ6vJnwI5sZe8v7y3/Gj4jXTb0ql+Dkbwmd6fOMeGLdzqsZ33RUH7haOtOI7dHy+nNeWg74m0N8uFOOkCSjbw==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -20428,7 +20449,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-28qSfVNbqgkIjajHclezIfn+MH7AH9ANu9g6zaZUWf0A8VE1HK5IGztuZMqA50VKqU1gUolAyamE162sObFc1g==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-wjxGWvhqs1Ed/LbUXQs0AalowwVYkH9XvQ5fJOMzx49wDwlUTzfAzCbYUHZ6NX6TeyJyTIgfWJ1/6qiPk8eEDw==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -20470,7 +20491,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-9+1wdPUmhKNpoAabxeFi2Ju5Ddv9fiH+bOejGTHx7nqM3oZwJIEpCub6RDTz6LDOw1dgZdGrlabKl5vzbQ3Vxg==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-an9Nle4GkiYRwwc3MwFPhUzWMwxqMQxMnc+El/iull/SxEOqA/WAdLz3hABNb4sOmlQ7qsnSk3jFz8PzAREmbg==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -20512,7 +20533,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-bfzZIgGMZU1v383tCARiuEZJr6p73XaMxhrn219kEc9so/hdd8SEo7HG4GZbmdRAUUrwl69nN4yx1s3uqRGP9w==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-+NLzmen6TTmiLZ5pBVbs7CD3he2uLx2kuYQn8dyoYkGwx1JbTONX4KfW9j692qz7H/3xfGfm1uZ82U8zIYdq1w==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -20554,7 +20575,7 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-AOPFRzK4SFTQSyEmvqPeAvTCusLRdtLW7yOKCGMXw3+qca4lzTL7u8y/H+2lDFcFva/ONjaIZtbW0txE/0B2KQ==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-HmqU0cC3CCEZ/c6rHqvfxvVF+jCs0nlrAyZRzJlVwp60ltiIVqnJRCeLnnIRgaFdKtPcqNZZzoN5O8GZtW10Vg==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
@@ -20598,7 +20619,7 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-PQEhcIqGzRVotTvZxo1BNLyFZsp9I9lX4S7CpRIK6Us7L3gHwpkONOkIbXhrtsd4RTixb2pSBn78cicbQIRkfg==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-RgnfEHicrvIUdKwHDc3vbmJbK4k3nxe5Uxw2ny0pvi+Iq5Onmf5+LNpB0gAnpuaHN2oirrsUc54MCbtuvl75Lg==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
@@ -20641,7 +20662,7 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-lUvchWtFnO4PVxpApV/9COpf898w8Uc1CSLPt49jfDKg/OsQbioKxBNf1mhHc+RBjydiJR7kmD1YKUFiKAg6Vw==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-oNOfCUrRZ9nSNujUeiWWVvZjo8fl4cgZvFgX9ilxY3ok4/98+lh/ZTEzaZpzZjx4RmxPK1PMp4U52ikeIT6tyQ==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -20686,7 +20707,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-4adw8qAI8K6OO8u8w8z3ZZXxUiJkjY+P41XKJGc75arAfPyX6auR9F8gkKOsSjqOeC2/o5Lcl73asUqGzuJy3Q==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-2SxTEteVPqFJckmIpL9b33e1lmAHoFxbJyqytjod3JYIc1vSflMlHzDAbo9o/oHKMZaZ1PFSXoN6L8x2RW8hag==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20737,7 +20758,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-4JjlsE4A+bNxM+nHjmFclP15O+BOaFkunXcjbjHgoRWEBBf0lkgV4Wc6B3raAel5lZ2LLYCaAj8kvQENzp8EKQ==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-qcfg/OQJvMA2ZblKvDg4aFFdyjqlSNHTHWSvmgiJZnP420DicHbNImkwv5ECxp06S+xES0BEpuW18mk/qqo8rg==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -20778,7 +20799,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-MCg2ahJuXQv3Fe/r9lJyomcyLiGlvWC0z53NmHcRYoVzhCa9PjtJp6UDPdiN5ID4Y8OxTSqGogfHyP2vwbiG8w==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-Aq7VX49Iv02/yYrWdxuBT1iKsYKe32p36J1cfzMrJpyHCu7igDEIrwkgQIglWCaRXKEbgPt/48qPUe6UTiKZ1Q==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -20817,7 +20838,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-fRx1ZFSbocqLeQ84gy9205ktc9C66xFQ+b+qVmVwJyu8ipZPHJBlNnJKs+XyZvg6K84/9jt6POf8hSi4gZCrfQ==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-aUZBPzWAEkY70jPGp6wGQIoMg3Enzs2UJ8xd0rupiL2vSWXzSFf5qIqV57Wnqpy6r+K3+JuVr648u23n8pcM7A==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -20862,7 +20883,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-EiXgMAt7MW3HL8d7vfSYlVKFa2TZ+3frm0qPRr1SQNNxrwJVqQFoZ8jf7UIajvM4JlWxwxhYSybVGlRn5GWKZA==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-4jTQhFw5gAq2AhisyFF805+oflgAxdY8I2tkfz4hHZpg+kJqicll2Zjj7GWhN3x0d78R6pVRdj9HVY3WxPTrLw==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -20925,7 +20946,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-YsV82Jd+8z9vX7SKf+nHrc7unSRy+nYIa+IfYNVLdYZkfNNtIzJ/O+sQHMhsJrra6xLskN4HnnnsKH9fO6M7TA==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-WncKiqHPi9I1EUXCHIr2kkBL6pHpg+uNvgLOffyGAovV9qNdBBftsIU3/o4lCtCW4FoJrPhh8QcsAYx5J+XfVQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -20975,7 +20996,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-lzgOUGt++6t8W9JgFHiObinGG04jf6YAichkHlISkHXvWiizGJDcdKaRkNziwXM+oshsFjuKjFgCmg7VAoaYIQ==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-kydrKA98KrR9EDykijoyzxZpCOasxqq4UA1DUipYTJ32sdlQi4Q4nGLhlEcVv6aGy1k5dY8ttFjO8ANj/Wsr2g==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -21022,7 +21043,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-Wx4tJw/7sUdANiL26eqNYD5pRSSlvh/SkRGMXplnoXjHvqh5GjrzxvAQ8BpvlYITnJUedZ2RQqRXNixY5uixXg==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-4IR4V+egyWewgLjveBuy0u2fUQwJQCCSw/3QWurQV6TPDoSk5tuy6/4dQXiZUfjNlfl6TlSdwpuhKXvFPLtkwA==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -21073,7 +21094,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-P9nZVg/REuuTYFiRTV1rL7b7bxgiO7rZ+4tYZjMYypiVNVBixC3CdamrD6OZgdgcSvRkuvjm1jMoco3JZ1c8aA==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-uhfg0o0+3cgFW+YenpOy0gXgo0U20X/utSTREejuBusHvHLtv6J3xGCPbcsAxw5gEzpIegE23zz7e9mayUXB9A==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -21122,7 +21143,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-44urOCNkChXC4wKyQbHGJyICaBVgX/EEAiEqyXlo+6BhpmCwwHYu4GJs39Hjd/ud29wOYLgsPepAzl4aL97ewA==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-2QCdgpdPSxCLkDmAqFVVCISfFQEIuunesEIKfrVDL72ufMhd0TXsRMk1yTvEPpv/b/Ln+UpHS82VaqiT8eg9xA==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -21167,7 +21188,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-7NZnvAwcNrVYL0er/7JJn2q4Dcv+07+K+LgHbeIufCc2qPxjbwFKM6c1FO9rTMvyANjRVrR4eHx55J6jfS3gCw==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-LIuKpkMn6K2gGL25qqw+LIEADBKZn/OF14IGchz0/PDU3/1+YrfDHxkLDMzBMi2+kXrOKmjdxCXweobdgQa5rA==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -21213,7 +21234,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-8E/WM/YFOilxL+fnJFphg9dyfYkd9TGaSfvo1VTNQxKzmLXY2jNQNyvrvqouS50biwBpnpynOcDppKAC2NINoA==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-E3UNR2yNXfopDOinosH1SC/6+NiKwqgImdQGrEnoDMoW1ZEEcuY6I6lAx6ONrx5/5xBD+OHnMznP/zvKqQve9g==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -21257,7 +21278,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-65nW/GbWZIFjUMQdXjW8s9e2wqXn+D147qqIkw5WxwHBXUOUO2OzUjW3XcyZV/ZuDHFwpPslAfqHyP/xhu7Ecg==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-DxBRRuW81j+ZNp2URQZw2Sq1VU2nvKkuUbO9OFAQG1tMXTUJ2UjnIRTEoenrd99zuH6BrUv09IY7zJKfhCv2Lg==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -21303,7 +21324,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-55ec6zYY5VIEJVLChT6u8BApwIaRpduxZcDR6UJR8m2LARDlM4TkBfHcxS6jw3w39lweHirRR0HBW6TvWik3jA==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-jH/ZDimqeVuKGw/AllrntZcSqsiT38PRiROQOdzlCVRZZgkoSfwpsoM1Valt8fNRKeMaTQwpMhDyZ5CuLs0zUw==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -21351,7 +21372,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-CAvFC4Q6XL6EWecHdIOrwaQvkBCPVnx3FPyWr9hlG1N8eZNU+kJLQZYs8JbqULBxDok2b+45UA7EcvsOZjkuaQ==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-yiZT70frTUVFHS2Mo9InwwCKLSXyg75zSkD9heRYdNDCAn88R2FE54e8nCXrqOAQDeccVIJcXVOaWXKAAy+TFg==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -21392,7 +21413,7 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-0ssi920CN7SLdyQb3VdVuvK0g9/V0iVaZlzEV1KMMQxPl0uXMdCpfy1h7aPvikLnaetjchCVmxYiRdS8/jZBwA==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-ClUzXwBpZsixZkzgaTVzYNAjWOplyuQyQZ6J2M5OEZuYqiuRHZ3EHV9Pz9gx7skCmN0NP/0ZbscvPgM/lSJQWA==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
@@ -21427,7 +21448,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-SPktEyftj+YlKCvy+UUjDp9IniuUehJjZ8Edh9ew9katr2hjesLJt12xNgxOjejXdjZI/rPwbm63kBmreKFJSA==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-tRrEMHAtYa+oVimy5ab0MDmwGfPXJfIOmnlfKNTpyK3evYvpyD14aw/AhvMM5i4TFm7utkIgAgr4CevyL98vag==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -21468,7 +21489,7 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-p/WVCaSTsfUe4Y7gtdVYEfFevaRuZT2GWC7e9e/Ru699k4WYZoHAF9Kdut/jzAGoAhtWfil+68rFrsTeLFuAtg==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-FY2dfqYSbJ+rjlPOVgwAdhfbSfOqxjpTYUOx0cObE31yxOgNnFzSxZmMvGd0fwvPPoCCaExnXQeWwbnizoq79g==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
@@ -21510,7 +21531,7 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-NXQiohtGO912Ft5AiNmnO60PHsuraOyF1+dk9WYP4ICkkL8cuP2GixJpAc8zICYGNVlb76wTVdf8zCFwmHimYA==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-odckpBQw502JDzFJEE2YmF2q4BDttMkgwNnK6LGom/gKwtNlCqYX7q0QSrGggEvqd9+Fe3eJUsVYkde6jnWpTQ==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
@@ -21553,7 +21574,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-Tew+OTxOc2iA31XMHvhIWMXXVYXLCA2/qRhN74JWqWDdGLRpmzKMPZ2PnZfn+IYRd/vN2mVqBEiOqxQdlPj5kQ==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-C/vLGMWcmzyAVXCeCbhrVt3383tU+q7Jy5BO2c/z2Gy/3w4dnrGSEz3Z+fPZNsStxG+lidSx4vGPCmAnEH5kfQ==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -21571,7 +21592,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-59wCpvAIFd+hVOdlADUEn0fb/0yNC20+SdKIC54kkGQPlpPxkpnC7N2EAFtg+z6FI5UOSvjTsDeqTr5u11RBWA==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-9mtv2GhYC48HoLcYWY54DXWZd9TyCKEjy2EyWyz/YRAwEHH1Bg99S2z/vUvs1+0CAr3MXqOcPVduYQIAyDR50Q==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -21611,7 +21632,7 @@ packages:
     dev: false
 
   file:projects/test-utils-perf.tgz:
-    resolution: {integrity: sha512-8qhq5ooTMcMBowWuYUKu/fvAD4Bj+b7SfsCII1NpFbyy2PptJtVhbtF2zJWSqkRzF+i+4nGwuYclyL1YeTDwQA==, tarball: file:projects/test-utils-perf.tgz}
+    resolution: {integrity: sha512-qY4pUcbUKeJA438+9NoHJ/agdK31YRMqXRoS7J7yZ/zG1n/+F2QmNU7CkwZef6uXCxD8/+HCVpxppd+ypX/nlQ==, tarball: file:projects/test-utils-perf.tgz}
     name: '@rush-temp/test-utils-perf'
     version: 0.0.0
     dependencies:
@@ -21639,7 +21660,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-txkzetMc4WQYN6EePYqTNYjlWeQI+p3wJ9T0C/aQbcjh/CFbT8U6dvwK738ZG3F43DFIcl7XIOSQyc5842sUSQ==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-ZEW7YUeSYcnol3DEXAydO7/PsGUAU5JGtAUzTVtH1seg1I5UFeXEI3AgD0ZFJrQz/5GfiZQqRIn0QAQwJ4p7DA==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -21675,7 +21696,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-pu242+kd8vCVMtaHFmC/xfTB5fQQaeOs5zeCE2XBHtoW+Y2B35fNQ5L8OGcYXnqWOltYKWKpUR2UmH8O4fgm7Q==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-BEo47wPS7QWx8Mb7vCJaGUFXtsSpq4PmnwKrxlyEnue92ZRaXYSQw1EWoP1j8TXdl2OO1tl2aAuJvNc2+VjzQQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -21722,7 +21743,7 @@ packages:
     dev: false
 
   file:projects/vite-plugin-browser-test-map.tgz:
-    resolution: {integrity: sha512-gC6f2ICdYw8k0OXjikon0MXViBINdVCh+QNc4YQD8qMoYSZr2xbxcYCglJaEaRJy/7QNelhvzB9Ftb2I21+nEA==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
+    resolution: {integrity: sha512-9WyTGuzfMHFjT+K+UqyKOdweE6+ZGrJpzPGId+J1BiIvPVrswsGIyPASSAEGt8HqLNhKZJQDAD8YhL9xz4yp9g==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
     name: '@rush-temp/vite-plugin-browser-test-map'
     version: 0.0.0
     dependencies:
@@ -21737,7 +21758,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-bqASNsKP+gzUPxkCP/Rkk0R6rrun7AZMb364W4sRhDNnF5VjBGTRcHxEg8lGh47ez3C2tN2EI6oIgF8a65nIAA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-3Pcx0yoFnczcGxSJEgk12gXLV2iMFIfQpugMky3GOEWcLWtPcJEhNhMU2TNcFUiH2Lq6x6gXTwotArELtQThvw==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -21798,7 +21819,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-SlWmcPJ9rIN5M5urPMr3j3j4iJvccqhFcGGf4aMe36DZnboK6YVsieJ2DR1uE3SnaMV/ud2t0QC3YlwjeTzZpQ==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-2+w18Vg9mbL55xAMTuCmZtju2R1c5wy+Xpj6eecLHkI55mUcpTs/Ez4GwhO4bW9fyUpjHGCOofdlqUlgd9c0lw==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -21854,7 +21875,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-i062iIdG07Pv1PRNpb5q3npLSCEHC37N+mMK73zTiCGXgivocnfGXjDOKIhb9gvAVVhcZ5ZxADKaMw/cOe8Cqg==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-acRgmxmkUX7oZu888qiRqieNahkfXR1Rdn5AZKDlJh4wHDEvcMRh/QePrWlxHrGL6VWWsTvxh5nehZU7dA/RQQ==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -21891,7 +21912,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-gmBO+MTNS9Jv3yJO+FAOzjiDD0ht39yqPendnnVmfJdFweyTWXX1cIOBDHdlq5Kp0mKzWY9TlAe3ckGLPxryxA==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-jxI9JLp5/jUlSqb2EXM3vf1KiMHLEsqpAcIU8QCq9+9X+fr/udulKS2iLL2BqklsIGlO4iJhe95o+7tzXOE6BQ==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Add JSON Merge Path support
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -62,7 +62,8 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "type-plus": "^7.6.0"
   },
   "devDependencies": {
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
@@ -74,7 +75,6 @@
     "eslint": "^8.0.0",
     "playwright": "^1.39.0",
     "rimraf": "^3.0.0",
-    "type-plus": "^7.6.0",
     "typescript": "~5.3.3",
     "vitest": "^1.2.1"
   },

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -65,15 +65,16 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
+    "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/node": "^18.0.0",
     "@vitest/browser": "^1.2.1",
     "eslint": "^8.0.0",
     "playwright": "^1.39.0",
     "rimraf": "^3.0.0",
+    "type-plus": "^7.6.0",
     "typescript": "~5.3.3",
     "vitest": "^1.2.1"
   },

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -19,3 +19,4 @@ export { isDefined, isObjectWithProperties, objectHasProperty } from "./typeGuar
 export { randomUUID } from "./uuidUtils";
 export { isBrowser, isBun, isNode, isDeno, isReactNative, isWebWorker } from "./checkEnvironment";
 export { uint8ArrayToString, stringToUint8Array, type EncodingType } from "./bytesEncoding";
+export { mergePatch, mergePatchStrict, type JsonMergePatch } from "./jsonMergePatch";

--- a/sdk/core/core-util/src/jsonMergePatch.ts
+++ b/sdk/core/core-util/src/jsonMergePatch.ts
@@ -3,16 +3,16 @@
 
 import { isObject } from "./object";
 
-export type JsonMergePatch<T> = T extends { [k: string]: unknown }
+export type JsonMergePatch<T> = T extends object
   ? JsonMergePatchObject<T>
   : // If T isn't an object, we just yield T
     T;
 
-type JsonMergePatchObject<T extends { [k: string]: unknown }> =
+type JsonMergePatchObject<T extends object> =
   // The recursion exits when the object doesn't contain string-keyed properties
   {
     // Checks if a property is optional or undefined already (no way to distinguish them AFAIK)
-    [K in keyof T]?: JsonMergePatchProperty<T[K]>;
+    [K in keyof T as K extends string ? K : never]?: JsonMergePatchProperty<T[K]>;
   };
 
 type JsonMergePatchProperty<T> = undefined extends T

--- a/sdk/core/core-util/src/jsonMergePatch.ts
+++ b/sdk/core/core-util/src/jsonMergePatch.ts
@@ -4,17 +4,23 @@
 import type { IsArray, IsTuple, IsFunction } from "type-plus";
 import { isObject } from "./object";
 
-export type JsonMergePatch<T> = T extends object
+export type JsonMergePatch<T> = IsStrictObject<
+  T,
+  T extends object
+    ? JsonMergePatchObject<T> & {
+        //
+      }
+    : never,
+  T
+>;
+
+type IsStrictObject<T, Then = true, Else = false> = T extends object
   ? IsArray<
       T,
-      T,
-      IsTuple<
-        T,
-        T,
-        IsFunction<T, T, T extends Date ? T : T extends RegExp ? T : JsonMergePatchObject<T>>
-      >
+      Else,
+      IsTuple<T, Else, IsFunction<T, Else, T extends Date ? Else : T extends RegExp ? Else : Then>>
     >
-  : T;
+  : Else;
 
 type JsonMergePatchObject<T extends object> =
   // The recursion exits when the object doesn't contain string-keyed properties
@@ -39,7 +45,7 @@ type JsonMergePatchProperty<T> = undefined extends T
  * returns `patch`.
  */
 export function mergePatch<T>(target: T, patch: JsonMergePatch<T>): T {
-  return mergePatchStrict(target, patch, (p): p is T => true);
+  return mergePatchStrict(target, patch, (_): _ is T => true);
 }
 
 /**

--- a/sdk/core/core-util/src/jsonMergePatch.ts
+++ b/sdk/core/core-util/src/jsonMergePatch.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { isObject } from "./object";
+
+export type JsonMergePatch<T> = T extends { [k: string]: unknown }
+  ? JsonMergePatchObject<T>
+  : // If T isn't an object, we just yield T
+    T;
+
+type JsonMergePatchObject<T extends { [k: string]: unknown }> =
+  // The recursion exits when the object doesn't contain string-keyed properties
+  {
+    // Checks if a property is optional or undefined already (no way to distinguish them AFAIK)
+    [K in keyof T]?: JsonMergePatchProperty<T[K]>;
+  };
+
+type JsonMergePatchProperty<T> = undefined extends T
+  ? // Recurses, adding null to the type union of only the optional properties
+    JsonMergePatch<NonNullable<T>> | null
+  : // If null is already present, this preserves it
+    JsonMergePatch<NonNullable<T>> | (T & null);
+
+/**
+ * Applies `patch` to `target` according to the JSON Merge Patch RFC's spec. Does not remove
+ * required fields.
+ * @param target - The target of the patch.
+ * @param patch - The patch. The TS type will prevent the removal of required fields from object
+ * types, but no such validation is done in the function body.
+ * @returns - If the patch and target are non-array objects, returns the patched target. Otherwise
+ * returns `patch`.
+ */
+export function mergePatch<T>(target: T, patch: JsonMergePatch<T>): T {
+  return mergePatchStrict(target, patch, (p): p is T => true);
+}
+
+/**
+ * Applies `patch` to `target` according to the JSON Merge Patch RFC's spec. Does not remove
+ * required fields.
+ * @param target - The target of the patch.
+ * @param patch - The patch. The TS type will prevent the removal of required fields from object
+ * types, but no such validation is done in the function body.
+ * @param typeGuard - A callback to provide for the handling of cases where either `target` or
+ * `patch` is not an object. If this callback is not provided, the function returns `undefined`
+ * when any input isn't a non-array object. This function should return a truthy value only when
+ * `patch` is a suitable fallback for the patched target. Specifically, this function has no way
+ * to account for missing required fields at runtime, so this function should return false when
+ * such fields are missing.
+ * @returns - If the patch and target are non-array objects, returns the patched target.
+ * If the type guard is defined and returns a truthy value for `patch`, returns `patch` as-is.
+ * Returns undefined otherwise.
+ */
+export function mergePatchStrict<T>(
+  target: T,
+  patch: JsonMergePatch<T>,
+  typeGuard: (patch: T | JsonMergePatch<T>) => patch is T
+): T;
+export function mergePatchStrict<T>(target: T, patch: JsonMergePatch<T>): T | undefined;
+export function mergePatchStrict<T>(
+  target: T,
+  patch: JsonMergePatch<T>,
+  typeGuard?: (patch: T | JsonMergePatch<T>) => patch is T
+): T | undefined {
+  if (!isObject(target) || !isObject(patch)) {
+    return typeGuard?.(patch) ? patch : undefined;
+  }
+
+  const keysToRemove = Object.entries(patch)
+    .filter(([_, value]) => value === null)
+    .map(([key, _]) => key);
+
+  const patchedEntries = Object.entries(patch).filter(([key, _]) => !keysToRemove.includes(key));
+
+  for (const entry of patchedEntries) {
+    const [key, value] = entry;
+    const childTarget = target[key];
+    if (isObject(childTarget)) {
+      entry[1] = mergePatchStrict(childTarget, value as JsonMergePatch<typeof childTarget>);
+    }
+  }
+
+  return Object.fromEntries([
+    ...Object.entries(target).filter(([key, _]) => !keysToRemove.includes(key)),
+    ...patchedEntries,
+  ]) as T;
+}

--- a/sdk/core/core-util/src/jsonMergePatch.ts
+++ b/sdk/core/core-util/src/jsonMergePatch.ts
@@ -1,12 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import type { IsArray, IsTuple, IsFunction } from "type-plus";
 import { isObject } from "./object";
 
 export type JsonMergePatch<T> = T extends object
-  ? JsonMergePatchObject<T>
-  : // If T isn't an object, we just yield T
-    T;
+  ? IsArray<
+      T,
+      T,
+      IsTuple<
+        T,
+        T,
+        IsFunction<T, T, T extends Date ? T : T extends RegExp ? T : JsonMergePatchObject<T>>
+      >
+    >
+  : T;
 
 type JsonMergePatchObject<T extends object> =
   // The recursion exits when the object doesn't contain string-keyed properties

--- a/sdk/core/core-util/test/public/jsonMergePatch.spec.ts
+++ b/sdk/core/core-util/test/public/jsonMergePatch.spec.ts
@@ -85,6 +85,33 @@ describe("jsonMergePatch", function () {
         d?: number | null;
       } | null;
     };
+
+    interface Person {
+      name: string;
+      lastName: string;
+      email: string;
+      twitterHandle?: string;
+      githubHandle?: string;
+      awards: {
+        trackAndField?: Medal;
+        soccer?: Medal;
+      };
+    }
+
+    type Medal = "gold" | "silver" | "bronze";
+
+    interface ExpectJsonMergePatchPerson {
+      name?: string;
+      lastName?: string;
+      email?: string;
+      twitterHandle?: string | null;
+      githubHandle?: string | null;
+      awards?: {
+        trackAndField?: "gold" | "silver" | "bronze" | null;
+        soccer?: Medal | null;
+      };
+    }
+
     it("test types are declared correctly", function () {
       assert(testType.equal<Bar, Baz>(true));
       assert(testType.equal<ExpectJsonMergePatchBar, ExpectJsonMergePatchBaz>(true));
@@ -97,22 +124,29 @@ describe("jsonMergePatch", function () {
       assert(testType.true<BasicTest<ExpectJsonMergePatchFoo, Foo>>(true));
       assert(testType.true<BasicTest<ExpectJsonMergePatchBar, Bar>>(true));
       assert(testType.true<BasicTest<ExpectJsonMergePatchBaz, Baz>>(true));
+      assert(testType.true<BasicTest<ExpectJsonMergePatchPerson, Person>>(true));
 
       assert(testType.true<WithNullTest<ExpectJsonMergePatchFoo, Foo>>(true));
       assert(testType.true<WithNullTest<ExpectJsonMergePatchBar, Bar>>(true));
       assert(testType.true<WithNullTest<ExpectJsonMergePatchBaz, Baz>>(true));
+      assert(testType.true<WithNullTest<ExpectJsonMergePatchPerson, Person>>(true));
 
       assert(testType.true<CanAssignTest<Foo, ExpectJsonMergePatchFoo>>(true));
       assert(testType.true<CanAssignTest<Bar, ExpectJsonMergePatchBar>>(true));
       assert(testType.true<CanAssignTest<Baz, ExpectJsonMergePatchBaz>>(true));
+      assert(testType.true<CanAssignTest<Person, ExpectJsonMergePatchPerson>>(true));
     });
 
     it("parametric type has the correct behavior with type unions", function () {
       assert(
         testType.true<
           BasicTest<
-            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo",
-            Foo | Bar | Baz | "foo"
+            | ExpectJsonMergePatchFoo
+            | ExpectJsonMergePatchBar
+            | ExpectJsonMergePatchBaz
+            | ExpectJsonMergePatchPerson
+            | "foo",
+            Foo | Bar | Baz | Person | "foo"
           >
         >(true)
       );
@@ -120,8 +154,12 @@ describe("jsonMergePatch", function () {
       assert(
         testType.true<
           WithNullTest<
-            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo",
-            Foo | Bar | Baz | "foo"
+            | ExpectJsonMergePatchFoo
+            | ExpectJsonMergePatchBar
+            | ExpectJsonMergePatchBaz
+            | ExpectJsonMergePatchPerson
+            | "foo",
+            Foo | Bar | Baz | Person | "foo"
           >
         >(true)
       );
@@ -129,11 +167,30 @@ describe("jsonMergePatch", function () {
       assert(
         testType.true<
           CanAssignTest<
-            Foo | Bar | Baz | "foo",
-            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo"
+            Foo | Bar | Baz | Person | "foo",
+            | ExpectJsonMergePatchFoo
+            | ExpectJsonMergePatchBar
+            | ExpectJsonMergePatchBaz
+            | ExpectJsonMergePatchPerson
+            | "foo"
           >
         >(true)
       );
+    });
+
+    it("Is identical to the input with arrays, tuples, functions, RegExp and Date", function () {
+      type FooArray = Array<{ a: string; b?: string; c?: { a: string } }>;
+      type FooTuple = [
+        { a: string; b?: string; c?: { a: string } },
+        { a: string; b?: string; c?: { a: string } }
+      ];
+      type FooFunction = () => void;
+
+      assert(testType.equal<FooArray, JsonMergePatch<FooArray>>(true));
+      assert(testType.equal<FooTuple, JsonMergePatch<FooTuple>>(true));
+      assert(testType.equal<FooFunction, JsonMergePatch<FooFunction>>(true));
+      assert(testType.equal<RegExp, JsonMergePatch<RegExp>>(true));
+      assert(testType.equal<Date, JsonMergePatch<Date>>(true));
     });
   });
 

--- a/sdk/core/core-util/test/public/jsonMergePatch.spec.ts
+++ b/sdk/core/core-util/test/public/jsonMergePatch.spec.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, it, assert } from "vitest";
+import { testType, type RecursivePartial, type IsEqual, type StrictCanAssign } from "type-plus";
+import { mergePatchStrict, type JsonMergePatch } from "../../src/jsonMergePatch";
+
+describe("jsonMergePatch", function () {
+  describe("type", function () {
+    type Foo = {
+      a: number;
+      b: number | null;
+      c?: number;
+      d?: number | null;
+    };
+    type ExpectJsonMergePatchFoo = {
+      a?: number;
+      b?: number | null;
+      c?: number | null;
+      d?: number | null;
+    };
+    type Bar = {
+      a: Foo;
+      b: Foo | null;
+      c?: Foo;
+      d?: Foo | null;
+    };
+    type ExpectJsonMergePatchBar = {
+      a?: ExpectJsonMergePatchFoo;
+      b?: ExpectJsonMergePatchFoo | null;
+      c?: ExpectJsonMergePatchFoo | null;
+      d?: ExpectJsonMergePatchFoo | null;
+    };
+    // should equal bar
+    type Baz = {
+      a: {
+        a: number;
+        b: number | null;
+        c?: number;
+        d?: number | null;
+      };
+      b: {
+        a: number;
+        b: number | null;
+        c?: number;
+        d?: number | null;
+      } | null;
+      c?: {
+        a: number;
+        b: number | null;
+        c?: number;
+        d?: number | null;
+      };
+      d?: {
+        a: number;
+        b: number | null;
+        c?: number;
+        d?: number | null;
+      } | null;
+    };
+
+    type ExpectJsonMergePatchBaz = {
+      a?: {
+        a?: number;
+        b?: number | null;
+        c?: number | null;
+        d?: number | null;
+      };
+      b?: {
+        a?: number;
+        b?: number | null;
+        c?: number | null;
+        d?: number | null;
+      } | null;
+      c?: {
+        a?: number;
+        b?: number | null;
+        c?: number | null;
+        d?: number | null;
+      } | null;
+      d?: {
+        a?: number;
+        b?: number | null;
+        c?: number | null;
+        d?: number | null;
+      } | null;
+    };
+    it("test types are declared correctly", function () {
+      assert(testType.equal<Bar, Baz>(true));
+      assert(testType.equal<ExpectJsonMergePatchBar, ExpectJsonMergePatchBaz>(true));
+    });
+
+    type BasicTest<Expect, Test> = IsEqual<Expect, JsonMergePatch<Test>>;
+    type WithNullTest<Expect, Test> = IsEqual<Expect & null, JsonMergePatch<Test> & null>;
+    type CanAssignTest<A, B> = StrictCanAssign<A, B>;
+    it("parametric type has the correct behavior", function () {
+      assert(testType.true<BasicTest<ExpectJsonMergePatchFoo, Foo>>(true));
+      assert(testType.true<BasicTest<ExpectJsonMergePatchBar, Bar>>(true));
+      assert(testType.true<BasicTest<ExpectJsonMergePatchBaz, Baz>>(true));
+
+      assert(testType.true<WithNullTest<ExpectJsonMergePatchFoo, Foo>>(true));
+      assert(testType.true<WithNullTest<ExpectJsonMergePatchBar, Bar>>(true));
+      assert(testType.true<WithNullTest<ExpectJsonMergePatchBaz, Baz>>(true));
+
+      assert(testType.true<CanAssignTest<Foo, ExpectJsonMergePatchFoo>>(true));
+      assert(testType.true<CanAssignTest<Bar, ExpectJsonMergePatchBar>>(true));
+      assert(testType.true<CanAssignTest<Baz, ExpectJsonMergePatchBaz>>(true));
+    });
+
+    it("parametric type has the correct behavior with type unions", function () {
+      assert(
+        testType.true<
+          BasicTest<
+            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo",
+            Foo | Bar | Baz | "foo"
+          >
+        >(true)
+      );
+
+      assert(
+        testType.true<
+          WithNullTest<
+            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo",
+            Foo | Bar | Baz | "foo"
+          >
+        >(true)
+      );
+
+      assert(
+        testType.true<
+          CanAssignTest<
+            Foo | Bar | Baz | "foo",
+            ExpectJsonMergePatchFoo | ExpectJsonMergePatchBar | ExpectJsonMergePatchBaz | "foo"
+          >
+        >(true)
+      );
+    });
+  });
+
+  describe("function", function () {
+    describe("conforms to the RFC example", function () {
+      it("1", function () {
+        const original = {
+          a: "b",
+          c: {
+            d: "e",
+            f: "g",
+          },
+        };
+        const patch = {
+          a: "z",
+          c: {
+            f: null,
+          },
+        };
+        const expect = {
+          a: "z",
+          c: {
+            d: "e",
+          },
+        };
+        assert.deepEqual(
+          mergePatchStrict(original as RecursivePartial<typeof original>, patch),
+          expect
+        );
+      });
+      it("2", function () {
+        const original = {
+          title: "Goodbye!",
+          author: {
+            givenName: "John",
+            familyName: "Doe",
+          },
+          tags: ["example", "sample"],
+          content: "This will be unchanged",
+        };
+        const patch = {
+          title: "Hello!",
+          phoneNumber: "+01-123-456-7890",
+          author: {
+            familyName: null,
+          },
+          tags: ["example"],
+        };
+        const expect = {
+          title: "Hello!",
+          author: {
+            givenName: "John",
+          },
+          tags: ["example"],
+          content: "This will be unchanged",
+          phoneNumber: "+01-123-456-7890",
+        };
+        assert.deepEqual(
+          mergePatchStrict(original as RecursivePartial<typeof original>, patch),
+          expect
+        );
+      });
+    });
+  });
+});

--- a/sdk/core/core-util/tsconfig.json
+++ b/sdk/core/core-util/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist-esm",
     "declarationDir": "./types/latest",
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-util

### Issues associated with this PR

https://github.com/Azure/autorest.typescript/issues/2001

### Describe the problem that is addressed by this PR

DPG needs support for [JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386). This change adds a utility parametric type that yields the shape of a valid patch. It also adds a function for implementation on client side. Though I'm now realizing I don't think anyone has asked for it...

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
