### PR TITLE
[core] Update bun and deno checks

### DIFF
--- a/sdk/core/core-util/src/checkEnvironment.ts
+++ b/sdk/core/core-util/src/checkEnvironment.ts
@@ -76,8 +76,6 @@ export const isNode =
   !isDeno &&
   !isBun;
 
-
-
 /**
  * A constant that indicates whether the environment the code is running is in React-Native.
  */

--- a/sdk/core/core-util/src/checkEnvironment.ts
+++ b/sdk/core/core-util/src/checkEnvironment.ts
@@ -61,6 +61,11 @@ export const isDeno =
   typeof Deno.version.deno !== "undefined";
 
 /**
+ * A constant that indicates whether the environment the code is running is Bun.sh.
+ */
+export const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
+
+/**
  * A constant that indicates whether the environment the code is running is Node.JS.
  */
 export const isNode =
@@ -68,12 +73,10 @@ export const isNode =
   Boolean(process.version) &&
   Boolean(process.versions?.node) &&
   // Deno thought it was a good idea to spoof process.versions.node, see https://deno.land/std@0.177.0/node/process.ts?s=versions
-  !isDeno;
+  !isDeno &&
+  !isBun;
 
-/**
- * A constant that indicates whether the environment the code is running is Bun.sh.
- */
-export const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
+
 
 /**
  * A constant that indicates whether the environment the code is running is in React-Native.

--- a/sdk/core/ts-http-runtime/src/util/checkEnvironment.ts
+++ b/sdk/core/ts-http-runtime/src/util/checkEnvironment.ts
@@ -33,10 +33,9 @@ export const isWebWorker =
     self.constructor?.name === "SharedWorkerGlobalScope");
 
 /**
- * A constant that indicates whether the environment the code is running is Node.JS.
+ * A constant that indicates whether the environment the code is running is Bun.sh.
  */
-export const isNode =
-  typeof process !== "undefined" && Boolean(process.version) && Boolean(process.versions?.node);
+export const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
 
 /**
  * A constant that indicates whether the environment the code is running is Deno.
@@ -47,9 +46,15 @@ export const isDeno =
   typeof Deno.version.deno !== "undefined";
 
 /**
- * A constant that indicates whether the environment the code is running is Bun.sh.
+ * A constant that indicates whether the environment the code is running is Node.JS.
  */
-export const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
+export const isNode =
+  typeof process !== "undefined" &&
+  Boolean(process.version) &&
+  Boolean(process.versions?.node) &&
+  // Deno thought it was a good idea to spoof process.versions.node, see https://deno.land/std@0.177.0/node/process.ts?s=versions
+  !isDeno &&
+  !isBun;
 
 /**
  * A constant that indicates whether the environment the code is running is in React-Native.


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-util
- @typespec/ts-http-runtime

### Issues associated with this PR


### Describe the problem that is addressed by this PR

The current logic would show Bun reporting as Node.  This changes the logic to ensure that Bun and Deno are detected correctly.  Bun gives the following information which can make it seem like it is Node as it has a `node` and `bun` version.

```js
> process.versions
{
  node: '21.6.0',
  bun: '1.0.25',
  webkit: 'a780bdf0255ae1a7ed15e4b3f31c14af705facae',
  boringssl: 'b275c5ce1c88bc06f5a967026d3c0ce1df2be815',
  openssl: '1.1.0',
  libarchive: 'dc321febde83dd0f31158e1be61a7aedda65e7a2',
  mimalloc: '7968d4285043401bb36573374710d47a4081a063',
  picohttpparser: '066d2b1e9ab820703db0837a7255d92d30f0c9f5',
  uwebsockets: 'a8ff7be642a3cd93e033b324cfd1fc966b69af12',
  zig: '0.12.0-dev.1828+225fe6ddb',
  zlib: '885674026394870b7e7a05b7bf1ec5eb7bd8a9c0',
  tinycc: '2d3ad9e0d32194ad7fd867b66ebe218dcc8cb5cd',
  lolhtml: '8d4c273ded322193d017042d1f48df2766b0f88b',
  ares: '0e7a5dee0fbb04080750cf6eabbe89d8bae87faa',
  usockets: 'a8ff7be642a3cd93e033b324cfd1fc966b69af12',
  v8: '11.3.244.8-node.15',
  uv: '1.46.0',
  napi: '9',
  modules: '115'
}
```

Test cases:

Deno 1.40.2

```js
> const isDeno =
  typeof Deno !== "undefined" &&
  typeof Deno.version !== "undefined" &&
  typeof Deno.version.deno !== "undefined";
undefined
> const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
undefined
> const isNode =
  typeof process !== "undefined" &&
  Boolean(process.version) &&
  Boolean(process.versions?.node) &&
  !isDeno &&
  !isBun;
undefined
> isDeno
true
> isBun
false
> isNode
false
>
```

Bun v1.0.25

```js
> const isDeno =
  typeof Deno !== "undefined" &&
  typeof Deno.version !== "undefined" &&
  typeof Deno.version.deno !== "undefined";
undefined
> const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
undefined
> const isNode =
  typeof process !== "undefined" &&
  Boolean(process.version) &&
  Boolean(process.versions?.node) &&
  !isDeno &&
  !isBun;
undefined
> isNode
false
> isDeno
false
> isBun
true
```


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
