### PR TITLE
[Azure Monitor OpenTelemetry] Fix Resource Type Issue

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix OpenTelemetry Resource type being used when resource is set on the AzureMonitorOpenTelemetryOptions.
+
 ### Other Changes
 
 ## 1.2.0 (2024-01-23)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix OpenTelemetry Resource type being used when resource is set on the AzureMonitorOpenTelemetryOptions.
+- Fix OpenTelemetry Resource type being used when resource is set on the AzureMonitorOpenTelemetryOptions by resource detector.
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -137,20 +137,20 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
       detectors: [envDetectorSync],
     };
     const envResource = detectResourcesSync(detectResourceConfig);
-    resource = resource.merge(envResource);
+    resource = resource.merge(envResource) as Resource;
 
     // Load resource attributes from Azure
     const azureResource: Resource = detectResourcesSync({
       detectors: [azureAppServiceDetector, azureFunctionsDetector],
     });
-    this._resource = resource.merge(azureResource);
+    this._resource = resource.merge(azureResource) as Resource;
 
     const vmResource = detectResourcesSync({
       detectors: [azureVmDetector],
     });
     if (vmResource.asyncAttributesPending) {
       vmResource.waitForAsyncAttributes?.().then(() => {
-        this._resource = this._resource.merge(vmResource);
+        this._resource = this._resource.merge(vmResource) as Resource;
       });
     }
   }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
#28433

### Describe the problem that is addressed by this PR
Types are set incorrectly on the resource detector returned resources.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
