### PR TITLE
[EngSys] remove leftover dev dependency `mocha-junit-reporter`

### DIFF
--- a/sdk/openai/openai-assistants/package.json
+++ b/sdk/openai/openai-assistants/package.json
@@ -117,7 +117,6 @@
     "karma-sourcemap-loader": "^0.4.0",
     "mkdirp": "^2.1.2",
     "mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.9",


### PR DESCRIPTION
We already replaced it with the Mocha builtin reporter. This instance must have been included because of an older version of codegen.

Resolves issue #28467.
