### PR TITLE
[JS] Communication Common | Renaming field name in Microsoft Teams App Identifier Serializer

### DIFF
--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 2.3.1 (Unreleased)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
 
-### Other Changes
+- Renamed field `teamAppId` to `appId` in `SerializedMicrosoftTeamsAppIdentifier` to match the REST specification.
 
 ## 2.3.0 (2023-09-27)
 

--- a/sdk/communication/communication-common/review/communication-common.api.md
+++ b/sdk/communication/communication-common/review/communication-common.api.md
@@ -159,8 +159,8 @@ export interface SerializedCommunicationUserIdentifier {
 
 // @public
 export interface SerializedMicrosoftTeamsAppIdentifier {
+    appId: string;
     cloud?: SerializedCommunicationCloudEnvironment;
-    teamsAppId: string;
 }
 
 // @public

--- a/sdk/communication/communication-common/src/identifierModelSerializer.ts
+++ b/sdk/communication/communication-common/src/identifierModelSerializer.ts
@@ -88,7 +88,7 @@ export interface SerializedMicrosoftTeamsAppIdentifier {
   /**
    * Id of the Microsoft Teams App.
    */
-  teamsAppId: string;
+  appId: string;
 
   /**
    * The cloud that the Microsoft Teams App belongs to. By default 'public' if missing.
@@ -174,7 +174,7 @@ export const serializeCommunicationIdentifier = (
       return {
         rawId: identifierKind.rawId ?? getIdentifierRawId(identifierKind),
         microsoftTeamsApp: {
-          teamsAppId: identifierKind.teamsAppId,
+          appId: identifierKind.teamsAppId,
           cloud: identifierKind.cloud ?? "public",
         },
       };
@@ -244,7 +244,7 @@ export const deserializeCommunicationIdentifier = (
   if (kind === "microsoftTeamsApp" && microsoftTeamsApp) {
     return {
       kind: "microsoftTeamsApp",
-      teamsAppId: assertNotNullOrUndefined({ microsoftTeamsApp }, "teamsAppId"),
+      teamsAppId: assertNotNullOrUndefined({ microsoftTeamsApp }, "appId"),
       cloud: assertNotNullOrUndefined({ microsoftTeamsApp }, "cloud"),
       rawId: assertNotNullOrUndefined({ microsoftTeamsApp: serializedIdentifier }, "rawId"),
     };


### PR DESCRIPTION
### Packages impacted by this PR
communication-common

### Describe the problem that is addressed by this PR
Renaming field `teamsAppId` to `appId` to match REST specification.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
