### PR TITLE
[core] allows choosing Fetch or XMLHttpRequest for browser HttpClient

### DIFF
--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.browser.ts
@@ -1,12 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import type { HttpClient } from "./interfaces";
+import type { CreateHttpClientOptions, HttpClient } from "./interfaces";
 import { createFetchHttpClient } from "./fetchHttpClient";
+import { createXhrHttpClient } from "./xhrHttpClient";
 
 /**
  * Create the correct HttpClient for the current environment.
  */
-export function createDefaultHttpClient(): HttpClient {
-  return createFetchHttpClient();
+export function createDefaultHttpClient(
+  options: CreateHttpClientOptions = { api: "fetch" },
+): HttpClient {
+  if (options.api === "fetch") {
+    return createFetchHttpClient();
+  } else if (options.api === "xhr") {
+    return createXhrHttpClient();
+  } else {
+    throw new Error(
+      `Unsupported value of "${options.browserApi}" for "browserApi". Only "fetch" or "xhr" is supported.`,
+    );
+  }
 }

--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.native.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.native.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import type { HttpClient } from "./interfaces";
+import type { CreateHttpClientOptions, HttpClient } from "./interfaces";
 import { createXhrHttpClient } from "./xhrHttpClient";
 
 /**
  * Create the correct HttpClient for the current environment.
  */
-export function createDefaultHttpClient(): HttpClient {
+export function createDefaultHttpClient(_options?: CreateHttpClientOptions): HttpClient {
   return createXhrHttpClient();
 }

--- a/sdk/core/core-rest-pipeline/src/defaultHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/defaultHttpClient.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import type { HttpClient } from "./interfaces";
+import type { CreateHttpClientOptions, HttpClient } from "./interfaces";
 import { createNodeHttpClient } from "./nodeHttpClient";
 
 /**
  * Create the correct HttpClient for the current environment.
  */
-export function createDefaultHttpClient(): HttpClient {
+export function createDefaultHttpClient(_options?: CreateHttpClientOptions): HttpClient {
   return createNodeHttpClient();
 }

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -305,6 +305,19 @@ export interface HttpClient {
 }
 
 /**
+ * Options to create HttpClient
+ * on behalf of a pipeline.
+ */
+export interface CreateHttpClientOptions {
+  /**
+   * Specifies whether to use Fetch or XMLHttpRequest for browsers.
+   * Defaults to "fetch".
+   * Currently this option is ignored in non-browser environments.
+   */
+  api: "fetch" | "xhr";
+}
+
+/**
  * Fired in response to upload or download progress.
  */
 export type TransferProgressEvent = {

--- a/sdk/core/core-rest-pipeline/test/browser/defaultHttpClient.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/defaultHttpClient.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert, describe, it } from "vitest";
+import { createDefaultHttpClient } from "../../src/defaultHttpClient";
+
+describe.only("createDefaultHttpClient", () => {
+  it("uses Fetch api by default", () => {
+    const client = createDefaultHttpClient();
+    assert.ok(client.constructor.name === "FetchHttpClient");
+  });
+
+  it("uses Fetch api when options specifying fetch", () => {
+    const client = createDefaultHttpClient({ api: "fetch" });
+    assert.ok(client.constructor.name === "FetchHttpClient");
+  });
+
+  it("uses Fetch api when options specifying xhr", () => {
+    const client = createDefaultHttpClient({ api: "xhr" });
+    assert.ok(client.constructor.name === "XhrHttpClient");
+  });
+});


### PR DESCRIPTION
Currently we don't expose the concrete types for our HttpClients. For browsers we return an instance of `FetchHttpClient` from `createDefaultHttpClient()`. However, some times a `XhrHttpClient` is desired, for example, because it has better support on upload progress reporting. But since `XhrHttpClient` is not exposed, customers cannot use it.

This PR provides an option to `createDefaultHttpClient()`, allowing choosing the underlying API.

### Packages impacted by this PR
`@azure/core-rest-pipeline`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could also expose `XhrHttpClient` directly. 
