### PR TITLE
[identity] Remove ! operators from accessToken handlers

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -22,7 +22,7 @@ import { fabricMsi } from "./fabricMsi";
 import { appServiceMsi2019 } from "./appServiceMsi2019";
 import { AppTokenProviderParameters, ConfidentialClientApplication } from "@azure/msal-node";
 import { DeveloperSignOnClientId } from "../../constants";
-import { MsalResult, MsalToken } from "../../msal/types";
+import { MsalResult, MsalToken, ValidMsalToken } from "../../msal/types";
 import { getMSALLogLevel } from "../../msal/utils";
 import { getLogLevel } from "@azure/logger";
 
@@ -383,20 +383,19 @@ export class ManagedIdentityCredential implements TokenCredential {
     this.ensureValidMsalToken(scopes, result, getTokenOptions);
     logger.getToken.info(formatSuccess(scopes));
     return {
-      token: result!.accessToken!,
-      expiresOnTimestamp: result!.expiresOn!.getTime(),
+      token: result.accessToken,
+      expiresOnTimestamp: result.expiresOn.getTime(),
     };
   }
 
   /**
    * Ensures the validity of the MSAL token
-   * @internal
    */
   private ensureValidMsalToken(
     scopes: string | string[],
     msalToken?: MsalToken,
     getTokenOptions?: GetTokenOptions,
-  ): void {
+  ): asserts msalToken is ValidMsalToken {
     const error = (message: string): Error => {
       logger.getToken.info(message);
       return new AuthenticationRequiredError({

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -215,8 +215,8 @@ export abstract class MsalBrowser implements MsalBrowserFlow {
     ensureValidMsalToken(scopes, result, getTokenOptions);
     this.logger.getToken.info(formatSuccess(scopes));
     return {
-      token: result!.accessToken!,
-      expiresOnTimestamp: result!.expiresOn!.getTime(),
+      token: result.accessToken,
+      expiresOnTimestamp: result.expiresOn.getTime(),
     };
   }
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -526,8 +526,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     ensureValidMsalToken(scopes, result, getTokenOptions);
     this.logger.getToken.info(formatSuccess(scopes));
     return {
-      token: result!.accessToken!,
-      expiresOnTimestamp: result!.expiresOn!.getTime(),
+      token: result.accessToken,
+      expiresOnTimestamp: result.expiresOn.getTime(),
     };
   }
 }

--- a/sdk/identity/identity/src/msal/types.ts
+++ b/sdk/identity/identity/src/msal/types.ts
@@ -16,6 +16,11 @@ export interface MsalToken {
 }
 
 /**
+ * Represents a valid (i.e. complete) MSAL token.
+ */
+export type ValidMsalToken = { [P in keyof MsalToken]-?: NonNullable<MsalToken[P]> };
+
+/**
  * Internal representation of MSAL's Account information.
  * Helps us to disambiguate the MSAL classes accross environments.
  * @internal

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AuthenticationRecord, MsalAccountInfo, MsalToken } from "./types";
+import { AuthenticationRecord, MsalAccountInfo, MsalToken, ValidMsalToken } from "./types";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
 import { CredentialLogger, credentialLogger, formatError } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
@@ -35,7 +35,7 @@ export function ensureValidMsalToken(
   scopes: string | string[],
   msalToken?: MsalToken,
   getTokenOptions?: GetTokenOptions,
-): void {
+): asserts msalToken is ValidMsalToken {
   const error = (message: string): Error => {
     logger.getToken.info(message);
     return new AuthenticationRequiredError({


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Split off a chunk from PR #28493

### Describe the problem that is addressed by this PR

Splitting off a chunk discovered in
[#28493](https://github.com/Azure/azure-sdk-for-js/pull/28493/files/484b309d3b2b3ed861bafba4f969c34ea73f8e30#r1480584766)
to show what it might look like and provide smaller commits.

This replaces the type signature of ensureValidMsalToken from void to an
assertion function and allow TypeScript to better understand that the properties
we requested exist and are valid.

I had to introduce a new type to avoid changing existing types which are relied
on in other areas

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

No, this is just type changes. Internal and do not require a changelog or tests.

### Provide a list of related PRs _(if any)_

#28493

### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
