### PR TITLE
[Monitor OpenTelemetry Exporter] Do Not Diag.Error If Sender is Sending Statsbeat Signals

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Errors are no longer thrown upon failed statsbeat export.
+
 ## 1.0.0-beta.19 (2024-01-23)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/base.ts
@@ -30,6 +30,10 @@ export abstract class AzureMonitorBaseExporter {
    * Instrumentation key to be used for exported envelopes
    */
   protected aadAudience: string | undefined;
+
+  /**
+   * Flag to determine if the Exporter is a Statsbeat Exporter
+   */
   private isStatsbeatExporter: boolean;
 
   /**

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatExporter.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatExporter.ts
@@ -33,6 +33,7 @@ export class AzureMonitorStatsbeatExporter
       instrumentationKey: this.instrumentationKey,
       trackStatsbeat: this.trackStatsbeat,
       exporterOptions: options,
+      isStatsbeatSender: true,
     });
   }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
@@ -30,6 +30,7 @@ export class HttpSender extends BaseSender {
     trackStatsbeat: boolean;
     exporterOptions: AzureMonitorExporterOptions;
     aadAudience?: string;
+    isStatsbeatSender?: boolean;
   }) {
     super(options);
     // Build endpoint using provided configuration or default values


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We should fail silently if errors occur in the sender when sending statsbeat metrics.


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
