### PR TITLE
[EngSys] pin http(s)-proxy-agent versions

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,7 +16,9 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "chai": "4.3.10"
+    "chai": "4.3.10",
+    "http-proxy-agent": "7.0.0",
+    "https-proxy-agent": "7.0.2"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1133,6 +1133,12 @@ dependencies:
   chai:
     specifier: 4.3.10
     version: 4.3.10
+  http-proxy-agent:
+    specifier: 7.0.0
+    version: 7.0.0
+  https-proxy-agent:
+    specifier: 7.0.2
+    version: 7.0.2
 
 packages:
 
@@ -6173,8 +6179,8 @@ packages:
       - supports-color
     dev: false
 
-  /http-proxy-agent@7.0.1:
-    resolution: {integrity: sha512-My1KCEPs6A0hb4qCVzYp8iEvA8j8YqcvXLZZH8C9OFuTYpYjHE7N2dtG3mRl1HMD4+VGXpF3XcDVcxGBT7yDZQ==}
+  /http-proxy-agent@7.0.0:
+    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -6204,8 +6210,8 @@ packages:
       - supports-color
     dev: false
 
-  /https-proxy-agent@7.0.3:
-    resolution: {integrity: sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==}
+  /https-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -7906,8 +7912,8 @@ packages:
       agent-base: 7.1.0
       debug: 4.3.4(supports-color@8.1.1)
       get-uri: 6.0.3
-      http-proxy-agent: 7.0.1
-      https-proxy-agent: 7.0.3
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -8282,8 +8288,8 @@ packages:
     dependencies:
       agent-base: 7.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      http-proxy-agent: 7.0.1
-      https-proxy-agent: 7.0.3
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
       lru-cache: 7.18.3
       pac-proxy-agent: 7.0.1
       proxy-from-env: 1.1.0
@@ -18045,7 +18051,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-SBD3kQGpwKzl39ay8T22Zt/wRMgjSm5IEZwZbYFOclnmeUVMz16kP83mUc0HvH9JDzWsvMY367Lf4MhxxTeTxQ==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-tjfZ2ZMJdnivMt4v+W634hl7JZrymsAVbJ7dL7ato/Wq62r03Z5HdJnEvvTGa4g+K+dI12QzE9+J3dNB2iHLNQ==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -18053,8 +18059,8 @@ packages:
       '@types/node': 18.19.15
       '@vitest/browser': 1.2.2(playwright@1.41.2)(vitest@1.2.2)
       eslint: 8.56.0
-      http-proxy-agent: 7.0.1
-      https-proxy-agent: 7.0.3
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
       playwright: 1.41.2
       rimraf: 3.0.2
       tslib: 2.6.2
@@ -18568,7 +18574,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-LV9ckIycccwaMvglK3T0baFkZNIScvRqCH9mlln3o+GJy2qqt+cYk4OOw7n6fGhLaH9fgPKHt2XV6/01QxQiWA==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-LKkyspqplsK2oHtm2KSiN0SfkJdMShA8cSZTbYwqNfBGwZZzXbW5QcVXxDiBBkIfE2tq7KGyqola2/lR1aFYSw==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -18596,7 +18602,7 @@ packages:
       dotenv: 16.4.4
       eslint: 8.56.0
       esm: 3.2.25
-      https-proxy-agent: 7.0.3
+      https-proxy-agent: 7.0.2
       is-buffer: 2.0.5
       jssha: 3.3.1
       karma: 6.4.2(debug@4.3.4)
@@ -21021,7 +21027,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-kQxRncyVjSOTIiW21TWfauxybzV8AJpfSoeYWcI+jgPVsPq2njhNTy1leNvIGjlhW+KhNYP8oHzuwpadWItcXA==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-LqhpJwnhHWnc84l3xMhtQgfpvY8Rc+kmbqZumXeR6fWjL/eC2o7ToXVic1R33AfvYoyuxGgMTYIrIpR+Rye+AA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -21048,7 +21054,7 @@ packages:
       eslint: 8.56.0
       esm: 3.2.25
       events: 3.3.0
-      https-proxy-agent: 7.0.3
+      https-proxy-agent: 7.0.2
       is-buffer: 2.0.5
       jssha: 3.3.1
       karma: 6.4.2(debug@4.3.4)
@@ -21835,7 +21841,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-mNMBUKeFOoO4miF+1uI5+vXQOPiUYNVej+9H7DWqqi50iYnTDYSaqkGBNJHNKNOF/7DZhRntbFb12mKZn6NF8w==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-f2uylLaEF1dj5JUULxsHnKELzKIAdNf3hoXlkqKhZG6IcDWyEHjUqO+UeRjLuhL4QGpToEMmzFSlY7v0rJ0upA==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -21851,8 +21857,8 @@ packages:
       cross-env: 7.0.3
       eslint: 8.56.0
       esm: 3.2.25
-      http-proxy-agent: 7.0.1
-      https-proxy-agent: 7.0.3
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
       inherits: 2.0.4
       karma: 6.4.2(debug@4.3.4)
       karma-chrome-launcher: 3.2.0

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -88,8 +88,8 @@
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.3.0",
     "@azure/logger": "^1.0.0",
-    "http-proxy-agent": "^7.0.1",
-    "https-proxy-agent": "^7.0.3",
+    "http-proxy-agent": "^7.0.0",
+    "https-proxy-agent": "^7.0.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -90,8 +90,8 @@
   },
   "dependencies": {
     "tslib": "^2.2.0",
-    "http-proxy-agent": "^7.0.1",
-    "https-proxy-agent": "^7.0.3"
+    "http-proxy-agent": "^7.0.0",
+    "https-proxy-agent": "^7.0.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -138,7 +138,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "esm": "^3.2.18",
-    "https-proxy-agent": "^7.0.3",
+    "https-proxy-agent": "^7.0.0",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
@@ -31,6 +31,6 @@
     "@azure/core-amqp": "^4.0.0",
     "ws": "^8.2.0",
     "@azure/identity": "^4.0.1",
-    "https-proxy-agent": "^7.0.3"
+    "https-proxy-agent": "^7.0.0"
   }
 }

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
@@ -35,7 +35,7 @@
     "@azure/core-amqp": "^4.0.0",
     "ws": "^8.2.0",
     "@azure/identity": "^4.0.1",
-    "https-proxy-agent": "^7.0.3"
+    "https-proxy-agent": "^7.0.0"
   },
   "devDependencies": {
     "@types/ws": "^7.2.4",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -143,7 +143,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "esm": "^3.2.18",
-    "https-proxy-agent": "^7.0.3",
+    "https-proxy-agent": "^7.0.0",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",

--- a/sdk/servicebus/service-bus/samples/v7-beta/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7-beta/javascript/package.json
@@ -28,7 +28,7 @@
     "@azure/service-bus": "next",
     "dotenv": "latest",
     "ws": "^8.0.0",
-    "https-proxy-agent": "^7.0.3",
+    "https-proxy-agent": "^7.0.0",
     "@azure/identity": "^4.0.1",
     "@azure/abort-controller": "^1.0.0"
   }

--- a/sdk/servicebus/service-bus/samples/v7-beta/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7-beta/typescript/package.json
@@ -32,7 +32,7 @@
     "@azure/service-bus": "next",
     "dotenv": "latest",
     "ws": "^8.0.0",
-    "https-proxy-agent": "^7.0.3",
+    "https-proxy-agent": "^7.0.0",
     "@azure/identity": "^4.0.1",
     "@azure/abort-controller": "^1.0.0"
   },

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -32,7 +32,7 @@
     "@azure/service-bus": "latest",
     "dotenv": "latest",
     "ws": "^8.0.0",
-    "https-proxy-agent": "^7.0.3",
+    "https-proxy-agent": "^7.0.0",
     "@azure/identity": "^4.0.1",
     "@azure/core-auth": "^1.3.0",
     "@azure/abort-controller": "^1.0.0"


### PR DESCRIPTION
The latest versions broke our tests:

```
> mocha -r ../../../common/tools/esm-workaround.js -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js  --reporter-option output=test-results.xml --timeout 1200000 --full-trace "dist-esm/test/internal/**/*.test.js"

/home/meng/git/jssdk/common/temp/node_modules/.pnpm/https-proxy-agent@7.0.3/node_modules/https-proxy-agent/dist/index.js:1
Error: Cannot find module 'node:url'
Require stack:
- /home/meng/git/jssdk/common/temp/node_modules/.pnpm/https-proxy-agent@7.0.3/node_modules/https-proxy-agent/dist/index.js
- /home/meng/git/jssdk/sdk/core/core-rest-pipeline/dist/index.js
- /home/meng/git/jssdk/sdk/monitor/monitor-opentelemetry-exporter/dist-esm/src/platform/nodejs/httpSender.js
...
```
