### PR TITLE
[dev-tool] remove `-r esm` from `test:node-ts-input` options

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -25,7 +25,7 @@ export default leafCommand(commandInfo, async (options) => {
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
   const defaultMochaArgs = `${
-    isModuleProj ? "--loader=ts-node/esm " : "-r esm "
+    isModuleProj ? "--loader=ts-node/esm " : ""
   }-r ts-node/register ${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,


### PR DESCRIPTION
Turns out that it is not needed. Mocha is able to load .ts test files without it.
