### PR TITLE
[Storage] remove usage of `require("buffer")`

### DIFF
--- a/sdk/storage/storage-common/src/PooledBuffer.ts
+++ b/sdk/storage/storage-common/src/PooledBuffer.ts
@@ -7,8 +7,8 @@ import { Readable } from "stream";
 /**
  * maxBufferLength is max size of each buffer in the pooled buffers.
  */
-// Can't use import as Typescript doesn't recognize "buffer".
-const maxBufferLength = require("buffer").constants.MAX_LENGTH;
+import buffer from "buffer";
+const maxBufferLength = buffer.constants.MAX_LENGTH;
 
 /**
  * This class provides a buffer container which conceptually has no hard size limit.


### PR DESCRIPTION
Related: https://github.com/Azure/azure-sdk-for-js/issues/27759

The comment suggests that importing may not work in the past. However, it builds fine and tests are passing now on our supported platforms.


### Packages impacted by this PR
`@azure/storage-*`
