### PR TITLE
[search] Enable CI and live test pipelines on search/stable branch

### DIFF
--- a/sdk/search/ci.yml
+++ b/sdk/search/ci.yml
@@ -1,11 +1,12 @@
 # NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
-                
+
 trigger:
   branches:
     include:
       - main
       - release/*
       - hotfix/*
+      - search/stable
   paths:
     include:
       - sdk/search/
@@ -19,6 +20,7 @@ pr:
       - feature/*
       - release/*
       - hotfix/*
+      - search/stable
     exclude:
       - feature/v4
   paths:


### PR DESCRIPTION
### Packages impacted by this PR

@search/search-documents
### Describe the problem that is addressed by this PR

Adds the `search/stable` branch, the source of truth for GA releases, to the CI and live test pipelines. 
### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Checklists
- [x] Added impacted package name to the issue description
