### PR TITLE
Add Maor as code owner for keyvault

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,7 @@
 /sdk/iot/ @xirzec
 
 # PRLabel: %KeyVault
-/sdk/keyvault/ @timovv @Azure/azsdk-keyvault
+/sdk/keyvault/ @timovv @maorleger @Azure/azsdk-keyvault
 
 # PRLabel: %OpenTelemetryInstrumentation
 /sdk/instrumentation/ @maorleger @joheredi @mpodwysocki


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Adding Maor as reviewer for Key Vault since he is back on the team and has lots of experience in this area!
