### PR TITLE
[keyvault] Rerecord flaky LRO tests

### DIFF
--- a/sdk/keyvault/keyvault-certificates/assets.json
+++ b/sdk/keyvault/keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-certificates",
-  "Tag": "js/keyvault/keyvault-certificates_c4d7677a4b"
+  "Tag": "js/keyvault/keyvault-certificates_cc63cee831"
 }

--- a/sdk/keyvault/keyvault-keys/assets.json
+++ b/sdk/keyvault/keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-keys",
-  "Tag": "js/keyvault/keyvault-keys_ed94a0d29e"
+  "Tag": "js/keyvault/keyvault-keys_6df28cb4fd"
 }

--- a/sdk/keyvault/keyvault-secrets/assets.json
+++ b/sdk/keyvault/keyvault-secrets/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-secrets",
-  "Tag": "js/keyvault/keyvault-secrets_66216a7633"
+  "Tag": "js/keyvault/keyvault-secrets_303fd01104"
 }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`
- `@azure/keyvault-keys`
- `@azure/keyvault-secrets`

### Describe the problem that is addressed by this PR

Since rerecording tests for the new service version I have noticed a significant regression in the reliability of the LRO "can resume from a stopped poller" tests in these 3 packages (to the point where CI seems to be failing maybe 50%+ of the time on at least one platform). There seems to be no regression from the norm in live mode, so I am hoping that rerecording the tests will resolve the issue for the time being.
 
Eventually we should go back to the drawing board on these tests -- even at the best of times they are unreliable (as evidenced by the `this.retries(5)` each of the tests have...). But this would require more thought and time to figure out what a good replacement would be.