### PR TITLE
[dev-tool] fix TypeError warning in load-source-maps Rollup plugin

### DIFF
--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -137,6 +137,11 @@ export function sourcemaps() {
       if (!id.endsWith(".js")) {
         return null;
       }
+      if (id.startsWith("\x00")) {
+        // Some Rollup plugins mark virtual modules with \0 prefix. Other plugins should not try to process it.
+        //     https://rollupjs.org/plugin-development/#conventions
+        return null;
+      }
       try {
         const code = await readFile(id, "utf8");
         if (code.includes("sourceMappingURL")) {


### PR DESCRIPTION
By conventions rollup plugins prefix virtual modules with \0. Other plugins should not try to process those virtual modules.

This PR updates our load-source-maps plugin to ignore modules whose id starts with "\x00" thus fixes the following warning.

```
(!) Plugin load-source-maps: TypeError: The argument 'path' must be a string, Uint8Array, or URL without null bytes. Received '\x00commonjsHelpers.js'
    at open (node:internal/fs/promises:605:10)
    at readFile (node:internal/fs/promises:1085:20)
    at Object.load (/home/runner/work/rushstack/rushstack/jssdk/common/tools/dev-tool/src/config/rollup.base.config.ts:141:36)
    at /home/runner/work/rushstack/rushstack/jssdk/common/temp/node_modules/.pnpm/rollup@4.12.0/node_modules/rollup/dist/shared/rollup.js:1009:40
    at async PluginDriver.hookFirstAndGetPlugin (/home/runner/work/rushstack/rushstack/jssdk/common/temp/node_modules/.pnpm/rollup@4.12.0/node_modules/rollup/dist/shared/rollup.js:909:28)
    at async /home/runner/work/rushstack/rushstack/jssdk/common/temp/node_modules/.pnpm/rollup@4.12.0/node_modules/rollup/dist/shared/rollup.js:19726:33
    at async Queue.work (/home/runner/work/rushstack/rushstack/jssdk/common/temp/node_modules/.pnpm/rollup@4.12.0/node_modules/rollup/dist/shared/rollup.js:20113:32)
  ...19 lines omitted...
```
