### PR TITLE
[doc][core-client] fix broken link

### DIFF
--- a/sdk/core/core-client/README.md
+++ b/sdk/core/core-client/README.md
@@ -35,10 +35,6 @@ This method is used to create a `Pipeline` instance that is customized with extr
 
 The method `createSerializer` creates a `Serializer` that is used to do the bulk of the work transforming data when making a request or processing a response. Given a corpus of `Mapper`s and the appropriate `OperationSpec` it can manufacture an HTTP request object from a user provided input or convert an HTTP response object into a user-friendly form.
 
-## Examples
-
-Examples can be found in the [samples](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-client/samples) folder.
-
 ## Next steps
 
 You can build and run the tests locally by executing `rushx test`. Explore the [test](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-client/test) folder to see advanced usage and behavior of the public classes.


### PR DESCRIPTION
core-client doesn't provide sample code because it is not intended to be consumed directly by Azure SDK customers.
