### PR TITLE
[CODEOWNERS] Fix issues and label dataplane paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,15 +66,14 @@
 /sdk/appconfiguration/ @HarshaNalluru @minhanh-phan
 
 # ServiceOwners:  @anilba06 @gkostal
-# AzureSdkOwners: @LarryOsterman @deyaaeldeen
 # ServiceLabel: %Attestation
+
 # PRLabel: %Attestation
 /sdk/attestation/ @LarryOsterman @deyaaeldeen @anilba06 @gkostal
 
-# ServiceOwners: @jingjlii @wanghoppe @dpwatrous @NickKouds
 # ServiceLabel: %Batch
 # PRLabel: %Batch
-/sdk/batch/ @jingjlii @wanghoppe @dpwatrous @NickKouds @deyaaeldeen
+/sdk/batch/ @jingjlii @wanghoppe @dpwatrous @NickKouds
 
 # PRLabel: %Communication
 # ServiceLabel: %Communication
@@ -129,9 +128,10 @@
 # ServiceLabel: %Container Registry
 /sdk/containerregistry/ @timovv @jeremymeng @Azure/azsdk-acr
 
-# PRLabel: %Cosmos
 # ServiceLabel: %Cosmos %Service Attention
 # ServiceOwners: @sajeetharan @simorenoh @v1k1
+
+# PRLabel: %Cosmos
 /sdk/cosmosdb/ @kushagraThapar @kirankumarkolli @simorenoh @v1k1
 
 # PRLabel: %Digital Twins
@@ -229,15 +229,14 @@
 # ServiceLabel: %Cognitive - Language
 /sdk/cognitivelanguage/ @quentinRobinson
 
-# PRLabel: %OpenAI
 # ServiceLabel: %OpenAI
-# AzureSdkOwners: @deyaaeldeen @minhanh-phan
 # ServiceOwners: @glharper
+
+# PRLabel: %OpenAI
 /sdk/openai/ @glharper @deyaaeldeen @minhanh-phan
 
 # PRLabel: %Image Analysis
 # ServiceLabel: %Image Analysis
-# ServiceOwners: @rhurey @dargilco
 /sdk/vision/ai-vision-image-analysis-rest/ @rhurey @dargilco 
 
 # PRLabel: %Schema Registry

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,7 +155,6 @@
 
 # PRLabel: %Iot
 # ServiceLabel: %Iot
-# AzureSdkOwners:  @xirzec
 /sdk/iot/ @xirzec
 
 # PRLabel: %KeyVault
@@ -241,22 +240,21 @@
 
 # PRLabel: %Schema Registry
 # ServiceLabel: %Schema Registry
-# AzureSdkOwners: @deyaaeldeen @minhanh-phan
-/sdk/schemaregistry/ @deyaaeldeen @minhanh-phan
+# AzureSdkOwners: @minhanh-phan
+/sdk/schemaregistry/ @minhanh-phan @deyaaeldeen 
 
 # PRLabel: %Cognitive - Form Recognizer
 # ServiceLabel: %Cognitive - Form Recognizer
-# AzureSdkOwners: @HarshaNalluru @jeremymeng
+# AzureSdkOwners: @HarshaNalluru
 /sdk/formrecognizer/ @HarshaNalluru @jeremymeng
 
 # PRLabel: %Cognitive - Metrics Advisor
 # ServiceLabel: %Cognitive - Metrics Advisor
-# AzureSdkOwners: @KarishmaGhiya @jeremymeng
+# AzureSdkOwners: @KarishmaGhiya
 /sdk/metricsadvisor/ @KarishmaGhiya @jeremymeng
 
 # PRLabel: %Cognitive - Content Safety
 # ServiceLabel: %Cognitive - Content Safety
-# AzureSdkOwners: @xirzec
 /sdk/contentsafety/ @xirzec
 
 # PRLabel: %Search

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,175 +30,258 @@
 /sdk/ @xirzec
 
 # PRLabel: %Azure.Core
-/sdk/core/ @xirzec @jeremymeng @deyaaeldeen @timovv
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners: @xirzec @jeremymeng @deyaaeldeen @timovv @mpodwysocki
+/sdk/core/ @xirzec @jeremymeng @deyaaeldeen @timovv @mpodwysocki
 
 # PRLabel: %Azure.Core
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners:  @jeremymeng @deyaaeldeen @HarshaNalluru
 /sdk/core/core-amqp/ @jeremymeng @deyaaeldeen @HarshaNalluru
 
 # PRLabel: %Azure.Core
-/sdk/core/core-auth/ @xirzec @jeremymeng @deyaaeldeen
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners: @jeremymeng @deyaaeldeen
+/sdk/core/core-auth/ @jeremymeng @deyaaeldeen
 
 # PRLabel: %Azure.Core
-/sdk/core/core-client-rest/ @xirzec @joheredi @jeremymeng @deyaaeldeen
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners: @joheredi @jeremymeng @deyaaeldeen
+/sdk/core/core-client-rest/ @joheredi @jeremymeng @deyaaeldeen
 
 # PRLabel: %Azure.Core
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners: @deyaaeldeen @joheredi
 /sdk/core/core-lro/ @deyaaeldeen @joheredi
 
 # PRLabel: %Azure.Core
-/sdk/core/core-tracing/ @xirzec @jeremymeng @joheredi @maorleger
+# ServiceLabel: %Azure.Core
+# AzureSdkOwners: @maorleger @jeremymeng @mpodwysocki
+/sdk/core/core-tracing/ @maorleger @jeremymeng @mpodwysocki
 
 # Service teams
+# ServiceLabel: %App Configuration
 # PRLabel: %App Configuration
+# AzureSdkOwners:  @HarshaNalluru @minhanh-phan
 /sdk/appconfiguration/ @HarshaNalluru @minhanh-phan
 
+# ServiceOwners:  @anilba06 @gkostal
+# AzureSdkOwners: @LarryOsterman @deyaaeldeen
+# ServiceLabel: %Attestation
 # PRLabel: %Attestation
 /sdk/attestation/ @LarryOsterman @deyaaeldeen @anilba06 @gkostal
 
+# ServiceOwners: @jingjlii @wanghoppe @dpwatrous @NickKouds
+# ServiceLabel: %Batch
 # PRLabel: %Batch
 /sdk/batch/ @jingjlii @wanghoppe @dpwatrous @NickKouds @deyaaeldeen
 
 # PRLabel: %Communication
-/sdk/communication/
+# ServiceLabel: %Communication
+/sdk/communication/ @akania
 
 # PRLabel: %Communication - Alpha IDs
+# ServiceLabel: %Communication - Alpha IDs
 /sdk/communication/communication-alpha-ids/ @danielav7
 
 # PRLabel: %Communication - Identity
+# ServiceLabel: %Communication - Identity
 /sdk/communication/communication-identity/ @AikoBB @maximrytych-ms @mjafferi-msft
 
 # PRLabel: %Communication - Chat
+# ServiceLabel: %Communication - Chat
 /sdk/communication/communication-chat/ @LuChen-Microsoft
 
 # PRLabel: %Communication - Email
+# ServiceLabel: %Communication - Email
 /sdk/communication/communication-email/ @yogeshmo
 
 # PRLabel: %Communication - Job Router
+# ServiceLabel: %Communication - Job Router
 /sdk/communication/communication-job-router/ @marche0133
 
 # PRLabel: %Communication - Phone Numbers
+# ServiceLabel: %Communication - Phone Numbers
 /sdk/communication/communication-phone-numbers/ @miguhern @whisper6284 @RoyHerrod @danielav7
 
 # PRLabel: %Communication - Network Traversal
+# ServiceLabel: %Communication - Network Traversal
 /sdk/communication/communication-network-traversal/ @ajpeacock0 @nathpete-msft
 
 # PRLabel: %Communication - Rooms
+# ServiceLabel: %Communication - Rooms
 /sdk/communication/communication-rooms/ @anujissarMS @minnieliu @paolamvhz @shwali-msft @allchiang-msft
 
 # PRLabel: %Communication - SMS
+# ServiceLabel: %Communication - SMS
 /sdk/communication/communication-sms/ @gfeitosa-msft @phermanov-msft @ilyapaliakou-msft
 
 # PRLabel: %Communication - Short Codes
+# ServiceLabel: %Communication - Short Codes
 /sdk/communication/communication-short-codes/ @danielav7
 
 # PRLabel: %Communication - Common
+# ServiceLabel: %Communication - Common
 /sdk/communication/communication-common/ @AikoBB @maximrytych-ms @mjafferi-msft
 
+# AzureSdkOwners: @timovv @jeremymeng
 # PRLabel: %Container Registry
-/sdk/containerregistry/ @jeremymeng @timovv @Azure/azsdk-acr
+# ServiceLabel: %Container Registry
+/sdk/containerregistry/ @timovv @jeremymeng @Azure/azsdk-acr
 
 # PRLabel: %Cosmos
+# ServiceLabel: %Cosmos %Service Attention
+# ServiceOwners: @sajeetharan @simorenoh @v1k1
 /sdk/cosmosdb/ @kushagraThapar @kirankumarkolli @simorenoh @v1k1
 
-# ServiceLabel: %Cosmos %Service Attention
-#/<NotInRepo>/ @sajeetharan @simorenoh @v1k1
-
 # PRLabel: %Digital Twins
+# ServiceLabel: %Digital Twins
 /sdk/digitaltwins/ @sjiherzig @johngallardo @olivakar
 
 # PRLabel: %Event Grid
-/sdk/eventgrid/ @ellismg @xirzec
+# AzureSdkOwners: @sarangan12 
+# ServiceLabel: %Event Grid
+/sdk/eventgrid/ @sarangan12
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/ @jeremymeng @deyaaeldeen @HarshaNalluru
+# ServiceLabel: %Event Hubs
+# AzureSdkOwners: @deyaaeldeen @jeremymeng 
+/sdk/eventhub/ @deyaaeldeen @jeremymeng @HarshaNalluru
 
 # PRLabel: %Azure.Identity
-/sdk/identity/ @KarishmaGhiya @maorleger @witemple-msft @schaabs @Azure/azure-sdk-write-identity
+# ServiceLabel: %Azure.Identity
+# AzureSdkOwners:  @KarishmaGhiya @maorleger
+/sdk/identity/ @KarishmaGhiya @maorleger @schaabs @Azure/azure-sdk-write-identity
 
 # PRLabel: %Iot
+# ServiceLabel: %Iot
+# AzureSdkOwners:  @xirzec
 /sdk/iot/ @xirzec
 
 # PRLabel: %KeyVault
+# ServiceLabel: %KeyVault
+# AzureSdkOwners:  @timovv @maorleger
 /sdk/keyvault/ @timovv @maorleger @Azure/azsdk-keyvault
 
 # PRLabel: %OpenTelemetryInstrumentation
-/sdk/instrumentation/ @maorleger @joheredi @mpodwysocki
+# ServiceLabel: %OpenTelemetryInstrumentation
+# AzureSdkOwners: @maorleger @mpodwysocki
+/sdk/instrumentation/ @maorleger @mpodwysocki
 
 # PRLabel: %Service Bus
+# ServiceLabel: %Service Bus
+# AzureSdkOwners: @jeremymeng @deyaaeldeen @HarshaNalluru
 /sdk/servicebus/ @jeremymeng @deyaaeldeen @HarshaNalluru
 
 # PRLabel: %Storage
-/sdk/storage/ @EmmaZhu @XiaoningLiu @jeremymeng @vinjiang @jiacfan @ljian3377
+# ServiceLabel: %Storage
+/sdk/storage/ @EmmaZhu @XiaoningLiu @vinjiang @jiacfan @ljian3377
 
 # PRLabel: %Synapse
+# ServiceLabel: %Synapse
+# AzureSdkOwners: @joheredi
 /sdk/synapse/ @joheredi
 
 # PRLabel: %Tables
+# ServiceLabel: %Tables
+# AzureSdkOwners: @joheredi
 /sdk/tables/ @joheredi
 
 # PRLabel: %Purview
+# ServiceLabel: %Purview
+# AzureSdkOwners: @qiaozha
 /sdk/purview/ @qiaozha
 
 # PRLabel: %Farmbeats
+# ServiceLabel: %Farmbeats
+# AzureSdkOwners: @joheredi
 /sdk/agrifood/ @joheredi
 
 # PRLabel: %ConfidentialLedger
+# ServiceLabel: %ConfidentialLedger
+# AzureSdkOwners: @joheredi
 /sdk/confidentialledger/ @joheredi
 
 # PRLabel: %DocumentTranslator
+# ServiceLabel: %DocumentTranslator
+# AzureSdkOwners: @joheredi
 /sdk/documenttranslator/ @joheredi
 
 # PRLabel: %WebPubSub
-/sdk/web-pubsub/ @vicancy @xirzec @bterlson
+# ServiceLabel: %WebPubSub
+/sdk/web-pubsub/ @vicancy
 
 # PRLabel: %EngSys
+# ServiceLabel: %EngSys
+# AzureSdkOwners: @ckairen @mikeharder @weshaggard @benbp
 /sdk/template/ @ckairen @mikeharder @weshaggard @benbp
 
+# PRLabel: %test-utils
+# ServiceLabel: %test-utils
+# AzureSdkOwners: @HarshaNalluru @timovv
 /sdk/test-utils/ @HarshaNalluru @timovv
 
 # PRLabel: %Cognitive - Text Analytics
-/sdk/textanalytics/ @quentinRobinson @minhanh-phan @deyaaeldeen @witemple-msft
+# ServiceLabel: %Cognitive - Text Analytics
+/sdk/textanalytics/ @quentinRobinson
 
 # PRLabel: %Cognitive - Language
-/sdk/cognitivelanguage/ @quentinRobinson @minhanh-phan @deyaaeldeen
+# ServiceLabel: %Cognitive - Language
+/sdk/cognitivelanguage/ @quentinRobinson
 
 # PRLabel: %OpenAI
+# ServiceLabel: %OpenAI
+# AzureSdkOwners: @deyaaeldeen @minhanh-phan
+# ServiceOwners: @glharper
 /sdk/openai/ @glharper @deyaaeldeen @minhanh-phan
 
 # PRLabel: %Image Analysis
-/sdk/vision/ai-vision-image-analysis-rest/ @rhurey @dargilco
-
-# ServiceLabel: %Image Analysis %Service Attention
-#/<NotInRepo>/ @rhurey @dargilco
+# ServiceLabel: %Image Analysis
+# ServiceOwners: @rhurey @dargilco
+/sdk/vision/ai-vision-image-analysis-rest/ @rhurey @dargilco 
 
 # PRLabel: %Schema Registry
-/sdk/schemaregistry/ @deyaaeldeen
+# ServiceLabel: %Schema Registry
+# AzureSdkOwners: @deyaaeldeen @minhanh-phan
+/sdk/schemaregistry/ @deyaaeldeen @minhanh-phan
 
 # PRLabel: %Cognitive - Form Recognizer
-/sdk/formrecognizer/ @witemple-msft @HarshaNalluru @jeremymeng
+# ServiceLabel: %Cognitive - Form Recognizer
+# AzureSdkOwners: @HarshaNalluru @jeremymeng
+/sdk/formrecognizer/ @HarshaNalluru @jeremymeng
 
 # PRLabel: %Cognitive - Metrics Advisor
+# ServiceLabel: %Cognitive - Metrics Advisor
+# AzureSdkOwners: @KarishmaGhiya @jeremymeng
 /sdk/metricsadvisor/ @KarishmaGhiya @jeremymeng
 
 # PRLabel: %Cognitive - Content Safety
+# ServiceLabel: %Cognitive - Content Safety
+# AzureSdkOwners: @xirzec
 /sdk/contentsafety/ @xirzec
 
 # PRLabel: %Search
-/sdk/search/ @dgetu @xirzec @Azure/azsdk-search
+# ServiceLabel: %Search
+# AzureSdkOwners: @dgetu
+/sdk/search/ @dgetu @Azure/azsdk-search
 
 # PRLabel: %Mixed Reality
+# ServiceLabel: %Mixed Reality
 /sdk/mixedreality/ @RamonArguelles
 
 # PRLabel: %Remote Rendering
+# ServiceLabel: %Remote Rendering
 /sdk/remoterendering/ @FlorianBorn71
 
 # PRLabel: %Maps
+# ServiceLabel: %Maps
 /sdk/maps/ @dubiety @andykao1213
 
 # Smoke Tests
 /common/smoke-test/ @xirzec @jeremymeng
 
 # API review files
-/sdk/**/review/*api.md @bterlson @xirzec @jeremymeng
+/sdk/**/review/*api.md @bterlson @xirzec @jeremymeng @mpodwysocki
 
 
 # Management Plane

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,7 +73,7 @@
 /sdk/communication/communication-email/ @yogeshmo
 
 # PRLabel: %Communication - Job Router
-/sdk/communication/communication-job-router/ @bgams @marche0133
+/sdk/communication/communication-job-router/ @marche0133
 
 # PRLabel: %Communication - Phone Numbers
 /sdk/communication/communication-phone-numbers/ @miguhern @whisper6284 @RoyHerrod @danielav7
@@ -82,7 +82,7 @@
 /sdk/communication/communication-network-traversal/ @ajpeacock0 @nathpete-msft
 
 # PRLabel: %Communication - Rooms
-/sdk/communication/communication-rooms/ @anujissarMS @minnieliu @paolamvhz @Mrayyan @shwali-msft @allchiang-msft
+/sdk/communication/communication-rooms/ @anujissarMS @minnieliu @paolamvhz @shwali-msft @allchiang-msft
 
 # PRLabel: %Communication - SMS
 /sdk/communication/communication-sms/ @gfeitosa-msft @phermanov-msft @ilyapaliakou-msft
@@ -100,7 +100,7 @@
 /sdk/cosmosdb/ @kushagraThapar @kirankumarkolli @simorenoh @v1k1
 
 # ServiceLabel: %Cosmos %Service Attention
-#/<NotInRepo>/ @sajeetharan @pjohari-ms @simorenoh @v1k1
+#/<NotInRepo>/ @sajeetharan @simorenoh @v1k1
 
 # PRLabel: %Digital Twins
 /sdk/digitaltwins/ @sjiherzig @johngallardo @olivakar
@@ -156,10 +156,10 @@
 /sdk/test-utils/ @HarshaNalluru @timovv
 
 # PRLabel: %Cognitive - Text Analytics
-/sdk/textanalytics/ @quentinRobinson @wangyuantao @minhanh-phan @deyaaeldeen @witemple-msft
+/sdk/textanalytics/ @quentinRobinson @minhanh-phan @deyaaeldeen @witemple-msft
 
 # PRLabel: %Cognitive - Language
-/sdk/cognitivelanguage/ @quentinRobinson @wangyuantao @minhanh-phan @deyaaeldeen
+/sdk/cognitivelanguage/ @quentinRobinson @minhanh-phan @deyaaeldeen
 
 # PRLabel: %OpenAI
 /sdk/openai/ @glharper @deyaaeldeen @minhanh-phan
@@ -180,7 +180,7 @@
 /sdk/metricsadvisor/ @KarishmaGhiya @jeremymeng
 
 # PRLabel: %Cognitive - Content Safety
-/sdk/contentsafety/ @bowgong @mengai @minjuewu
+/sdk/contentsafety/ @xirzec
 
 # PRLabel: %Search
 /sdk/search/ @dgetu @xirzec @Azure/azsdk-search
@@ -890,7 +890,7 @@
 #/<NotInRepo>/          @ctstone @vkurpad
 
 # ServiceLabel: %Cognitive - Anomaly Detector %Service Attention
-#/<NotInRepo>/          @yingqunpku @bowgong
+#/<NotInRepo>/          @yingqunpku
 
 # ServiceLabel: %Cognitive - Custom Vision %Service Attention
 #/<NotInRepo>/          @areddish @tburns10

--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,30 +1,22 @@
 jeremymeng is not a public member of Azure.
 mpodwysocki is not a public member of Azure.
-xirzec is not a public member of Azure.
 minhanh-phan is not a public member of Azure.
 anilba06 is not a public member of Azure.
 dpwatrous is not a public member of Azure.
 There are no owners defined for CODEOWNERS entry.
 danielav7 is not a public member of Azure.
-bgams is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 miguhern is not a public member of Azure.
 RoyHerrod is not a public member of Azure.
 ajpeacock0 is not a public member of Azure.
-Mrayyan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 shwali-msft is not a public member of Azure.
 allchiang-msft is not a public member of Azure.
 phermanov-msft is not a public member of Azure.
 ilyapaliakou-msft is not a public member of Azure.
 abkolant-MSFT is not a public member of Azure.
-pjohari-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 olivakar is not a public member of Azure.
 KarishmaGhiya is not a public member of Azure.
 schaabs is not a public member of Azure.
 EmmaZhu is not a public member of Azure.
-wangyuantao is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
-bowgong is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
-mengai is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
-minjuewu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 RamonArguelles is not a public member of Azure.
 MaryGao is not a public member of Azure.
 JacksonWeber is not a public member of Azure.


### PR DESCRIPTION
In order to aid with autotriage, we have to set some additional metadata inside of CODEOWNERS.

The main shift is we need to tag things with #ServiceLabel in order to have issues be triaged appropriately. Secondarily, for SDKs that are owned by the SDK team (anyone under Peter) we need to add an AzureSdkOwners entry even if it's redundant with the path ownership.

Related PRs from other languages:
https://github.com/Azure/azure-sdk-for-net/pull/41995
https://github.com/Azure/azure-sdk-for-java/pull/38797

I didn't touch Mgmt paths, will check with @lirenhe if this is something he can take care of.

While I was making changes, I cleaned up some errors that GitHub was complaining about when viewing the file.