### PR TITLE
[core] disable tshy selfLink

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -109,6 +109,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -105,6 +105,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -108,6 +108,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -110,6 +110,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -106,6 +106,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -121,6 +121,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -117,6 +117,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -125,6 +125,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -116,6 +116,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -111,6 +111,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -105,6 +105,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -105,6 +105,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -111,6 +111,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -121,6 +121,7 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   }
 }


### PR DESCRIPTION
The feature is to support any modules inside of the package to be able to import from the `dist/` of the package itself.  Currently we only ever need that for samples development and for that we add "paths" in tsconfig.json to point to the package's src/index.ts. We haven't needed to import a sub path down in `dist/`.

This PR disables selfLink for now until there's a need. Because with it enabled, tshy creates symlinks under the dist/ directory which broken build cache.

More info can be found at https://github.com/isaacs/tshy?tab=readme-ov-file#local-package-exports
