### PR TITLE
[@azure/openai] Fix the Return Type of Error

### DIFF
--- a/sdk/openai/openai/CHANGELOG.md
+++ b/sdk/openai/openai/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.0-beta.12 (2024-02-27)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix a bug to ensure that the errors thrown are of the type `RestError`.
 
 ## 1.0.0-beta.11 (2024-01-25)
 

--- a/sdk/openai/openai/src/api/client/openAIClient/index.ts
+++ b/sdk/openai/openai/src/api/client/openAIClient/index.ts
@@ -9,7 +9,11 @@
  * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
  */
 
-import { StreamableMethod, operationOptionsToRequestParameters } from "@azure-rest/core-client";
+import {
+  StreamableMethod,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
 import { createFile } from "@azure/core-rest-pipeline";
 import { uint8ArrayToString } from "@azure/core-util";
 import {
@@ -112,7 +116,7 @@ export async function _getAudioTranscriptionAsPlainTextDeserialize(
     | GetAudioTranscriptionAsPlainTextDefaultResponse,
 ): Promise<string> {
   if (isUnexpected(result)) {
-    throw result.body;
+    throw createRestError(result.body.error.message, result);
   }
 
   return result.body;
@@ -169,7 +173,7 @@ export async function _getAudioTranscriptionAsResponseObjectDeserialize(
     | GetAudioTranscriptionAsResponseObjectDefaultResponse,
 ): Promise<AudioTranscription> {
   if (isUnexpected(result)) {
-    throw result.body;
+    throw createRestError(result.body.error.message, result);
   }
 
   return {
@@ -244,7 +248,7 @@ export async function _getAudioTranslationAsPlainTextDeserialize(
   result: GetAudioTranslationAsPlainText200Response | GetAudioTranslationAsPlainTextDefaultResponse,
 ): Promise<string> {
   if (isUnexpected(result)) {
-    throw result.body;
+    throw createRestError(result.body.error.message, result);
   }
 
   return result.body;
@@ -297,7 +301,7 @@ export async function _getAudioTranslationAsResponseObjectDeserialize(
     | GetAudioTranslationAsResponseObjectDefaultResponse,
 ): Promise<AudioTranslation> {
   if (isUnexpected(result)) {
-    throw result.body;
+    throw createRestError(result.body.error.message, result);
   }
 
   return {
@@ -396,7 +400,7 @@ export async function _getCompletionsDeserialize(
   result: GetCompletions200Response | GetCompletionsDefaultResponse,
 ): Promise<Completions> {
   if (isUnexpected(result)) {
-    throw result.body.error;
+    throw createRestError(result.body.error.message, result);
   }
   return getCompletionsResult(result.body);
 }
@@ -405,7 +409,7 @@ export async function _getChatCompletionsDeserialize(
   result: GetChatCompletions200Response | GetChatCompletionsDefaultResponse,
 ): Promise<ChatCompletions> {
   if (isUnexpected(result)) {
-    throw result.body.error;
+    throw createRestError(result.body.error.message, result);
   }
   return getChatCompletionsResult(result.body);
 }
@@ -435,7 +439,7 @@ export async function _getImageGenerationsDeserialize(
   result: GetImageGenerations200Response | GetImageGenerationsDefaultResponse,
 ): Promise<ImageGenerations> {
   if (isUnexpected(result)) {
-    throw result.body.error;
+    throw createRestError(result.body.error.message, result);
   }
 
   return {
@@ -475,7 +479,7 @@ export async function _getEmbeddingsDeserialize(
   result: GetEmbeddings200Response | GetEmbeddingsDefaultResponse,
 ): Promise<Embeddings> {
   if (isUnexpected(result)) {
-    throw result.body.error;
+    throw createRestError(result.body.error.message, result);
   }
 
   return {
@@ -688,7 +692,7 @@ export async function getAudioTranscription<Format extends AudioResultFormat>(
       },
     });
   if (status !== "200") {
-    throw body.error;
+    throw createRestError(body.error.message, body);
   }
 
   return response_format !== "verbose_json"

--- a/sdk/openai/openai/src/rest/openAIClient.ts
+++ b/sdk/openai/openai/src/rest/openAIClient.ts
@@ -28,7 +28,7 @@ export default function createClient(
 ): OpenAIContext {
   const baseUrl = options.baseUrl ?? `${endpoint}/openai`;
   options.apiVersion = options.apiVersion ?? "2023-12-01-preview";
-  const userAgentInfo = `azsdk-js-openai-rest/1.0.0-beta.11`;
+  const userAgentInfo = `azsdk-js-openai-rest/1.0.0-beta.12`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/openai/openai/test/public/embeddings.spec.ts
+++ b/sdk/openai/openai/test/public/embeddings.spec.ts
@@ -52,7 +52,6 @@ describe("OpenAI", function () {
           // TODO: Update the error message expectations
           await assertOpenAiError(client.getEmbeddings(modelName, true as any), {
             messagePattern: /'\$\.input' is invalid/,
-            type: `invalid_request_error`,
             errorCode: null,
           });
         });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
In `@azure/openai` package, when an error is returned, it must be of instance `RestError`. But, it is not returned like that. This needs to be fixed. It has to be fixed in the generator. Timo seems to be working on this already. In the meantime, we are fixing this on our end for 2 reasons. We need to fix it before GA. LangChain JS SDK is waiting for this fix. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
No special design considerations.

### Are there test cases added in this PR? _(If not, why?)_
No. Existing test cases handle the scenarios very well.

### Provide a list of related PRs _(if any)_
NA

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
NA

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

@deyaaeldeen @minhanh-phan Please review and approve.

@xirzec FYI....