### PR TITLE
[Identity] update redis samples with scopes and TSG guide

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 4.1.0-beta.2 (Unreleased)
 
 ### Features Added
-- Updated Identity Azure Cache for Redis Code Samples with the new scope.
 
 ### Breaking Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.1.0-beta.2 (Unreleased)
 
 ### Features Added
+- Updated Identity Azure Cache for Redis Code Samples with the new scope.
 
 ### Breaking Changes
 

--- a/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
@@ -51,7 +51,7 @@ dotenv.config();
 async function main() {
   // Construct a Token Credential from Identity library, e.g. ClientSecretCredential / ClientCertificateCredential / ManagedIdentityCredential, etc.
   const credential = new DefaultAzureCredential();
-  const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+  const redisScope = "https://redis.azure.com/.default";
   
   // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
   let accessToken = await credential.getToken(
@@ -110,7 +110,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function returnPassword(credential: TokenCredential) {
-    const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+    const redisScope = "https://redis.azure.com/.default";
 
     // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
     return credential.getToken(redisScope);
@@ -185,7 +185,7 @@ function randomNumber(min, max) {
 }
 
 async function returnPassword(credential: TokenCredential) {
-    const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+    const redisScope = "https://redis.azure.com/.default";
 
     // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
     let accessToken = await credential.getToken(redisScope);
@@ -260,8 +260,8 @@ main().catch((err) => {
 
 In this error scenario, the username provided and the access token used as password are not compatible. To mitigate this error, navigate to your Azure Cache for Redis resource in the Azure portal. Confirm that:
 
-- In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
-- In **Advanced settings**, the **Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
+* In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
+* Under **Authentication** -> **Microsoft Entra Authentication** category the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
 
 ##### Permissions not granted / NOPERM Error
 

--- a/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
@@ -261,7 +261,7 @@ main().catch((err) => {
 In this error scenario, the username provided and the access token used as password are not compatible. To mitigate this error, navigate to your Azure Cache for Redis resource in the Azure portal. Confirm that:
 
 * In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
-* Under **Authentication** -> **Microsoft Entra Authentication** category the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
+* Under the **Authentication** -> **Microsoft Entra Authentication** category, the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
 
 ##### Permissions not granted / NOPERM Error
 

--- a/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
@@ -50,7 +50,7 @@ dotenv.config();
 async function main() {
   // Construct a Token Credential from Identity library, e.g. ClientSecretCredential / ClientCertificateCredential / ManagedIdentityCredential, etc.
   const credential = new DefaultAzureCredential();
-  const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+  const redisScope = "https://redis.azure.com/.default";
 
   // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
   let accessToken = await credential.getToken(redisScope);
@@ -110,7 +110,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function returnPassword(credential: TokenCredential) {
-    const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+    const redisScope = "https://redis.azure.com/.default";
 
     // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
     return credential.getToken(redisScope);
@@ -183,7 +183,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 async function returnPassword(credential: TokenCredential) {
-    const redisScope = "acca5fbb-b7e4-4009-81f1-37e38fd66d78/.default";
+    const redisScope = "https://redis.azure.com/.default";
 
     // Fetch a Microsoft Entra token to be used for authentication. This token will be used as the password.
     return credential.getToken(redisScope);
@@ -267,7 +267,7 @@ main().catch((err) => {
 In this error scenario, the username provided and the access token used as password are not compatible. To mitigate this error, navigate to your Azure Cache for Redis resource in the Azure portal. Confirm that:
 
 * In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
-* In **Advanced settings**, the **Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
+* Under **Authentication** -> **Microsoft Entra Authentication** category the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
 
 ##### Permissions not granted / NOPERM Error
 

--- a/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
@@ -267,7 +267,7 @@ main().catch((err) => {
 In this error scenario, the username provided and the access token used as password are not compatible. To mitigate this error, navigate to your Azure Cache for Redis resource in the Azure portal. Confirm that:
 
 * In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
-* Under **Authentication** -> **Microsoft Entra Authentication** category the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
+* Under the **Authentication** -> **Microsoft Entra Authentication** category, the **Enable Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
 
 ##### Permissions not granted / NOPERM Error
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/28511

### Describe the problem that is addressed by this PR
Begin using the new, human-readable scope (https://redis.azure.com/.default) in the ioredis & node-redis passwordless code samples for Redis.

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-java/pull/38747/files


### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
