### PR TITLE
[identity] Add recorded test for MSAL Client

### DIFF
--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_0658ec5d18"
+  "Tag": "js/identity/identity_3792066a26"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_3792066a26"
+  "Tag": "js/identity/identity_9b15d10264"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_a5ff1872c7"
+  "Tag": "js/identity/identity_0658ec5d18"
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -232,14 +232,14 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     }
 
     // At this point we should have a token, process it
-    ensureValidMsalToken(scopes, response ?? undefined, options);
+    ensureValidMsalToken(scopes, response, options);
     state.cachedAccount = response?.account ?? null;
 
     msalLogger.getToken.info(formatSuccess(scopes));
 
     return {
-      token: response!.accessToken,
-      expiresOnTimestamp: response!.expiresOn!.getTime(),
+      token: response.accessToken,
+      expiresOnTimestamp: response.expiresOn.getTime(),
     };
   }
 

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -33,7 +33,7 @@ const LatestAuthenticationRecordVersion = "1.0";
  */
 export function ensureValidMsalToken(
   scopes: string | string[],
-  msalToken?: MsalToken,
+  msalToken?: MsalToken | null,
   getTokenOptions?: GetTokenOptions,
 ): asserts msalToken is ValidMsalToken {
   const error = (message: string): Error => {

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -116,7 +116,6 @@ describe("MsalClient", function () {
   describe("#getTokenByClientSecret", function () {
     let sandbox: sinon.SinonSandbox;
 
-    // TODO: helper to fetch env vars
     const clientId = "client-id";
     const tenantId = "tenant-id";
 
@@ -218,7 +217,7 @@ describe("MsalClient", function () {
 
         sandbox
           .stub(ConfidentialClientApplication.prototype, "acquireTokenSilent")
-          .rejects(new AbortError("operation has been aborted")); // AbortErrors should get rethrown
+          .rejects(new AbortError("operation has been aborted")); // AbortErrors should get re-thrown
 
         const scopes = ["https://vault.azure.net/.default"];
         const clientSecret = process.env.AZURE_CLIENT_SECRET!;

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -24,7 +24,7 @@ describe("MsalClient", function () {
     });
 
     beforeEach(async function () {
-      ({ cleanup, recorder } = await msalNodeTestSetup(this.currentTest, "azure_client_id"));
+      ({ cleanup, recorder } = await msalNodeTestSetup(this.currentTest));
     });
 
     it("supports getTokenByClientSecret", async function () {

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -135,11 +135,6 @@ export async function msalNodeTestSetup(
             target: `client-request-id=[a-zA-Z0-9-]+`,
             value: `client-request-id=${playbackValues.correlationId}`,
           },
-          {
-            regex: true,
-            target: `client_id=[a-zA-Z0-9-]+`,
-            value: `client_id=${playbackClientId}`,
-          },
         ],
         bodyKeySanitizers: [
           {
@@ -183,13 +178,6 @@ export async function msalNodeTestSetup(
             jsonPath: "$.client_info",
             value:
               "eyJ1aWQiOiIxMjM0NTY3OC0xMjM0LTEyMzQtMTIzNC0xMjM0NTY3ODkwMTIiLCJ1dGlkIjoiMTIzNDU2NzgtMTIzNC0xMjM0LTEyMzQtMTIzNDU2Nzg5MDEyIn0K",
-          },
-        ],
-        uriSanitizers: [
-          {
-            regex: true,
-            target: "/[a-zA-Z0-9-]+/oauth2",
-            value: `/${PlaybackTenantId}/oauth2`,
           },
         ],
       },

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -135,6 +135,11 @@ export async function msalNodeTestSetup(
             target: `client-request-id=[a-zA-Z0-9-]+`,
             value: `client-request-id=${playbackValues.correlationId}`,
           },
+          {
+            regex: true,
+            target: `client_id=[a-zA-Z0-9-]+`,
+            value: `client_id=${playbackClientId}`,
+          },
         ],
         bodyKeySanitizers: [
           {
@@ -178,6 +183,13 @@ export async function msalNodeTestSetup(
             jsonPath: "$.client_info",
             value:
               "eyJ1aWQiOiIxMjM0NTY3OC0xMjM0LTEyMzQtMTIzNC0xMjM0NTY3ODkwMTIiLCJ1dGlkIjoiMTIzNDU2NzgtMTIzNC0xMjM0LTEyMzQtMTIzNDU2Nzg5MDEyIn0K",
+          },
+        ],
+        uriSanitizers: [
+          {
+            regex: true,
+            target: "/[a-zA-Z0-9-]+/oauth2",
+            value: `/${PlaybackTenantId}/oauth2`,
           },
         ],
       },


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28692

### Describe the problem that is addressed by this PR

Before we start adding features to MSAL Client, we need to have confidence that our stack and integration
with MSAL is properly setup.

This PR adds a place for recorded tests, removes the msalNodeTestSetup call from non-recorded tests,
and moves the "it supports clientSecretCredential" test to a recorded test

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could have pushed for _everything_ to be recorded, but some of the niche scenarios we setup are convoluted 
to test without mocking anyway. This moves us in the direction we want without over-complicating things

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
