### PR TITLE
[core-amqp] Update error from retry

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.2.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.2.1 (2024-03-04)
 
 ### Other Changes
+
+- Update the message of the error thrown from `retry` to include all errors occurred between retries.
 
 ## 4.2.0 (2024-02-01)
 

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -285,7 +285,8 @@ function compileErrors(errors: (MessagingError | Error)[]): MessagingError | Err
   if (!errors.length) {
     throw new RangeError("Error array is empty");
   }
-  const str = errors.map(error => `Error ${i}: ${errors[i]}`).join("\n\n");
+  let i = 0;
+  const str = errors.map((error) => `Error ${i++}: ${error}`).join("\n\n");
   const lastError = errors[errors.length - 1];
   lastError.message = str;
   return lastError;

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -283,12 +283,9 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
 
 function compileErrors(errors: (MessagingError | Error)[]): MessagingError | Error {
   if (!errors.length) {
-    throw new Error("Impossible to happen");
+    throw new RangeError("Error array is empty");
   }
-  let str = "";
-  for (let i = 0; i < errors.length; ++i) {
-    str += `Error ${i}: ${errors[i]}\n\n`;
-  }
+  const str = errors.map(error => `Error ${i}: ${errors[i]}`).join("\n\n");
   const lastError = errors[errors.length - 1];
   lastError.message = str;
   return lastError;

--- a/sdk/core/core-amqp/test/retry.spec.ts
+++ b/sdk/core/core-amqp/test/retry.spec.ts
@@ -67,7 +67,7 @@ const should = chai.should();
       } catch (err) {
         should.exist(err);
         should.equal(true, err instanceof MessagingError);
-        (err as MessagingError).message.should.equal("I would like to fail, not retryable.");
+        (err as MessagingError).message.should.match(/I would like to fail, not retryable./);
         counter.should.equal(1);
       }
     });
@@ -172,7 +172,7 @@ const should = chai.should();
       } catch (err) {
         should.exist(err);
         should.equal(true, err instanceof MessagingError);
-        (err as MessagingError).message.should.equal("I would like to fail.");
+        (err as MessagingError).message.should.match(/I would like to fail./);
         counter.should.equal(3);
       }
     });
@@ -196,7 +196,7 @@ const should = chai.should();
       } catch (err) {
         should.exist(err);
         should.equal(true, err instanceof MessagingError);
-        (err as MessagingError).message.should.equal("I would always like to fail, keep retrying.");
+        (err as MessagingError).message.should.match(/I would always like to fail, keep retrying./);
         counter.should.equal(5);
       }
     });
@@ -228,7 +228,7 @@ const should = chai.should();
       } catch (err) {
         should.exist(err);
         should.equal(true, err instanceof MessagingError);
-        (err as MessagingError).message.should.equal("I would always like to fail, keep retrying.");
+        (err as MessagingError).message.should.match(/I would always like to fail, keep retrying./);
         counter.should.equal(1);
         // Clear delay's setTimeout...we don't need it anymore.
         delayAbortController.abort();
@@ -263,7 +263,7 @@ const should = chai.should();
       } catch (err) {
         should.exist(err);
         should.equal(true, err instanceof MessagingError);
-        (err as MessagingError).message.should.equal("I would always like to fail, keep retrying.");
+        (err as MessagingError).message.should.match(/I would always like to fail, keep retrying./);
         counter.should.equal(2);
         // Clear delay's setTimeout...we don't need it anymore.
         delayAbortController.abort();
@@ -345,7 +345,7 @@ const should = chai.should();
         } catch (err) {
           should.exist(err);
           should.equal(true, err instanceof MessagingError);
-          (err as MessagingError).message.should.equal("I would like to fail, not retryable.");
+          (err as MessagingError).message.should.match(/I would like to fail, not retryable./);
           counter.should.equal(1);
         }
       });
@@ -454,7 +454,7 @@ const should = chai.should();
         } catch (err) {
           should.exist(err);
           should.equal(true, err instanceof MessagingError);
-          (err as MessagingError).message.should.equal("I would like to fail.");
+          (err as MessagingError).message.should.match(/I would like to fail./);
           counter.should.equal(3);
         }
       });

--- a/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/cancellation.spec.ts
@@ -5,14 +5,17 @@ import { EnvVarKeys, getEnvVars } from "../public/utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
 import { createReceiver, PartitionReceiver } from "../../src/partitionReceiver";
 import { EventHubSender } from "../../src/eventHubSender";
-import chai from "chai";
+import chai, { assert } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createConnectionContext } from "../../src/connectionContext";
 import { createMockServer } from "../public/utils/mockService";
 import { testWithServiceTypes } from "../public/utils/testWithServiceTypes";
+import { StandardAbortMessage } from "@azure/core-amqp";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
+
+const abortMsgRegex = new RegExp(StandardAbortMessage);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();
@@ -113,7 +116,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -126,7 +129,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
       }
@@ -150,7 +153,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -161,7 +164,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -172,7 +175,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
       }

--- a/sdk/eventhub/event-hubs/test/public/cancellation.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/cancellation.spec.ts
@@ -4,13 +4,16 @@
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { EventHubConsumerClient, EventHubProducerClient } from "../../src";
 import { AbortController } from "@azure/abort-controller";
-import chai from "chai";
+import chai, { assert } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createMockServer } from "./utils/mockService";
 import { testWithServiceTypes } from "./utils/testWithServiceTypes";
+import { StandardAbortMessage } from "@azure/core-amqp";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
+
+const abortMsgRegex = new RegExp(StandardAbortMessage);
 
 testWithServiceTypes((serviceVersion) => {
   const env = getEnvVars();
@@ -87,7 +90,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -98,7 +101,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -109,7 +112,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
       }
@@ -133,7 +136,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -144,7 +147,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -155,7 +158,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -166,7 +169,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
 
@@ -177,7 +180,7 @@ testWithServiceTypes((serviceVersion) => {
             throw new Error(TEST_FAILURE);
           } catch (err: any) {
             should.equal(err.name, "AbortError");
-            should.equal(err.message, "The operation was aborted.");
+            assert.match(err.message, abortMsgRegex);
           }
         });
       }

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -265,7 +265,7 @@ describe("AbortSignal", () => {
         await sender.createBatch({ abortSignal: taggedAbortSignal });
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        assert.match(err.message, abortMsgRegex);
         assert.equal(err.name, "AbortError");
       }
     });
@@ -294,7 +294,7 @@ describe("AbortSignal", () => {
         await sender.createBatch({ abortSignal: taggedAbortSignal });
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        assert.match(err.message, abortMsgRegex);
         assert.equal(err.name, "AbortError");
       }
     });

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -236,7 +236,7 @@ describe("AbortSignal", () => {
         await sender.open(undefined, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        assert.match(err.message, abortMsgRegex);
         assert.equal(err.name, "AbortError");
       }
     });

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -26,6 +26,8 @@ import { MessageSession } from "../../../src/session/messageSession";
 import { ProcessErrorArgs } from "../../../src";
 import { ReceiveMode } from "../../../src/models";
 
+const abortMsgRegex = new RegExp(StandardAbortMessage);
+
 describe("AbortSignal", () => {
   const defaultOptions = {
     lockRenewer: undefined,
@@ -108,7 +110,7 @@ describe("AbortSignal", () => {
         });
         assert.fail("AbortError should be thrown when the signal is already in an aborted state");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        assert.match(err.message, abortMsgRegex);
 
         // we aborted in the sync part of the abort check so these event listeners are never set up
         assert.isFalse(abortSignal.addWasCalled);
@@ -214,7 +216,7 @@ describe("AbortSignal", () => {
         await sender.open(undefined, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        assert.match(err.message, abortMsgRegex);
         assert.equal(err.name, "AbortError");
       }
     });
@@ -460,7 +462,7 @@ describe("AbortSignal", () => {
           );
         });
 
-        assert.equal(receivedErrors[0].message, "The operation was aborted.");
+        assert.match(receivedErrors[0].message, abortMsgRegex);
         assert.equal(receivedErrors[0].name, "AbortError");
       } finally {
         await receiver.close();

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -49,8 +49,13 @@ describe("MessageSender unit tests", () => {
       {
         name: "ServiceBusError",
         code: "GeneralError",
-        message:
-          "Error 0: ServiceBusError: Link failed to initialize, cannot get max message size.",
+        message: `Error 0: ServiceBusError: Link failed to initialize, cannot get max message size.
+
+Error 1: ServiceBusError: Link failed to initialize, cannot get max message size.
+
+Error 2: ServiceBusError: Link failed to initialize, cannot get max message size.
+
+Error 3: ServiceBusError: Link failed to initialize, cannot get max message size.`,
       },
     );
 
@@ -133,8 +138,13 @@ describe("MessageSender unit tests", () => {
     await assertThrows(() => messageSender.send({ body: "message" }), {
       name: "ServiceBusError",
       code: "GeneralError",
-      message:
-        "Error 0: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+      message: `Error 0: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
+
+Error 1: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
+
+Error 2: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
+
+Error 3: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.`,
     });
 
     assert.equal(openCalled, retryOptions.maxRetries + 1);

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -49,7 +49,8 @@ describe("MessageSender unit tests", () => {
       {
         name: "ServiceBusError",
         code: "GeneralError",
-        message: "Link failed to initialize, cannot get max message size.",
+        message:
+          "Error 0: ServiceBusError: Link failed to initialize, cannot get max message size.",
       },
     );
 
@@ -133,7 +134,7 @@ describe("MessageSender unit tests", () => {
       name: "ServiceBusError",
       code: "GeneralError",
       message:
-        "SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+        "Error 0: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
     });
 
     assert.equal(openCalled, retryOptions.maxRetries + 1);

--- a/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
@@ -218,7 +218,7 @@ describe("shared receiver code", () => {
 
       await assertThrows(() => retryForeverPromise, {
         name: "AbortError",
-        message: "Purposefully abort",
+        message: "Error 0: AbortError: Purposefully abort",
       });
 
       assert.notOk(onErrorError?.message);

--- a/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
@@ -184,7 +184,8 @@ describe("StreamingReceiver unit tests", () => {
 
       await assertThrows(() => subscribePromise, {
         name: "AbortError",
-        message: "Cannot request messages on the receiver since it is suspended.",
+        message:
+          "Error 0: AbortError: Cannot request messages on the receiver since it is suspended.",
       });
 
       // closeLink is called on cleanup when we fail to add credits (which we would because our receiver
@@ -223,14 +224,14 @@ describe("StreamingReceiver unit tests", () => {
 
       await assertThrows(() => subscribePromise, {
         name: "AbortError",
-        message: "Receiver was suspended during initialization.",
+        message: "Error 0: AbortError: Receiver was suspended during initialization.",
       });
 
       assert.isTrue(!closeLinkSpy.called, "closeLink should not be called if no link was created");
 
       assert.deepEqual(errors, [
         {
-          message: "Receiver was suspended during initialization.",
+          message: "Error 0: AbortError: Receiver was suspended during initialization.",
           errorSource: "receive",
         },
       ]);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-amqp

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The errors thrown between retries could differ and the customer wouldn't be able to know them unless they enable logging.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Another design is to provide an error handler callback to be called on all errors but since it is an extreme measure, we can revisit this latter if we get an ask for it.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
