### PR TITLE
[identity] Fix integration tests

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -55,7 +55,7 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 180000 'dist-esm/test/public/node/*.spec.js' 'dist-esm/test/internal/node/*.spec.js'",
+    "integration-test:node": "dev-tool run test:node-ts-input -- --timeout 180000 'test/public/node/*.spec.ts' 'test/internal/node/*.spec.ts'",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -30,7 +30,7 @@ describe("MsalClient", function () {
     it("supports getTokenByClientSecret", async function () {
       const scopes = ["https://vault.azure.net/.default"];
       const clientSecret = env.IDENTITY_SP_CLIENT_SECRET || env.AZURE_CLIENT_SECRET!;
-      const clientId = env.IDENTITY_SPI_CLIENT_ID || env.AZURE_CLIENT_ID!;
+      const clientId = env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!;
       const tenantId = env.IDENTITY_SP_TENANT_ID || env.AZURE_TENANT_ID!;
 
       const clientOptions = recorder.configureClientOptions({});

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -4,6 +4,8 @@
 import * as msalClient from "../../../src/msal/nodeFlows/msalClient";
 
 import { AuthenticationResult, ConfidentialClientApplication } from "@azure/msal-node";
+import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
+import { Recorder, env } from "@azure-tools/test-recorder";
 
 import { AbortError } from "@azure/abort-controller";
 import { AuthenticationRequiredError } from "../../../src/errors";
@@ -11,8 +13,6 @@ import { IdentityClient } from "../../../src/client/identityClient";
 import { assert } from "@azure/test-utils";
 import { credentialLogger } from "../../../src/util/logging";
 import sinon from "sinon";
-import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { Recorder } from "@azure-tools/test-recorder";
 
 describe("MsalClient", function () {
   describe("recorded tests", function () {
@@ -29,9 +29,9 @@ describe("MsalClient", function () {
 
     it("supports getTokenByClientSecret", async function () {
       const scopes = ["https://vault.azure.net/.default"];
-      const clientSecret = process.env.AZURE_CLIENT_SECRET!;
-      const clientId = process.env.AZURE_CLIENT_ID!;
-      const tenantId = process.env.AZURE_TENANT_ID!;
+      const clientSecret = env.IDENTITY_SP_CLIENT_SECRET || env.AZURE_CLIENT_SECRET!;
+      const clientId = env.IDENTITY_SPI_CLIENT_ID || env.AZURE_CLIENT_ID!;
+      const tenantId = env.IDENTITY_SP_TENANT_ID || env.AZURE_TENANT_ID!;
 
       const clientOptions = recorder.configureClientOptions({});
       const client = msalClient.createMsalClient(clientId, tenantId, {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A - nightly tests 

### Describe the problem that is addressed by this PR

Two issues are addressed in this PR:

When I added the live tests for MSAL Client via #28680 I did not realize Identity differs from other packages
in the env vars we use. In Identity, as shown in other live tests, we use `IDENTITY_SP_CLIENT_SECRET`, 
`IDENTITY_SP_TENANT_ID`, and `IDENTITY_SP_CLIENT_ID` instead of the usual `AZURE_` naming convention.

Not sure why that is, but I'm sure there's a reason. Using these env vars fixes the live test.

The second fixes an issue with our existing mocking solution that no longer plays nicely with core. When 
core was switched to ESM, our integration tests started failing because `http` and `https` are no longer
being correctly mocked [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/test/httpRequests.ts#L191-L192)

I have some suspicions but given that we're soon moving to ESM, Karishma and I decided to forgo the 
`js-input` style integration tests and use `ts-input` style tests instead until we migrate over.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
