### PR TITLE
Adding an environment variable to skip the pre push checks

### DIFF
--- a/common/git-hooks/pre-push
+++ b/common/git-hooks/pre-push
@@ -121,7 +121,7 @@ async function execute(listOfModifiedProjects, check_script, fix_script) {
   return false;
 }
 
-console.log("Preparing the pre-push script....\n");
+console.log("Running the Pre Push Checks on your commits. You could skip these checks by setting SKIP_PREPUSH_CHECKS to true.\n");
 
 async function main() {
   const skipPrePushChecks = getEnvVariable('SKIP_PREPUSH_CHECKS');

--- a/common/git-hooks/pre-push
+++ b/common/git-hooks/pre-push
@@ -2,6 +2,10 @@
 
 const { execSync } = require("child_process");
 
+function getEnvVariable(name) {
+    return process.env[name];
+}
+
 function preparePrePushRemote() {
   try {
     execSync("git remote add prepush https://github.com/Azure/azure-sdk-for-js.git");
@@ -120,6 +124,11 @@ async function execute(listOfModifiedProjects, check_script, fix_script) {
 console.log("Preparing the pre-push script....\n");
 
 async function main() {
+  const skipPrePushChecks = getEnvVariable('SKIP_PREPUSH_CHECKS');
+  if (skipPrePushChecks !== undefined && skipPrePushChecks.trim().toLowerCase() === 'true') {
+    console.log("Skipping pre-push checks as SKIP_PREPUSH_CHECKS is set to true");
+    process.exit(0);
+  }
   const localCommits = getLocalCommitsNotMerged();
   if (localCommits.length != 0 && localCommits[0].trim() == "") {
     console.log("No local commits to push");


### PR DESCRIPTION
The Pre Push script has some scenarios which is causing issues to developers. I am working on resolving these issues. But, In the mean time, there must be an easy way for the developers to push their commits to github,

As discussed with @xirzec, I am adding an environment variable to skip these checks.