### PR TITLE
Handle Perf Tests Folders in the Pre Push Scripts

### DIFF
--- a/common/git-hooks/pre-push
+++ b/common/git-hooks/pre-push
@@ -8,11 +8,19 @@ function getEnvVariable(name) {
 
 function preparePrePushRemote() {
   try {
-    execSync("git remote add prepush https://github.com/Azure/azure-sdk-for-js.git");
+    execSync("git remote add prepush https://github.com/Azure/azure-sdk-for-js.git", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
   } catch (e) {
     console.log("Remote 'prepush' already exists. No need to add it again. Continuing...");
-  }  
-  execSync("git fetch prepush");
+  }
+  console.log(`Fetching updates from the remote 'prepush' repository...`);
+  execSync("git fetch prepush", {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  console.log(`Fetched updates from the remote 'prepush' repository.`);
 }
 
 function getLocalCommitsNotMerged() {
@@ -58,6 +66,9 @@ function extractPathPrefix(inputString) {
   const match = inputString.match(regex);
 
   if (match && match[1]) {
+    if(match[1].endsWith("perf-tests")) {
+      return (match[1] + "/" + (inputString.replace(match[1], "").split("/")[1]));
+    }
     return match[1];
   } else {
     return null;


### PR DESCRIPTION
@mpodwysocki has reported an issue with the scenario that when the files under perf-tests are modified, the script fails. It is a special case and now it is handled correctly with this PR changes. 

@mpodwysocki @HarshaNalluru   Can you please review and approve the PR?