### PR TITLE
CosmosDB client-side encryption Add TTL for keys

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -22,7 +22,10 @@
     "./dist-esm/src/request/defaultAgent.js": "./dist-esm/src/request/defaultAgent.browser.js",
     "./dist-esm/src/utils/atob.js": "./dist-esm/src/utils/atob.browser.js",
     "./dist-esm/src/utils/digest.js": "./dist-esm/src/utils/digest.browser.js",
-    "./dist-esm/src/utils/hmac.js": "./dist-esm/src/utils/hmac.browser.js"
+    "./dist-esm/src/utils/hmac.js": "./dist-esm/src/utils/hmac.browser.js",
+    "./dist-esm/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.js": "./dist-esm/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.browser.js",
+    "./dist-esm/src/encryption/EncryptionKey/DataEncryptionKey.js": "./dist-esm/src/encryption/EncryptionKey/DataEncryptionKey.browser.js",
+    "./dist-esm/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.js": "./dist-esm/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.browser.js"
   },
   "files": [
     "changelog.md",
@@ -96,7 +99,8 @@
     "tslib": "^2.2.0",
     "universal-user-agent": "^6.0.0",
     "uuid": "^8.3.0",
-    "@azure/abort-controller": "^1.0.0"
+    "@azure/abort-controller": "^1.0.0",
+    "@azure/keyvault-keys": "^4.8.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -757,6 +757,8 @@ export interface CosmosClientOptions {
     diagnosticLevel?: CosmosDbDiagnosticLevel;
     // (undocumented)
     enableEncryption?: boolean;
+    // (undocumented)
+    encryptionKeyTimeToLiveInHours?: number;
     endpoint: string;
     key?: string;
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+/// <reference types="node" />
 /// <reference lib="dom" />
 /// <reference lib="esnext.asynciterable" />
 
@@ -31,6 +32,15 @@ export interface Agent {
 
 // @public (undocumented)
 export type AggregateType = "Average" | "Count" | "Max" | "Min" | "Sum";
+
+// @public (undocumented)
+export class AzureKeyVaultEncryptionKeyResolver implements EncryptionKeyResolver {
+    constructor(credentials: TokenCredential, url: string);
+    // (undocumented)
+    unwrapKey(encryptionKeyId: string, algorithm: string, wrappedKey: Buffer): Promise<Buffer>;
+    // (undocumented)
+    wrapKey(encryptionKeyId: string, algorithm: string, key: Buffer): Promise<Buffer>;
+}
 
 // @public (undocumented)
 export type BulkOperationResponse = OperationResponse[] & {
@@ -172,6 +182,10 @@ export class ClientContext {
     }): Promise<Response_2<any>>;
     // (undocumented)
     clearSessionToken(path: string): void;
+    // Warning: (ae-forgotten-export) The symbol "ClientEncryptionKeyPropertiesCache" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    clientEncryptionKeyPropertiesCache: ClientEncryptionKeyPropertiesCache;
     // (undocumented)
     create<T, U = T>({ body, path, resourceType, resourceId, diagnosticNode, options, partitionKey, }: {
         body: T;
@@ -194,6 +208,16 @@ export class ClientContext {
     }): Promise<Response_2<T & Resource>>;
     // (undocumented)
     diagnosticLevel: CosmosDbDiagnosticLevel;
+    // (undocumented)
+    enableEncyption: boolean;
+    // Warning: (ae-forgotten-export) The symbol "EncryptionKeyStoreProvider" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    encryptionKeyStoreProvider: EncryptionKeyStoreProvider;
+    // Warning: (ae-forgotten-export) The symbol "EncryptionSettingsCache" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    encryptionSettingsCache: EncryptionSettingsCache;
     // (undocumented)
     execute<T>({ sprocLink, params, options, partitionKey, diagnosticNode, }: {
         sprocLink: string;
@@ -281,6 +305,63 @@ export class ClientContext {
         partitionKey?: PartitionKey;
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & U & Resource>>;
+}
+
+// @public (undocumented)
+export class ClientEncryptionIncludedPath {
+    constructor(path: string, clientEncryptionKeyId: string, encryptionType: EncryptionType, encryptionAlgortihm: EncryptionAlgorithm);
+    // (undocumented)
+    clientEncryptionKeyId: string;
+    // (undocumented)
+    encryptionAlgorithm: EncryptionAlgorithm;
+    // (undocumented)
+    encryptionType: EncryptionType;
+    // (undocumented)
+    path: string;
+}
+
+// @public (undocumented)
+export interface ClientEncryptionKeyDefinition {
+    id: string;
+}
+
+// @public (undocumented)
+export class ClientEncryptionKeyProperties {
+    constructor(id: string, encryptionAlgorithm: string, wrappedDataEncryptionKey: Buffer, encryptionKeyWrapMetadata: EncryptionKeyWrapMetadata);
+    // (undocumented)
+    encryptionAlgorithm: string;
+    // (undocumented)
+    encryptionKeyWrapMetadata: EncryptionKeyWrapMetadata;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    wrappedDataEncryptionKey: Buffer;
+}
+
+// @public (undocumented)
+export interface ClientEncryptionKeyRequest extends ClientEncryptionKeyDefinition {
+    // (undocumented)
+    encryptionAlgorithm: string;
+    // (undocumented)
+    keyWrapMetadata: EncryptionKeyWrapMetadata;
+    // (undocumented)
+    wrappedDataEncryptionKey: string;
+}
+
+// @public
+export class ClientEncryptionKeyResponse extends ResourceResponse<ClientEncryptionKeyDefinition & Resource> {
+    constructor(resource: ClientEncryptionKeyDefinition & Resource, headers: CosmosHeaders, statusCode: number, clientEncryptionKeyProperties: ClientEncryptionKeyProperties, diagnostics: CosmosDiagnostics);
+    // (undocumented)
+    readonly clientEncryptionKeyProperties: ClientEncryptionKeyProperties;
+}
+
+// @public (undocumented)
+export class ClientEncryptionPolicy {
+    constructor(includedPaths: ClientEncryptionIncludedPath[], policyFormatVersion?: number);
+    // (undocumented)
+    includedPaths: ClientEncryptionIncludedPath[];
+    // (undocumented)
+    policyFormatVersion: number;
 }
 
 // @public (undocumented)
@@ -577,6 +658,7 @@ export class Container {
     getQueryPlan(query: string | SqlQuerySpec): Promise<Response_2<PartitionedQueryExecutionInfo>>;
     // (undocumented)
     readonly id: string;
+    initializeEncryption(): Promise<void>;
     item(id: string, partitionKeyValue?: PartitionKey): Item;
     get items(): Items;
     read(options?: RequestOptions): Promise<ContainerResponse>;
@@ -593,6 +675,7 @@ export class Container {
 
 // @public (undocumented)
 export interface ContainerDefinition {
+    clientEncryptionPolicy?: ClientEncryptionPolicy;
     conflictResolutionPolicy?: ConflictResolutionPolicy;
     defaultTtl?: number;
     geospatialConfig?: {
@@ -672,8 +755,12 @@ export interface CosmosClientOptions {
     defaultHeaders?: CosmosHeaders_2;
     // (undocumented)
     diagnosticLevel?: CosmosDbDiagnosticLevel;
+    // (undocumented)
+    enableEncryption?: boolean;
     endpoint: string;
     key?: string;
+    // (undocumented)
+    keyEncryptionKeyResolver?: EncryptionKeyResolver;
     permissionFeed?: PermissionDefinition[];
     resourceTokens?: {
         [resourcePath: string]: string;
@@ -737,10 +824,12 @@ export class Database {
     readonly client: CosmosClient;
     container(id: string): Container;
     readonly containers: Containers;
+    createClientEncryptionKey(id: string, encryptionAlgorithm: EncryptionAlgorithm, keyWrapMetadata: EncryptionKeyWrapMetadata): Promise<ClientEncryptionKeyResponse>;
     delete(options?: RequestOptions): Promise<DatabaseResponse>;
     // (undocumented)
     readonly id: string;
     read(options?: RequestOptions): Promise<DatabaseResponse>;
+    readClientEncryptionKey(id: string): Promise<ClientEncryptionKeyResponse>;
     // (undocumented)
     readInternal(diagnosticNode: DiagnosticNodeInternal, options?: RequestOptions): Promise<DatabaseResponse>;
     readOffer(options?: RequestOptions): Promise<OfferResponse>;
@@ -934,6 +1023,47 @@ export enum DiagnosticNodeType {
     QUERY_REPAIR_NODE = "QUERY_REPAIR_NODE",// Node representing background refresh.
     // (undocumented)
     REQUEST_ATTEMPTS = "REQUEST_ATTEMPTS"
+}
+
+// @public (undocumented)
+export enum EncryptionAlgorithm {
+    // (undocumented)
+    AEAD_AES_256_CBC_HMAC_SHA256 = "AEAD_AES_256_CBC_HMAC_SHA256"
+}
+
+// @public (undocumented)
+export interface EncryptionKeyResolver {
+    // (undocumented)
+    unwrapKey(encryptionKeyId: string, algorithm: string, wrappedKey: Buffer): Promise<Buffer>;
+    // (undocumented)
+    wrapKey(encryptionKeyId: string, algorithm: string, key: Buffer): Promise<Buffer>;
+}
+
+// @public (undocumented)
+export enum EncryptionKeyResolverName {
+    // (undocumented)
+    AzureKeyVault = "AZURE_KEY_VAULT"
+}
+
+// @public (undocumented)
+export class EncryptionKeyWrapMetadata {
+    constructor(type: EncryptionKeyResolverName, name: string, value: string, algorithm: KeyEncryptionKeyAlgorithm);
+    // (undocumented)
+    algorithm: KeyEncryptionKeyAlgorithm;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    type: EncryptionKeyResolverName;
+    // (undocumented)
+    value: string;
+}
+
+// @public (undocumented)
+export enum EncryptionType {
+    // (undocumented)
+    DETERMINISTIC = "Deterministic",
+    // (undocumented)
+    RANDOMIZED = "Randomized"
 }
 
 // @public (undocumented)
@@ -1226,6 +1356,12 @@ export interface JSONObject {
 
 // @public (undocumented)
 export type JSONValue = boolean | number | string | null | JSONArray | JSONObject;
+
+// @public (undocumented)
+export enum KeyEncryptionKeyAlgorithm {
+    // (undocumented)
+    RSA_OAEP = "RSA-OAEP"
+}
 
 // @public
 interface Location_2 {
@@ -1899,6 +2035,8 @@ export class ResourceResponse<TResource> {
 
 // @public (undocumented)
 export enum ResourceType {
+    // (undocumented)
+    clientencryptionkey = "clientEncryptionKeys",
     // (undocumented)
     conflicts = "conflicts",
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -46,7 +46,11 @@ import {
 import { DefaultDiagnosticFormatter, DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { EncryptionKeyStoreProvider } from "./encryption/EncryptionKeyStoreProvider";
-import { EncryptionSettingsCache, ClientEncryptionKeyPropertiesCache } from "./encryption";
+import {
+  EncryptionSettingsCache,
+  ClientEncryptionKeyPropertiesCache,
+  ProtectedDataEncryptionKey,
+} from "./encryption";
 const logger: AzureLogger = createClientLogger("ClientContext");
 
 const QueryJsonContentType = "application/query+json";
@@ -66,6 +70,7 @@ export class ClientContext {
   public encryptionKeyStoreProvider: EncryptionKeyStoreProvider;
   public clientEncryptionKeyPropertiesCache: ClientEncryptionKeyPropertiesCache;
   public encryptionSettingsCache: EncryptionSettingsCache; // cache to store encryption settings for containers. Key is databaseRid+containerRid
+  private readonly encryptionKeyTimeToLiveInHours: number;
   public constructor(
     private cosmosClientOptions: CosmosClientOptions,
     private globalEndpointManager: GlobalEndpointManager,
@@ -100,9 +105,14 @@ export class ClientContext {
       this.encryptionKeyStoreProvider = new EncryptionKeyStoreProvider(
         cosmosClientOptions.keyEncryptionKeyResolver,
         "AzureKeyVault",
+        this.encryptionKeyTimeToLiveInHours,
       );
       this.encryptionSettingsCache = new EncryptionSettingsCache();
       this.clientEncryptionKeyPropertiesCache = new ClientEncryptionKeyPropertiesCache();
+      this.encryptionKeyTimeToLiveInHours = cosmosClientOptions.encryptionKeyTimeToLiveInHours
+        ? cosmosClientOptions.encryptionKeyTimeToLiveInHours
+        : 2;
+      ProtectedDataEncryptionKey.clearCacheOnTtlExpiry(this.encryptionKeyTimeToLiveInHours);
     }
     this.initializeDiagnosticSettings(diagnosticLevel);
   }

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -45,7 +45,8 @@ import {
 } from "./diagnostics/DiagnosticWriter";
 import { DefaultDiagnosticFormatter, DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
-
+import { EncryptionKeyStoreProvider } from "./encryption/EncryptionKeyStoreProvider";
+import { EncryptionSettingsCache, ClientEncryptionKeyPropertiesCache } from "./encryption";
 const logger: AzureLogger = createClientLogger("ClientContext");
 
 const QueryJsonContentType = "application/query+json";
@@ -61,12 +62,17 @@ export class ClientContext {
   private diagnosticWriter: DiagnosticWriter;
   private diagnosticFormatter: DiagnosticFormatter;
   public partitionKeyDefinitionCache: { [containerUrl: string]: any }; // TODO: PartitionKeyDefinitionCache
+  public enableEncyption: boolean;
+  public encryptionKeyStoreProvider: EncryptionKeyStoreProvider;
+  public clientEncryptionKeyPropertiesCache: ClientEncryptionKeyPropertiesCache;
+  public encryptionSettingsCache: EncryptionSettingsCache; // cache to store encryption settings for containers. Key is databaseRid+containerRid
   public constructor(
     private cosmosClientOptions: CosmosClientOptions,
     private globalEndpointManager: GlobalEndpointManager,
     private clientConfig: ClientConfigDiagnostic,
     public diagnosticLevel: CosmosDbDiagnosticLevel,
   ) {
+    this.enableEncyption = cosmosClientOptions.enableEncryption;
     this.connectionPolicy = cosmosClientOptions.connectionPolicy;
     this.sessionContainer = new SessionContainer();
     this.partitionKeyDefinitionCache = {};
@@ -89,6 +95,14 @@ export class ClientContext {
           },
         }),
       );
+    }
+    if (this.enableEncyption) {
+      this.encryptionKeyStoreProvider = new EncryptionKeyStoreProvider(
+        cosmosClientOptions.keyEncryptionKeyResolver,
+        "AzureKeyVault",
+      );
+      this.encryptionSettingsCache = new EncryptionSettingsCache();
+      this.clientEncryptionKeyPropertiesCache = new ClientEncryptionKeyPropertiesCache();
     }
     this.initializeDiagnosticSettings(diagnosticLevel);
   }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -74,6 +74,15 @@ export class CosmosClient {
       throw new Error("Invalid endpoint specified");
     }
 
+    if (
+      optionsOrConnectionString.enableEncryption &&
+      !optionsOrConnectionString.keyEncryptionKeyResolver
+    ) {
+      throw new Error(
+        "KeyEncryptionKeyResolver needs to be provided to enable client-side encryption.",
+      );
+    }
+
     const clientConfig: ClientConfigDiagnostic =
       this.initializeClientConfigDiagnostic(optionsOrConnectionString);
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -7,6 +7,7 @@ import { ConnectionPolicy, ConsistencyLevel } from "./documents";
 import { PluginConfig } from "./plugins/Plugin";
 import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
+import { EncryptionKeyResolver } from "./encryption";
 
 // We expose our own Agent interface to avoid taking a dependency on and leaking node types. This interface should mirror the node Agent interface
 export interface Agent {
@@ -54,6 +55,8 @@ export interface CosmosClientOptions {
   /** A custom string to append to the default SDK user agent. */
   userAgentSuffix?: string;
   diagnosticLevel?: CosmosDbDiagnosticLevel;
+  enableEncryption?: boolean;
+  keyEncryptionKeyResolver?: EncryptionKeyResolver;
   /** @internal */
   plugins?: PluginConfig[];
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -57,6 +57,7 @@ export interface CosmosClientOptions {
   diagnosticLevel?: CosmosDbDiagnosticLevel;
   enableEncryption?: boolean;
   keyEncryptionKeyResolver?: EncryptionKeyResolver;
+  encryptionKeyTimeToLiveInHours?: number;
   /** @internal */
   plugins?: PluginConfig[];
 }

--- a/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Container.ts
@@ -381,7 +381,23 @@ export class Container {
           partitionKeyPaths,
           clientEncryptionPolicy,
         );
+        // set the encryption settings in the cache
         this.clientContext.encryptionSettingsCache.setEncryptionSettings(key, enryptionSettings);
+        const clientEncryptionKeyIds = [
+          ...new Set(
+            clientEncryptionPolicy.includedPaths.map((item) => item.clientEncryptionKeyId),
+          ),
+        ];
+        // fetch and set clientEncryptionKeys in the cache
+        for (const clientEncryptionKeyId of clientEncryptionKeyIds) {
+          const res = await this.database.readClientEncryptionKey(clientEncryptionKeyId);
+          let encryptionKeyProperties = res.clientEncryptionKeyProperties;
+          const key = this.database.id + "/" + clientEncryptionKeyId;
+          this.clientContext.clientEncryptionKeyPropertiesCache.setClientEncryptionKeyProperties(
+            key,
+            encryptionKeyProperties,
+          );
+        }
       }, this.clientContext);
     }
   }

--- a/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
@@ -4,6 +4,7 @@ import { IndexingPolicy, PartitionKeyDefinition } from "../../documents";
 import { ConflictResolutionPolicy } from "../Conflict/ConflictResolutionPolicy";
 import { UniqueKeyPolicy } from "./UniqueKeyPolicy";
 import { GeospatialType } from "../../documents/GeospatialType";
+import { ClientEncryptionPolicy } from "../../encryption";
 
 export interface ContainerDefinition {
   /** The id of the container. */
@@ -22,4 +23,6 @@ export interface ContainerDefinition {
   geospatialConfig?: {
     type: GeospatialType;
   };
+  /** Encryption policy for the container, contains path that needs to be encrypted */
+  clientEncryptionPolicy?: ClientEncryptionPolicy;
 }

--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -183,6 +183,10 @@ export class Containers {
       };
     }
 
+    if (this.clientContext.enableEncyption && body.clientEncryptionPolicy) {
+      //TODO: add checks for checking partition key paths
+    }
+
     const response = await this.clientContext.create<ContainerRequest, ContainerDefinition>({
       body,
       path,

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -278,6 +278,7 @@ export enum ResourceType {
   item = "docs",
   pkranges = "pkranges",
   partitionkey = "partitionKey",
+  clientencryptionkey = "clientEncryptionKeys",
 }
 
 /**

--- a/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.browser.ts
@@ -1,0 +1,4 @@
+export class AeadAes256CbcHmacSha256Algorithm {}
+export function randomBytes(_size: number): Buffer {
+  throw new Error("Client-side random generator not supported in browser environment");
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/AeadAes256CbcHmacSha256Algorithm.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { EncryptionType } from "../enums";
+import { createCipheriv, randomBytes, createHmac, createDecipheriv } from "crypto";
+import { DataEncryptionKey } from "../EncryptionKey";
+
+export class AeadAes256CbcHmacSha256Algorithm {
+  private algoVersion = 0x1;
+  private blockSizeInBytes = 16;
+  private encryptionType: EncryptionType;
+  private dataEncryptionKey: DataEncryptionKey;
+  private version: Buffer;
+  private versionSize: Buffer;
+  private keySizeInBytes: number;
+  private minimumCipherTextLength: number;
+
+  constructor(dataEncryptionKey: DataEncryptionKey, encryptionType: EncryptionType) {
+    this.dataEncryptionKey = dataEncryptionKey;
+    this.encryptionType = encryptionType;
+    this.version = Buffer.from([this.algoVersion]);
+    this.versionSize = Buffer.from([1]);
+    this.keySizeInBytes = 32;
+    this.minimumCipherTextLength = 1 + 2 * this.blockSizeInBytes + this.keySizeInBytes;
+  }
+
+  public encrypt(plainTextBuffer: Buffer): Buffer {
+    let iv: Buffer;
+    // create initialization vector
+    if (this.encryptionType === EncryptionType.RANDOMIZED) {
+      iv = randomBytes(16);
+    } else {
+      const ivHmac = createHmac("sha256", this.dataEncryptionKey.ivKeyBuffer);
+      ivHmac.update(plainTextBuffer);
+      iv = ivHmac.digest().slice(0, this.blockSizeInBytes);
+    }
+    // create cipher text
+    const cipher = createCipheriv("aes-256-cbc", this.dataEncryptionKey.encryptionKeyBuffer, iv);
+    const cipherTextBuffer = Buffer.concat([cipher.update(plainTextBuffer), cipher.final()]);
+    const authTagBuffer = this.generateAuthenticationTag(iv, cipherTextBuffer);
+    return Buffer.concat([Buffer.from([this.algoVersion]), authTagBuffer, iv, cipherTextBuffer]);
+  }
+
+  public decrypt(cipherTextBuffer: Buffer): Buffer {
+    if (cipherTextBuffer.length < this.minimumCipherTextLength) {
+      throw new Error("Invalid cipher text length");
+    }
+    if (cipherTextBuffer[0] !== this.algoVersion) {
+      console.log("0 pos ", cipherTextBuffer[0]);
+      throw new Error("Invalid cipher text version");
+    }
+    let authTagStartIndex = 1;
+    let authTagLength = this.keySizeInBytes;
+    let ivStartIndex = authTagStartIndex + authTagLength;
+    let ivLength = this.blockSizeInBytes;
+    let cipherTextStartIndex = ivStartIndex + ivLength;
+    let cipherTextLength = cipherTextBuffer.length - cipherTextStartIndex;
+
+    let authenticationTag = cipherTextBuffer.slice(
+      authTagStartIndex,
+      authTagStartIndex + authTagLength,
+    );
+    let iv = cipherTextBuffer.slice(ivStartIndex, ivStartIndex + ivLength);
+    let cipherText = cipherTextBuffer.slice(
+      cipherTextStartIndex,
+      cipherTextStartIndex + cipherTextLength,
+    );
+
+    this.validateAuthenticationTag(authenticationTag, iv, cipherText);
+
+    let result: Buffer;
+
+    const decipher = createDecipheriv(
+      "aes-256-cbc",
+      this.dataEncryptionKey.encryptionKeyBuffer,
+      iv,
+    );
+    const decrypted = decipher.update(cipherText);
+    result = Buffer.concat([decrypted, decipher.final()]);
+    return result;
+  }
+
+  private generateAuthenticationTag(iv: Buffer, cipherTextBuffer: Buffer): Buffer {
+    const hmac = createHmac("sha256", this.dataEncryptionKey.macKeyBuffer);
+    const buffer = Buffer.concat([this.version, iv, cipherTextBuffer, this.versionSize]);
+    return hmac.update(buffer).digest();
+  }
+  private validateAuthenticationTag(authenticationTag: Buffer, iv: Buffer, cipherText: Buffer) {
+    const expectedAuthTag = this.generateAuthenticationTag(iv, cipherText);
+    if (!authenticationTag.equals(expectedAuthTag)) {
+      throw new Error("Invalid authentication tag");
+    }
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/AeadAes256CbcHmacSha256Algorithm/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { AeadAes256CbcHmacSha256Algorithm } from "./AeadAes256CbcHmacSha256Algorithm";

--- a/sdk/cosmosdb/cosmos/src/encryption/Cache/ClientEncryptionKeyPropertiesCache.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/Cache/ClientEncryptionKeyPropertiesCache.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientEncryptionKeyProperties } from "../ClientEncryptionKey/ClientEncryptionKeyProperties";
+
+export class ClientEncryptionKeyPropertiesCache {
+  // key is database id + '/'+ clientEncryptionKeyId
+  private clientEncryptionKeyPropertiesCache: Map<string, ClientEncryptionKeyProperties>;
+
+  constructor() {
+    this.clientEncryptionKeyPropertiesCache = new Map<string, ClientEncryptionKeyProperties>();
+  }
+
+  public getClientEncryptionKeyProperties(key: string): ClientEncryptionKeyProperties | undefined {
+    return this.clientEncryptionKeyPropertiesCache.get(key);
+  }
+  public setClientEncryptionKeyProperties(
+    key: string,
+    clientEncryptionKeyProperties: ClientEncryptionKeyProperties,
+  ): void {
+    this.clientEncryptionKeyPropertiesCache.set(key, clientEncryptionKeyProperties);
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/Cache/ClientEncryptionKeyPropertiesCache.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/Cache/ClientEncryptionKeyPropertiesCache.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ClientEncryptionKeyProperties } from "../ClientEncryptionKey/ClientEncryptionKeyProperties";
-
+import { ClientEncryptionKeyProperties } from "../ClientEncryptionKey";
+/**
+ * The cache used to store the properties of the client encryption key
+ */
 export class ClientEncryptionKeyPropertiesCache {
   // key is database id + '/'+ clientEncryptionKeyId
   private clientEncryptionKeyPropertiesCache: Map<string, ClientEncryptionKeyProperties>;

--- a/sdk/cosmosdb/cosmos/src/encryption/Cache/EncryptionSettingsCache.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/Cache/EncryptionSettingsCache.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import { EncryptionSettings } from "../EncryptionSettings";
-/**@hidden */
+/**
+ * @hidden
+ * The cache used to store encryption settings for a container.
+ */
 export class EncryptionSettingsCache {
   //key is databaseId + '/' + containerId
   private encryptionSettingsCache: Map<string, EncryptionSettings>;

--- a/sdk/cosmosdb/cosmos/src/encryption/Cache/EncryptionSettingsCache.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/Cache/EncryptionSettingsCache.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { EncryptionSettings } from "../EncryptionSettings";
+/**@hidden */
+export class EncryptionSettingsCache {
+  //key is databaseId + '/' + containerId
+  private encryptionSettingsCache: Map<string, EncryptionSettings>;
+
+  constructor() {
+    this.encryptionSettingsCache = new Map<string, EncryptionSettings>();
+  }
+
+  public getEncryptionSettings(key: string): EncryptionSettings | undefined {
+    return this.encryptionSettingsCache.get(key);
+  }
+
+  public setEncryptionSettings(key: string, encryptionSettings: EncryptionSettings): void {
+    this.encryptionSettingsCache.set(key, encryptionSettings);
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/Cache/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/Cache/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { ClientEncryptionKeyPropertiesCache } from "./ClientEncryptionKeyPropertiesCache";
+export { EncryptionSettingsCache } from "./EncryptionSettingsCache";

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionIncludedPath.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionIncludedPath.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { EncryptionType, EncryptionAlgorithm } from "./enums";
+
+export class ClientEncryptionIncludedPath {
+  public path: string;
+
+  public clientEncryptionKeyId: string;
+
+  public encryptionType: EncryptionType;
+
+  public encryptionAlgorithm: EncryptionAlgorithm;
+
+  constructor(
+    path: string,
+    clientEncryptionKeyId: string,
+    encryptionType: EncryptionType,
+    encryptionAlgortihm: EncryptionAlgorithm,
+  ) {
+    this.path = path;
+    this.clientEncryptionKeyId = clientEncryptionKeyId;
+    this.encryptionType = encryptionType;
+    this.encryptionAlgorithm = encryptionAlgortihm;
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyDefinition.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface ClientEncryptionKeyDefinition {
+  /** id of the client encryption key */
+  id: string;
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyProperties.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyProperties.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { EncryptionKeyWrapMetadata } from "../EncryptionKeyWrapMetadata";
+
+export class ClientEncryptionKeyProperties {
+  id: string;
+  encryptionAlgorithm: string;
+  wrappedDataEncryptionKey: Buffer;
+  encryptionKeyWrapMetadata: EncryptionKeyWrapMetadata;
+
+  constructor(
+    id: string,
+    encryptionAlgorithm: string,
+    wrappedDataEncryptionKey: Buffer,
+    encryptionKeyWrapMetadata: EncryptionKeyWrapMetadata,
+  ) {
+    this.id = id;
+    this.encryptionAlgorithm = encryptionAlgorithm;
+    this.wrappedDataEncryptionKey = wrappedDataEncryptionKey;
+    this.encryptionKeyWrapMetadata = encryptionKeyWrapMetadata;
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyRequest.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyRequest.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientEncryptionKeyDefinition } from "./ClientEncryptionKeyDefinition";
+import { EncryptionKeyWrapMetadata } from "../EncryptionKeyWrapMetadata";
+
+export interface ClientEncryptionKeyRequest extends ClientEncryptionKeyDefinition {
+  encryptionAlgorithm: string;
+  keyWrapMetadata: EncryptionKeyWrapMetadata;
+  wrappedDataEncryptionKey: string;
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/ClientEncryptionKeyResponse.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { CosmosDiagnostics } from "../../CosmosDiagnostics";
+import { CosmosHeaders } from "../../queryExecutionContext";
+import { ResourceResponse } from "../../request/ResourceResponse";
+import { Resource } from "../../client/Resource";
+import { ClientEncryptionKeyDefinition } from "./ClientEncryptionKeyDefinition";
+import { ClientEncryptionKeyProperties } from "./ClientEncryptionKeyProperties";
+
+/** Response object for ClientEncryptionKey operations */
+export class ClientEncryptionKeyResponse extends ResourceResponse<
+  ClientEncryptionKeyDefinition & Resource
+> {
+  constructor(
+    resource: ClientEncryptionKeyDefinition & Resource,
+    headers: CosmosHeaders,
+    statusCode: number,
+    clientEncryptionKeyProperties: ClientEncryptionKeyProperties,
+    diagnostics: CosmosDiagnostics,
+  ) {
+    super(resource, headers, statusCode, diagnostics);
+    this.clientEncryptionKeyProperties = clientEncryptionKeyProperties;
+  }
+  public readonly clientEncryptionKeyProperties: ClientEncryptionKeyProperties;
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionKey/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { ClientEncryptionKeyDefinition } from "./ClientEncryptionKeyDefinition";
+export { ClientEncryptionKeyProperties } from "./ClientEncryptionKeyProperties";
+export { ClientEncryptionKeyResponse } from "./ClientEncryptionKeyResponse";
+export { ClientEncryptionKeyRequest } from "./ClientEncryptionKeyRequest";

--- a/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/ClientEncryptionPolicy.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ErrorResponse } from "..";
+import { ClientEncryptionIncludedPath } from "./ClientEncryptionIncludedPath";
+import { EncryptionAlgorithm } from "./enums";
+
+export class ClientEncryptionPolicy {
+  public includedPaths: ClientEncryptionIncludedPath[];
+
+  public policyFormatVersion: number;
+
+  constructor(includedPaths: ClientEncryptionIncludedPath[], policyFormatVersion?: number) {
+    this.validatePolicyVersion(this.policyFormatVersion);
+    this.validateIncludedPaths(includedPaths, this.policyFormatVersion);
+    this.includedPaths = includedPaths;
+    this.policyFormatVersion = policyFormatVersion || 1;
+  }
+
+  private validatePolicyVersion(policyFormatVersion: number) {
+    if (policyFormatVersion < 1 || policyFormatVersion > 2) {
+      throw new ErrorResponse("Supported versions of client encryption policy are 1 and 2.");
+    }
+  }
+
+  private validateIncludedPaths(
+    includedPaths: ClientEncryptionIncludedPath[],
+    policyFormatVersion: number,
+  ) {
+    const paths = new Set<string>();
+    for (const includedPath of includedPaths) {
+      if (paths.has(includedPath.path)) {
+        throw new ErrorResponse(
+          `Duplicate path found: ${includedPath.path} in client encryption policy.`,
+        );
+      }
+      this.validateClientEncryptionIncludedPath(includedPath, policyFormatVersion);
+      paths.add(includedPath.path);
+    }
+  }
+
+  private validateClientEncryptionIncludedPath(
+    includedPath: ClientEncryptionIncludedPath,
+    policyFormatVersion: number,
+  ) {
+    if (includedPath.path === undefined || includedPath.path === null || includedPath.path === "") {
+      throw new ErrorResponse("Path needs to be defined in ClientEncryptionIncludedPath.");
+    }
+    if (
+      includedPath.clientEncryptionKeyId === undefined ||
+      includedPath.clientEncryptionKeyId === null ||
+      includedPath.clientEncryptionKeyId === "" ||
+      typeof includedPath.clientEncryptionKeyId !== "string"
+    ) {
+      throw new ErrorResponse(
+        "ClientEncryptionKeyId needs to be defined in ClientEncryptionIncludedPath.",
+      );
+    }
+    if (includedPath.encryptionAlgorithm !== EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA256) {
+      throw new ErrorResponse("Invalid encryption algorithm in ClientEncryptionIncludedPath.");
+    }
+    //TODO: add check for checking encryption type
+    if (includedPath.path[0] !== "/") {
+      throw new ErrorResponse("Path in ClientEncryptionIncludedPath needs to start with '/'.");
+      console.log(policyFormatVersion);
+    }
+    // TODO: place further checks for path
+  }
+
+  //TODO: add checks for checking partition key paths
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.browser.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export abstract class DataEncryptionKey {};
+
+export function createHmac(_algorithm: string, _key: Buffer): Promise<Buffer> {
+  throw new Error("Client-side hmac generator not supported in browser environment");
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.browser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export abstract class DataEncryptionKey {};
+export abstract class DataEncryptionKey {}
 
 export function createHmac(_algorithm: string, _key: Buffer): Promise<Buffer> {
   throw new Error("Client-side hmac generator not supported in browser environment");

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/DataEncryptionKey.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createHmac } from "crypto";
+
+export abstract class DataEncryptionKey {
+  private rootKeyBuffer: Buffer;
+  private keySizeInBits = 256;
+  private keySizeInBytes = this.keySizeInBits / 8;
+
+  public encryptionKeyBuffer: Buffer;
+  public macKeyBuffer: Buffer;
+  public ivKeyBuffer: Buffer;
+  public name: string;
+
+  constructor(rootKey: Buffer, name: string) {
+    if (rootKey.length !== this.keySizeInBytes) {
+      throw new Error("Invalid root key size");
+    }
+    this.rootKeyBuffer = rootKey;
+    this.name = name;
+
+    const encryptionKeySalt = `Microsoft SQL Server cell encryption key with encryption algorithm:AEAD_AES_256_CBC_HMAC_SHA256 and key length:${this.keySizeInBits}`;
+    const macKeySalt = `Microsoft SQL Server cell MAC key with encryption algorithm:AEAD_AES_256_CBC_HMAC_SHA256 and key length:${this.keySizeInBits}`;
+    const ivKeySalt = `Microsoft SQL Server cell IV key with encryption algorithm:AEAD_AES_256_CBC_HMAC_SHA256 and key length:${this.keySizeInBits}`;
+
+    this.encryptionKeyBuffer = this.getHmacWithSha256(encryptionKeySalt, this.rootKeyBuffer);
+    this.macKeyBuffer = this.getHmacWithSha256(macKeySalt, this.rootKeyBuffer);
+    this.ivKeyBuffer = this.getHmacWithSha256(ivKeySalt, this.rootKeyBuffer);
+  }
+
+  private getHmacWithSha256(plainText: string, key: Buffer): Buffer {
+    const hmac = createHmac("sha256", key);
+    hmac.update(Buffer.from(plainText, "utf16le"));
+    return hmac.digest();
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.browser.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export class ProtectedDataEncryptionKey {};
+
+export function randomBytes(_size: number): Promise<string> {
+  throw new Error("Client-side random generator not supported in browser environment");
+}
+export function createHmac(_algorithm: string, _key: string): Promise<string> {
+  throw new Error("Client-side random generator not supported in browser environment");
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.browser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export class ProtectedDataEncryptionKey {};
+export class ProtectedDataEncryptionKey {}
 
 export function randomBytes(_size: number): Promise<string> {
   throw new Error("Client-side random generator not supported in browser environment");

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { DataEncryptionKey } from "./DataEncryptionKey";
+import { KeyEncryptionKey } from "../KeyEncryptionKey";
+import { randomBytes } from "crypto";
+
+export class ProtectedDataEncryptionKey extends DataEncryptionKey {
+  public keyEncryptionKey: KeyEncryptionKey;
+
+  public encryptedValue: Buffer;
+
+  public name: string;
+
+  private static protectedDataEncryptionKeyCache: { [key: string]: ProtectedDataEncryptionKey } =
+    {};
+
+  private constructor(
+    name: string,
+    keyEncryptionKey: KeyEncryptionKey,
+    rawKey: Buffer,
+    encryptedKey: Buffer,
+  ) {
+    super(rawKey, name);
+    this.name = name;
+    this.keyEncryptionKey = keyEncryptionKey;
+    this.encryptedValue = encryptedKey;
+  }
+
+  public static async create(
+    name: string,
+    keyEncryptionKey: KeyEncryptionKey,
+    encryptedValue?: Buffer,
+  ): Promise<ProtectedDataEncryptionKey> {
+    let rawKey: Buffer;
+    let encryptedKey: Buffer;
+    if (encryptedValue) {
+      rawKey = await keyEncryptionKey.unwrapEncryptionKey(encryptedValue);
+      encryptedKey = encryptedValue;
+    } else {
+      rawKey = this.generateColumnEncryptionKey();
+      encryptedKey = await keyEncryptionKey.wrapEncryptionKey(rawKey);
+    }
+    const newKey = new ProtectedDataEncryptionKey(name, keyEncryptionKey, rawKey, encryptedKey);
+
+    return newKey;
+  }
+
+  public static async getOrCreate(
+    name: string,
+    keyEncryptionKey: KeyEncryptionKey,
+    encryptedValue: Buffer,
+  ): Promise<ProtectedDataEncryptionKey> {
+    const key = JSON.stringify([name, keyEncryptionKey, encryptedValue.toString("hex")]);
+    if (this.protectedDataEncryptionKeyCache[key] === undefined) {
+      const protectedKey = await this.create(name, keyEncryptionKey, encryptedValue);
+      this.protectedDataEncryptionKeyCache[key] = protectedKey;
+    }
+    return this.protectedDataEncryptionKeyCache[key];
+  }
+
+  private static generateColumnEncryptionKey(): Buffer {
+    return randomBytes(32);
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { DataEncryptionKey } from "./DataEncryptionKey";
+export { ProtectedDataEncryptionKey } from "./ProtectedDataEncryptionKey";

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/AzureKeyVaultEncryptionKeyResolver.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/AzureKeyVaultEncryptionKeyResolver.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { TokenCredential } from "@azure/core-auth";
+import { EncryptionKeyResolver } from "./EncryptionKeyResolver";
+import { KeyClient } from "@azure/keyvault-keys";
+
+export class AzureKeyVaultEncryptionKeyResolver implements EncryptionKeyResolver {
+  private client: KeyClient;
+
+  constructor(credentials: TokenCredential, url: string) {
+    this.client = new KeyClient(url, credentials);
+  }
+
+  public async wrapKey(encryptionKeyId: string, algorithm: string, key: Buffer): Promise<Buffer> {
+    console.log(algorithm);
+    const [keyName, keyVersion] = this.getKeyDetails(encryptionKeyId);
+    const cryptographyClient = this.client.getCryptographyClient(keyName, {
+      keyVersion: keyVersion,
+    });
+    const res = await cryptographyClient.wrapKey("RSA-OAEP", key);
+    return Buffer.from(res.result);
+  }
+
+  public async unwrapKey(
+    encryptionKeyId: string,
+    algorithm: string,
+    wrappedKey: Buffer,
+  ): Promise<Buffer> {
+    console.log(algorithm);
+    const [keyName, keyVersion] = this.getKeyDetails(encryptionKeyId);
+    const cryptographyClient = this.client.getCryptographyClient(keyName, {
+      keyVersion: keyVersion ? keyVersion : "",
+    });
+    const res = await cryptographyClient.unwrapKey("RSA-OAEP", wrappedKey);
+    return Buffer.from(res.result);
+  }
+  //TODO: improve this
+  private getKeyDetails(encryptionKeyId: string): [string, string] {
+    const url = new URL(encryptionKeyId);
+    const parts = url.pathname.split("/");
+    if (parts.length === 4 || parts.length === 5) {
+      return [parts[2], parts[3]];
+    }
+    if (parts.length === 3) {
+      return [parts[2], undefined];
+    }
+    return [undefined, undefined];
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/EncryptionKeyResolver.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/EncryptionKeyResolver.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface EncryptionKeyResolver {
+  wrapKey(encryptionKeyId: string, algorithm: string, key: Buffer): Promise<Buffer>;
+  unwrapKey(encryptionKeyId: string, algorithm: string, wrappedKey: Buffer): Promise<Buffer>;
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyResolver/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { AzureKeyVaultEncryptionKeyResolver } from "./AzureKeyVaultEncryptionKeyResolver";
+export { EncryptionKeyResolver } from "./EncryptionKeyResolver";

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyStoreProvider.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyStoreProvider.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { EncryptionKeyResolver } from "./EncryptionKeyResolver";
+import { KeyEncryptionKeyAlgorithm } from "./enums";
+
+export class EncryptionKeyStoreProvider {
+  public RsaOaepEncryptionAlgorithm: string = "RSA-OAEP";
+
+  private keyEncryptionKeyResolver: EncryptionKeyResolver;
+  // buffer to store the unwrapped encryption key. Key is the path of the encryption key
+  private unwrappedEncryptionKeyCache: { [key: string]: Buffer };
+
+  public providerName: string;
+
+  constructor(keyEncryptionKeyResolver: EncryptionKeyResolver, providerName: string) {
+    this.keyEncryptionKeyResolver = keyEncryptionKeyResolver;
+    this.providerName = providerName;
+    this.unwrappedEncryptionKeyCache = {};
+  }
+
+  public async wrapKey(
+    encryptionKeyId: string,
+    algorithm: KeyEncryptionKeyAlgorithm,
+    key: Buffer,
+  ): Promise<Buffer> {
+    const keyEncryptionKey = await this.keyEncryptionKeyResolver.wrapKey(
+      encryptionKeyId,
+      algorithm,
+      key,
+    );
+    return keyEncryptionKey;
+  }
+
+  public async unwrapKey(
+    encryptionKeyId: string,
+    algorithm: KeyEncryptionKeyAlgorithm,
+    wrappedKey: Buffer,
+  ): Promise<Buffer> {
+    if (!this.unwrappedEncryptionKeyCache[encryptionKeyId]) {
+      const plainEncryptionKey = await this.keyEncryptionKeyResolver.unwrapKey(
+        encryptionKeyId,
+        algorithm,
+        wrappedKey,
+      );
+      this.unwrappedEncryptionKeyCache[encryptionKeyId] = plainEncryptionKey;
+    }
+    return this.unwrappedEncryptionKeyCache[encryptionKeyId];
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyStoreProvider.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyStoreProvider.ts
@@ -3,20 +3,28 @@
 
 import { EncryptionKeyResolver } from "./EncryptionKeyResolver";
 import { KeyEncryptionKeyAlgorithm } from "./enums";
-
+/**
+ * Class to store encryption keys in unwrapped form and provide an interface for wrapping and unwrapping the keys.
+ */
 export class EncryptionKeyStoreProvider {
   public RsaOaepEncryptionAlgorithm: string = "RSA-OAEP";
-
+  private cacheTimeToLive: number;
   private keyEncryptionKeyResolver: EncryptionKeyResolver;
-  // buffer to store the unwrapped encryption key. Key is the path of the encryption key
-  private unwrappedEncryptionKeyCache: { [key: string]: Buffer };
+  // cache to store the unwrapped encryption key. Key is the path of the encryption key
+  private unwrappedEncryptionKeyCache: { [key: string]: [Date, Buffer] };
 
   public providerName: string;
 
-  constructor(keyEncryptionKeyResolver: EncryptionKeyResolver, providerName: string) {
+  constructor(
+    keyEncryptionKeyResolver: EncryptionKeyResolver,
+    providerName: string,
+    cacheTimeToLive?: number,
+  ) {
     this.keyEncryptionKeyResolver = keyEncryptionKeyResolver;
     this.providerName = providerName;
     this.unwrappedEncryptionKeyCache = {};
+    this.cacheTimeToLive = cacheTimeToLive;
+    this.clearCacheOnTtlExpiry();
   }
 
   public async wrapKey(
@@ -43,8 +51,22 @@ export class EncryptionKeyStoreProvider {
         algorithm,
         wrappedKey,
       );
-      this.unwrappedEncryptionKeyCache[encryptionKeyId] = plainEncryptionKey;
+      this.unwrappedEncryptionKeyCache[encryptionKeyId] = [new Date(), plainEncryptionKey];
     }
-    return this.unwrappedEncryptionKeyCache[encryptionKeyId];
+    return this.unwrappedEncryptionKeyCache[encryptionKeyId][1];
+  }
+
+  private async clearCacheOnTtlExpiry(): Promise<void> {
+    setInterval(() => {
+      const now = new Date();
+      for (const key in this.unwrappedEncryptionKeyCache) {
+        if (
+          now.getTime() - this.unwrappedEncryptionKeyCache[key][0].getTime() >
+          this.cacheTimeToLive
+        ) {
+          delete this.unwrappedEncryptionKeyCache[key];
+        }
+      }
+    }, 300000);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyWrapMetadata.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKeyWrapMetadata.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { EncryptionKeyResolverName, KeyEncryptionKeyAlgorithm } from "./enums";
+
+export class EncryptionKeyWrapMetadata {
+  public type: EncryptionKeyResolverName;
+
+  public name: string;
+
+  public value: string;
+
+  public algorithm: KeyEncryptionKeyAlgorithm;
+
+  constructor(
+    type: EncryptionKeyResolverName,
+    name: string,
+    value: string,
+    algorithm: KeyEncryptionKeyAlgorithm,
+  ) {
+    this.type = type;
+    this.name = name;
+    this.value = value;
+    this.algorithm = algorithm;
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionProcessor.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionProcessor.ts
@@ -1,0 +1,2 @@
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT license.

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionSettingForProperty.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionSettingForProperty.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientEncryptionIncludedPath } from "./ClientEncryptionIncludedPath";
+import { ClientEncryptionKeyProperties } from "./ClientEncryptionKey";
+import { EncryptionAlgorithm, EncryptionType } from "./enums";
+import { EncryptionKeyStoreProvider } from "./EncryptionKeyStoreProvider";
+import { AeadAes256CbcHmacSha256Algorithm } from "./AeadAes256CbcHmacSha256Algorithm";
+import { KeyEncryptionKey } from "./KeyEncryptionKey";
+import { ProtectedDataEncryptionKey } from "./EncryptionKey";
+
+export class EncryptionSettingForProperty {
+  encryptionKeyId: string;
+  encryptionType: EncryptionType;
+  encryptionAlgorithm: EncryptionAlgorithm;
+
+  constructor(clientEncryptionIncludedPath: ClientEncryptionIncludedPath) {
+    this.encryptionKeyId = clientEncryptionIncludedPath.clientEncryptionKeyId;
+    this.encryptionType = clientEncryptionIncludedPath.encryptionType;
+    this.encryptionAlgorithm = clientEncryptionIncludedPath.encryptionAlgorithm;
+  }
+
+  public async buildEncryptionAlgorithm(
+    encryptionType: EncryptionType,
+    clientEncryptionKeyProperties: ClientEncryptionKeyProperties,
+    encryptionKeyStoreProvider: EncryptionKeyStoreProvider,
+  ): Promise<AeadAes256CbcHmacSha256Algorithm> {
+    const protectedDataEncryptionKey = await this.buildProtectedDataEncryptionKey(
+      clientEncryptionKeyProperties,
+      encryptionKeyStoreProvider,
+    );
+    const encryptionAlgorithm = new AeadAes256CbcHmacSha256Algorithm(
+      protectedDataEncryptionKey,
+      encryptionType,
+    );
+
+    return encryptionAlgorithm;
+  }
+
+  private async buildProtectedDataEncryptionKey(
+    clientEncryptionKeyProperties: ClientEncryptionKeyProperties,
+    encryptionKeyStoreProvider: EncryptionKeyStoreProvider,
+  ): Promise<ProtectedDataEncryptionKey> {
+    const keyEncryptionKey = KeyEncryptionKey.getOrCreate(
+      clientEncryptionKeyProperties.encryptionKeyWrapMetadata.name,
+      clientEncryptionKeyProperties.encryptionKeyWrapMetadata.value,
+      encryptionKeyStoreProvider,
+    );
+    const protectedDataEncryptionKey = await ProtectedDataEncryptionKey.getOrCreate(
+      this.encryptionKeyId,
+      keyEncryptionKey,
+      clientEncryptionKeyProperties.wrappedDataEncryptionKey,
+    );
+    return protectedDataEncryptionKey;
+  }
+  //TODO: in class calling these functions, implement methods to get the latest clientEncryptionKeyProperties if any thing goes wrong. EncryptionProcessor in our case.
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionSettings.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionSettings.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientEncryptionPolicy } from "./ClientEncryptionPolicy";
+import { EncryptionSettingForProperty } from "./EncryptionSettingForProperty";
+
+export class EncryptionSettings {
+  public id: string;
+
+  public partitionKeyPaths: string[];
+
+  public pathsToEncrypt: string[] = [];
+
+  private encryptionSettingForProperties: { [key: string]: EncryptionSettingForProperty } = {};
+
+  private constructor(id: string, partitionKeyPaths: string[]) {
+    this.id = id;
+    this.partitionKeyPaths = partitionKeyPaths;
+  }
+
+  public static create(
+    id: string,
+    partitionKeyPaths: string[],
+    clientEncryptionPolicy: ClientEncryptionPolicy,
+  ): EncryptionSettings {
+    const encryptionSettings = new EncryptionSettings(id, partitionKeyPaths);
+    //TODO: basic checks on clientEncryptionPolicy
+
+    for (const includedPath of clientEncryptionPolicy.includedPaths) {
+      const encryptionSettingForProperty = new EncryptionSettingForProperty(includedPath);
+      encryptionSettings.setEncryptionProperty(includedPath.path, encryptionSettingForProperty);
+    }
+    return encryptionSettings;
+  }
+
+  private setEncryptionProperty(
+    key: string,
+    encryptionSettingForProperty: EncryptionSettingForProperty,
+  ) {
+    this.encryptionSettingForProperties[key] = encryptionSettingForProperty;
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/KeyEncryptionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/KeyEncryptionKey.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { KeyEncryptionKeyAlgorithm } from "./enums/KeyEncryptionKeyAlgorithm";
+import { EncryptionKeyStoreProvider } from "./EncryptionKeyStoreProvider";
+
+export class KeyEncryptionKey {
+  private encryptionAlgorithm: KeyEncryptionKeyAlgorithm;
+
+  private static keyEncryptionKeyCache: { [key: string]: KeyEncryptionKey } = {};
+
+  public name: string;
+
+  public path: string;
+
+  public keyStoreProvider: EncryptionKeyStoreProvider;
+
+  constructor(name: string, path: string, keyStoreProvider: EncryptionKeyStoreProvider) {
+    this.name = name;
+    this.path = path;
+    this.keyStoreProvider = keyStoreProvider;
+    this.encryptionAlgorithm = KeyEncryptionKeyAlgorithm.RSA_OAEP;
+  }
+
+  public static getOrCreate(
+    name: string,
+    path: string,
+    keyStoreProvider: EncryptionKeyStoreProvider,
+  ) {
+    if (!KeyEncryptionKey.keyEncryptionKeyCache) {
+      KeyEncryptionKey.keyEncryptionKeyCache = {};
+    }
+    const key = JSON.stringify([name, path, keyStoreProvider]);
+    if (!KeyEncryptionKey.keyEncryptionKeyCache[key]) {
+      KeyEncryptionKey.keyEncryptionKeyCache[key] = new KeyEncryptionKey(
+        name,
+        path,
+        keyStoreProvider,
+      );
+    }
+    return KeyEncryptionKey.keyEncryptionKeyCache[key];
+  }
+
+  public async wrapEncryptionKey(plainTextEncryptionKey: Buffer): Promise<Buffer> {
+    return await this.keyStoreProvider.wrapKey(
+      this.path,
+      this.encryptionAlgorithm,
+      plainTextEncryptionKey,
+    );
+  }
+
+  public async unwrapEncryptionKey(wrappedEncryptionKey: Buffer): Promise<Buffer> {
+    return await this.keyStoreProvider.unwrapKey(
+      this.path,
+      this.encryptionAlgorithm,
+      wrappedEncryptionKey,
+    );
+  }
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/KeyEncryptionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/KeyEncryptionKey.ts
@@ -3,7 +3,9 @@
 
 import { KeyEncryptionKeyAlgorithm } from "./enums/KeyEncryptionKeyAlgorithm";
 import { EncryptionKeyStoreProvider } from "./EncryptionKeyStoreProvider";
-
+/**
+ * A wrapper class containing the info about the client encryption key and key store provider to wrap and unwrap the key.
+ */
 export class KeyEncryptionKey {
   private encryptionAlgorithm: KeyEncryptionKeyAlgorithm;
 
@@ -30,7 +32,7 @@ export class KeyEncryptionKey {
     if (!KeyEncryptionKey.keyEncryptionKeyCache) {
       KeyEncryptionKey.keyEncryptionKeyCache = {};
     }
-    const key = JSON.stringify([name, path, keyStoreProvider]);
+    const key = JSON.stringify([name, path]);
     if (!KeyEncryptionKey.keyEncryptionKeyCache[key]) {
       KeyEncryptionKey.keyEncryptionKeyCache[key] = new KeyEncryptionKey(
         name,

--- a/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionAlgorithm.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionAlgorithm.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export enum EncryptionAlgorithm {
+  AEAD_AES_256_CBC_HMAC_SHA256 = "AEAD_AES_256_CBC_HMAC_SHA256",
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionKeyResolverName.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionKeyResolverName.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export enum EncryptionKeyResolverName {
+  AzureKeyVault = "AZURE_KEY_VAULT",
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionType.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/enums/EncryptionType.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export enum EncryptionType {
+  DETERMINISTIC = "Deterministic",
+  RANDOMIZED = "Randomized",
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/enums/KeyEncryptionKeyAlgorithm.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/enums/KeyEncryptionKeyAlgorithm.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export enum KeyEncryptionKeyAlgorithm {
+  RSA_OAEP = "RSA-OAEP",
+}

--- a/sdk/cosmosdb/cosmos/src/encryption/enums/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/enums/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { EncryptionType } from "./EncryptionType";
+export { EncryptionAlgorithm } from "./EncryptionAlgorithm";
+export { EncryptionKeyResolverName } from "./EncryptionKeyResolverName";
+export { KeyEncryptionKeyAlgorithm } from "./KeyEncryptionKeyAlgorithm";

--- a/sdk/cosmosdb/cosmos/src/encryption/index.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export * from "./ClientEncryptionKey";
+export * from "./enums";
+export * from "./Cache";
+export * from "./EncryptionKeyResolver";
+export { ClientEncryptionIncludedPath } from "./ClientEncryptionIncludedPath";
+export { ClientEncryptionPolicy } from "./ClientEncryptionPolicy";
+export { EncryptionKeyWrapMetadata } from "./EncryptionKeyWrapMetadata";
+export { EncryptionKeyStoreProvider } from "./EncryptionKeyStoreProvider";
+export { EncryptionSettings } from "./EncryptionSettings";
+export { KeyEncryptionKey } from "./KeyEncryptionKey";
+export { EncryptionSettingForProperty } from "./EncryptionSettingForProperty";
+export { ProtectedDataEncryptionKey } from "./EncryptionKey";
+// export { EncryptionProcessor } from "./EncryptionProcessor";

--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -123,3 +123,12 @@ export { SasTokenPermissionKind } from "./common/constants";
 export { createAuthorizationSasToken } from "./utils/SasToken";
 export { RestError } from "@azure/core-rest-pipeline";
 export { AbortError } from "@azure/abort-controller";
+export * from "./encryption/enums";
+export * from "./encryption/ClientEncryptionKey";
+export * from "./encryption/EncryptionKeyResolver";
+export {
+  ClientEncryptionIncludedPath,
+  ClientEncryptionPolicy,
+  ClientEncryptionKeyProperties,
+  EncryptionKeyWrapMetadata,
+} from "./encryption";

--- a/sdk/cosmosdb/cosmos/tsconfig.strict.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.strict.json
@@ -143,6 +143,7 @@
     "src/utils/hashing",
     "src/client/SasToken/SasTokenProperties.ts",
     "src/client/SasToken/PermissionScopeValues.ts",
+    "src/encryption/*",
     "test/public/common/TestHelpers.ts",
     "test/internal/session.spec.ts",
     "test/internal/unit/auth.spec.ts",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/28760

### Describe the problem that is addressed by this PR
This PR adds TTL logic for encryption keys in the client.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
