### PR TITLE
[identity] Refactor plugin definitions

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -19,6 +19,7 @@ import {
   publicToMsal,
   randomUUID,
 } from "../utils";
+import { hasNativeBroker, nativeBrokerInfo, persistenceProvider } from "./msalPlugins";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
@@ -32,7 +33,6 @@ import { CredentialFlowGetTokenOptions } from "../credentials";
 import { IdentityClient } from "../../client/identityClient";
 import { LogPolicyOptions } from "@azure/core-rest-pipeline";
 import { MultiTenantTokenCredentialOptions } from "../../credentials/multiTenantTokenCredentialOptions";
-import { NativeBrokerPluginControl } from "../../plugins/provider";
 import { RegionalAuthority } from "../../regionalAuthority";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
 import { getLogLevel } from "@azure/logger";
@@ -65,50 +65,6 @@ export interface MsalNodeOptions extends MsalFlowOptions {
     enableUnsafeSupportLogging?: boolean;
   };
 }
-
-/**
- * The current persistence provider, undefined by default.
- * @internal
- */
-export let persistenceProvider:
-  | ((options?: TokenCachePersistenceOptions) => Promise<msalNode.ICachePlugin>)
-  | undefined = undefined;
-
-/**
- * An object that allows setting the persistence provider.
- * @internal
- */
-export const msalNodeFlowCacheControl = {
-  setPersistence(pluginProvider: Exclude<typeof persistenceProvider, undefined>): void {
-    persistenceProvider = pluginProvider;
-  },
-};
-
-/**
- * The current native broker provider, undefined by default.
- * @internal
- */
-export let nativeBrokerInfo:
-  | {
-      broker: msalNode.INativeBrokerPlugin;
-    }
-  | undefined = undefined;
-
-export function hasNativeBroker(): boolean {
-  return nativeBrokerInfo !== undefined;
-}
-
-/**
- * An object that allows setting the native broker provider.
- * @internal
- */
-export const msalNodeFlowNativeBrokerControl: NativeBrokerPluginControl = {
-  setNativeBroker(broker): void {
-    nativeBrokerInfo = {
-      broker,
-    };
-  },
-};
 
 /**
  * MSAL partial base client for Node.js.

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -3,12 +3,13 @@
 
 import * as msalNode from "@azure/msal-node";
 
-import { MsalNode, MsalNodeOptions, hasNativeBroker } from "./msalNodeCommon";
+import { MsalNode, MsalNodeOptions } from "./msalNodeCommon";
 
 import { AccessToken } from "@azure/core-auth";
 import { CredentialFlowGetTokenOptions } from "../credentials";
 import { credentialLogger } from "../../util/logging";
 import { handleMsalError } from "../utils";
+import { hasNativeBroker } from "./msalPlugins";
 import open from "open";
 
 /**

--- a/sdk/identity/identity/src/plugins/consumer.ts
+++ b/sdk/identity/identity/src/plugins/consumer.ts
@@ -5,7 +5,8 @@ import { AzurePluginContext, IdentityPlugin } from "./provider";
 import {
   msalNodeFlowCacheControl,
   msalNodeFlowNativeBrokerControl,
-} from "../msal/nodeFlows/msalNodeCommon";
+} from "../msal/nodeFlows/msalPlugins";
+
 import { vsCodeCredentialControl } from "../credentials/visualStudioCodeCredential";
 
 /**

--- a/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
@@ -5,11 +5,9 @@ import { ICachePlugin, INativeBrokerPlugin } from "@azure/msal-node";
 import {
   PluginConfiguration,
   generatePluginConfiguration,
-} from "../../../src/msal/nodeFlows/msalPlugins";
-import {
   msalNodeFlowCacheControl,
   msalNodeFlowNativeBrokerControl,
-} from "../../../src/msal/nodeFlows/msalNodeCommon";
+} from "../../../src/msal/nodeFlows/msalPlugins";
 
 import { MsalClientOptions } from "../../../src/msal/nodeFlows/msalClient";
 import { assert } from "@azure/test-utils";


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28679

### Describe the problem that is addressed by this PR

When migrating plugin support to MSALClient I noticed that msalNodeCommon
defines all the plugin declarations. To avoid duplication, provide an easy path 
to migrate (by avoiding imports on msalNodeCommon) and provide a single
source of truth for plugin settings it made sense to migrate all the definitions
to a single file.

This is purely mechanical, just moving things around and updating imports


### Provide a list of related PRs _(if any)_

#28493

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
