### PR TITLE
[identity] increment package version for cache-persistence

### DIFF
--- a/sdk/identity/identity-cache-persistence/CHANGELOG.md
+++ b/sdk/identity/identity-cache-persistence/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.1.0 (2024-03-05)
 
 ### Other Changes

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/identity-cache-persistence",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "sdk-type": "client",
   "description": "A secure, persistent token cache for Azure Identity credentials that uses the OS secret-management API",
   "main": "dist/index.js",


### PR DESCRIPTION
Automation failed to increment package version due to the prepush hook not
working on CI. This PR runs the same script and increments the package version
for @azure/identity-cache-persistence after release.
