### PR TITLE
[identity] MSALClient CAE support for confidentialClientApplication

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -445,7 +445,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         this.cachedClaims = optionsClaims;
       }
       if (this.cachedClaims && !optionsClaims) {
-        (options as any).claims = this.cachedClaims;
+        options.claims = this.cachedClaims;
       }
       // We don't return the promise since we want to catch errors right here.
       return await this.getTokenSilent(scopes, options);

--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -3,6 +3,8 @@
 
 import * as msalNode from "@azure/msal-node";
 
+import { CACHE_CAE_SUFFIX, CACHE_NON_CAE_SUFFIX } from "../../constants";
+
 import { MsalClientOptions } from "./msalClient";
 import { NativeBrokerPluginControl } from "../../plugins/provider";
 import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
@@ -16,6 +18,7 @@ export interface PluginConfiguration {
    */
   cache: {
     cachePlugin?: Promise<msalNode.ICachePlugin>;
+    cachePluginCae?: Promise<msalNode.ICachePlugin>;
   };
   /**
    * Configuration for the broker plugin.
@@ -100,7 +103,14 @@ export function generatePluginConfiguration(options: MsalClientOptions): PluginC
       );
     }
 
-    config.cache.cachePlugin = persistenceProvider(options.tokenCachePersistenceOptions);
+    config.cache.cachePlugin = persistenceProvider({
+      name: `${options.tokenCachePersistenceOptions.name}.${CACHE_NON_CAE_SUFFIX}`,
+      ...options.tokenCachePersistenceOptions,
+    });
+    config.cache.cachePluginCae = persistenceProvider({
+      name: `${options.tokenCachePersistenceOptions.name}.${CACHE_CAE_SUFFIX}`,
+      ...options.tokenCachePersistenceOptions,
+    });
   }
 
   if (options.brokerOptions?.enabled) {

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as msalClient from "../../../src/msal/nodeFlows/msalClient";
+import * as msalPlugins from "../../../src/msal/nodeFlows/msalPlugins";
 
 import { AuthenticationResult, ConfidentialClientApplication } from "@azure/msal-node";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
@@ -109,6 +110,109 @@ describe("MsalClient", function () {
           () => msalClient.generateMsalConfiguration("client-id", "invalid-tenant-id$%*^@#(;"),
           /Invalid tenant id provided/,
         );
+      });
+    });
+  });
+
+  describe("CAE support", function () {
+    let sandbox: sinon.SinonSandbox;
+    let subject: msalClient.MsalClient;
+
+    const clientId = "client-id";
+    const tenantId = "tenant-id";
+
+    afterEach(async function () {
+      sandbox.restore();
+    });
+
+    beforeEach(async function () {
+      sandbox = sinon.createSandbox();
+    });
+
+    describe("when CAE is enabled", function () {
+      const enableCae = true;
+
+      it("uses the CAE cache", async function () {
+        const cachePluginCae = {
+          afterCacheAccess: sinon.stub(),
+          beforeCacheAccess: sinon.stub(),
+        };
+        const cachePlugin = {
+          afterCacheAccess: sinon.stub(),
+          beforeCacheAccess: sinon.stub(),
+        };
+
+        sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
+          broker: {
+            enableMsaPassthrough: false,
+          },
+          cache: {
+            cachePlugin: Promise.resolve(cachePlugin),
+            cachePluginCae: Promise.resolve(cachePluginCae),
+          },
+        });
+
+        subject = msalClient.createMsalClient(clientId, tenantId, {
+          tokenCachePersistenceOptions: {
+            enabled: true,
+          },
+        });
+
+        try {
+          await subject.getTokenByClientSecret(
+            ["https://vault.azure.net/.default"],
+            "client-secret",
+            { enableCae },
+          );
+        } catch (e) {
+          // ignore errors
+        }
+
+        assert.isAbove(cachePluginCae.beforeCacheAccess.callCount, 0);
+        assert.equal(cachePlugin.beforeCacheAccess.callCount, 0);
+      });
+    });
+
+    describe("when CAE is disabled", function () {
+      const enableCae = false;
+      it("initializes the default cache", async function () {
+        const cachePluginCae = {
+          afterCacheAccess: sinon.stub(),
+          beforeCacheAccess: sinon.stub(),
+        };
+        const cachePlugin = {
+          afterCacheAccess: sinon.stub(),
+          beforeCacheAccess: sinon.stub(),
+        };
+
+        sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
+          broker: {
+            enableMsaPassthrough: false,
+          },
+          cache: {
+            cachePlugin: Promise.resolve(cachePlugin),
+            cachePluginCae: Promise.resolve(cachePluginCae),
+          },
+        });
+
+        subject = msalClient.createMsalClient(clientId, tenantId, {
+          tokenCachePersistenceOptions: {
+            enabled: true,
+          },
+        });
+
+        try {
+          await subject.getTokenByClientSecret(
+            ["https://vault.azure.net/.default"],
+            "client-secret",
+            { enableCae },
+          );
+        } catch (e) {
+          // ignore errors
+        }
+
+        assert.isAbove(cachePlugin.beforeCacheAccess.callCount, 0);
+        assert.equal(cachePluginCae.beforeCacheAccess.callCount, 0);
       });
     });
   });

--- a/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../src/msal/nodeFlows/msalPlugins";
 
 import { MsalClientOptions } from "../../../src/msal/nodeFlows/msalClient";
+import Sinon from "sinon";
 import { assert } from "@azure/test-utils";
 
 describe("#generatePluginConfiguration", function () {
@@ -46,14 +47,10 @@ describe("#generatePluginConfiguration", function () {
 
     it("configures the cache plugin correctly", async function () {
       options.tokenCachePersistenceOptions = { enabled: true };
-      // TODO: use stub
-      const cachePlugin: ICachePlugin = {
-        afterCacheAccess: async () => {
-          // no-op
-        },
-        beforeCacheAccess: async () => {
-          // no-op
-        },
+
+      const cachePlugin = {
+        afterCacheAccess: Sinon.stub(),
+        beforeCacheAccess: Sinon.stub(),
       };
       const pluginProvider: () => Promise<ICachePlugin> = () => Promise.resolve(cachePlugin);
       msalNodeFlowCacheControl.setPersistence(pluginProvider);
@@ -61,6 +58,21 @@ describe("#generatePluginConfiguration", function () {
       assert.exists(result.cache.cachePlugin);
       const plugin = await result.cache.cachePlugin;
       assert.strictEqual(plugin, cachePlugin);
+    });
+
+    it("configures the CAE cache plugin correctly", async function () {
+      options.tokenCachePersistenceOptions = { enabled: true };
+
+      const cachePluginCae = {
+        afterCacheAccess: Sinon.stub(),
+        beforeCacheAccess: Sinon.stub(),
+      };
+      const pluginProvider: () => Promise<ICachePlugin> = () => Promise.resolve(cachePluginCae);
+      msalNodeFlowCacheControl.setPersistence(pluginProvider);
+      const result = generatePluginConfiguration(options);
+      assert.exists(result.cache.cachePluginCae);
+      const plugin = await result.cache.cachePluginCae;
+      assert.strictEqual(plugin, cachePluginCae);
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28675

### Describe the problem that is addressed by this PR

This PR adds CAE support for MSALClient as part of the larger refactor. With CAE
support, a developer can pass `enableCae` to a token credential request and use
a different cache and different client capabilities.

With this change, I'm able to run live and recorded tests using clientSecretCredential
with MSALClient backend!

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
