### PR TITLE
[EngSys] Fix prettier path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
   "typescript.disableAutomaticTypeAcquisition": true,
   "typescript.preferences.quoteStyle": "double",
   "git.ignoreLimitWarning": true,
-  "prettier.prettierPath": "./common/tools/dev-tool/node_modules/prettier",
+  "prettier.prettierPath": "./common/tools/dev-tool/node_modules/prettier/index.cjs",
   "search.exclude": {
     "test-results*.xml": true,
     "**/temp/*": true,


### PR DESCRIPTION
### Packages impacted by this PR

N/A

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

I was setting up my tooling demo for the team and ran into a bug in the prettier v3,
chasing down the error, looks like it is [this issue](https://github.com/prettier/prettier-vscode/issues/3007#issuecomment-1628836459) and while there's no fix released yet, 
the common workaround seems to work on a new machine for me.

This should in theory fix prettier for folks (if it's not working) using VSCode