### PR TITLE
[core-client] Share state between ESM and CJS

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -134,6 +134,7 @@
     "Sybase",
     "Teradata",
     "tmpdir",
+    "tshy",
     "uaecentral",
     "uksouth",
     "ukwest",

--- a/sdk/core/core-client/.tshy/browser.json
+++ b/sdk/core/core-client/.tshy/browser.json
@@ -5,7 +5,9 @@
     "../src/**/*.mts",
     "../src/**/*.tsx"
   ],
-  "exclude": [],
+  "exclude": [
+    ".././src/state-cjs.cts"
+  ],
   "compilerOptions": {
     "outDir": "../.tshy-build/browser"
   }

--- a/sdk/core/core-client/.tshy/commonjs.json
+++ b/sdk/core/core-client/.tshy/commonjs.json
@@ -7,7 +7,8 @@
   ],
   "exclude": [
     "../src/**/*.mts",
-    "../src/base64-browser.mts"
+    "../src/base64-browser.mts",
+    "../src/state-browser.mts"
   ],
   "compilerOptions": {
     "outDir": "../.tshy-build/commonjs"

--- a/sdk/core/core-client/.tshy/esm.json
+++ b/sdk/core/core-client/.tshy/esm.json
@@ -6,7 +6,9 @@
     "../src/**/*.tsx"
   ],
   "exclude": [
-    ".././src/base64-browser.mts"
+    ".././src/state-cjs.cts",
+    ".././src/base64-browser.mts",
+    ".././src/state-browser.mts"
   ],
   "compilerOptions": {
     "outDir": "../.tshy-build/esm"

--- a/sdk/core/core-client/.tshy/react-native.json
+++ b/sdk/core/core-client/.tshy/react-native.json
@@ -6,7 +6,9 @@
     "../src/**/*.tsx"
   ],
   "exclude": [
-    ".././src/base64-browser.mts"
+    ".././src/state-cjs.cts",
+    ".././src/base64-browser.mts",
+    ".././src/state-browser.mts"
   ],
   "compilerOptions": {
     "outDir": "../.tshy-build/react-native"

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -65,7 +65,7 @@
     "pack": "npm pack 2>&1",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run clean && tshy && npm run unit-test:node && npm run integration-test:node",
-    "test": "npm run clean && tshy && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
+    "test": "npm run clean && tshy && npm run unit-test:node && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser": "npm run build:test && dev-tool run test:vitest --no-test-proxy --browser",
     "unit-test:node": "dev-tool run test:vitest --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"

--- a/sdk/core/core-client/src/operationHelpers.ts
+++ b/sdk/core/core-client/src/operationHelpers.ts
@@ -11,6 +11,8 @@ import {
   ParameterPath,
 } from "./interfaces.js";
 
+import { state } from "./state.js";
+
 /**
  * @internal
  * Retrieves the value to use for a given operation argument
@@ -106,7 +108,6 @@ function getPropertyFromParameterPath(
   return result;
 }
 
-const operationRequestMap = new WeakMap<OperationRequest, OperationRequestInfo>();
 const originalRequestSymbol = Symbol.for("@azure/core-client original request");
 
 function hasOriginalRequest(
@@ -119,11 +120,11 @@ export function getOperationRequestInfo(request: OperationRequest): OperationReq
   if (hasOriginalRequest(request)) {
     return getOperationRequestInfo(request[originalRequestSymbol]);
   }
-  let info = operationRequestMap.get(request);
+  let info = state.operationRequestMap.get(request);
 
   if (!info) {
     info = {};
-    operationRequestMap.set(request, info);
+    state.operationRequestMap.set(request, info);
   }
   return info;
 }

--- a/sdk/core/core-client/src/state-browser.mts
+++ b/sdk/core/core-client/src/state-browser.mts
@@ -1,5 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { OperationRequest, OperationRequestInfo } from "./interfaces.js";
 
+/**
+ * Browser-only implementation of the module's state. The browser esm variant will not load the commonjs state, so we do not need to share state between the two.
+ */
 export const state = {
   operationRequestMap: new WeakMap<OperationRequest, OperationRequestInfo>(),
 };

--- a/sdk/core/core-client/src/state-browser.mts
+++ b/sdk/core/core-client/src/state-browser.mts
@@ -1,0 +1,5 @@
+import { OperationRequest, OperationRequestInfo } from "./interfaces.js";
+
+export const state = {
+  operationRequestMap: new WeakMap<OperationRequest, OperationRequestInfo>(),
+};

--- a/sdk/core/core-client/src/state-cjs.cts
+++ b/sdk/core/core-client/src/state-cjs.cts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @internal
+ *
+ * Holds the singleton operationRequestMap, to be shared across CJS and ESM imports.
+ */
+export const state = {
+  operationRequestMap: new WeakMap(),
+};

--- a/sdk/core/core-client/src/state-cjs.cts
+++ b/sdk/core/core-client/src/state-cjs.cts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 
 /**
- * @internal
- *
  * Holds the singleton operationRequestMap, to be shared across CJS and ESM imports.
  */
 export const state = {

--- a/sdk/core/core-client/src/state.ts
+++ b/sdk/core/core-client/src/state.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { OperationRequest, OperationRequestInfo } from "./interfaces.js";
+
+// @ts-expect-error The recommended approach to sharing module state between ESM and CJS.
+// See https://github.com/isaacs/tshy/blob/main/README.md#module-local-state for additional information.
+import { state as cjsState } from "../commonjs/state.js";
+
+/**
+ * Defines the shared state between CJS and ESM by re-exporting the CJS state.
+ */
+export const state = cjsState as {
+  operationRequestMap: WeakMap<OperationRequest, OperationRequestInfo>;
+};

--- a/sdk/core/core-client/vitest.config.ts
+++ b/sdk/core/core-client/vitest.config.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
 
 export default defineConfig({
   test: {
@@ -13,6 +14,9 @@ export default defineConfig({
       toFake: ["setTimeout", "Date"],
     },
     watch: false,
+    alias: {
+      "../commonjs/state.js": resolve("./src/state-cjs.cts"),
+    },
     include: ["test/**/*.spec.ts"],
     exclude: ["test/**/browser/*.spec.ts"],
     coverage: {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-client

### Issues associated with this PR

N/A, follow up on #28631 

### Describe the problem that is addressed by this PR

If you are exporting both CommonJS and ESM forms of a package, then it is possible for both versions to be loaded at 
run-time. However, the CommonJS build is a different module from the ESM build, and thus a different thing from the
point of view of the JavaScript interpreter in Node.js.

https://github.com/isaacs/tshy/blob/main/README.md#dual-package-hazards

tshy handles this by building programs into separate folders and treats "dual
module hazards" as a fact of life.

One of the hazards of dual-modules is shared module-global state.

In core-clientwe have a module-global operationRequestMap that is used for deserializing. 
In order to ensure it works in this dual-package world we must use one of multiple-recommended
workarounds.

In this case, the tshy documentation provides a solution to this with a
well-documented path forward. This is what is implemented here.

Please refer to
https://github.com/isaacs/tshy/blob/main/README.md#module-local-state for added
//context.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The obvious alternative is to just not do anything since tests have not been failing; however, that
seems risky. While _this_ particular issue has not come up in tests, a similar one came up for core-tracing.

I am open to just _not_ doing anything of course - I love not adding code so just give me a reason!

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
