### PR TITLE
[identity] Fix nightly tests

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -4,7 +4,7 @@
 import * as msal from "@azure/msal-node";
 
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
-import { PluginConfiguration, generatePluginConfiguration } from "./msalPlugins";
+import { PluginConfiguration, msalPlugins } from "./msalPlugins";
 import { credentialLogger, formatSuccess } from "../../util/logging";
 import {
   defaultLoggerCallback,
@@ -141,7 +141,7 @@ export function createMsalClient(
     cachedAccount: createMsalClientOptions.authenticationRecord
       ? publicToMsal(createMsalClientOptions.authenticationRecord)
       : null,
-    pluginConfiguration: generatePluginConfiguration(createMsalClientOptions),
+    pluginConfiguration: msalPlugins.generatePluginConfiguration(createMsalClientOptions),
   };
 
   const confidentialApps: Map<string, msal.ConfidentialClientApplication> = new Map();

--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -82,7 +82,7 @@ export const msalNodeFlowNativeBrokerControl: NativeBrokerPluginControl = {
  * @param options - options for creating the MSAL client
  * @returns plugin configuration
  */
-export function generatePluginConfiguration(options: MsalClientOptions): PluginConfiguration {
+function generatePluginConfiguration(options: MsalClientOptions): PluginConfiguration {
   const config: PluginConfiguration = {
     cache: {},
     broker: {
@@ -130,3 +130,10 @@ export function generatePluginConfiguration(options: MsalClientOptions): PluginC
 
   return config;
 }
+
+/**
+ * Wraps generatePluginConfiguration as a writeable property for test stubbing purposes.
+ */
+export const msalPlugins = {
+  generatePluginConfiguration,
+};

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import * as msalClient from "../../../src/msal/nodeFlows/msalClient";
-import * as msalPlugins from "../../../src/msal/nodeFlows/msalPlugins";
 
 import { AuthenticationResult, ConfidentialClientApplication } from "@azure/msal-node";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
@@ -13,6 +12,7 @@ import { AuthenticationRequiredError } from "../../../src/errors";
 import { IdentityClient } from "../../../src/client/identityClient";
 import { assert } from "@azure/test-utils";
 import { credentialLogger } from "../../../src/util/logging";
+import { msalPlugins } from "../../../src/msal/nodeFlows/msalPlugins";
 import sinon from "sinon";
 
 describe("MsalClient", function () {

--- a/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
@@ -4,9 +4,9 @@
 import { ICachePlugin, INativeBrokerPlugin } from "@azure/msal-node";
 import {
   PluginConfiguration,
-  generatePluginConfiguration,
   msalNodeFlowCacheControl,
   msalNodeFlowNativeBrokerControl,
+  msalPlugins,
 } from "../../../src/msal/nodeFlows/msalPlugins";
 
 import { MsalClientOptions } from "../../../src/msal/nodeFlows/msalClient";
@@ -21,7 +21,7 @@ describe("#generatePluginConfiguration", function () {
   });
 
   it("returns a PluginConfiguration with default values", function () {
-    const result = generatePluginConfiguration(options);
+    const result = msalPlugins.generatePluginConfiguration(options);
     const expected: PluginConfiguration = {
       cache: {},
       broker: {
@@ -40,7 +40,7 @@ describe("#generatePluginConfiguration", function () {
     it("should throw an error if persistence provider is not configured", () => {
       options.tokenCachePersistenceOptions = { enabled: true };
       assert.throws(
-        () => generatePluginConfiguration(options),
+        () => msalPlugins.generatePluginConfiguration(options),
         /Persistent token caching was requested/,
       );
     });
@@ -54,7 +54,7 @@ describe("#generatePluginConfiguration", function () {
       };
       const pluginProvider: () => Promise<ICachePlugin> = () => Promise.resolve(cachePlugin);
       msalNodeFlowCacheControl.setPersistence(pluginProvider);
-      const result = generatePluginConfiguration(options);
+      const result = msalPlugins.generatePluginConfiguration(options);
       assert.exists(result.cache.cachePlugin);
       const plugin = await result.cache.cachePlugin;
       assert.strictEqual(plugin, cachePlugin);
@@ -69,7 +69,7 @@ describe("#generatePluginConfiguration", function () {
       };
       const pluginProvider: () => Promise<ICachePlugin> = () => Promise.resolve(cachePluginCae);
       msalNodeFlowCacheControl.setPersistence(pluginProvider);
-      const result = generatePluginConfiguration(options);
+      const result = msalPlugins.generatePluginConfiguration(options);
       assert.exists(result.cache.cachePluginCae);
       const plugin = await result.cache.cachePluginCae;
       assert.strictEqual(plugin, cachePluginCae);
@@ -86,7 +86,7 @@ describe("#generatePluginConfiguration", function () {
     it("throws an error if native broker is not configured", () => {
       options.brokerOptions = { enabled: true, parentWindowHandle };
       assert.throws(
-        () => generatePluginConfiguration(options),
+        () => msalPlugins.generatePluginConfiguration(options),
         /Broker for WAM was requested to be enabled/,
       );
     });
@@ -100,7 +100,7 @@ describe("#generatePluginConfiguration", function () {
       const nativeBrokerPlugin: INativeBrokerPlugin = {} as INativeBrokerPlugin;
       msalNodeFlowNativeBrokerControl.setNativeBroker(nativeBrokerPlugin);
 
-      const result = generatePluginConfiguration(options);
+      const result = msalPlugins.generatePluginConfiguration(options);
       assert.strictEqual(result.broker.nativeBrokerPlugin, nativeBrokerPlugin);
       assert.strictEqual(result.broker.enableMsaPassthrough, true);
       assert.strictEqual(result.broker.parentWindowHandle, parentWindowHandle);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Nightly test failures

### Describe the problem that is addressed by this PR

Our nightly tests started failing with a `TypeError: Descriptor for property
generatePluginConfiguration is non-configurable and non-writable` error.

I'm far from an expert here, but I believe the error is due to ESModules being
immutable, whereas CJS Modules are mutable.

Wrapping the stubbable / mockable object is a reasonable workaround to keep
tests green regardless of whether they get run as ESM or CJS

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Deleting the tests is an option, or an integration test. Neither seem to fit the
bill here. Once we have credentials migrated over we may be able to delete some
of the unit tests and rely on recorded tests to test the various scenarios. But
we are not there yet.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
