### PR TITLE
[dev-tool] revert old files back to ts-node

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -5,10 +5,11 @@ import { leafCommand, makeCommandInfo } from "../../framework/command";
 
 import concurrently from "concurrently";
 import { createPrinter } from "../../util/printer";
+import { isModuleProject } from "../../util/resolveProject";
 import { runTestsWithProxyTool } from "../../util/testUtils";
 
 export const commandInfo = makeCommandInfo(
-  "test:node-tsx-js",
+  "test:node-js-input",
   "runs the node tests using mocha with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
     "no-test-proxy": {
@@ -17,13 +18,31 @@ export const commandInfo = makeCommandInfo(
       default: false,
       description: "whether to run with test-proxy",
     },
+    "use-esm-workaround": {
+      shortName: "uew",
+      kind: "boolean",
+      default: false,
+      description:
+        "when true, uses the `esm` npm package for tests. Otherwise uses esm4mocha if needed",
+    },
   },
 );
 
 export default leafCommand(commandInfo, async (options) => {
+  const isModule = await isModuleProject();
+  let esmLoaderArgs = "";
+
+  if (isModule === false) {
+    if (options["use-esm-workaround"] === false) {
+      esmLoaderArgs = "--loader=../../../common/tools/esm4mocha.mjs";
+    } else {
+      esmLoaderArgs = "-r ../../../common/tools/esm-workaround -r esm";
+    }
+  }
+
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
-  const defaultMochaArgs = `-r source-map-support/register.js ${reporterArgs} --full-trace`;
+  const defaultMochaArgs = `${esmLoaderArgs} -r source-map-support/register.js ${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
   );
@@ -31,7 +50,7 @@ export default leafCommand(commandInfo, async (options) => {
     ? updatedArgs.join(" ")
     : '--timeout 5000000 "dist-esm/test/{,!(browser)/**/}/*.spec.js"';
   const command = {
-    command: `c8 mocha --require tsx ${defaultMochaArgs} ${mochaArgs}`,
+    command: `c8 mocha ${defaultMochaArgs} ${mochaArgs}`,
     name: "node-tests",
   };
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -8,7 +8,7 @@ import { runTestsWithProxyTool } from "../../util/testUtils";
 import { createPrinter } from "../../util/printer";
 
 export const commandInfo = makeCommandInfo(
-  "test:node-tsx-ts",
+  "test:node-ts-input",
   "runs the node tests using mocha with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
     "no-test-proxy": {
@@ -25,7 +25,7 @@ export default leafCommand(commandInfo, async (options) => {
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
   const defaultMochaArgs = `${
-    isModuleProj ? "--loader=ts-node/esm " : ""
+    isModuleProj ? "--loader=ts-node/esm " : "-r esm "
   }-r ts-node/register ${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Reverts back to the original for the testing ts-node for JS and TS.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- https://github.com/Azure/azure-sdk-for-js/pull/28801

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
