### PR TITLE
Adding the createFailed and AnswerFailed events on the call automation SDK

### DIFF
--- a/sdk/communication/communication-call-automation/assets.json
+++ b/sdk/communication/communication-call-automation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-call-automation",
-  "Tag": "js/communication/communication-call-automation_3c8effc58e"
+  "Tag": "js/communication/communication-call-automation_3bb6edca35"
 }

--- a/sdk/communication/communication-call-automation/assets.json
+++ b/sdk/communication/communication-call-automation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-call-automation",
-  "Tag": "js/communication/communication-call-automation_3bb6edca35"
+  "Tag": "js/communication/communication-call-automation_22a209c61b"
 }

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
@@ -22,30 +22,74 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:40.4102928+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
         "operationContext": "addParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
+        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:00.6384967+00:00",
+      "time": "2024-03-08T21:37:40.3634744+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
+      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
         "participants": [
           {
             "identifier": {
@@ -72,79 +116,35 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
+        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:00.7165763+00:00",
+      "time": "2024-03-08T21:37:40.3947633+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
+      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
         "operationContext": "addParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:00.7010137+00:00",
+      "time": "2024-03-08T21:37:40.4102928+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:00.7165763+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
+      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
     }
   ],
   {
@@ -170,85 +170,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
         "operationContext": "addParticipantsAnswer2",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:08.9832519+00:00",
+      "time": "2024-03-08T21:37:48.6373583+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85"
+      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:09.4832577+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
         "operationContext": "addParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -258,79 +203,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:32:09.4832577+00:00",
+      "time": "2024-03-08T21:37:48.9655424+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
+      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:09.62381+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
         "participants": [
           {
             "identifier": {
@@ -368,24 +258,134 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:09.4988114+00:00",
+      "time": "2024-03-08T21:37:48.9655424+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
+      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:49.0592372+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:48.9655424+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
         "participants": [
           {
             "identifier": {
@@ -423,15 +423,125 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
+        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:10.0300675+00:00",
+      "time": "2024-03-08T21:37:49.5593014+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
+      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:49.6374189+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:49.5593014+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
         "operationContext": "addParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:19.5657312+00:00",
+      "time": "2024-03-08T21:32:00.6384967+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
+      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
         "participants": [
           {
             "identifier": {
@@ -72,79 +72,79 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:19.5969766+00:00",
+      "time": "2024-03-08T21:32:00.7165763+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
+      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:19.6282249+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "operationContext": "addParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
+        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:19.6282249+00:00",
+      "time": "2024-03-08T21:32:00.7010137+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:00.7165763+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
     }
   ],
   {
@@ -170,30 +170,85 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+      "source": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "eventSource": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
         "operationContext": "addParticipantsAnswer2",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "callConnectionId": "411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:26.5189412+00:00",
+      "time": "2024-03-08T21:32:08.9832519+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
+      "subject": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:09.4832577+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "operationContext": "addParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -203,24 +258,79 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
+        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T06:56:26.7533199+00:00",
+      "time": "2024-03-08T21:32:09.4832577+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+      "source": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+        "eventSource": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-3041-459d-8dc4-ca8bb3e1fa85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:09.62381+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-3041-459d-8dc4-ca8bb3e1fa85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "participants": [
           {
             "identifier": {
@@ -258,79 +368,24 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
+        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:26.7533199+00:00",
+      "time": "2024-03-08T21:32:09.4988114+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+      "source": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:26.7533199+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "eventSource": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271",
         "participants": [
           {
             "identifier": {
@@ -368,180 +423,15 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "callConnectionId": "411f0b00-2206-4317-9012-055d341c6271",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:26.8939504+00:00",
+      "time": "2024-03-08T21:32:10.0300675+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:27.3158864+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:27.3315312+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:27.4564579+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
+      "subject": "calling/callConnections/411f0b00-2206-4317-9012-055d341c6271"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
+      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
+        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
         "operationContext": "addParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0788-4e8d-8e76-5753d141e789",
+        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:54:40.746015+00:00",
+      "time": "2024-03-08T06:56:19.5657312+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789"
+      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
+      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
+        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
         "participants": [
           {
             "identifier": {
@@ -55,7 +55,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -65,29 +66,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0788-4e8d-8e76-5753d141e789",
+        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:54:40.746015+00:00",
+      "time": "2024-03-08T06:56:19.5969766+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789"
+      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
         "participants": [
           {
             "identifier": {
@@ -97,7 +99,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -107,40 +110,41 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-a370-42eb-9403-c2d88b330bc9",
+        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:54:40.8397743+00:00",
+      "time": "2024-03-08T06:56:19.6282249+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9"
+      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
         "operationContext": "addParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-a370-42eb-9403-c2d88b330bc9",
+        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:54:40.8397743+00:00",
+      "time": "2024-03-08T06:56:19.6282249+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9"
+      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
     }
   ],
   {
@@ -166,134 +170,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f",
+      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f",
+        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
         "operationContext": "addParticipantsAnswer2",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9218-421c-86be-cb808bc4100f",
+        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:54:54.6377958+00:00",
+      "time": "2024-03-08T06:56:26.5189412+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f"
+      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0788-4e8d-8e76-5753d141e789",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:54:55.1222236+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0788-4e8d-8e76-5753d141e789"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9218-421c-86be-cb808bc4100f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:54:55.1222236+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9218-421c-86be-cb808bc4100f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9",
+        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
         "operationContext": "addParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -303,15 +203,345 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-a370-42eb-9403-c2d88b330bc9",
+        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-01-04T13:54:55.1690901+00:00",
+      "time": "2024-03-08T06:56:26.7533199+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-a370-42eb-9403-c2d88b330bc9"
+      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:26.7533199+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:26.7533199+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:26.8939504+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8ead-40c0-89b6-813028019867",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:27.3158864+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8ead-40c0-89b6-813028019867"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-976e-4de0-9777-d92f44ba64a1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:27.3315312+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-976e-4de0-9777-d92f44ba64a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8776-4e7d-8545-3f2e58b87cdd",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:27.4564579+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8776-4e7d-8545-3f2e58b87cdd"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
@@ -22,145 +22,149 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261",
+      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261",
-        "operationContext": "cancelAddCreateAnswer",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b00b-430b-be94-c5e26efa4261",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:55:54.8379005+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b00b-430b-be94-c5e26efa4261",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:55:54.8535359+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b00b-430b-be94-c5e26efa4261"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-5c1c-453e-ac00-6084be25e84b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:55:54.9316037+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b",
+        "eventSource": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
         "operationContext": "cancelAddCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-5c1c-453e-ac00-6084be25e84b",
+        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:55:54.9316037+00:00",
+      "time": "2024-03-08T06:57:03.0091706+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b"
+      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b",
+      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:57:03.0247457+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:57:03.056061+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "operationContext": "cancelAddCreateAnswer",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:57:03.056061+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
       "type": "Microsoft.Communication.CancelAddParticipantSucceeded",
       "data": {
-        "invitationId": "f08736db-22ea-4f9e-a71e-d7740e63adba",
+        "invitationId": "aa0d97f8-4b12-4ca8-a83a-3766228a9efb",
         "operationContext": "cancelAdd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-5c1c-453e-ac00-6084be25e84b",
+        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CancelAddParticipantSucceeded"
       },
-      "time": "2024-01-04T13:56:02.1509756+00:00",
+      "time": "2024-03-08T06:57:07.7442673+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-5c1c-453e-ac00-6084be25e84b"
+      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
@@ -22,149 +22,149 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
+      "source": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
-        "operationContext": "cancelAddCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T06:57:03.0091706+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:57:03.0247457+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:57:03.056061+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "eventSource": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
         "operationContext": "cancelAddCreateAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-155e-4e1d-99ea-00cdc4bc0a8d",
+        "callConnectionId": "411f0b00-dcc5-4ecc-8394-fa08679490e7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:03.056061+00:00",
+      "time": "2024-03-08T21:32:41.5924184+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-155e-4e1d-99ea-00cdc4bc0a8d"
+      "subject": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3",
+      "source": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:41.6079923+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:41.6549312+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "operationContext": "cancelAddCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:32:41.6549312+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
       "type": "Microsoft.Communication.CancelAddParticipantSucceeded",
       "data": {
-        "invitationId": "aa0d97f8-4b12-4ca8-a83a-3766228a9efb",
+        "invitationId": "3f27f93d-cf48-4101-90ae-29445b0cfcaa",
         "operationContext": "cancelAdd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-f664-4581-b479-78b080f922a3",
+        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CancelAddParticipantSucceeded"
       },
-      "time": "2024-03-08T06:57:07.7442673+00:00",
+      "time": "2024-03-08T21:32:46.347469+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-f664-4581-b479-78b080f922a3"
+      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+      "source": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "eventSource": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
         "operationContext": "cancelAddCreateAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "callConnectionId": "421f0b00-b2ae-42ed-93d9-260c55a41871",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:41.5924184+00:00",
+      "time": "2024-03-08T21:38:23.8905626+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7"
+      "subject": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+      "source": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "eventSource": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
         "participants": [
           {
             "identifier": {
@@ -72,24 +72,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-dcc5-4ecc-8394-fa08679490e7",
+        "callConnectionId": "421f0b00-b2ae-42ed-93d9-260c55a41871",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:41.6079923+00:00",
+      "time": "2024-03-08T21:38:23.9061909+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-dcc5-4ecc-8394-fa08679490e7"
+      "subject": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "eventSource": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
         "participants": [
           {
             "identifier": {
@@ -116,55 +116,55 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:41.6549312+00:00",
+      "time": "2024-03-08T21:38:23.9531188+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
+      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "eventSource": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
         "operationContext": "cancelAddCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:41.6549312+00:00",
+      "time": "2024-03-08T21:38:23.9531188+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
+      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9",
+      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
       "type": "Microsoft.Communication.CancelAddParticipantSucceeded",
       "data": {
-        "invitationId": "3f27f93d-cf48-4101-90ae-29445b0cfcaa",
+        "invitationId": "313f266e-c54a-4843-88a6-84a66b1b8f57",
         "operationContext": "cancelAdd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-3e1a-4b90-b568-a1d932a585c9",
+        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CancelAddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:32:46.347469+00:00",
+      "time": "2024-03-08T21:38:28.7198819+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-3e1a-4b90-b568-a1d932a585c9"
+      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+      "source": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+        "eventSource": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
         "operationContext": "listParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+        "callConnectionId": "411f0b00-4f00-413e-9512-143e65bc66eb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:10.3000375+00:00",
+      "time": "2024-03-08T21:31:53.7477313+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5"
+      "subject": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+      "source": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+        "eventSource": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
         "participants": [
           {
             "identifier": {
@@ -72,44 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
+        "callConnectionId": "411f0b00-4f00-413e-9512-143e65bc66eb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:10.3468566+00:00",
+      "time": "2024-03-08T21:31:53.8258563+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5"
+      "subject": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+      "source": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "eventSource": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
         "operationContext": "listParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "callConnectionId": "411f0b00-beda-4297-bf41-dc32901cb469",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:10.3624744+00:00",
+      "time": "2024-03-08T21:31:53.8102845+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1"
+      "subject": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+      "source": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "eventSource": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
         "participants": [
           {
             "identifier": {
@@ -136,15 +136,15 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "callConnectionId": "411f0b00-beda-4297-bf41-dc32901cb469",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:10.3624744+00:00",
+      "time": "2024-03-08T21:31:53.8258563+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1"
+      "subject": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
@@ -22,30 +22,63 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
+      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
+        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
         "operationContext": "listParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-4f00-413e-9512-143e65bc66eb",
+        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:31:53.7477313+00:00",
+      "time": "2024-03-08T21:37:32.4250079+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb"
+      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
+      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb",
+        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 0,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:37:32.4250079+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
         "participants": [
           {
             "identifier": {
@@ -72,44 +105,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-4f00-413e-9512-143e65bc66eb",
+        "callConnectionId": "421f0b00-b014-4eca-b06f-c8dfe2337605",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:31:53.8258563+00:00",
+      "time": "2024-03-08T21:37:32.4876083+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-4f00-413e-9512-143e65bc66eb"
+      "subject": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
+      "source": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
+        "eventSource": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
         "operationContext": "listParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-beda-4297-bf41-dc32901cb469",
+        "callConnectionId": "421f0b00-b014-4eca-b06f-c8dfe2337605",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:31:53.8102845+00:00",
+      "time": "2024-03-08T21:37:32.4876083+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469"
+      "subject": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
+      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469",
+        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
         "participants": [
           {
             "identifier": {
@@ -136,15 +169,15 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-beda-4297-bf41-dc32901cb469",
+        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:31:53.8258563+00:00",
+      "time": "2024-03-08T21:37:33.0188504+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-beda-4297-bf41-dc32901cb469"
+      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7",
+      "source": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7",
+        "eventSource": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
         "operationContext": "listParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-fec1-44da-8b3a-3112f9584da7",
+        "callConnectionId": "421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:54:26.1654933+00:00",
+      "time": "2024-03-08T06:56:10.3000375+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7"
+      "subject": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd",
+      "source": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd",
+        "eventSource": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
         "participants": [
           {
             "identifier": {
@@ -55,7 +55,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -65,82 +66,85 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-261a-435a-a136-2b766145adfd",
+        "callConnectionId": "421f0b00-9260-49e9-ab12-a6f4ed6d85b5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:54:26.1811225+00:00",
+      "time": "2024-03-08T06:56:10.3468566+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd"
+      "subject": "calling/callConnections/421f0b00-9260-49e9-ab12-a6f4ed6d85b5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-fec1-44da-8b3a-3112f9584da7",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:54:26.1811225+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-fec1-44da-8b3a-3112f9584da7"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd",
+      "source": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd",
+        "eventSource": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
         "operationContext": "listParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-261a-435a-a136-2b766145adfd",
+        "callConnectionId": "421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:54:26.1811225+00:00",
+      "time": "2024-03-08T06:56:10.3624744+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-261a-435a-a136-2b766145adfd"
+      "subject": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9e60-4dc4-b37d-a3de6d74f3c1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:10.3624744+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9e60-4dc4-b37d-a3de6d74f3c1"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
@@ -22,48 +22,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:24.5771023+00:00",
+      "time": "2024-03-08T21:38:06.5154356+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:32:24.6396687+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "participants": [
           {
             "identifier": {
@@ -90,24 +71,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:24.6708585+00:00",
+      "time": "2024-03-08T21:38:06.5310077+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "participants": [
           {
             "identifier": {
@@ -134,15 +115,34 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:24.6708585+00:00",
+      "time": "2024-03-08T21:38:06.7810657+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:38:06.7966563+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   {
@@ -168,194 +168,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:31.0333669+00:00",
+      "time": "2024-03-08T21:38:13.968592+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:31.2833999+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:31.2833999+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:31.424015+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "operationContext": "addParticipant",
         "participant": {
           "rawId": "sanitized",
@@ -365,24 +200,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:32:31.2833999+00:00",
+      "time": "2024-03-08T21:38:14.218591+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "participants": [
           {
             "identifier": {
@@ -418,26 +253,136 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:31.8776899+00:00",
+      "time": "2024-03-08T21:38:14.218591+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:14.218591+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:14.218591+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "participants": [
           {
             "identifier": {
@@ -475,24 +420,134 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:31.8776899+00:00",
+      "time": "2024-03-08T21:38:14.8123462+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:14.827968+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:14.827968+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "participants": [
           {
             "identifier": {
@@ -530,24 +585,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:32.004298+00:00",
+      "time": "2024-03-08T21:38:15.4061534+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "participants": [
           {
             "identifier": {
@@ -585,24 +640,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:32.4417582+00:00",
+      "time": "2024-03-08T21:38:15.4217244+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "participants": [
           {
             "identifier": {
@@ -640,134 +695,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:32.4417582+00:00",
+      "time": "2024-03-08T21:38:15.4217244+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 7,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:32.5823797+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 7,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:32.9887166+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "participants": [
           {
             "identifier": {
@@ -805,24 +750,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:33.0043171+00:00",
+      "time": "2024-03-08T21:38:15.9999232+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "participants": [
           {
             "identifier": {
@@ -858,26 +803,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 7,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:33.1605109+00:00",
+      "time": "2024-03-08T21:38:15.9999232+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "participants": [
           {
             "identifier": {
@@ -913,26 +858,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 7,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:33.5823897+00:00",
+      "time": "2024-03-08T21:38:16.0467512+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "participants": [
           {
             "identifier": {
@@ -945,325 +890,6 @@
             "isMuted": false,
             "isOnHold": false
           },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 7,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:33.5668172+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:33.7549753+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:34.1299796+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:34.2954152+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:34.1613281+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:34.7329894+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
-        "participants": [
           {
             "identifier": {
               "rawId": "sanitized",
@@ -1285,39 +911,28 @@
             },
             "isMuted": false,
             "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
           }
         ],
-        "sequenceNumber": 10,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
+        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:34.8579726+00:00",
+      "time": "2024-03-08T21:38:16.5780399+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
+      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
         "participants": [
           {
             "identifier": {
@@ -1330,50 +945,6 @@
             "isMuted": false,
             "isOnHold": false
           },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:34.7173686+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
-        "participants": [
           {
             "identifier": {
               "rawId": "sanitized",
@@ -1395,6 +966,50 @@
             },
             "isMuted": false,
             "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:16.6092362+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": true,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -1408,17 +1023,17 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 10,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:35.3111028+00:00",
+      "time": "2024-03-08T21:38:16.6249232+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
@@ -22,29 +22,48 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:40.7989397+00:00",
+      "time": "2024-03-08T21:32:24.5771023+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:32:24.6396687+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -71,43 +90,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:40.8301375+00:00",
+      "time": "2024-03-08T21:32:24.6708585+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T06:56:40.877013+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -134,15 +134,15 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:40.8614465+00:00",
+      "time": "2024-03-08T21:32:24.6708585+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   {
@@ -168,29 +168,194 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:53.1757149+00:00",
+      "time": "2024-03-08T21:32:31.0333669+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:31.2833999+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:31.2833999+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:31.424015+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "operationContext": "addParticipant",
         "participant": {
           "rawId": "sanitized",
@@ -200,189 +365,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T06:56:53.456963+00:00",
+      "time": "2024-03-08T21:32:31.2833999+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:53.4725396+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:53.4725396+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:53.4725396+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -420,79 +420,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:54.019486+00:00",
+      "time": "2024-03-08T21:32:31.8776899+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:54.019486+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -530,24 +475,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:54.019486+00:00",
+      "time": "2024-03-08T21:32:31.8776899+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -585,24 +530,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:54.5507306+00:00",
+      "time": "2024-03-08T21:32:32.004298+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -640,24 +585,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:54.5663095+00:00",
+      "time": "2024-03-08T21:32:32.4417582+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -695,24 +640,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:54.5819769+00:00",
+      "time": "2024-03-08T21:32:32.4417582+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -750,24 +695,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.0976307+00:00",
+      "time": "2024-03-08T21:32:32.5823797+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -805,24 +750,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.0976307+00:00",
+      "time": "2024-03-08T21:32:32.9887166+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -860,24 +805,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.1288112+00:00",
+      "time": "2024-03-08T21:32:33.0043171+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -915,24 +860,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.6600773+00:00",
+      "time": "2024-03-08T21:32:33.1605109+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -970,24 +915,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.6446157+00:00",
+      "time": "2024-03-08T21:32:33.5823897+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -1025,24 +970,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:55.6757642+00:00",
+      "time": "2024-03-08T21:32:33.5668172+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -1080,24 +1025,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:56.1809536+00:00",
+      "time": "2024-03-08T21:32:33.7549753+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "participants": [
           {
             "identifier": {
@@ -1135,79 +1080,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:56.1809536+00:00",
+      "time": "2024-03-08T21:32:34.1299796+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 8,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:56.2122134+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -1245,24 +1135,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:56.7121516+00:00",
+      "time": "2024-03-08T21:32:34.2954152+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -1300,24 +1190,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:56.7434058+00:00",
+      "time": "2024-03-08T21:32:34.1613281+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -1355,24 +1245,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:56.7590841+00:00",
+      "time": "2024-03-08T21:32:34.7329894+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "source": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "eventSource": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb",
         "participants": [
           {
             "identifier": {
@@ -1410,24 +1300,79 @@
         ],
         "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "callConnectionId": "411f0b00-48c0-4685-8905-737a9847cbdb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:57.274664+00:00",
+      "time": "2024-03-08T21:32:34.8579726+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+      "subject": "calling/callConnections/411f0b00-48c0-4685-8905-737a9847cbdb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "source": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "eventSource": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-7d30-41b8-a3e5-118affc68ab5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:34.7173686+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-7d30-41b8-a3e5-118affc68ab5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "participants": [
           {
             "identifier": {
@@ -1465,70 +1410,15 @@
         ],
         "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "callConnectionId": "411f0b00-ce8c-4def-b16e-3c81ef60b88b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:57.3059116+00:00",
+      "time": "2024-03-08T21:32:35.3111028+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": true,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 10,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:57.2902881+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+      "subject": "calling/callConnections/411f0b00-ce8c-4def-b16e-3c81ef60b88b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
@@ -22,29 +22,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d58e-40f6-8f91-d260042c0209",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:55:24.744086+00:00",
+      "time": "2024-03-08T06:56:40.7989397+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209"
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "participants": [
           {
             "identifier": {
@@ -54,7 +54,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -64,48 +65,49 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d58e-40f6-8f91-d260042c0209",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:24.744086+00:00",
+      "time": "2024-03-08T06:56:40.8301375+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209"
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:55:24.7753314+00:00",
+      "time": "2024-03-08T06:56:40.877013+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
         "participants": [
           {
             "identifier": {
@@ -115,7 +117,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -125,20 +128,21 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:24.7753314+00:00",
+      "time": "2024-03-08T06:56:40.8614465+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   {
@@ -164,29 +168,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:55:38.7929865+00:00",
+      "time": "2024-03-08T06:56:53.1757149+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23"
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
         "operationContext": "addParticipant",
         "participant": {
           "rawId": "sanitized",
@@ -196,24 +200,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-01-04T13:55:38.933557+00:00",
+      "time": "2024-03-08T06:56:53.456963+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "participants": [
           {
             "identifier": {
@@ -223,7 +227,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -233,7 +238,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -243,29 +249,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:38.9491772+00:00",
+      "time": "2024-03-08T06:56:53.4725396+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23"
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "participants": [
           {
             "identifier": {
@@ -275,7 +282,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -285,7 +293,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -295,29 +304,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:38.9491772+00:00",
+      "time": "2024-03-08T06:56:53.4725396+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
         "participants": [
           {
             "identifier": {
@@ -327,7 +337,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -337,7 +348,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -347,81 +359,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-e1ec-433e-9c58-71e1c1200d23",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:55:40.13679+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d58e-40f6-8f91-d260042c0209",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:38.933557+00:00",
+      "time": "2024-03-08T06:56:53.4725396+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "participants": [
           {
             "identifier": {
@@ -431,7 +392,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -441,7 +403,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -451,81 +414,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:55:40.1524766+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:41.3198768+00:00",
+      "time": "2024-03-08T06:56:54.019486+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23"
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "participants": [
           {
             "identifier": {
@@ -535,7 +447,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -545,7 +458,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -555,29 +469,85 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:54.019486+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d58e-40f6-8f91-d260042c0209",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:40.1524766+00:00",
+      "time": "2024-03-08T06:56:54.019486+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "participants": [
           {
             "identifier": {
@@ -587,7 +557,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -597,7 +568,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -607,29 +579,305 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": true
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:54.5507306+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:54.5663095+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:54.5819769+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:55.0976307+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:55.0976307+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-e1ec-433e-9c58-71e1c1200d23",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:42.5074841+00:00",
+      "time": "2024-03-08T06:56:55.1288112+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-e1ec-433e-9c58-71e1c1200d23"
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "participants": [
           {
             "identifier": {
@@ -639,7 +887,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -649,7 +898,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -659,29 +909,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-379c-4224-b8c1-b3ad7e671e15",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:41.3354448+00:00",
+      "time": "2024-03-08T06:56:55.6600773+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-379c-4224-b8c1-b3ad7e671e15"
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209",
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "participants": [
           {
             "identifier": {
@@ -691,7 +942,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -701,7 +953,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -711,20 +964,571 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d58e-40f6-8f91-d260042c0209",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:41.3354448+00:00",
+      "time": "2024-03-08T06:56:55.6446157+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d58e-40f6-8f91-d260042c0209"
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:55.6757642+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.1809536+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.1809536+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 8,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.2122134+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.7121516+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.7434058+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:56.7590841+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": true,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 10,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-a782-4166-a3c7-f2fef4a0ba71",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:57.274664+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-a782-4166-a3c7-f2fef4a0ba71"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": true,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 10,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9f85-47d6-b1fc-eb0e487c846f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:57.3059116+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9f85-47d6-b1fc-eb0e487c846f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": true,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 10,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-e01f-4428-9849-c6593f5a6e59",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:56:57.2902881+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-e01f-4428-9849-c6593f5a6e59"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
@@ -1,4 +1,59 @@
 [
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:10.0613985+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
+    }
+  ],
   {
     "to": {
       "kind": "communicationUser",
@@ -22,94 +77,50 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:56:33.2642458+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-        "operationContext": "removeParticipantCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T06:56:33.2486719+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:56:33.2174182+00:00",
+      "time": "2024-03-08T21:32:15.873888+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
+      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "operationContext": "removeParticipantCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:32:15.9363853+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
         "participants": [
           {
             "identifier": {
@@ -136,44 +147,68 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:33.2642458+00:00",
+      "time": "2024-03-08T21:32:15.9520172+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
+      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-      "type": "Microsoft.Communication.CallDisconnected",
+      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
-        "operationContext": "removeParticipantCreateCall",
+        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:56:34.8580131+00:00",
+      "time": "2024-03-08T21:32:15.9520172+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
+      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
       "type": "Microsoft.Communication.RemoveParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
         "operationContext": "removeParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -183,35 +218,55 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RemoveParticipantSucceeded"
       },
-      "time": "2024-03-08T06:56:34.9361417+00:00",
+      "time": "2024-03-08T21:32:17.6239044+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
+      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:56:34.9674404+00:00",
+      "time": "2024-03-08T21:32:17.6708477+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
+      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "operationContext": "removeParticipantCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-03-08T21:32:17.7958566+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
@@ -1,59 +1,4 @@
 [
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f50b-4275-9a46-53c85e40cb2b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:10.0613985+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f50b-4275-9a46-53c85e40cb2b"
-    }
-  ],
   {
     "to": {
       "kind": "communicationUser",
@@ -77,50 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
-        "operationContext": "removeParticipantsAnswer",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:32:15.873888+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:15.9363853+00:00",
+      "time": "2024-03-08T21:37:57.6687101+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
+      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
         "participants": [
           {
             "identifier": {
@@ -147,24 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:15.9520172+00:00",
+      "time": "2024-03-08T21:37:57.6843442+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
+      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+        "operationContext": "removeParticipantsAnswer",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:37:57.6687101+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
         "participants": [
           {
             "identifier": {
@@ -191,24 +136,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
+        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:15.9520172+00:00",
+      "time": "2024-03-08T21:37:57.6843442+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
+      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
       "type": "Microsoft.Communication.RemoveParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
         "operationContext": "removeParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -218,55 +163,55 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RemoveParticipantSucceeded"
       },
-      "time": "2024-03-08T21:32:17.6239044+00:00",
+      "time": "2024-03-08T21:37:59.1843522+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
+      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65",
+        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0d67-441e-8ec6-c76928785e65",
+        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:32:17.6708477+00:00",
+      "time": "2024-03-08T21:37:59.2468533+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0d67-441e-8ec6-c76928785e65"
+      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-0ae9-46a3-ba84-a34b04bccca1",
+        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:32:17.7958566+00:00",
+      "time": "2024-03-08T21:37:59.6062835+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-0ae9-46a3-ba84-a34b04bccca1"
+      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
@@ -22,10 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
+      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
+        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "participants": [
           {
             "identifier": {
@@ -35,7 +35,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -45,69 +46,70 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e42-49d8-a63d-9ab40787d973",
+        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:07.9457991+00:00",
+      "time": "2024-03-08T06:56:33.2642458+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973"
+      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
+      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
-        "operationContext": "removeParticipantsAnswer",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e42-49d8-a63d-9ab40787d973",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:55:07.9301673+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:55:07.9926678+00:00",
+      "time": "2024-03-08T06:56:33.2486719+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777"
+      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "operationContext": "removeParticipantsAnswer",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:56:33.2174182+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
         "participants": [
           {
             "identifier": {
@@ -117,7 +119,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -127,29 +130,50 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:55:07.9926678+00:00",
+      "time": "2024-03-08T06:56:33.2642458+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777"
+      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+        "operationContext": "removeParticipantCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-03-08T06:56:34.8580131+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
       "type": "Microsoft.Communication.RemoveParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "eventSource": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "operationContext": "removeParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -159,55 +183,35 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b4bf-4a28-8ca5-fc055b3c7777",
+        "callConnectionId": "421f0b00-7ac9-4b5a-ae8a-3258d513761f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RemoveParticipantSucceeded"
       },
-      "time": "2024-01-04T13:55:11.5242201+00:00",
+      "time": "2024-03-08T06:56:34.9361417+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777"
+      "subject": "calling/callConnections/421f0b00-7ac9-4b5a-ae8a-3258d513761f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
+      "source": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973",
+        "eventSource": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e42-49d8-a63d-9ab40787d973",
+        "callConnectionId": "421f0b00-cf7b-4643-90a5-8926460cae1f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:55:11.5242201+00:00",
+      "time": "2024-03-08T06:56:34.9674404+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e42-49d8-a63d-9ab40787d973"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
-      "type": "Microsoft.Communication.CallDisconnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777",
-        "operationContext": "removeParticipantCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-b4bf-4a28-8ca5-fc055b3c7777",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
-      },
-      "time": "2024-01-04T13:55:11.6180411+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-b4bf-4a28-8ca5-fc055b3c7777"
+      "subject": "calling/callConnections/421f0b00-cf7b-4643-90a5-8926460cae1f"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
+++ b/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
@@ -22,30 +22,74 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:21.8824808+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
         "operationContext": "recordingAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:58:21.8864495+00:00",
+      "time": "2024-03-08T06:58:21.8824808+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "participants": [
           {
             "identifier": {
@@ -55,49 +99,61 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 0,
+        "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:58:21.8864495+00:00",
+      "time": "2024-03-08T06:58:21.9605484+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "operationContext": "recordingCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:58:21.9177675+00:00",
+      "time": "2024-03-08T06:58:21.9605484+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb"
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "participants": [
           {
             "identifier": {
@@ -107,7 +163,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -117,201 +174,53 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-4e44-4a21-9adf-e22fd76ebadb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:58:21.9177675+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:58:23.0896932+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged",
-      "type": "Microsoft.Communication.RecordingStateChanged",
-      "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ",
-        "state": "inactive",
-        "startDateTime": "0001-01-01T00:00:00+00:00",
-        "recordingType": "acs",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0695-4fa0-8b86-f1a2ed834b89",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.RecordingStateChanged"
-      },
-      "time": "2024-01-04T13:58:34.9828678+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:58:34.9828678+00:00",
+      "time": "2024-03-08T06:58:26.8668543+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb"
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:58:34.9828678+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ",
         "state": "active",
-        "startDateTime": "2024-01-04T13:58:35.232275+00:00",
+        "startDateTime": "2024-03-08T06:58:26.4192074+00:00",
         "recordingType": "acs",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0695-4fa0-8b86-f1a2ed834b89",
+        "callConnectionId": "421f0b00-d37e-42b5-8c58-0d803c596283",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-01-04T13:58:35.8891917+00:00",
+      "time": "2024-03-08T06:58:26.8668543+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LWFzc2UtMDEuY29udi5za3lwZS5jb20vY29udi9hNWNWNncxZXlFT3ZIRUZhWm52Yk53P2k9OSZlPTYzODM4NjE4OTY4OTI2OTg0Mw==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MDFmMDcwMC0wNjk1LTRmYTAtOGI4Ni1mMWEyZWQ4MzRiODkiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI3N2Y4ZTZmZS0yNmM3LTRiODAtYTFlZS1lOWI5OTQyZTJmOTkifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
         "participants": [
           {
             "identifier": {
@@ -321,7 +230,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -331,29 +241,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-4e44-4a21-9adf-e22fd76ebadb",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:58:36.1860826+00:00",
+      "time": "2024-03-08T06:58:26.8668543+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-4e44-4a21-9adf-e22fd76ebadb"
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "participants": [
           {
             "identifier": {
@@ -363,7 +274,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -373,29 +285,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:58:36.2017818+00:00",
+      "time": "2024-03-08T06:58:27.4148061+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
         "participants": [
           {
             "identifier": {
@@ -405,7 +318,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -415,20 +329,222 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:27.4148061+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "type": "Microsoft.Communication.PlayCompleted",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "resultInformation": {
+          "code": 200,
+          "subCode": 0,
+          "message": "Action completed successfully."
+        },
+        "operationContext": "recordingPlay",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.PlayCompleted"
+      },
+      "time": "2024-03-08T06:58:27.9304848+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-9488-401a-9a68-02a7f6bb7f33",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:58:37.4675102+00:00",
+      "time": "2024-03-08T06:58:27.9774017+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-9488-401a-9a68-02a7f6bb7f33"
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:27.9617328+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 6,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:28.5398753+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 6,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:28.5398753+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
+++ b/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
@@ -22,10 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
         "participants": [
           {
             "identifier": {
@@ -52,108 +52,108 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:46.5228987+00:00",
+      "time": "2024-03-08T21:39:29.5080308+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "operationContext": "recordingCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:33:46.5542094+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:46.5542094+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
         "operationContext": "recordingAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:46.5228987+00:00",
+      "time": "2024-03-08T21:39:29.5080308+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:39:29.5861543+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "operationContext": "recordingCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:39:29.5861543+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
         "participants": [
           {
             "identifier": {
@@ -180,91 +180,91 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:50.9323147+00:00",
+      "time": "2024-03-08T21:39:34.6831704+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:39:34.6831704+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ",
         "state": "active",
-        "startDateTime": "2024-03-08T21:33:50.7036326+00:00",
+        "startDateTime": "2024-03-08T21:39:34.3666276+00:00",
         "recordingType": "acs",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-73c7-4859-94e7-f8fe774aea9f",
+        "callConnectionId": "421f0b00-ed42-41f0-9cbc-48ffda080121",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-03-08T21:33:50.9323147+00:00",
+      "time": "2024-03-08T21:39:34.6831704+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:51.213573+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
         "participants": [
           {
             "identifier": {
@@ -291,24 +291,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:51.5105187+00:00",
+      "time": "2024-03-08T21:39:35.3394745+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "participants": [
           {
             "identifier": {
@@ -335,112 +335,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:51.7796101+00:00",
+      "time": "2024-03-08T21:39:35.3394745+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:52.0608632+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:52.3421153+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -448,24 +360,24 @@
         },
         "operationContext": "recordingPlay",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:33:52.4514943+00:00",
+      "time": "2024-03-08T21:39:35.3550509+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "participants": [
           {
             "identifier": {
@@ -490,26 +402,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 6,
+        "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:52.8889237+00:00",
+      "time": "2024-03-08T21:39:36.5582401+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
         "participants": [
           {
             "identifier": {
@@ -534,17 +446,17 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 6,
+        "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:52.9046225+00:00",
+      "time": "2024-03-08T21:39:36.5582401+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
+++ b/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
@@ -22,10 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
         "participants": [
           {
             "identifier": {
@@ -52,108 +52,108 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:21.8824808+00:00",
+      "time": "2024-03-08T21:33:46.5228987+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
-        "operationContext": "recordingAnswer",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T06:58:21.8824808+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:58:21.9605484+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "operationContext": "recordingCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:58:21.9605484+00:00",
+      "time": "2024-03-08T21:33:46.5542094+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:33:46.5542094+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "operationContext": "recordingAnswer",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:33:46.5228987+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "participants": [
           {
             "identifier": {
@@ -180,47 +180,47 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:26.8668543+00:00",
+      "time": "2024-03-08T21:33:50.9323147+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ",
         "state": "active",
-        "startDateTime": "2024-03-08T06:58:26.4192074+00:00",
+        "startDateTime": "2024-03-08T21:33:50.7036326+00:00",
         "recordingType": "acs",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d37e-42b5-8c58-0d803c596283",
+        "callConnectionId": "411f0b00-73c7-4859-94e7-f8fe774aea9f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-03-08T06:58:26.8668543+00:00",
+      "time": "2024-03-08T21:33:50.9323147+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDEuY29udi5za3lwZS5jb20vY29udi9xX2R2VF8zUFJFYTVvM3JiVUd0UG5BP2k9OCZlPTYzODQ1NDMzMjkwODc4MDg4Ng==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1kMzdlLTQyYjUtOGM1OC0wZDgwM2M1OTYyODMiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI4YTYyM2ZlZC02ZjZiLTQxYTAtOGIyOC0yMmIwMTZkMGViMjIifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzd2UtMDItc2RmLWFrcy5jb252LnNreXBlLmNvbS9jb252L2JFeER4aEJMWFVxOHpUaWJQcGttY0E/aT0xMC02MC0xMC0yNDkmZT02Mzg0NTQ2ODY3MjY1NzYwMTc=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MTFmMGIwMC03M2M3LTQ4NTktOTRlNy1mOGZlNzc0YWVhOWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiIyMjY4ZWI4Yy1hZDg3LTQ1ZmMtODUzNC1mNDE0OTllOTRhOWUifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
         "participants": [
           {
             "identifier": {
@@ -247,24 +247,24 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:26.8668543+00:00",
+      "time": "2024-03-08T21:33:51.213573+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "participants": [
           {
             "identifier": {
@@ -291,24 +291,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:27.4148061+00:00",
+      "time": "2024-03-08T21:33:51.5105187+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
         "participants": [
           {
             "identifier": {
@@ -335,24 +335,112 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:27.4148061+00:00",
+      "time": "2024-03-08T21:33:51.7796101+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:33:52.0608632+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:33:52.3421153+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -360,112 +448,24 @@
         },
         "operationContext": "recordingPlay",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T06:58:27.9304848+00:00",
+      "time": "2024-03-08T21:33:52.4514943+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+      "source": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:58:27.9774017+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:58:27.9617328+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "eventSource": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "participants": [
           {
             "identifier": {
@@ -492,24 +492,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8617-44b4-ba79-e4c4bf972add",
+        "callConnectionId": "411f0b00-1e87-48ab-8ed5-72fb7d5f3bad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:28.5398753+00:00",
+      "time": "2024-03-08T21:33:52.8889237+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8617-44b4-ba79-e4c4bf972add"
+      "subject": "calling/callConnections/411f0b00-1e87-48ab-8ed5-72fb7d5f3bad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+      "source": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "eventSource": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3",
         "participants": [
           {
             "identifier": {
@@ -536,15 +536,15 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8d6c-48d8-91ec-86785572c9a5",
+        "callConnectionId": "411f0b00-c0ec-4ee1-974b-3076032692b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:28.5398753+00:00",
+      "time": "2024-03-08T21:33:52.9046225+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8d6c-48d8-91ec-86785572c9a5"
+      "subject": "calling/callConnections/411f0b00-c0ec-4ee1-974b-3076032692b3"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
@@ -22,10 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
+      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "operationContext": "operationContextAnswerCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:55:46.4344578+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
+        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
         "participants": [
           {
             "identifier": {
@@ -35,7 +55,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -45,69 +66,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d821-48bf-b4d7-2eecd560844d",
+        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:53:55.7324065+00:00",
+      "time": "2024-03-08T06:55:46.4188246+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d"
+      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
-        "operationContext": "operationContextAnswerCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d821-48bf-b4d7-2eecd560844d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:53:55.7167862+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
-        "operationContext": "operationContextCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-759b-4279-8fee-66a58c29e311",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:53:55.7949435+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
+      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
+        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
         "participants": [
           {
             "identifier": {
@@ -117,7 +99,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -127,60 +110,81 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-759b-4279-8fee-66a58c29e311",
+        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:53:55.779278+00:00",
+      "time": "2024-03-08T06:55:46.4813292+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311"
+      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
-      "type": "Microsoft.Communication.CallDisconnected",
+      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+      "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311",
+        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
         "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-759b-4279-8fee-66a58c29e311",
+        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
+        "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:53:59.2327653+00:00",
+      "time": "2024-03-08T06:55:46.4813292+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-759b-4279-8fee-66a58c29e311"
+      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
+      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d",
-        "operationContext": "operationContextAnswerCall",
+        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-d821-48bf-b4d7-2eecd560844d",
+        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:53:59.2484162+00:00",
+      "time": "2024-03-08T06:55:47.9657876+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-d821-48bf-b4d7-2eecd560844d"
+      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "operationContext": "operationContextAnswerCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-03-08T06:55:48.0282263+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:55:46.4344578+00:00",
+      "time": "2024-03-08T21:31:39.9663718+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
+      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "participants": [
           {
             "identifier": {
@@ -72,24 +72,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:55:46.4188246+00:00",
+      "time": "2024-03-08T21:31:40.0444533+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
+      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "participants": [
           {
             "identifier": {
@@ -116,75 +116,75 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:55:46.4813292+00:00",
+      "time": "2024-03-08T21:31:40.0444533+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
+      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:55:46.4813292+00:00",
+      "time": "2024-03-08T21:31:40.0289276+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
+      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7a51-4619-9d5b-2d06a43ae17b",
+        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:55:47.9657876+00:00",
+      "time": "2024-03-08T21:31:41.607045+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7a51-4619-9d5b-2d06a43ae17b"
+      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d31c-4715-8aef-4443f37c52c9",
+        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:55:48.0282263+00:00",
+      "time": "2024-03-08T21:31:41.6851645+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d31c-4715-8aef-4443f37c52c9"
+      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:31:39.9663718+00:00",
+      "time": "2024-03-08T21:37:18.0158141+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
+      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
         "participants": [
           {
             "identifier": {
@@ -72,24 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:31:40.0444533+00:00",
+      "time": "2024-03-08T21:37:18.0158141+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
+      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
+      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "operationContext": "operationContextCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:37:18.0627211+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
+        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
         "participants": [
           {
             "identifier": {
@@ -116,75 +136,55 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
+        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:31:40.0444533+00:00",
+      "time": "2024-03-08T21:37:18.0627211+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
+      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
-        "operationContext": "operationContextCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:31:40.0289276+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
+      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441",
-        "operationContext": "operationContextCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-f4ac-4d90-95b2-0b4b21736441",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
-      },
-      "time": "2024-03-08T21:31:41.607045+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-f4ac-4d90-95b2-0b4b21736441"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
-      "type": "Microsoft.Communication.CallDisconnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-5fc7-4e82-bf99-34ff8ca95ff5",
+        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:31:41.6851645+00:00",
+      "time": "2024-03-08T21:37:19.7502105+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-5fc7-4e82-bf99-34ff8ca95ff5"
+      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "operationContext": "operationContextCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-03-08T21:37:19.7345971+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
@@ -22,24 +22,24 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09",
+      "source": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f",
       "type": "Microsoft.Communication.CreateCallFailed",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09",
+        "eventSource": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f",
         "resultInformation": {
           "code": 603,
           "subCode": 0,
           "message": "Decline. DiagCode: 603#0.@"
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-beb8-4623-919f-6b40efa12b09",
+        "callConnectionId": "411f0b00-c0f2-4c93-abb2-aa974347027f",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CreateCallFailed"
       },
-      "time": "2024-03-08T06:56:00.4125059+00:00",
+      "time": "2024-03-08T21:31:47.4039737+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09"
+      "subject": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
@@ -22,20 +22,24 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-7539-4784-b1ea-cd57a598c685",
-      "type": "Microsoft.Communication.CallDisconnected",
+      "source": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09",
+      "type": "Microsoft.Communication.CreateCallFailed",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-7539-4784-b1ea-cd57a598c685",
-        "operationContext": "operationContextRejectCall",
+        "eventSource": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09",
+        "resultInformation": {
+          "code": 603,
+          "subCode": 0,
+          "message": "Decline. DiagCode: 603#0.@"
+        },
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-7539-4784-b1ea-cd57a598c685",
+        "callConnectionId": "421f0b00-beb8-4623-919f-6b40efa12b09",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
+        "publicEventType": "Microsoft.Communication.CreateCallFailed"
       },
-      "time": "2024-01-04T13:54:12.2650422+00:00",
+      "time": "2024-03-08T06:56:00.4125059+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-7539-4784-b1ea-cd57a598c685"
+      "subject": "calling/callConnections/421f0b00-beb8-4623-919f-6b40efa12b09"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
@@ -22,24 +22,24 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f",
+      "source": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827",
       "type": "Microsoft.Communication.CreateCallFailed",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f",
+        "eventSource": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827",
         "resultInformation": {
           "code": 603,
           "subCode": 0,
           "message": "Decline. DiagCode: 603#0.@"
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-c0f2-4c93-abb2-aa974347027f",
+        "callConnectionId": "421f0b00-d931-441b-bf88-58b09e9de827",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CreateCallFailed"
       },
-      "time": "2024-03-08T21:31:47.4039737+00:00",
+      "time": "2024-03-08T21:37:25.9377797+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-c0f2-4c93-abb2-aa974347027f"
+      "subject": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
@@ -22,94 +22,94 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
+      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:39:05.4893087+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
+        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
+        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:22.5068067+00:00",
+      "time": "2024-03-08T21:39:05.4893087+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
+      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:22.5068067+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
+        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:22.6005543+00:00",
+      "time": "2024-03-08T21:39:05.5674975+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
+      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "participants": [
           {
             "identifier": {
@@ -136,75 +136,75 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
+        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:22.6005543+00:00",
+      "time": "2024-03-08T21:39:05.5674975+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
+      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
       "type": "Microsoft.Communication.PlayCanceled",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "operationContext": "CancelplayToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
+        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCanceled"
       },
-      "time": "2024-03-08T21:33:24.131773+00:00",
+      "time": "2024-03-08T21:39:07.2549531+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
+      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
+        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:25.3193351+00:00",
+      "time": "2024-03-08T21:39:08.4112185+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
+      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
+      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
+        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
+        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:25.3974587+00:00",
+      "time": "2024-03-08T21:39:08.4737327+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
+      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:43.9122992+00:00",
+      "time": "2024-03-08T21:33:22.5068067+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
+      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
         "participants": [
           {
             "identifier": {
@@ -72,139 +72,139 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:43.9591733+00:00",
+      "time": "2024-03-08T21:33:22.5068067+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
+      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:57:43.9591733+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:43.9591733+00:00",
+      "time": "2024-03-08T21:33:22.6005543+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
+      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:33:22.6005543+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
       "type": "Microsoft.Communication.PlayCanceled",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
         "operationContext": "CancelplayToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCanceled"
       },
-      "time": "2024-03-08T06:57:45.5998689+00:00",
+      "time": "2024-03-08T21:33:24.131773+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
+      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+      "source": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "eventSource": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
+        "callConnectionId": "411f0b00-e71c-4e42-866a-453d9877833f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:46.8029622+00:00",
+      "time": "2024-03-08T21:33:25.3193351+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
+      "subject": "calling/callConnections/411f0b00-e71c-4e42-866a-453d9877833f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+      "source": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "eventSource": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "callConnectionId": "411f0b00-e115-48bf-b408-33feedfdd5d5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:46.8655068+00:00",
+      "time": "2024-03-08T21:33:25.3974587+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
+      "subject": "calling/callConnections/411f0b00-e115-48bf-b408-33feedfdd5d5"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e04-413a-9b5e-b02759908051",
+        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:57:30.3101884+00:00",
+      "time": "2024-03-08T06:57:43.9122992+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051"
+      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "participants": [
           {
             "identifier": {
@@ -55,7 +55,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -65,142 +66,145 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e04-413a-9b5e-b02759908051",
+        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:57:30.3258031+00:00",
+      "time": "2024-03-08T06:57:43.9591733+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051"
+      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:57:43.9591733+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:57:30.3883243+00:00",
+      "time": "2024-03-08T06:57:43.9591733+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239"
+      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-ce1c-463a-8ffa-2e86a6a6c239",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:57:30.3727507+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
       "type": "Microsoft.Communication.PlayCanceled",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "operationContext": "CancelplayToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCanceled"
       },
-      "time": "2024-01-04T13:57:33.9198494+00:00",
+      "time": "2024-03-08T06:57:45.5998689+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239"
+      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+      "source": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "eventSource": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-ce1c-463a-8ffa-2e86a6a6c239",
+        "callConnectionId": "421f0b00-13ef-4942-98b8-1df4f4c26b8b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:57:36.1075228+00:00",
+      "time": "2024-03-08T06:57:46.8029622+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-ce1c-463a-8ffa-2e86a6a6c239"
+      "subject": "calling/callConnections/421f0b00-13ef-4942-98b8-1df4f4c26b8b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+      "source": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051",
+        "eventSource": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-8e04-413a-9b5e-b02759908051",
+        "callConnectionId": "421f0b00-aea3-4ec9-82ef-393df3fd982f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:57:36.1388376+00:00",
+      "time": "2024-03-08T06:57:46.8655068+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-8e04-413a-9b5e-b02759908051"
+      "subject": "calling/callConnections/421f0b00-aea3-4ec9-82ef-393df3fd982f"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
@@ -22,134 +22,138 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-80ab-45c1-b923-a8776c5d8c1d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:56:53.4703527+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0a30-48dd-9303-766f08019c43",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:56:53.4546795+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
+      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
-        "operationContext": "playToAllCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-80ab-45c1-b923-a8776c5d8c1d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:56:53.4703527+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
+        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0a30-48dd-9303-766f08019c43",
+        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:56:53.4390729+00:00",
+      "time": "2024-03-08T06:57:30.9121817+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43"
+      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
+      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:57:30.9590046+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:57:30.9746813+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "operationContext": "playToAllCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:57:30.9746813+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
+        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -157,55 +161,55 @@
         },
         "operationContext": "playToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-80ab-45c1-b923-a8776c5d8c1d",
+        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-01-04T13:57:14.4328996+00:00",
+      "time": "2024-03-08T06:57:36.881004+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d"
+      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
+      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d",
+        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-80ab-45c1-b923-a8776c5d8c1d",
+        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:57:16.40183+00:00",
+      "time": "2024-03-08T06:57:37.6310232+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-80ab-45c1-b923-a8776c5d8c1d"
+      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
+      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43",
+        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-0a30-48dd-9303-766f08019c43",
+        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:57:16.417459+00:00",
+      "time": "2024-03-08T06:57:37.6934646+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-0a30-48dd-9303-766f08019c43"
+      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:09.7088092+00:00",
+      "time": "2024-03-08T21:38:52.3016596+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
+      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "participants": [
           {
             "identifier": {
@@ -72,88 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:09.7088092+00:00",
+      "time": "2024-03-08T21:38:52.3172836+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
+      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:52.3642538+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:09.7243839+00:00",
+      "time": "2024-03-08T21:38:52.3642538+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
+      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:33:09.7243839+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -161,55 +161,55 @@
         },
         "operationContext": "playToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:33:15.5838726+00:00",
+      "time": "2024-03-08T21:38:58.1299007+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
+      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:16.412035+00:00",
+      "time": "2024-03-08T21:38:59.0048585+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
+      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
+        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:16.4901346+00:00",
+      "time": "2024-03-08T21:38:59.0673616+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
+      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:30.9121817+00:00",
+      "time": "2024-03-08T21:33:09.7088092+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
+      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "participants": [
           {
             "identifier": {
@@ -72,88 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:30.9590046+00:00",
+      "time": "2024-03-08T21:33:09.7088092+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
+      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:57:30.9746813+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:30.9746813+00:00",
+      "time": "2024-03-08T21:33:09.7243839+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
+      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:33:09.7243839+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -161,55 +161,55 @@
         },
         "operationContext": "playToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T06:57:36.881004+00:00",
+      "time": "2024-03-08T21:33:15.5838726+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
+      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+      "source": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "eventSource": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-3815-4d5f-9692-ef5cebaf2903",
+        "callConnectionId": "411f0b00-e67d-4d17-974a-50eb8c1b53b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:37.6310232+00:00",
+      "time": "2024-03-08T21:33:16.412035+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-3815-4d5f-9692-ef5cebaf2903"
+      "subject": "calling/callConnections/411f0b00-e67d-4d17-974a-50eb8c1b53b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+      "source": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "eventSource": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-781d-49b7-a962-0638bacf3d9b",
+        "callConnectionId": "411f0b00-7e7d-43aa-9e53-e1319c76ea91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:37.6934646+00:00",
+      "time": "2024-03-08T21:33:16.4901346+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-781d-49b7-a962-0638bacf3d9b"
+      "subject": "calling/callConnections/411f0b00-7e7d-43aa-9e53-e1319c76ea91"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:53.6600666+00:00",
+      "time": "2024-03-08T21:38:36.0029069+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
         "participants": [
           {
             "identifier": {
@@ -72,44 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:53.6912558+00:00",
+      "time": "2024-03-08T21:38:36.0341077+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:38:36.0653533+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:32:53.7381244+00:00",
+      "time": "2024-03-08T21:38:36.0653533+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
         "participants": [
           {
             "identifier": {
@@ -122,39 +166,6 @@
             "isMuted": false,
             "isOnHold": false
           },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:32:53.7225512+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
-        "participants": [
           {
             "identifier": {
               "rawId": "sanitized",
@@ -165,39 +176,28 @@
             },
             "isMuted": false,
             "isOnHold": true
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:57.0044323+00:00",
+      "time": "2024-03-08T21:38:39.7372743+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "participants": [
           {
             "identifier": {
@@ -208,7 +208,7 @@
               }
             },
             "isMuted": false,
-            "isOnHold": true
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -219,29 +219,29 @@
               }
             },
             "isMuted": false,
-            "isOnHold": false
+            "isOnHold": true
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:32:57.0044323+00:00",
+      "time": "2024-03-08T21:38:39.7372743+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -249,24 +249,24 @@
         },
         "operationContext": "playAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:33:01.7856638+00:00",
+      "time": "2024-03-08T21:38:44.6123274+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
         "participants": [
           {
             "identifier": {
@@ -293,24 +293,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:01.8169607+00:00",
+      "time": "2024-03-08T21:38:44.6435749+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "participants": [
           {
             "identifier": {
@@ -337,55 +337,55 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:01.8169607+00:00",
+      "time": "2024-03-08T21:38:44.6592091+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:03.3482311+00:00",
+      "time": "2024-03-08T21:38:46.2061446+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:03.4263598+00:00",
+      "time": "2024-03-08T21:38:46.2842181+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
@@ -22,94 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T06:57:14.7302047+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:57:14.7000233+00:00",
+      "time": "2024-03-08T21:32:53.6600666+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
+      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
-        "operationContext": "playAudioCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T06:57:14.7145807+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "participants": [
           {
             "identifier": {
@@ -136,24 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:14.7302047+00:00",
+      "time": "2024-03-08T21:32:53.6912558+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
+      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "operationContext": "playAudioCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:32:53.7381244+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "participants": [
           {
             "identifier": {
@@ -175,29 +131,29 @@
               }
             },
             "isMuted": false,
-            "isOnHold": true
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:18.4028738+00:00",
+      "time": "2024-03-08T21:32:53.7225512+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "participants": [
           {
             "identifier": {
@@ -208,7 +164,7 @@
               }
             },
             "isMuted": false,
-            "isOnHold": false
+            "isOnHold": true
           },
           {
             "identifier": {
@@ -219,29 +175,73 @@
               }
             },
             "isMuted": false,
-            "isOnHold": true
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:18.4028738+00:00",
+      "time": "2024-03-08T21:32:57.0044323+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": true
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T21:32:57.0044323+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -249,24 +249,24 @@
         },
         "operationContext": "playAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T06:57:23.5123623+00:00",
+      "time": "2024-03-08T21:33:01.7856638+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "participants": [
           {
             "identifier": {
@@ -293,24 +293,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:23.5279826+00:00",
+      "time": "2024-03-08T21:33:01.8169607+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "participants": [
           {
             "identifier": {
@@ -337,55 +337,55 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:57:23.5279826+00:00",
+      "time": "2024-03-08T21:33:01.8169607+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
+      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+      "source": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+        "eventSource": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
+        "callConnectionId": "411f0b00-bbb4-4c68-bc8f-0514bb84be63",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:24.8092508+00:00",
+      "time": "2024-03-08T21:33:03.3482311+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
+      "subject": "calling/callConnections/411f0b00-bbb4-4c68-bc8f-0514bb84be63"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+      "source": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "eventSource": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
+        "callConnectionId": "411f0b00-98fd-45f2-b6c4-fbd30525e5e7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:57:24.8873769+00:00",
+      "time": "2024-03-08T21:33:03.4263598+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
+      "subject": "calling/callConnections/411f0b00-98fd-45f2-b6c4-fbd30525e5e7"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
@@ -22,30 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
-        "operationContext": "playAudioCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:56:15.480259+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
         "participants": [
           {
             "identifier": {
@@ -55,7 +35,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -65,49 +46,70 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:15.511458+00:00",
+      "time": "2024-03-08T06:57:14.7302047+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-97a3-48bb-946e-f87a63e62395",
+        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:56:15.4958338+00:00",
+      "time": "2024-03-08T06:57:14.7000233+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395"
+      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
+        "operationContext": "playAudioCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:57:14.7145807+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
         "participants": [
           {
             "identifier": {
@@ -117,7 +119,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -127,29 +130,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-97a3-48bb-946e-f87a63e62395",
+        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:15.4958338+00:00",
+      "time": "2024-03-08T06:57:14.7302047+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395"
+      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
         "participants": [
           {
             "identifier": {
@@ -159,7 +163,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -169,29 +174,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": true
           }
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:19.261861+00:00",
+      "time": "2024-03-08T06:57:18.4028738+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
         "participants": [
           {
             "identifier": {
@@ -201,7 +207,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -211,29 +218,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": true
           }
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-97a3-48bb-946e-f87a63e62395",
+        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:19.261861+00:00",
+      "time": "2024-03-08T06:57:18.4028738+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395"
+      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -241,24 +249,24 @@
         },
         "operationContext": "playAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-01-04T13:56:36.9976507+00:00",
+      "time": "2024-03-08T06:57:23.5123623+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
         "participants": [
           {
             "identifier": {
@@ -268,7 +276,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -278,29 +287,30 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:37.0288941+00:00",
+      "time": "2024-03-08T06:57:23.5279826+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
         "participants": [
           {
             "identifier": {
@@ -310,7 +320,8 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -320,60 +331,61 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-97a3-48bb-946e-f87a63e62395",
+        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:56:37.0288941+00:00",
+      "time": "2024-03-08T06:57:23.5279826+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395"
+      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+      "source": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "eventSource": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-31f7-4e27-98d1-c7a096f4e3f7",
+        "callConnectionId": "421f0b00-1278-4873-8406-fd982ab83607",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:56:38.8597105+00:00",
+      "time": "2024-03-08T06:57:24.8092508+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-31f7-4e27-98d1-c7a096f4e3f7"
+      "subject": "calling/callConnections/421f0b00-1278-4873-8406-fd982ab83607"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+      "source": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395",
+        "eventSource": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-97a3-48bb-946e-f87a63e62395",
+        "callConnectionId": "421f0b00-b01a-4f91-8fa9-395004c4f965",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:56:38.8753817+00:00",
+      "time": "2024-03-08T06:57:24.8873769+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-97a3-48bb-946e-f87a63e62395"
+      "subject": "calling/callConnections/421f0b00-b01a-4f91-8fa9-395004c4f965"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
@@ -1,23 +1,4 @@
 [
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5",
-      "type": "Microsoft.Communication.CallDisconnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0b00-58b7-4517-bb2c-9e6992abffa5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
-      },
-      "time": "2024-03-08T21:26:00.8338+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5"
-    }
-  ],
   {
     "to": {
       "kind": "phoneNumber",
@@ -41,48 +22,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:33:33.4134186+00:00",
+      "time": "2024-03-08T21:39:16.1300989+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
+      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:33:33.538473+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
         "participants": [
           {
             "identifier": {
@@ -109,24 +71,43 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:33.5539858+00:00",
+      "time": "2024-03-08T21:39:16.1300989+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
+      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T21:39:16.2082231+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
         "participants": [
           {
             "identifier": {
@@ -153,93 +134,93 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:33:33.538473+00:00",
+      "time": "2024-03-08T21:39:16.4454559+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
+      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
       "type": "Microsoft.Communication.SendDtmfTonesCompleted",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
         "operationContext": "ContinuousDtmfRecognitionSend",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.SendDtmfTonesCompleted"
       },
-      "time": "2024-03-08T21:33:38.2415958+00:00",
+      "time": "2024-03-08T21:39:21.1954969+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
+      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
       "type": "Microsoft.Communication.ContinuousDtmfRecognitionStopped",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
         "operationContext": "ContinuousDtmfRecognitionStop",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ContinuousDtmfRecognitionStopped"
       },
-      "time": "2024-03-08T21:33:39.0384262+00:00",
+      "time": "2024-03-08T21:39:21.8830024+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
+      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
+        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:40.2416151+00:00",
+      "time": "2024-03-08T21:39:23.0548241+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
+      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
         "version": "2023-10-03-preview",
-        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
+        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:33:40.4447631+00:00",
+      "time": "2024-03-08T21:39:23.2892567+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
+      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
@@ -1,4 +1,23 @@
 [
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "401f0b00-58b7-4517-bb2c-9e6992abffa5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-03-08T21:26:00.8338+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/401f0b00-58b7-4517-bb2c-9e6992abffa5"
+    }
+  ],
   {
     "to": {
       "kind": "phoneNumber",
@@ -22,48 +41,48 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:58:07.1479113+00:00",
+      "time": "2024-03-08T21:33:33.4134186+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
+      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T06:58:07.2416157+00:00",
+      "time": "2024-03-08T21:33:33.538473+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "participants": [
           {
             "identifier": {
@@ -90,36 +109,25 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:07.225994+00:00",
+      "time": "2024-03-08T21:33:33.5539858+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "phoneNumber",
-              "phoneNumber": {
-                "value": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
           {
             "identifier": {
               "rawId": "sanitized",
@@ -130,97 +138,108 @@
             },
             "isMuted": false,
             "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "phoneNumber",
+              "phoneNumber": {
+                "value": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T06:58:07.3822398+00:00",
+      "time": "2024-03-08T21:33:33.538473+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
+      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
       "type": "Microsoft.Communication.SendDtmfTonesCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "operationContext": "ContinuousDtmfRecognitionSend",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.SendDtmfTonesCompleted"
       },
-      "time": "2024-03-08T06:58:13.9448316+00:00",
+      "time": "2024-03-08T21:33:38.2415958+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
       "type": "Microsoft.Communication.ContinuousDtmfRecognitionStopped",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "operationContext": "ContinuousDtmfRecognitionStop",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ContinuousDtmfRecognitionStopped"
       },
-      "time": "2024-03-08T06:58:14.5542126+00:00",
+      "time": "2024-03-08T21:33:39.0384262+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "source": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "eventSource": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "callConnectionId": "411f0b00-b02a-44d9-af4a-5bc35899e0b9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:58:15.773038+00:00",
+      "time": "2024-03-08T21:33:40.2416151+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+      "subject": "calling/callConnections/411f0b00-b02a-44d9-af4a-5bc35899e0b9"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+      "source": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "eventSource": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
+        "callConnectionId": "411f0b00-2c63-4d3e-adb9-02c0323e97f9",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T06:58:15.991783+00:00",
+      "time": "2024-03-08T21:33:40.4447631+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
+      "subject": "calling/callConnections/411f0b00-2c63-4d3e-adb9-02c0323e97f9"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
@@ -22,29 +22,92 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-01-04T13:57:51.7181755+00:00",
+      "time": "2024-03-08T06:58:07.1479113+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef"
+      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-03-08T06:58:07.2416157+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "phoneNumber",
+              "phoneNumber": {
+                "value": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-03-08T06:58:07.225994+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
         "participants": [
           {
             "identifier": {
@@ -54,7 +117,8 @@
                 "value": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           },
           {
             "identifier": {
@@ -64,159 +128,99 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": false
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-01-04T13:57:51.7025558+00:00",
+      "time": "2024-03-08T06:58:07.3822398+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef"
+      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-383c-430b-8294-b15170b76617",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-01-04T13:57:52.0776421+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "phoneNumber",
-              "phoneNumber": {
-                "value": "sanitized"
-              }
-            },
-            "isMuted": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-383c-430b-8294-b15170b76617",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-01-04T13:57:52.9370184+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
       "type": "Microsoft.Communication.SendDtmfTonesCompleted",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "operationContext": "ContinuousDtmfRecognitionSend",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.SendDtmfTonesCompleted"
       },
-      "time": "2024-01-04T13:57:59.0469098+00:00",
+      "time": "2024-03-08T06:58:13.9448316+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef"
+      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
       "type": "Microsoft.Communication.ContinuousDtmfRecognitionStopped",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "operationContext": "ContinuousDtmfRecognitionStop",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ContinuousDtmfRecognitionStopped"
       },
-      "time": "2024-01-04T13:58:00.8751965+00:00",
+      "time": "2024-03-08T06:58:14.5542126+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef"
+      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+      "source": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "eventSource": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-1b44-47f8-9969-2db0c54eb3ef",
+        "callConnectionId": "421f0b00-d566-49fe-b844-54d5a8d7e6a5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:58:03.0785144+00:00",
+      "time": "2024-03-08T06:58:15.773038+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-1b44-47f8-9969-2db0c54eb3ef"
+      "subject": "calling/callConnections/421f0b00-d566-49fe-b844-54d5a8d7e6a5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
+      "source": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617",
+        "eventSource": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb",
         "version": "2023-10-03-preview",
-        "callConnectionId": "401f0700-383c-430b-8294-b15170b76617",
+        "callConnectionId": "421f0b00-019f-4247-92e4-b53ae844d9eb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-01-04T13:58:03.7504511+00:00",
+      "time": "2024-03-08T06:58:15.991783+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/401f0700-383c-430b-8294-b15170b76617"
+      "subject": "calling/callConnections/421f0b00-019f-4247-92e4-b53ae844d9eb"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -65,6 +65,7 @@ export interface AddParticipantSucceeded extends Omit<RestAddParticipantSucceede
 
 // @public
 export interface AnswerCallEventResult {
+    failureResult?: AnswerFailed;
     isSuccess: boolean;
     successResult?: CallConnected;
 }
@@ -83,6 +84,18 @@ export interface AnswerCallResult {
     callConnection: CallConnection;
     callConnectionProperties: CallConnectionProperties;
     waitForEventProcessor(abortSignal?: AbortSignalLike, timeoutInMs?: number): Promise<AnswerCallEventResult>;
+}
+
+// Warning: (ae-forgotten-export) The symbol "RestAnswerFailed" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface AnswerFailed extends Omit<RestAnswerFailed, "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"> {
+    callConnectionId: string;
+    correlationId: string;
+    kind: "AnswerFailed";
+    // Warning: (ae-forgotten-export) The symbol "RestResultInformation" needs to be exported by the entry point index.d.ts
+    resultInformation?: RestResultInformation;
+    serverCallId: string;
 }
 
 // @public
@@ -106,7 +119,7 @@ export interface CallAutomationClientOptions extends CommonClientOptions {
 }
 
 // @public
-export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | TeamsComplianceRecordingStateChanged | TeamsRecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed;
+export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | TeamsComplianceRecordingStateChanged | TeamsRecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed | CreateCallFailed | AnswerFailed;
 
 // @public
 export class CallAutomationEventProcessor {
@@ -203,7 +216,7 @@ export class CallMedia {
     playToAll(playSources: (FileSource | TextSource | SsmlSource)[], options?: PlayOptions): Promise<PlayResult>;
     sendDtmfTones(tones: Tone[] | DtmfTone[], targetParticipant: CommunicationIdentifier, options?: SendDtmfTonesOptions): Promise<SendDtmfTonesResult>;
     startContinuousDtmfRecognition(targetParticipant: CommunicationIdentifier, options?: ContinuousDtmfRecognitionOptions): Promise<void>;
-    startHoldMusic(targetParticipant: CommunicationIdentifier, playSource: FileSource | TextSource | SsmlSource, loop?: boolean, operationContext?: string | undefined): Promise<void>;
+    startHoldMusic(targetParticipant: CommunicationIdentifier, playSource: FileSource | TextSource | SsmlSource, operationContext?: string | undefined): Promise<void>;
     // @deprecated
     startRecognizing(targetParticipant: CommunicationIdentifier, maxTonesToCollect: number, options: CallMediaRecognizeDtmfOptions): Promise<StartRecognizingResult>;
     startRecognizing(targetParticipant: CommunicationIdentifier, options: CallMediaRecognizeDtmfOptions | CallMediaRecognizeChoiceOptions | CallMediaRecognizeSpeechOptions | CallMediaRecognizeSpeechOrDtmfOptions): Promise<StartRecognizingResult>;
@@ -423,8 +436,20 @@ export interface ContinuousDtmfRecognitionToneReceived extends Omit<RestContinuo
 
 // @public
 export interface CreateCallEventResult {
+    failureResult?: CreateCallFailed;
     isSuccess: boolean;
     successResult?: CallConnected;
+}
+
+// Warning: (ae-forgotten-export) The symbol "RestCreateCallFailed" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface CreateCallFailed extends Omit<RestCreateCallFailed, "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"> {
+    callConnectionId: string;
+    correlationId: string;
+    kind: "CreateCallFailed";
+    resultInformation?: RestResultInformation;
+    serverCallId: string;
 }
 
 // @public
@@ -772,8 +797,6 @@ export interface RemoveParticipantSucceeded extends Omit<RestRemoveParticipantSu
     serverCallId: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "RestResultInformation" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export interface ResultInformation extends Omit<RestResultInformation, "code" | "subCode" | "message"> {
     code: number;

--- a/sdk/communication/communication-call-automation/src/callAutomationClient.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationClient.ts
@@ -209,6 +209,13 @@ export class CallAutomationClient {
                 createCallEventResult.isSuccess = true;
                 createCallEventResult.successResult = event;
                 return true;
+              } else if (
+                event.callConnectionId === callConnectionId &&
+                event.kind === "CreateCallFailed"
+              ) {
+                createCallEventResult.isSuccess = false;
+                createCallEventResult.failureResult = event;
+                return true;
               } else {
                 return false;
               }
@@ -348,6 +355,11 @@ export class CallAutomationClient {
               if (event.callConnectionId === callConnectionId && event.kind === "CallConnected") {
                 answerCallEventResult.isSuccess = true;
                 answerCallEventResult.successResult = event;
+                return true;
+              }
+              if (event.callConnectionId === callConnectionId && event.kind === "AnswerFailed") {
+                answerCallEventResult.isSuccess = false;
+                answerCallEventResult.failureResult = event;
                 return true;
               } else {
                 return false;

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -36,6 +36,8 @@ import {
   TranscriptionStopped,
   TranscriptionUpdated,
   TranscriptionFailed,
+  CreateCallFailed,
+  AnswerFailed,
 } from "./models/events";
 
 import { CloudEventMapper } from "./models/mapper";
@@ -159,6 +161,12 @@ export function parseCallAutomationEvent(
       break;
     case "Microsoft.Communication.TranscriptionFailed":
       callbackEvent = { kind: "TranscriptionFailed" } as TranscriptionFailed;
+      break;
+    case "Microsoft.Communication.CreateCallFailed":
+      callbackEvent = { kind: "CreateCallFailed" } as CreateCallFailed;
+      break;
+    case "Microsoft.Communication.AnswerFailed":
+      callbackEvent = { kind: "AnswerFailed" } as AnswerFailed;
       break;
     default:
       throw new TypeError(`Unknown Call Automation Event type: ${eventType}`);

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -608,19 +608,16 @@ export class CallMedia {
    *
    * @param targetParticipant - The targets to play to.
    * @param playSource - A PlaySource representing the source to play.
-   * @param loop - To play the audio continously until stopped.
    * @param operationContext - Operation Context.
    */
   public async startHoldMusic(
     targetParticipant: CommunicationIdentifier,
     playSource: FileSource | TextSource | SsmlSource,
-    loop: boolean = true,
     operationContext: string | undefined = undefined,
   ): Promise<void> {
     const holdRequest: StartHoldMusicRequest = {
       targetParticipant: serializeCommunicationIdentifier(targetParticipant),
       playSourceInfo: this.createPlaySourceInternal(playSource),
-      loop: loop,
       operationContext: operationContext,
     };
 

--- a/sdk/communication/communication-call-automation/src/eventprocessor/eventResponses.ts
+++ b/sdk/communication/communication-call-automation/src/eventprocessor/eventResponses.ts
@@ -19,6 +19,8 @@ import {
   CallTransferFailed,
   CancelAddParticipantSucceeded,
   CancelAddParticipantFailed,
+  CreateCallFailed,
+  AnswerFailed,
 } from "../models/events";
 
 /**
@@ -43,6 +45,8 @@ export interface AnswerCallEventResult {
   isSuccess: boolean;
   /** contains success event if the result was successful */
   successResult?: CallConnected;
+  /** contains failure event if the result was failure */
+  failureResult?: AnswerFailed;
 }
 
 /**
@@ -65,6 +69,8 @@ export interface CreateCallEventResult {
   isSuccess: boolean;
   /** contains success event if the result was successful */
   successResult?: CallConnected;
+  /** contains failure event if the result was failure */
+  failureResult?: CreateCallFailed;
 }
 
 /**

--- a/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
@@ -53,6 +53,8 @@ export interface CommunicationIdentifierModel {
   phoneNumber?: PhoneNumberIdentifierModel;
   /** The Microsoft Teams user. */
   microsoftTeamsUser?: MicrosoftTeamsUserIdentifierModel;
+  /** The Microsoft Teams application. */
+  microsoftTeamsApp?: MicrosoftTeamsAppIdentifierModel;
 }
 
 /** A user that got created with an Azure Communication Services resource. */
@@ -74,6 +76,14 @@ export interface MicrosoftTeamsUserIdentifierModel {
   /** True if the Microsoft Teams user is anonymous. By default false if missing. */
   isAnonymous?: boolean;
   /** The cloud that the Microsoft Teams user belongs to. By default 'public' if missing. */
+  cloud?: CommunicationCloudEnvironmentModel;
+}
+
+/** A Microsoft Teams application. */
+export interface MicrosoftTeamsAppIdentifierModel {
+  /** The Id of the Microsoft Teams application. */
+  appId: string;
+  /** The cloud that the Microsoft Teams application belongs to. By default 'public' if missing. */
   cloud?: CommunicationCloudEnvironmentModel;
 }
 
@@ -143,8 +153,8 @@ export interface CallConnectionPropertiesInternal {
   correlationId?: string;
   /** Identity of the answering entity. Only populated when identity is provided in the request. */
   answeredBy?: CommunicationUserIdentifierModel;
-  /** The original PSTN target of the incoming Call. */
-  originalPstnTarget?: PhoneNumberIdentifierModel;
+  /** Identity of the original Pstn target of an incoming Call. Only populated when the original target is a Pstn number. */
+  answeredFor?: PhoneNumberIdentifierModel;
 }
 
 /** The Communication Services error. */
@@ -420,15 +430,44 @@ export interface UpdateTranscriptionRequest {
 }
 
 /** The request payload for holding participant from the call. */
+export interface HoldRequest {
+  /** Participant to be held from the call. */
+  targetParticipant: CommunicationIdentifierModel;
+  /** Prompt to play while in hold. */
+  playSourceInfo?: PlaySourceInternal;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
+  /**
+   * Set a callback URI that overrides the default callback URI set by CreateCall/AnswerCall for this operation.
+   * This setup is per-action. If this is not set, the default callback URI set by CreateCall/AnswerCall will be used.
+   */
+  operationCallbackUri?: string;
+}
+
+/** The request payload for holding participant from the call. */
+export interface UnholdRequest {
+  /**
+   * Participants to be hold from the call.
+   * Only ACS Users are supported.
+   */
+  targetParticipant: CommunicationIdentifierModel;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
+}
+
+/** The request payload for holding participant from the call. */
 export interface StartHoldMusicRequest {
   /** Participant to be held from the call. */
   targetParticipant: CommunicationIdentifierModel;
   /** Prompt to play while in hold. */
-  playSourceInfo: PlaySourceInternal;
-  /** If the prompt will be looped or not. */
-  loop?: boolean;
+  playSourceInfo?: PlaySourceInternal;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
+  /**
+   * Set a callback URI that overrides the default callback URI set by CreateCall/AnswerCall for this operation.
+   * This setup is per-action. If this is not set, the default callback URI set by CreateCall/AnswerCall will be used.
+   */
+  operationCallbackUri?: string;
 }
 
 /** The request payload for holding participant from the call. */
@@ -503,6 +542,8 @@ export interface CallParticipantInternal {
   identifier?: CommunicationIdentifierModel;
   /** Is participant muted */
   isMuted?: boolean;
+  /** Is participant on hold. */
+  isOnHold?: boolean;
 }
 
 /** The request payload for adding participant to the call. */
@@ -1989,6 +2030,92 @@ export interface RestTranscriptionFailed {
   readonly correlationId?: string;
 }
 
+/** The CreateCallFailed event */
+export interface RestCreateCallFailed {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
+/** AnswerFailed event */
+export interface RestAnswerFailed {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
+export interface RestHoldFailed {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
 /** Azure Open AI Dialog */
 export interface AzureOpenAIDialog extends BaseDialog {
   /** Polymorphic discriminator, which specifies the different types this object can be */
@@ -2021,6 +2148,8 @@ export enum KnownCommunicationIdentifierModelKind {
   PhoneNumber = "phoneNumber",
   /** MicrosoftTeamsUser */
   MicrosoftTeamsUser = "microsoftTeamsUser",
+  /** MicrosoftTeamsApp */
+  MicrosoftTeamsApp = "microsoftTeamsApp",
 }
 
 /**
@@ -2031,7 +2160,8 @@ export enum KnownCommunicationIdentifierModelKind {
  * **unknown** \
  * **communicationUser** \
  * **phoneNumber** \
- * **microsoftTeamsUser**
+ * **microsoftTeamsUser** \
+ * **microsoftTeamsApp**
  */
 export type CommunicationIdentifierModelKind = string;
 
@@ -2452,6 +2582,8 @@ export enum KnownTranscriptionStatus {
   TranscriptionStarted = "transcriptionStarted",
   /** TranscriptionFailed */
   TranscriptionFailed = "transcriptionFailed",
+  /** TranscriptionResumed */
+  TranscriptionResumed = "transcriptionResumed",
   /** TranscriptionUpdated */
   TranscriptionUpdated = "transcriptionUpdated",
   /** TranscriptionStopped */
@@ -2467,6 +2599,7 @@ export enum KnownTranscriptionStatus {
  * ### Known values supported by the service
  * **transcriptionStarted** \
  * **transcriptionFailed** \
+ * **transcriptionResumed** \
  * **transcriptionUpdated** \
  * **transcriptionStopped** \
  * **unspecifiedError**
@@ -2749,6 +2882,14 @@ export interface CallMediaUpdateTranscriptionOptionalParams
   extends coreClient.OperationOptions {}
 
 /** Optional parameters. */
+export interface CallMediaHoldOptionalParams
+  extends coreClient.OperationOptions {}
+
+/** Optional parameters. */
+export interface CallMediaUnholdOptionalParams
+  extends coreClient.OperationOptions {}
+
+/** Optional parameters. */
 export interface CallMediaStartHoldMusicOptionalParams
   extends coreClient.OperationOptions {}
 
@@ -2766,7 +2907,7 @@ export type CallDialogStartDialogResponse = DialogStateResponse;
 /** Optional parameters. */
 export interface CallDialogStopDialogOptionalParams
   extends coreClient.OperationOptions {
-  /** Opeation callback URI. */
+  /** Operation callback URI. */
   operationCallbackUri?: string;
 }
 

--- a/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
@@ -129,6 +129,13 @@ export const CommunicationIdentifierModel: coreClient.CompositeMapper = {
           className: "MicrosoftTeamsUserIdentifierModel",
         },
       },
+      microsoftTeamsApp: {
+        serializedName: "microsoftTeamsApp",
+        type: {
+          name: "Composite",
+          className: "MicrosoftTeamsAppIdentifierModel",
+        },
+      },
     },
   },
 };
@@ -181,6 +188,28 @@ export const MicrosoftTeamsUserIdentifierModel: coreClient.CompositeMapper = {
         serializedName: "isAnonymous",
         type: {
           name: "Boolean",
+        },
+      },
+      cloud: {
+        serializedName: "cloud",
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const MicrosoftTeamsAppIdentifierModel: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MicrosoftTeamsAppIdentifierModel",
+    modelProperties: {
+      appId: {
+        serializedName: "appId",
+        required: true,
+        type: {
+          name: "String",
         },
       },
       cloud: {
@@ -391,8 +420,8 @@ export const CallConnectionPropertiesInternal: coreClient.CompositeMapper = {
           className: "CommunicationUserIdentifierModel",
         },
       },
-      originalPstnTarget: {
-        serializedName: "originalPSTNTarget",
+      answeredFor: {
+        serializedName: "answeredFor",
         type: {
           name: "Composite",
           className: "PhoneNumberIdentifierModel",
@@ -1175,6 +1204,63 @@ export const UpdateTranscriptionRequest: coreClient.CompositeMapper = {
   },
 };
 
+export const HoldRequest: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "HoldRequest",
+    modelProperties: {
+      targetParticipant: {
+        serializedName: "targetParticipant",
+        type: {
+          name: "Composite",
+          className: "CommunicationIdentifierModel",
+        },
+      },
+      playSourceInfo: {
+        serializedName: "playSourceInfo",
+        type: {
+          name: "Composite",
+          className: "PlaySourceInternal",
+        },
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String",
+        },
+      },
+      operationCallbackUri: {
+        serializedName: "operationCallbackUri",
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const UnholdRequest: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "UnholdRequest",
+    modelProperties: {
+      targetParticipant: {
+        serializedName: "targetParticipant",
+        type: {
+          name: "Composite",
+          className: "CommunicationIdentifierModel",
+        },
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
 export const StartHoldMusicRequest: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -1194,14 +1280,14 @@ export const StartHoldMusicRequest: coreClient.CompositeMapper = {
           className: "PlaySourceInternal",
         },
       },
-      loop: {
-        serializedName: "loop",
-        type: {
-          name: "Boolean",
-        },
-      },
       operationContext: {
         serializedName: "operationContext",
+        type: {
+          name: "String",
+        },
+      },
+      operationCallbackUri: {
+        serializedName: "operationCallbackUri",
         type: {
           name: "String",
         },
@@ -1419,6 +1505,12 @@ export const CallParticipantInternal: coreClient.CompositeMapper = {
       },
       isMuted: {
         serializedName: "isMuted",
+        type: {
+          name: "Boolean",
+        },
+      },
+      isOnHold: {
+        serializedName: "isOnHold",
         type: {
           name: "Boolean",
         },
@@ -4007,6 +4099,138 @@ export const RestTranscriptionFailed: coreClient.CompositeMapper = {
         type: {
           name: "Composite",
           className: "TranscriptionUpdate",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestCreateCallFailed: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestCreateCallFailed",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestAnswerFailed: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestAnswerFailed",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestHoldFailed: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestHoldFailed",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
         },
       },
       callConnectionId: {

--- a/sdk/communication/communication-call-automation/src/generated/src/models/parameters.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/parameters.ts
@@ -29,6 +29,8 @@ import {
   ContinuousDtmfRecognitionRequest as ContinuousDtmfRecognitionRequestMapper,
   SendDtmfTonesRequest as SendDtmfTonesRequestMapper,
   UpdateTranscriptionRequest as UpdateTranscriptionRequestMapper,
+  HoldRequest as HoldRequestMapper,
+  UnholdRequest as UnholdRequestMapper,
   StartHoldMusicRequest as StartHoldMusicRequestMapper,
   StopHoldMusicRequest as StopHoldMusicRequestMapper,
   StartDialogRequest as StartDialogRequestMapper,
@@ -221,6 +223,16 @@ export const sendDtmfTonesRequest: OperationParameter = {
 export const updateTranscriptionRequest: OperationParameter = {
   parameterPath: "updateTranscriptionRequest",
   mapper: UpdateTranscriptionRequestMapper,
+};
+
+export const holdRequest: OperationParameter = {
+  parameterPath: "holdRequest",
+  mapper: HoldRequestMapper,
+};
+
+export const unholdRequest: OperationParameter = {
+  parameterPath: "unholdRequest",
+  mapper: UnholdRequestMapper,
 };
 
 export const startHoldMusicRequest: OperationParameter = {

--- a/sdk/communication/communication-call-automation/src/generated/src/operations/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/operations/callConnection.ts
@@ -464,7 +464,7 @@ const muteOperationSpec: coreClient.OperationSpec = {
   path: "/calling/callConnections/{callConnectionId}/participants:mute",
   httpMethod: "POST",
   responses: {
-    202: {
+    200: {
       bodyMapper: Mappers.MuteParticipantsResult,
     },
     default: {

--- a/sdk/communication/communication-call-automation/src/generated/src/operations/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/operations/callMedia.ts
@@ -29,6 +29,10 @@ import {
   CallMediaSendDtmfTonesResponse,
   UpdateTranscriptionRequest,
   CallMediaUpdateTranscriptionOptionalParams,
+  HoldRequest,
+  CallMediaHoldOptionalParams,
+  UnholdRequest,
+  CallMediaUnholdOptionalParams,
   StartHoldMusicRequest,
   CallMediaStartHoldMusicOptionalParams,
   StopHoldMusicRequest,
@@ -195,6 +199,40 @@ export class CallMediaImpl implements CallMedia {
     return this.client.sendOperationRequest(
       { callConnectionId, updateTranscriptionRequest, options },
       updateTranscriptionOperationSpec,
+    );
+  }
+
+  /**
+   * Hold participant from the call using identifier.
+   * @param callConnectionId The call connection id.
+   * @param holdRequest The participants to be hold from the call.
+   * @param options The options parameters.
+   */
+  hold(
+    callConnectionId: string,
+    holdRequest: HoldRequest,
+    options?: CallMediaHoldOptionalParams,
+  ): Promise<void> {
+    return this.client.sendOperationRequest(
+      { callConnectionId, holdRequest, options },
+      holdOperationSpec,
+    );
+  }
+
+  /**
+   * Unhold participants from the call using identifier.
+   * @param callConnectionId The call connection id.
+   * @param unholdRequest The participants to be hold from the call.
+   * @param options The options parameters.
+   */
+  unhold(
+    callConnectionId: string,
+    unholdRequest: UnholdRequest,
+    options?: CallMediaUnholdOptionalParams,
+  ): Promise<void> {
+    return this.client.sendOperationRequest(
+      { callConnectionId, unholdRequest, options },
+      unholdOperationSpec,
     );
   }
 
@@ -378,6 +416,38 @@ const updateTranscriptionOperationSpec: coreClient.OperationSpec = {
     },
   },
   requestBody: Parameters.updateTranscriptionRequest,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.callConnectionId],
+  headerParameters: [Parameters.contentType, Parameters.accept],
+  mediaType: "json",
+  serializer,
+};
+const holdOperationSpec: coreClient.OperationSpec = {
+  path: "/calling/callConnections/{callConnectionId}:hold",
+  httpMethod: "POST",
+  responses: {
+    200: {},
+    default: {
+      bodyMapper: Mappers.CommunicationErrorResponse,
+    },
+  },
+  requestBody: Parameters.holdRequest,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.callConnectionId],
+  headerParameters: [Parameters.contentType, Parameters.accept],
+  mediaType: "json",
+  serializer,
+};
+const unholdOperationSpec: coreClient.OperationSpec = {
+  path: "/calling/callConnections/{callConnectionId}:unhold",
+  httpMethod: "POST",
+  responses: {
+    200: {},
+    default: {
+      bodyMapper: Mappers.CommunicationErrorResponse,
+    },
+  },
+  requestBody: Parameters.unholdRequest,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.endpoint, Parameters.callConnectionId],
   headerParameters: [Parameters.contentType, Parameters.accept],

--- a/sdk/communication/communication-call-automation/src/generated/src/operationsInterfaces/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/operationsInterfaces/callMedia.ts
@@ -24,6 +24,10 @@ import {
   CallMediaSendDtmfTonesResponse,
   UpdateTranscriptionRequest,
   CallMediaUpdateTranscriptionOptionalParams,
+  HoldRequest,
+  CallMediaHoldOptionalParams,
+  UnholdRequest,
+  CallMediaUnholdOptionalParams,
   StartHoldMusicRequest,
   CallMediaStartHoldMusicOptionalParams,
   StopHoldMusicRequest,
@@ -128,6 +132,28 @@ export interface CallMedia {
     callConnectionId: string,
     updateTranscriptionRequest: UpdateTranscriptionRequest,
     options?: CallMediaUpdateTranscriptionOptionalParams,
+  ): Promise<void>;
+  /**
+   * Hold participant from the call using identifier.
+   * @param callConnectionId The call connection id.
+   * @param holdRequest The participants to be hold from the call.
+   * @param options The options parameters.
+   */
+  hold(
+    callConnectionId: string,
+    holdRequest: HoldRequest,
+    options?: CallMediaHoldOptionalParams,
+  ): Promise<void>;
+  /**
+   * Unhold participants from the call using identifier.
+   * @param callConnectionId The call connection id.
+   * @param unholdRequest The participants to be hold from the call.
+   * @param options The options parameters.
+   */
+  unhold(
+    callConnectionId: string,
+    unholdRequest: UnholdRequest,
+    options?: CallMediaUnholdOptionalParams,
   ): Promise<void>;
   /**
    * Hold participant from the call using identifier.

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -35,6 +35,8 @@ import {
   RestTranscriptionStopped,
   RestTranscriptionUpdated,
   RestTranscriptionFailed,
+  RestCreateCallFailed,
+  RestAnswerFailed,
 } from "../generated/src/models";
 
 import { CallParticipant } from "./models";
@@ -69,7 +71,9 @@ export type CallAutomationEvent =
   | TranscriptionStarted
   | TranscriptionStopped
   | TranscriptionUpdated
-  | TranscriptionFailed;
+  | TranscriptionFailed
+  | CreateCallFailed
+  | AnswerFailed;
 
 export interface ResultInformation
   extends Omit<RestResultInformation, "code" | "subCode" | "message"> {
@@ -596,4 +600,38 @@ export interface TranscriptionFailed
   resultInformation?: RestResultInformation;
   /** kind of this event. */
   kind: "TranscriptionFailed";
+}
+
+export interface CreateCallFailed
+  extends Omit<
+    RestCreateCallFailed,
+    "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
+  > {
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** kind of this event. */
+  kind: "CreateCallFailed";
+}
+
+export interface AnswerFailed
+  extends Omit<
+    RestAnswerFailed,
+    "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
+  > {
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** kind of this event. */
+  kind: "AnswerFailed";
 }

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -13,7 +13,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: package-2023-10-03-preview
 require:
-  - https://github.com/Azure/azure-rest-api-specs/blob/384aedb56cfbadfa16ccb35737eab58dfeae81c5/specification/communication/data-plane/CallAutomation/readme.md
+  - https://github.com/Azure/azure-rest-api-specs/blob/77d25dd8426c4ba1619d15582a8c9d9b2f6890e8/specification/communication/data-plane/CallAutomation/readme.md
 package-version: 1.2.0-beta.1
 model-date-time-as-string: false
 optional-response-headers: true
@@ -155,4 +155,13 @@ directive:
   - rename-model:
       from: TranscriptionFailed
       to: RestTranscriptionFailed
+  - rename-model:
+      from: CreateCallFailed
+      to: RestCreateCallFailed
+  - rename-model:
+      from: AnswerFailed
+      to: RestAnswerFailed
+  - rename-model:
+      from: HoldFailed
+      to: RestHoldFailed
 ```

--- a/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callAutomationClient.spec.ts
@@ -302,7 +302,7 @@ describe("Call Automation Main Client Live Tests", function () {
       await receiverCallAutomationClient.rejectCall(incomingCallContext);
     }
 
-    const callDisconnectedEvent = await waitForEvent("CallDisconnected", callConnectionId, 8000);
-    assert.isDefined(callDisconnectedEvent);
+    const createCallFailedEvent = await waitForEvent("CreateCallFailed", callConnectionId, 8000);
+    assert.isDefined(createCallFailedEvent);
   }).timeout(60000);
 });

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -346,7 +346,6 @@ describe("CallMedia Unit Tests", async function () {
     assert.equal(data.targetParticipant.rawId, CALL_TARGET_ID);
     assert.equal(data.playSourceInfo.kind, "text");
     assert.equal(data.playSourceInfo.text.text, playSource.text);
-    assert.equal(data.loop, true);
     assert.equal(request.method, "POST");
   });
 


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Added the CreatCallFailed and AnswerFailed event.

This changed is tested against the Contoso app.



