### PR TITLE
Add the `span.status.message` from open telemetry if present

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -140,6 +140,14 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
     remoteDependencyData.type = DependencyTypes.InProc;
   }
 
+  if (span.status.message) {
+    // If the span status has a message, add it to the properties of the remoteDependencyData.
+    if(remoteDependencyData.properties === undefined) {
+      remoteDependencyData.properties = {};
+    }
+    remoteDependencyData.properties['message'] = span.status.message;
+  }
+
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
   const dbSystem = span.attributes[SemanticAttributes.DB_SYSTEM];
   const rpcSystem = span.attributes[SemanticAttributes.RPC_SYSTEM];
@@ -242,6 +250,15 @@ function createRequestData(span: ReadableSpan): RequestData {
   };
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
   const grpcStatusCode = span.attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE];
+
+  if (span.status.message) {
+    // If the span status has a message, add it to the properties of the requestData.
+    if(requestData.properties === undefined) {
+      requestData.properties = {};
+    }
+    requestData.properties['message'] = span.status.message;
+  }
+
   if (httpMethod) {
     requestData.url = getUrl(span.attributes);
     const httpStatusCode = span.attributes[SemanticAttributes.HTTP_STATUS_CODE];

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -139,7 +139,6 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
   if (span.kind === SpanKind.INTERNAL && span.parentSpanId) {
     remoteDependencyData.type = DependencyTypes.InProc;
   }
-
   if (span.status.message) {
     // If the span status has a message, add it to the properties of the remoteDependencyData.
     if(remoteDependencyData.properties === undefined) {
@@ -147,7 +146,6 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
     }
     remoteDependencyData.properties['span.status.message'] = span.status.message;
   }
-
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
   const dbSystem = span.attributes[SemanticAttributes.DB_SYSTEM];
   const rpcSystem = span.attributes[SemanticAttributes.RPC_SYSTEM];
@@ -250,7 +248,6 @@ function createRequestData(span: ReadableSpan): RequestData {
   };
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
   const grpcStatusCode = span.attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE];
-
   if (span.status.message) {
     // If the span status has a message, add it to the properties of the requestData.
     if(requestData.properties === undefined) {
@@ -258,7 +255,6 @@ function createRequestData(span: ReadableSpan): RequestData {
     }
     requestData.properties['span.status.message'] = span.status.message;
   }
-
   if (httpMethod) {
     requestData.url = getUrl(span.attributes);
     const httpStatusCode = span.attributes[SemanticAttributes.HTTP_STATUS_CODE];

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -145,7 +145,7 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
     if(remoteDependencyData.properties === undefined) {
       remoteDependencyData.properties = {};
     }
-    remoteDependencyData.properties['message'] = span.status.message;
+    remoteDependencyData.properties['span.status.message'] = span.status.message;
   }
 
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
@@ -256,7 +256,7 @@ function createRequestData(span: ReadableSpan): RequestData {
     if(requestData.properties === undefined) {
       requestData.properties = {};
     }
-    requestData.properties['message'] = span.status.message;
+    requestData.properties['span.status.message'] = span.status.message;
   }
 
   if (httpMethod) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -141,10 +141,10 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
   }
   if (span.status.message) {
     // If the span status has a message, add it to the properties of the remoteDependencyData.
-    if(remoteDependencyData.properties === undefined) {
+    if (remoteDependencyData.properties === undefined) {
       remoteDependencyData.properties = {};
     }
-    remoteDependencyData.properties['span.status.message'] = span.status.message;
+    remoteDependencyData.properties["span.status.message"] = span.status.message;
   }
   const httpMethod = span.attributes[SemanticAttributes.HTTP_METHOD];
   const dbSystem = span.attributes[SemanticAttributes.DB_SYSTEM];
@@ -250,10 +250,10 @@ function createRequestData(span: ReadableSpan): RequestData {
   const grpcStatusCode = span.attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE];
   if (span.status.message) {
     // If the span status has a message, add it to the properties of the requestData.
-    if(requestData.properties === undefined) {
+    if (requestData.properties === undefined) {
       requestData.properties = {};
     }
-    requestData.properties['span.status.message'] = span.status.message;
+    requestData.properties["span.status.message"] = span.status.message;
   }
   if (httpMethod) {
     requestData.url = getUrl(span.attributes);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.test.ts
@@ -307,6 +307,7 @@ describe("spanUtils.ts", () => {
         });
         span.setStatus({
           code: SpanStatusCode.OK,
+          message: "SERVER_SPAN",
         });
         span.end();
         const expectedTime = hrTimeToDate(span.startTime);
@@ -322,7 +323,9 @@ describe("spanUtils.ts", () => {
           name: `parent span`,
           version: 2,
           source: undefined,
-          properties: {}, // Should not add sampleRate
+          properties: {
+            "span.status.message": "SERVER_SPAN",
+          }, // Should not add sampleRate
           measurements: {},
         };
 
@@ -403,6 +406,7 @@ describe("spanUtils.ts", () => {
         });
         span.setStatus({
           code: SpanStatusCode.OK,
+          message: "CLIENT_SPAN",
         });
         span.end();
         const expectedTags: Tags = {
@@ -411,6 +415,7 @@ describe("spanUtils.ts", () => {
         };
         const expectedProperties = {
           "extra.attribute": "foo",
+          "span.status.message": "CLIENT_SPAN",
         };
 
         const expectedBaseData: Partial<RemoteDependencyData> = {
@@ -458,6 +463,7 @@ describe("spanUtils.ts", () => {
         });
         span.setStatus({
           code: SpanStatusCode.OK,
+          message: "SERVER_SPAN",
         });
         span.end();
         const expectedTags: Tags = {};
@@ -467,6 +473,7 @@ describe("spanUtils.ts", () => {
         const expectedProperties = {
           "extra.attribute": "foo",
           "_MS.links": JSON.stringify([{ operation_Id: "traceid", id: "spanId" }]),
+          "span.status.message": "SERVER_SPAN",
         };
 
         const expectedBaseData: Partial<RequestData> = {


### PR DESCRIPTION
The current azure sdk open telemetry monitor exporter doesn't ever read the `span.status.message` to pass through to application insights. It only checks the [`span.status.code`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts#L130C1-L130C57)


### Packages impacted by this PR
[`@azure/monitor-opentelemetry-exporter`](https://www.npmjs.com/package/@azure/monitor-opentelemetry-exporter)

### Issues associated with this PR

#28869

### Describe the problem that is addressed by this PR

Currently, when calling setting the status of a `span` the `message` of the span doesn't get exported to application insights.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Just updated a few of the existing test cases to add a message to the status provided.

### Provide a list of related PRs _(if any)_

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
