### PR TITLE
[identity] ClientSecretCredential, ClientCertificateCredential, ClientAssertionCredetial use MSALClient

### DIFF
--- a/sdk/identity/identity/src/credentials/clientAssertionCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientAssertionCredential.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
 
 import { ClientAssertionCredentialOptions } from "./clientAssertionCredentialOptions";
-import { MsalClientAssertion } from "../msal/nodeFlows/msalClientAssertion";
-import { MsalFlow } from "../msal/flows";
 import { credentialLogger } from "../util/logging";
 import { tracingClient } from "../util/tracing";
 
@@ -19,10 +18,10 @@ const logger = credentialLogger("ClientAssertionCredential");
  * Authenticates a service principal with a JWT assertion.
  */
 export class ClientAssertionCredential implements TokenCredential {
-  private msalFlow: MsalFlow;
+  private msalClient: MsalClient;
   private tenantId: string;
   private additionallyAllowedTenantIds: string[];
-  private clientId: string;
+  private getAssertion: () => Promise<string>;
   private options: ClientAssertionCredentialOptions;
 
   /**
@@ -50,15 +49,13 @@ export class ClientAssertionCredential implements TokenCredential {
     this.additionallyAllowedTenantIds = resolveAdditionallyAllowedTenantIds(
       options?.additionallyAllowedTenants,
     );
-    this.clientId = clientId;
+
     this.options = options;
-    this.msalFlow = new MsalClientAssertion({
+    this.getAssertion = getAssertion;
+    this.msalClient = createMsalClient(clientId, tenantId, {
       ...options,
       logger,
-      clientId: this.clientId,
-      tenantId: this.tenantId,
       tokenCredentialOptions: this.options,
-      getAssertion,
     });
   }
 
@@ -82,8 +79,9 @@ export class ClientAssertionCredential implements TokenCredential {
           logger,
         );
 
+        const clientAssertion = await this.getAssertion();
         const arrayScopes = Array.isArray(scopes) ? scopes : [scopes];
-        return this.msalFlow.getToken(arrayScopes, newOptions);
+        return this.msalClient.getTokenByClientAssertion(arrayScopes, clientAssertion, newOptions);
       },
     );
   }

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
 
 import { ClientSecretCredentialOptions } from "./clientSecretCredentialOptions";
-import { MsalClientSecret } from "../msal/nodeFlows/msalClientSecret";
-import { MsalFlow } from "../msal/flows";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";
@@ -27,7 +26,8 @@ const logger = credentialLogger("ClientSecretCredential");
 export class ClientSecretCredential implements TokenCredential {
   private tenantId: string;
   private additionallyAllowedTenantIds: string[];
-  private msalFlow: MsalFlow;
+  private msalClient: MsalClient;
+  private clientSecret: string;
 
   /**
    * Creates an instance of the ClientSecretCredential with the details
@@ -51,17 +51,15 @@ export class ClientSecretCredential implements TokenCredential {
       );
     }
 
+    this.clientSecret = clientSecret;
     this.tenantId = tenantId;
     this.additionallyAllowedTenantIds = resolveAdditionallyAllowedTenantIds(
       options?.additionallyAllowedTenants,
     );
 
-    this.msalFlow = new MsalClientSecret({
+    this.msalClient = createMsalClient(clientId, tenantId, {
       ...options,
       logger,
-      clientId,
-      tenantId,
-      clientSecret,
       tokenCredentialOptions: options,
     });
   }
@@ -87,7 +85,7 @@ export class ClientSecretCredential implements TokenCredential {
         );
 
         const arrayScopes = ensureScopes(scopes);
-        return this.msalFlow.getToken(arrayScopes, newOptions);
+        return this.msalClient.getTokenByClientSecret(arrayScopes, this.clientSecret, newOptions);
       },
     );
   }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -341,7 +341,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     certificate: CertificateParts,
     options: GetTokenOptions = {},
   ): Promise<AccessToken> {
-    msalLogger.getToken.info(`Attempting to acquire token using client assertion`);
+    msalLogger.getToken.info(`Attempting to acquire token using client certificate`);
 
     state.msalConfig.auth.clientCertificate = certificate;
 

--- a/sdk/identity/identity/src/msal/types.ts
+++ b/sdk/identity/identity/src/msal/types.ts
@@ -73,3 +73,23 @@ export interface AuthenticationRecord {
    */
   username: string;
 }
+
+/**
+ * Represents a parsed certificate
+ * @internal
+ */
+export interface CertificateParts {
+  /**
+   * Hex encoded X.509 SHA-1 thumbprint of the certificate.
+   */
+  thumbprint: string;
+
+  /**
+   * The PEM encoded private key.
+   */
+  privateKey: string;
+  /**
+   * x5c header.
+   */
+  x5c?: string;
+}

--- a/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
@@ -10,7 +10,6 @@ import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup
 import { ClientAssertionCredential } from "../../../src";
 import { ConfidentialClientApplication } from "@azure/msal-node";
 import { Context } from "mocha";
-import { MsalNode } from "../../../src/msal/nodeFlows/msalNodeCommon";
 import Sinon from "sinon";
 import { assert } from "chai";
 import { createJWTTokenFromCertificate } from "../../public/node/utils/utils";
@@ -18,14 +17,12 @@ import { env } from "@azure-tools/test-recorder";
 
 describe("ClientAssertionCredential (internal)", function () {
   let cleanup: MsalTestCleanup;
-  let getTokenSilentSpy: Sinon.SinonSpy;
   let doGetTokenSpy: Sinon.SinonSpy;
 
   beforeEach(async function (this: Context) {
     const setup = await msalNodeTestSetup(this.currentTest);
     cleanup = setup.cleanup;
 
-    getTokenSilentSpy = setup.sandbox.spy(MsalNode.prototype, "getTokenSilent");
     doGetTokenSpy = Sinon.spy(
       ConfidentialClientApplication.prototype,
       "acquireTokenByClientCredential",
@@ -97,7 +94,6 @@ describe("ClientAssertionCredential (internal)", function () {
       // We're ignoring errors since our main goal here is to ensure that we send the correct parameters to MSAL.
     }
 
-    assert.equal(getTokenSilentSpy.callCount, 1);
     assert.equal(doGetTokenSpy.callCount, 1);
 
     // TODO: you can test if this matches

--- a/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
@@ -6,18 +6,17 @@
 import { AzureLogger, setLogLevel } from "@azure/logger";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
 import { Recorder, delay, env, isLiveMode, isPlaybackMode } from "@azure-tools/test-recorder";
+
 import { AbortController } from "@azure/abort-controller";
 import { ClientSecretCredential } from "../../../src";
 import { ConfidentialClientApplication } from "@azure/msal-node";
 import { Context } from "mocha";
 import { GetTokenOptions } from "@azure/core-auth";
-import { MsalNode } from "../../../src/msal/nodeFlows/msalNodeCommon";
 import Sinon from "sinon";
 import { assert } from "chai";
 
 describe("ClientSecretCredential (internal)", function () {
   let cleanup: MsalTestCleanup;
-  let getTokenSilentSpy: Sinon.SinonSpy;
   let doGetTokenSpy: Sinon.SinonSpy;
   let recorder: Recorder;
 
@@ -25,8 +24,6 @@ describe("ClientSecretCredential (internal)", function () {
     const setup = await msalNodeTestSetup(this.currentTest);
     cleanup = setup.cleanup;
     recorder = setup.recorder;
-
-    getTokenSilentSpy = setup.sandbox.spy(MsalNode.prototype, "getTokenSilent");
 
     // MsalClientSecret calls to this method underneath.
     doGetTokenSpy = setup.sandbox.spy(
@@ -71,27 +68,6 @@ describe("ClientSecretCredential (internal)", function () {
     });
   });
 
-  // This is not the way to test persistence with acquireTokenByClientCredential,
-  // since acquireTokenByClientCredential caches at the method level, and not with the same cache used for acquireTokenSilent.
-  // I'm leaving this here so I can remember about this in the future.
-  it.skip("Authenticates silently after the initial request", async function () {
-    const credential = new ClientSecretCredential(
-      env.AZURE_TENANT_ID!,
-      env.AZURE_CLIENT_ID!,
-      env.AZURE_CLIENT_SECRET!,
-    );
-
-    const { token: firstToken } = await credential.getToken(scope);
-    assert.equal(getTokenSilentSpy.callCount, 1);
-    assert.equal(doGetTokenSpy.callCount, 1);
-
-    const { token: secondToken } = await credential.getToken(scope);
-    assert.strictEqual(firstToken, secondToken);
-    assert.equal(getTokenSilentSpy.callCount, 2);
-
-    assert.equal(doGetTokenSpy.callCount, 1);
-  });
-
   it("Authenticates with tenantId on getToken", async function (this: Context) {
     // The live environment isn't ready for this test
     if (isLiveMode()) {
@@ -105,7 +81,6 @@ describe("ClientSecretCredential (internal)", function () {
     );
 
     await credential.getToken(scope, { tenantId: env.AZURE_TENANT_ID } as GetTokenOptions);
-    assert.equal(getTokenSilentSpy.callCount, 1);
     assert.equal(doGetTokenSpy.callCount, 1);
   });
 

--- a/sdk/identity/identity/test/internal/node/workloadIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/workloadIdentityCredential.spec.ts
@@ -3,11 +3,6 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
-import path from "path";
-import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { env } from "@azure-tools/test-recorder";
-import { Context } from "mocha";
-import { assert } from "@azure/test-utils";
 import {
   AccessToken,
   DefaultAzureCredential,
@@ -15,7 +10,13 @@ import {
   WorkloadIdentityCredential,
   WorkloadIdentityCredentialOptions,
 } from "../../../src";
+import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
+
 import { AuthenticationResult } from "@azure/msal-node";
+import { Context } from "mocha";
+import { assert } from "@azure/test-utils";
+import { env } from "@azure-tools/test-recorder";
+import path from "path";
 import sinon from "sinon";
 
 describe("WorkloadIdentityCredential", function () {
@@ -125,26 +126,18 @@ describe("WorkloadIdentityCredential", function () {
   });
 });
 
-async function validateWorkloadIdentityCredential(
+function validateWorkloadIdentityCredential(
   credential: WorkloadIdentityCredential,
   token: AccessToken,
   options: { clientId: string; tenantId: string; tokenFilePath: string },
-) {
-  const {
-    clientId: expectedClientId,
-    tenantId: expectedTenantId,
-    tokenFilePath: expectedFederatedTokenFilePath,
-  } = options;
+): void {
+  const { tenantId: expectedTenantId, tokenFilePath: expectedFederatedTokenFilePath } = options;
   const actualFederatedTokenFilePath = credential["federatedTokenFilePath"];
   const clientAssertionCredential = credential["client"];
-  const actualClientId = clientAssertionCredential
-    ? clientAssertionCredential["clientId"]
-    : undefined;
   const actualTenantId = clientAssertionCredential
     ? clientAssertionCredential["tenantId"]
     : undefined;
   assert.equal(actualFederatedTokenFilePath, expectedFederatedTokenFilePath);
-  assert.equal(actualClientId, expectedClientId);
   assert.equal(actualTenantId, expectedTenantId);
   assert.ok(token?.token);
   assert.ok(token?.expiresOnTimestamp! > Date.now());


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28875 

### Describe the problem that is addressed by this PR

Now that 4.1.0 is shipped we can merge this change which begins migrating credentials to the MSALClient pattern
and away from the MsalNodeCommon base class.


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
