### PR TITLE
[EngSys] Use tsx for min/max testing

### DIFF
--- a/eng/tools/dependency-testing/templates/package.json
+++ b/eng/tools/dependency-testing/templates/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc -p .",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "mocha -r esm-workaround.js -r esm --require source-map-support/register --reporter mocha-multi-reporter.js  --reporter-option output=test-results.xml --timeout 350000 --full-trace \"dist-esm/**/{,!(browser)/**/}*.spec.js\" --exit",
+    "integration-test:node": "mocha --require tsx --require source-map-support/register --reporter mocha-multi-reporter.js  --reporter-option output=test-results.xml --timeout 350000 --full-trace \"dist-esm/**/{,!(browser)/**/}*.spec.js\" --exit",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser"
   },
   "repository": {


### PR DESCRIPTION
### Packages impacted by this PR

N/A

### Issues associated with this PR

Build failures

### Describe the problem that is addressed by this PR

`esm` is slowly becoming a larger problem for us and we've been on a mission to
remove it. min/max tests fail because esm is unable to handle safe-navigation
operators (?.) 

While a separate PR switches tests to use tsx, this PR focuses on min/max tests
and can be merged separately.

### Provide a list of related PRs _(if any)_

#28826
