### PR TITLE
[monitor] Fix pipeline issue from missing dependency

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10451,7 +10451,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-6KmwcmAc6Zw8aAD3MJMfxMFu/eU1by4j5WCbNbMnTh+SAEBmhRppxYLE57CHk/4zJEAr+ssjbLGmiSDO9XWAqg==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-iNr+bUFLjcImxSkKGfTvrMXdvN+Xr2uo0pe1VAQ5yxDLRwekMIoD0LJTgxqbMH9X+0ZTQdvANRTXKGf0Vg5gMQ==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -10484,7 +10484,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-1gJtIqsdb3A7n3iKVYX+cO9GlxwAx98jKfiFw+9rOmBZzyH3+AVNwCR5y/qego33s7BOEtVBYTBfE+RE2g+u7A==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-wAQvtrrdmX+2Bva2/aeO1N4UYS/nOcPQrPdBDFE6ZWAOzeOF7/EozfYF/754AYKYjmWhJ1eVKk6fwkDsPZvqEQ==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -10528,7 +10528,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-4RFMxeQv1SvqJCIIXuHWetqcaZypgMXBD4y5KRpyYJTn5IqgypkpxQDlU5Fzau51QjuGovlngIFGYhUK6ChHZw==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-1D5XNSIsMuHod/Ga1MvLOMSZ7SnsmJ1C1QQps7z/Lu3Bn2HeE/PaprRY6oLdG0lpFv2QImE5IXWffLrL6VG08g==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -10572,7 +10572,7 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-6lwZLHLgH7pSNwF2YBkR18lySMvokaRLXby1EOj1ARxHwO1txv3VJzB4MkbITljyQAwwf0LBy7FZWGq++7wHKQ==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-pKa4o99jHH5JO9Y0rzBJC9xekW78nEjxZ549EGZAum2Ro6+cUR3x3l/EGL5Re5dHyhfljfxpX2MYvNFIBAMvkw==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
@@ -10615,7 +10615,7 @@ packages:
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-BzeiADIeoIIlJ8LRyX4rq6JouqAj7vz9S+/YE9KQXRP9URaP0ke8pY0Wzi4mOEW7dIrecN0ePd0TJqxrImmrdQ==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-K1pn4bMflvrhHSOp2OIfBXRZaHGszteFE7TxUJQW1yv6OsRM02nnclIcKavqg9fboSWrDg5cWjyPBgzC2hKrvA==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
@@ -10659,7 +10659,7 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-nJmJTeS99cjSGz7F593eBVWe9e8z5MlBcL/RPYc1X7GqLarVvQDy8CRvNotVwlKqZXIDFU5SZQfm79ariToNEA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-dWR4dFSVukPRd0wgny/m2a0LUBL1vlLQHpVTzjunyoM71gap1ZUGhPiSZ+6HVEu9KgEEp65QtUYp4Oic2fsXdA==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
@@ -10702,7 +10702,7 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-diW8HFTJtQYPHtBCCTcY5ijE8lH5+MrWF36K19IFl6McafkYs8mh5/oXLXV/PBTnXtUk00gDT58b2X6iC4mrXA==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-obvG9Pyeh3oCfjyjfZIdiWnUUh3QHYdQ+oWUO9bE4ZT+Nqa3Ix7v4UJnm70eedgqTtK1/QNQDQXTqc2ANnXUJg==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -10749,7 +10749,7 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-zgE5BUWLB90nEH+Nd+UHPHz7t08SHyUzrjQ/EgBiUuoHTBkP2q7cHziIl7AlO9LjBIU1zMe+zQyYPihhvP0SNw==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-SmlaqC8pKs7sb67AsLVRmaIn0+f3npLN63yN7BHhFdpf+Rth+DLDhZ1dzhLjqXUZQdPkFqriSrWJkV0ROs5iMQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -10797,7 +10797,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-qnXx4I2V8KgR+lYOuTi6Ku4zWlgMz8WmYssVtNG3LDQtrcDmi8eqHQhCYuz51S2LebSDT0e4HOX0QVsNibqHEw==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-Xxb9oGASDhz+Qjv4Lmb1oyjsToKVg0s+vXlaizxhh/t6q1lZaADyNAa/vOdKz8ycOcGbuBNY4mE1G4nudGrLQg==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -10844,7 +10844,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-L55Jdp4pix57yOZRUz3E61njkW4SsdSaxP7pTkl37rWvz0uWdz7hngTuxyiVNkq0ILjlMsI9nEdce5cZOkl64Q==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-+t8Q7pUW63hRFCgAA14Kg2ypyBKvBH9fI/Zta/k1fegdI78goRNjsExAMBGrk/fV18C6qHIzON8C6GGhJTjPfA==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -10869,7 +10869,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-ywS2xkL3j+OT/TGdNqEnlS3sn6dCjDmjdc7Tq0S6WG5UWtP7jJxV+xViqzVI/ND4MB7YpZDSdaw4J49XttTxDA==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-LHiJRXI1Y8vFpannHomfmMKM10Amp/vSzyZoIF+NwHc2ZJdsmsqWdctyXNmOYTFVNIogKt0CryjLZpiGp534YQ==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -10912,7 +10912,7 @@ packages:
     dev: false
 
   file:projects/ai-personalizer.tgz:
-    resolution: {integrity: sha512-1YSdKuRqIO9U6bdAngcYXnJAqg1sFvk+fNl0D/2cOL56RV0lNrbTaxnJEo4yvM7/aQ4/JojgOP4i48BnP1fQWg==, tarball: file:projects/ai-personalizer.tgz}
+    resolution: {integrity: sha512-8pWBjymcvSVHxWk4tougH/CzuZYnHVWNeFDGkMpMX3u34GMs4EqoTCTZZxz8cGt66RmJND3A08pOmtVwkaK+yA==, tarball: file:projects/ai-personalizer.tgz}
     name: '@rush-temp/ai-personalizer'
     version: 0.0.0
     dependencies:
@@ -10955,7 +10955,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-xIVLnFsYlJw7fjbKeTAjnneKWoeSgvcEK7QPZG6LLZfQpoErjPDJh/1VinYhM+kfuuDFkddCtZ9IGK2uZ1o9Dw==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-z21IyncrTycb7fJSyH486fdoc3bfSICN5efEkp+/N1Ed26rKd2HSw9HUgEbqJXUyMAkFlD+XzbhIc2LGs/a6rw==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -11001,7 +11001,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-ETbxAv2PSXMdT9s2t6fy84Th7wl4mon7K0lOInT5nWAMd9MeqdjPxQ1ivqW9jDA1vovsKQ8qUaPIuBYn5QrnhQ==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-PwMYx4S6HQOcwVprsWOXUQcIy13EeJm7xcDNfd4VShU6STuGTgNdf0F5+pp24+LLfZ5fcOWxfqOxfGemcwettw==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
@@ -11044,7 +11044,7 @@ packages:
     dev: false
 
   file:projects/ai-vision-image-analysis.tgz:
-    resolution: {integrity: sha512-tKgHLBvnEh7Q9FyyOC6WnpAFb4NJxOK2LFfaAWiZSEVwi1vlfkdAckelu0lPxqSiY7rwllrC8VsBGAWcQ415/Q==, tarball: file:projects/ai-vision-image-analysis.tgz}
+    resolution: {integrity: sha512-BTGRoZOmU+cmrNgx8b5wgrZ3PqbiO0rSQ+8jGNwVZP6TUcBN1Ne9nYHnIQxZCaGB2vf+4uKJ6NCMCw2TkLsu0Q==, tarball: file:projects/ai-vision-image-analysis.tgz}
     name: '@rush-temp/ai-vision-image-analysis'
     version: 0.0.0
     dependencies:
@@ -11087,7 +11087,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-4Rktgk3WHldMSBL7EMvssgkC2lds/H6eF789SNkPmwvTv8lrk/BQhpO3gkltFpJ4MNolcsuLVfs47kgqFndM3g==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-ILWxIgL8Fu+WN9uD8SqwoDsJGBAKDKlgXHhB0ggTzXayZ/890ADv+LJxN65P+TvxfAlzsE9NMg/JrtsU2DCvsg==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -11129,7 +11129,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-Wyj3HbKSuoSY7eNvMUldvhnMqi5kKO8QXcP5Kab2D+RI76V1TYiDNB/1ffC+jN96ZsLOvaOH1xpFeGIcRfnjgw==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-ryd7sqfaOWJhxOOsThaBeSvhi2vuX6n4budqkOZyjeTNTYHhvme7eK+BZYSuB8EPjTr27FcsT3QkB5oSadhnIg==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -11180,7 +11180,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-yZ5eoxFyedjpLHPzgkwFAv2HhPvIWNHm1yn/sa8fqSp+SLfb/D2gOciNlANeEiiUgy9xldH4WXfTONmn+Wsf4w==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-hdktXjbcBGvA0FHTn22UDjSVXhFlQU56GwYbHaqj+rphRrYSM4gply8nms7Ob6wguO7YPdwkFlkXIFcVmX/AtQ==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -11219,7 +11219,7 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-ROD8jk3cSov/vE48keG4Nu0rftlbMlbMwQbuL8cw564ZjyxcYvmKwW/mj+dyWtjYbuCj27/MTG11+baciBUgEw==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-OTfKEJPA4yb4uvJh4k/vEuleTC8VFATTm6fufuGRo/tfZzh1sl4h7YXjBvr4UbSUOeNxHEwV/xsVJHGh1jvXbA==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -11245,7 +11245,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-Eq8GFhNd/oJociPIg1rktInQeN9SNAGJzOhamq2MgkU56XwmS6wcBn1JOti8JJeKaE/QXO3yKpewSyct3g+Qjg==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-KHlACz3MiXabvxhbQZNVZ76eLFAPV8hlyR9XYb3vpYJ0rC8o+oFVimtXtjIvS/5t77FUwscIeIq6VmHDRKlGxQ==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -11271,7 +11271,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-K60F16ABp0NPA67efoMfwVPIevG22mZLc9IDlRWUsF1sEI+r0j87PM1XpcvxyPaBwdj/m9hJlA1YncxM7iNxJg==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-gKdDM68eaEu4Lxc2m/MZBfsrYuve36VXh36B8GkQhr2Fy74fkB0hxVIaybXwRkBQe+NFheOV2nR2eWjU8VkCOQ==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -11297,7 +11297,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-+pRFPielS0gDX8JVCaOPr0hufVi5RDa6CVbp3lRglARFGjy3zK2Cf6/QJUZXmoxEdYTFqKjwgIcJdkCJk+bwFQ==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-I7XVaUB5zLRaozqNoPd0XDmfpMBMbEicQxn8lFbAe5pm1C9l3C07LLk6jU6UkwO7XMZ6KHmtvvGmsdP/83W4IQ==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -11325,7 +11325,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-JzZWr0hc/ZNg1TekAQAKyht82tdhGnk+NZG0fJ36AqsfwWP3xm9la0zFq2S6OdhG/pEzmFW32Gt/ewJ2No6zWg==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-ju2yrtwuRTesvgr/BfJcgDWjH4/TgLJsKospTQ64cZEpJgkiVjKf96UNryaVel4MxuxM85NKYxarul71R6mN2Q==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -11352,7 +11352,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-maN4MPboagaxwfe8eh2nHyfAicYFfJGj3qAcGGKNEQ86MCXL6cC00xIdUT08QO5Mu2AF/u17gCs6znuDHwKDvw==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-NtiILsjaOd0fwgZhEL7+SaP2a02m4zETgRa8/34N9PNcn8MN/tZFmvmDh6ZjROqIg1X/GIxyKIpwnQSfhE/+/w==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -11378,7 +11378,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-gtrl3Hqq0gmpifajc4RgLdCXIH7sT72oPGIklzYW37Y4fssGQNeoWMXwvP5d4vLG/Apz3WXyPyxs4rcPCNQwBA==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-4v96saBHfbHekdsUuRpNLycDOlo+7v5dYJCPOaomud0XrAdl5c2hbpPNag7Mu5FxywXPMyc3NiCdi5etZY8WAQ==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -11405,7 +11405,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-7WPgejLGKgOh2vPVgdi0dMKg+iBkbUeoopTskBmNemYPZv/IbY2L07kru2erL0s11m3teLBDro/ssrPrqDboCA==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-IvoH/GAa4+uOxQ54m9x2GHYy/18gIvzXH6tZmbH4IHkMn9BiBIDq3Z0Bg0RoQ3fnf79sRjhN4TpNq9jW1rD0EQ==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -11432,7 +11432,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-I34zQkAWNFmMo89ZFt2EM4nUwIymNs3zAmF640abJkJh/L+GNu2fMfy2dI5IrOhj/f1+KTrpGRpDPTz/IrnnDQ==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-WveWOZAHZWF58vZvK3pdvIx84fyR4VWrcCydr3F/UStxrXcgPVpW5qZYEucy6sdsql1keOff0i5QEpvySgvT9A==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -11457,7 +11457,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-+qvA56xDmFhYVyBkJSMPw5rssZ7dcUPhEsdUoENLA6hLLgauw7hoyagObPLVJrEGXNCgkABSR5V8+bTf3uWtQQ==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-kWl3JeqgYBz4K19XI76Pq2kdLSwC8yG+PtqruJng/HadLD47zI49erNs4te6JNytsobVRzc9GLcXwL7G1xSdPQ==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -11485,7 +11485,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-n9SiDwWNM6NvRyxLXP85XacmYutdry1HFVz14/Ku6TF6yvZ5/VLx9unSPUKd1kKaG/GiwcrXn4v/xlKfAqi+Wg==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-oCf1w1dQgRqUaU8CuQI+35t3/VOmv9NqUnRe4kKetJWZNDj2BsOeqOnLLewVUsYYwSCowOeX3L+zOiyxQvbpqw==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -11513,7 +11513,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-mkO1V5mAXU3DXRK51F/22W8UVpQtDdbq8T7Eqa0yOdByJjdBLB4FBnqwJmcYKTIdyUT7vmS3FqT6kQuOOzEPcg==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-TwZgQgk0vsQbAgaGZjjA9QH+89/zcVRTkZqB/8BMnYP4CyjGWj46pRc92Aj9ef03vC5/I6sxyZUhfZZtZ0mZfw==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11540,7 +11540,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-njmusO6mmbSKbVWfPaO5s8ZxhbVPJdCUBSqrB32Zz1XGljPg1TyEwNoYxVEaN12vcwvSmcwQBqnhx/2/9D2/hQ==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-/QFWX/YoXfT4/nIu3WtRXEWrCHYS4rIyFHhm76cNjBIBWjONfbQQZt+jKkrmd7dlUik5t3CUF632KC9zn8vcAA==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -11583,7 +11583,7 @@ packages:
     dev: false
 
   file:projects/arm-astro.tgz:
-    resolution: {integrity: sha512-pfLYFPuJdkULAxrnj9El8VyRO+vaLNJgInb0OAgAWYtrvXpn5IUO2uSSrnAFHcQbi405BS+X6gCMQDZhmPC+DA==, tarball: file:projects/arm-astro.tgz}
+    resolution: {integrity: sha512-9WhXfWQ2IRgbLqxa1ZPCCpAHEIgBGTbEGhQDzaF6tiaOb8iBnU4o2Tjk2WhoN7opuV+opjcsYQOmMfOGsH0iFg==, tarball: file:projects/arm-astro.tgz}
     name: '@rush-temp/arm-astro'
     version: 0.0.0
     dependencies:
@@ -11611,7 +11611,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-W9YXfJPtPSHsFheKhG9b0Z6mwPLgf0W//VXP/Y6WmgUwddcKGxG4ltBYSvVGIsweYmCgblAAQ2QeLb9rbR4JmA==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-CC5FeafaJaQQUVap3hU16FnRfk/dH+MQstKPMluYUN3yOSwoSnzOYpUhE2A8A/X3ntd5ZayS3eCQ8KQoDttPqQ==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -11636,7 +11636,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-4YEuNADyUOVmwESJbnO5v1amsCokgIjVBv1+7JDeFyeVOHwYIsI5CBWBccu40Y5lXa+OuuinEf6SyRF8+hFq6Q==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-SE+y4mqIuScTDDH6hBlhT41I+8QTNBR9wA9540ymYjYAlchKpYGojSrxiTZnxKGnQ9ioWaikEWPkoKY9eALJdA==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11662,7 +11662,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-UAaYVqdL+QU7UGdM4HnWbie2G6uofI3o9ATwno6B8gPQoWXO6u77l7yXPVX79p84dqt9HnJxMFwwjQXfm6wkVw==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-y3ID88BoTobWQ90d8h8i21UIMdjhhjnCfkIaHG4XYDzucNddjyvRl1LYHCRIheUBgbp6sKuUsIUymAmOh8870w==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -11689,7 +11689,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-WZJfe67gslSRoYPk6z6Qfoi1fwxp2GEwDB8elkicB5wKc7o10NsgpKrPHJr180zGEaqgP5AVjDXU4i9qDMox4g==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-TrPitisx+wX1fn+WDN5+Imn4wpDYRRki5hMTk2AxNwAVSTekGwdrgahKvchCEybBAw+Ow6UVvpBnxtCddFQ6bw==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -11715,7 +11715,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-fU4K8Q56JPN5PdbmdhCozG+AxiyjQnD2yV3AQC4UmhSYtQqnf5iw+98MMNS2Rv3fybvvFJ6gBKF/O0am/EhX4A==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-ZYcv8NIFOEDa/+Hr6hyv6D411e5d6jgSvcDP3R4o+XPXVYeBgHnfJuFkHiawfZ9lsfupgr4jZvXodhkB+MCe1Q==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -11742,7 +11742,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-vvOMpwBsj6dUZhJa2p8KBuZ76OXRloJt9IzrwLN3OduAcirG/1kXWajm7ttOKv7kbgdkgYosdoVW/y5K3+ZdUg==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-LK0uvecM2hEjGv0O4sWN3GU2z/Aq5IuFulZuA4/GBWMeKaLG26v15677xEJ9aTVSOHttQG5A7VubPKPy2hhnjg==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -11769,7 +11769,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-rjtKIBKvq6ND8N2gDtElANgFd5mLw7fQFEA8cC+7OomaKl5R5QvAjeeLv6fAKgMZK5qpFIGFVzb3yhBrduc34g==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-D2DwhGegbgi6zoaZVoPaiWck6nevz5Nr5XjYDXCEneOhKC5yXdC4d+tJ2RVGHO7lXqmQD0CXbpnm+VZoHHxKaA==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -11795,7 +11795,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-wrt99LenEOf4kvtZZgZ0KjUceMo53uXxApffabcRTHH+Ld/YJuj+Mc3O7n8VE4nrQm7XkBrNotHyZ5o0WBBqKQ==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-hK5vGbD/wzs92bRHzjfoiMgmtULUmvBX/Dy4glEGxjdB2nVJj2YJQnHrEJEGqXsxsrAKCi4HLkPN7JOgzS+uIQ==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -11820,7 +11820,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-GsBAUCcQuPH/hPNL/XTrlL2Z9og7Em4vq/WV2UL54qxKYd9CPCyHr8hm30qhvLDVoe9OB6Nf5emR0FEbdpzm3A==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-wnd5b+JTHJgKEzDePeSWPoY+ff9OT9kOF8KTRhjLNDQzuXvkt6fBpQujQ2DxsPazK2eT0jC6WFff4Bn5qd67Og==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -11847,7 +11847,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-KurIkPZ2lUf3lMlZ4lNcbkzxlmTtzgoENoiODXck+4dtqb1FvRFugG35AOdhIH9F+gblOhQV6faOpVq/N00bDw==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-kFoYePU/3fnaxe08ofujx8mhP9UXbkLl78TUGykAWG68KD66Q5lMFfhKxbu3tL34Q/h13YSKCqETwwHk4Yq1Kw==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -11875,7 +11875,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-fdcZKOWwbBbDHqIbe0j8phG0vzRbjF1ZqKG1d/9FafYnu5l3QtPaCboBY/RYlw+CRarYp9yxdFrEnM8IcrJRSQ==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-pWMLj2SwHE9cooxAADD0taGAJlO+ZNiwbqFHUrgUHzmEAg/MRGrjZrq5wnhLTaR7XBWXue7nfwdd8sN9yCV94w==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -11903,7 +11903,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-GEUeAL6i+mZgPNLvk9zwai9NrPtFdscZzU1L/CeLqcKntRJQeYYZWU31LlbwaLQsoiwJm1u2Z4ESqXswcHqsQg==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-8Ar2AtBLcmHBiIqIcd0WaKxupb6+mw5/2dV01aDSOELTcJiUesXoPCWHXBeNlOCsp0ozacWvBcs7my/kOCt/2Q==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -11929,7 +11929,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-A65JYJp+n/aj/DdNeMs3KEE1iPkRUbVk4L2dCidglVInOSYGdvCv8tAyBxEbJo82KcN4lpRUlXl/T95na3nNDw==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-mnDKuxl54/MRRwmaR2neH1bb23gs8aMaZOwCPOIsALGwGAvoGyWJFH5TbSMo+eVhkfMSlvgVSB7pxpwFWV2PTw==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -11955,7 +11955,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-0J61YSYrnqNHnwt+3iVjsB7P8iw6OfCyp+jAKIAE6QMciS0iVzTAXepo6yQdTTgPUOhKyD5a9nZnBVRfStofAg==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-TEuEGBl+SWiYAmnrlhJbDiF0cYhEjQ700OYM/bk5Ol0Wepc0hEF7vGqDthzObsjy6MSvNhbKzQEWWEieliC5Sg==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -11982,7 +11982,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-G2My3ELDLnMAu1hU1+U8cWflO3o4jnvXZoRl5tc7kbzjKk2/olbkV79sTEHsFWDzn6B6OWtXCE422YKUD89Vrw==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-hdoZpJkxaB/yaRxVRdvNAraroDsYzLyO+glVTjNQ1AMaxOmTBt/Lh7QGjbqRlOLViXBCom9kBxoJ8L3NHTqfMw==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -12009,7 +12009,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-DsaCiFJEbPuBwYg10wpaeEdE3xRlpV73CgAEi8nWif9kv+JRH+AiYndpFgazGrJcnHbXoWy1HRoihs4uSRqlkQ==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-wr+WPh67FWR2NRQKgrbkqsy/U4CvwO7/gbotwbxLolAiDKZxPmVw+OV8UHihBcgaJ2l80xeHbOvTlg8KAwH/8Q==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -12034,7 +12034,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-b9VZ25FT7P33XmmdcqIuurof8/qlDCefvuFzJZcP5W8vww54laviQp3OZMe21gZNoTF0tJCAsisUwCRFtGkfaQ==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-n3UKJZpU3gfZLABS+bNjCW0zmXeYr49am/B9uSITckGvuhu/JqN8O+MqSKG2yhZ+0+rcH68DRD1+xN4EfTObEg==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -12059,7 +12059,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-AYe2IRqlS5udUUwHLB+nBpfwEGN+g3f+4mU3aYzFq4VPJa0+sn4WyhR9uq1kH2ZM1N7mHyMOwqmbF16k95RXrA==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-D/9pHkYWHNIGglI/J6hu38+kHRLQI9k+XjIhJBi4LcFHzCKJ8vrF3lbO05y+p338a2mteTddG749eNGnfpRDQA==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -12088,7 +12088,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-9v35I+3xKtYLWq9DIAQqu5k0btXBqcThaBewMC4E5FjwyNUb8eEHi2c/602OiAx8MP7UgxJm05ZTmxCOkamXYw==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-ceoamDcbMZIYDtblhTT5SzwQB/f/ZfOeZTKmgCrIWOgRqq7EblaCWEsPgE81I8b5xs6If+DdhtgT+Ihysyz+Pw==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -12115,7 +12115,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-KtJEFzp8CujGIy5qfF93himm77C3TyZBSIWoYy+S3Blenj+D7Sx4IRCSG18goRF2MZPzBk8+DaADJ9jysCci2g==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-cuP9Lj6fq8aOX+H2Gb/o7cKZQ+IOaADcMQ19mgt5epCNgWsNZeXqYm0ypDcyAo1D5FdU2NbQ8576vKXphvX39w==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12141,7 +12141,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-rDkddX2oFvwSl3L1L46ftJvLhW889lRV9x814MVYX3SPzba70rjRpF9i/WtgcePpk/GO50bly0HEhSRA+5+g4g==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-YBAusB0+e3cjkTEQMfr3Q8xAxRRS0JbcnVmnt9cyB3MC02XeXGB+oIjKP/TY08cq1IT9HHTKosMrWfKKStGf9g==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -12166,7 +12166,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-8E4bEbSKH3YBk46CzI7NvKJMvaydAv8IPy8jGbu8MoLoDjp2RiGVWu2VyExx6Fw99kt1AGk+V46xF0e4PTwtcg==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-JJ0/r61xKy+uCmtVCD0p+dATwjU3ygUHe93NgfBnGqM6n5k2+Ai3qKIJqz3Wi44e2XEDEFywK6aN76zOZZToBw==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -12191,7 +12191,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-uPS2+p1oI2HYbDoM/nIA24Zp4g4luf44EwFtnc/IcqJbC5WXGUyw5XpP521K/LRjqrhcpvYnJUTXvsihMjAXGg==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-28goF7jU56MIHXDocfXRU5JuIZswJWtgWggniRkeihyxhqHlKZ8C/piQs9oz4H66tkJT1hZJyNfBdUZTXIOjKg==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -12219,7 +12219,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-2pDKAUFh7gYxN+AxznwxTdgYakg6UZrlVhES6ckbX0YlQnf4DeDXa8Pa6HUMK9ubYaaVjuH8KQOLN/cJoeIDiA==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-j5ZxYBDOMNSO0GulYlTmjT9vYMOd4CgHsYczwi5yMg9IeCAVscfPlXCKwC5rt2B8DpSxbqDGuBlUJc5bkWOQHQ==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -12248,7 +12248,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-sugpl9M5blLaRNbg6GQn76g7xom9iu1jKejYj5KeNhn5iHgbpHPXjo4OQcs8IRmwd2tRnkLwksIuAxm2W6QuYw==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-wSxjWtY7Gayq5u+Vrbc5SF8S65rlr/heUQBVi59n/ceKQ9wwSmFFIANjvHGBCVjeEV8h/STQRyo9ohorR1BqGA==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12275,7 +12275,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-nnxE+DnW6deUaCiJsb6Vdz1zOTzv6uoW3B0vNx42bn8LVf7O84d/0k60ls7Nbp77vr2C97NnkISLcLPWhUmzwg==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-rfM24fKeGnO3k+9xouP8VC9tZO37dejzMq69JJfgX+QQ03NhhI0+7W1Sfydq6z+nHpvT0rZ5dq55sG24fSouGA==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -12319,7 +12319,7 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-3wcjT0JV7C63qdIAx0daBkxtRYAD86cGgwmM8bUNhScppREhP+LDLpAQKr07Dc+CNmtDTZyIf1+CvOlChK3NYw==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-pBzv+N2QSgppOXMHAJzMkaE/qaiUmi/ecnoLl+UGY6ejTy3yIhiM2pgeAULdLqwe2J7L8R+LIzhAbNz+tv1O6Q==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -12346,7 +12346,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-2vzIrVRG8t/kToRBElJNytrUk5YKVVhc1c0boPHZ/FZzHvRT6cLvfpXN1XTyNQdUWde5jpLMPe6vSC1w9fkHUQ==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-nJjOjZ00EbI/BClYWgzLvAPYRKzxdXuf+OCzB7A5p8nOTHL+IiOJc0H+4FNsc3CNJxCWBoOSEYIpL0GKnygItQ==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -12374,7 +12374,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-w1gIubjRTzBHfnaTbZz/c1dP5955JMMUqizIoyNLeoTWTDWehQxSVqZNYnch91imOTmzB+TxU7GlIsntOJwL+g==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-T5BQynIcWR+pR0OBRmCgiNLPARef7bQptKTgvCsnPfsewfWLV3YMa85iAcoPLMduQ5/JtR5DCET5pyDFPjKoEA==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -12401,7 +12401,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-2FDsNPauBwRkdMElXzq9rWo4XkrVxbLu9qqIOG6riyhoLTT+LgA0TJEV+iG6gu/NgRng840zTpNo8yuPQGGWQA==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-gIGza2f9pMwhSMoWvuoOMowtkiBRZ4FLs4eo3jWkQOdfUV8yW7Aqs4pcve0CLxCtD7juxoQ+VsCyAbJNwiPIag==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -12427,7 +12427,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-xJAXM2Ld+QXlUS+lRl2h8kvvABj5+B04QH+tBPup9lHEzMW058av9Zg1Q2FTerpNTXl9AtrIY7fiOLzPoS/UaA==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-Jh00YMt5IjPlB570BSjOupuw8nrDwcPaRinDvCspv1XfVTn8ca64lljJkn6YVvg7Ewka5vm+k2xjgje+wgHJug==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -12454,7 +12454,7 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-UtNY5pFfILJVY5uKq3grSAj/eX8knsdw/pjkfvOgFOUMLn+Zc2KTgJ4sX1fqUGLFz4o1OJ4NAc9uSbOIdBd5Cw==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-eGal/cz0lUPpDx7YSpPlprQK9yKIV0jJ52YANdbKgTKQi11dEyXhB+NFfUmBxpk/hGAYSCYdQRtXEij3gUSDWg==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -12482,7 +12482,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-CgE1+0qzGsKIGBfvZjAaeQ3jI+BkFnyy2s1J2hS/GDxqqS6ONXukQkR+wtq8chLjG5/Rkp3E7vNw8UO/iYLsAw==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-6T0lGGJ3XCcGfzzlWPbJImUGNvh0mPDht6imcPFhw/LHb4eLsVi53/Kp6JLQKbAS8UTpXuWtQwGAHP3blgWguA==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -12510,7 +12510,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-mnoUjEOVqAMufPECqy+8yqBMX/PI8zFX8yfgbPgXC6vtxk26pLTAqEo9NfVkzboai86QG1zLE8Bjy98RhV4gOw==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-EEAj4QAchBgQ5gEyUXlyVFbt6rYVQlyQsmNDEl/xF/4/9fZe25OPTHhbQqBjg3BhyCzPI/vzVpFu6PxaKHBKVQ==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -12553,7 +12553,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-/O2LUTrmXAZhj+9FnT4Ai7koBQY/Mjl6hgjFNcIvWhv/DZV/sOUAdGUE+1L6X37a/NMegSmFEzrvwA/7w1Zvsw==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-L7FZF+zECSYP3h0lGOxlcba5MIoAaS4cLDcLw9uI7OgkNOeXvwVp3AIyVM0gY0zQtqMMV8yOHSdMnb0aBGNa5w==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -12581,7 +12581,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-ZLOw/zxspfcaDH8PvlS0yHmTEUeyQZ4JAW3tBxOgiAoLllY0qXvrfYEYH/WY8bq8dL5elf1Krb9WuKe0IH3PxQ==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-D1OaeYIGlvVSBRKL77fzRSsc7CLEJfB/VT+MeX7zxhr04M6LNfpT8M3Gxs19IFYtRy3V069aQ0MbeSLQ2nyHBw==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -12609,7 +12609,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-1kFWZx86s/1MB7d50kKIqEXOd20/HYaa76Vr6znMZ1oi7VhNM82bwcFXhqr/Ha8QJp7+tp95dRGyOkZPX4Q6OQ==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-oolLtC+bh7x7BChJYnlqD3JM5TOeiyN4KMITqWQnVrzp4kL8W9CSGoT3eCJptWWGLIIdDds5pUx07PbB2VyK2w==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -12636,7 +12636,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-tU2jx2ArM2PKoHgCaJni2AJbDbwV6tUw5nsXggsmpilbQrbIrbgkiyj5NqHpsH82QI1Y+SE9R0hPPVtotb6JQQ==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-RnC0T5i0CFwhUqicfDmIHEAcGBzNptHyVaS3nWy9Cm1l5+Up5PUf63HnwYcDtIn+E/BZZFFRQa4f5mBJ1eWzSw==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -12663,7 +12663,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-DaJqL0jm0XwPs/tGBQilxBHgPGeQSxZOP20x3p5LYEE6M+cX0BFf7KPt+aI9ORzB0VFehMh+c2HNMepUy8ksjA==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-7oyjRjn4wwCMSoO2yAYUGqE35HvvvmD+b1b72A/XlCjKky+i0yJBhx49yXxOttek4WzzoaOxDA+CMNaRZKTfwg==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -12689,7 +12689,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-FUpsLqJ868RBg6ZQlqON83WYnD0bGYjQbMUrRS4Gj5qM6W2oU6+ne/9ixmbnWm5Ol7MjkM/C/yo5HFpKKELZCw==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-CkZcQ41MBIbPmZsddog4V7xZvYQmGMNe5bJ26IBeELZMLvZdC1U+CEteUQCd+bWEIhm+3SHZeoPohmgvbyHqRQ==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -12717,7 +12717,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-95x+lKer6oJ/LYK5mUj//gdCQO3LciDM45igpyBCF0nkTXEddLM2MfM7Puiiozs0FfyykLUwVBxpnoLHE7IdvQ==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-9Ho7a21W7lc5nfCXQMrjEatGfcwGbA4n+tEiRUwhFc5iF6BCdw5yP+qU192soLinMW1WHagom40zXT3/suIJ4w==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -12744,7 +12744,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-aUw/CoDH0URZhZMkb1n15XCPdGJ6kMIZTRxR3Aiio1FEy+s02GYAmtiwWDybhHtfy89U1x2deFaqmMmN5ggDiw==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-2KU2P7WPFDddoatPMuhvDwICItynOhnR0YGUzONCXjgcyZ5nwmA/Nb/X9T5NHrjLxP72sOSMHnhwVu47fHoPTQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12771,7 +12771,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-qoayTHHIiQQzO5sYgATMJ/TdqpfGaInAWAwUa4RB12pw19AhyrcUj19X0F4npIHhWcA1E8W40sg+xPO0j4K4Ig==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-DWu7ADx8EkbeH9DsufkkjANTx0p+g301D4mFVpbJMXC0MarD64knAGX8Q9PTD3Hb8TdNRK5GRkwnRPyR1Eygvg==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -12797,7 +12797,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-n/SMNzAiyfN/lFpt5YJzd32fES9ze8jGLUbLkIxNW7w6TdqkPVXTMB7B6EcLuqmxFJPfek4A2LMJu2dBx+UhcA==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-WAtAXKJCfNKF/uJy3vZmZ+CE/PXZa8uOReOOz0NbfHdUo9ompAUAH291ZpBMP/oyMavRNBCIqrHFcUbnLVnHdw==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -12825,7 +12825,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-iG9whd+FoDBL6MT9pzGFw7LY7lhcOx8OOZR6WzTzzkxD/PPfJDSNxMICeWrIwseaUKHEQ9urN2FhDCkAnTQ7tQ==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-G3ZU/CjjEMr60xcEIdmS9mKFc0xdvut+pWl3VouNsC564gB21KvYoyzay77yUzbBJlU99fAmkWyUovFoO5fdSA==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -12851,7 +12851,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-m7YpvxhygnEI2hacwst8DGNvAY77ZK1NpYENUa1210NPWMZgEl1HKQOKJ1yL6vLwC0x5i99k7cOhiSVVU/qZJw==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-zdSyPOGITXN9mRdxHC+LFI4f3ZOh+hP/ZckLNl84YXRVqSQoB1QQKawY2SCvqJ0tncIqBASHXMfRUt3KzC7gdQ==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -12879,7 +12879,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-QKVsn1q48eaGWWjThiViemDuRkhUPRV7LbClKMNFHVQ34AvGNqq0MudYx9QuAqXOKtYelXwZb5fjlPcNDRolxA==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-DEESanPBKFpZDHHeIkAkVYya0p+L95cmwlI/3B7V6ZcagEEX34to4tLeGIqW3yQ+Gx0P9z5XxWilDnbI6iP6jg==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -12907,7 +12907,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-QL5xwYAg2Qkccprt0iBNs1d9gQmavTnls/LgX+lQlCDTafSagMzKyRkLU/5xFFtNaDK0O/cAo/JePDAxi7lD+g==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-yzVw8Q2+JxjUvyeRTbq/j0vQhkEHW8t6TR3fZ9mECDlaG8Q+N+NKmrbTAomwbRbNPlgFKukLP7r+rHjXunD69w==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -12933,7 +12933,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-2tfaY9yVh5aJuPz8eS1/PbLP9E3nJIbyWHVanL347BOpqPIQkYe2zHSsxoUahOBqJqB90g36FOQWNo/m6Eiu7w==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-kv/yjdIuPAYgY/6GWaiPjnu31bSTCwHvfHaqsZVaKR/4+4b7AauMO3KuDdr8UkkWRyhIkUFI2RvxjHmi2b5+Gg==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -12959,7 +12959,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-RqdUOXE/gW+7zXfFneqfQFn9j7PgM9AsXFc0n8xMzrRGrCz+Uqh6ia4cGW3A4wehnQpz2gYXDW9wJHMLQeT7Rw==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-JtJ/t64GsctvAnLtCM4/55fMH379WeaFMASG1sW5DJ3x2C+n02sPVRM8Z6Mu/T32JXZwJf0KSj+7wzXBQhAjIQ==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -12987,7 +12987,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-cgw3iDKW2y2/oMPVBzv5NqsaTleca6OtAVz8eE2oNT+F9oQqPazDj4faSRDacLp5f6KqK6xFic6QjskNxXjcqA==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-ivDbQzCDJKN8hQwxYGFMkn+vJAjxdvzQ8lYzHqyMxBc/3qifsKwEPAOcZ+TUiD8+c8hsKTmRPaHu4UZKaJHsIA==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -13014,7 +13014,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-L1tbQid0NzP48zct5cpTnU7J/5GrGMKoQFjx/pvenb9fY8mSPQre8CHc73Y5zyerehemv6eRjKy7eU8NDcV1zg==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-tfRJMGzxOftlogx/5EpDXnGQCHTYaHfKmkt4VKXB3LI5phOLpybJQt3GwHzErp5a3xz/TcpYT2otMdZBGoNLlA==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -13040,7 +13040,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-L7sX1Hp5EvvKokbHuNAvLkgBkFbo915Y+RGdasvN1LT81KW0AceqnoWLIQksovU/wM6I7FN0OGIEFisODYzsIg==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-zV09nRqplUpK5w5By61XKVG/v70haO0z+1yA3ZtgMinQyV6qwGyRf8BQAt1VPWV5sgUiL6MtkFPKrJe3oNgctA==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -13066,7 +13066,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-CSmAgzjlR+IZFb5bp67z2SVFs9NQ9LS0VRLKZzpwCRkplrQBfMMPeu7/z/5vlc2QaHUyj5GEXWcUl3tqa3Yk0A==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-J2lsKIst4SNdWTPVT4yPLwK8a/PL+6OBYrjvqM6kqp/MTpGbVppzDEgpjYLyf2F/YGMT0vKsCx2OZmdfz3TTvQ==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -13093,7 +13093,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-aCEH3Yr5kA48YQh5EE7OIP0hieQ37FXMh7vNdh7xvd45KAI1e77Q99uhvqvNAam+mNYNo8jo+nn3Rl7cpqv4mg==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-0OwGVUxeTCi2Z67hUZA+iIq2OcgIaU8R0S+EGFKN3DZ/tQlkV0iLLcXHPO3BNl5Qjc42eLPPIvlUbCa94hSQ9Q==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -13119,7 +13119,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-mL5ybtkui/g7nDHobTu3HbF5JqO4Z6MjqZaWUuvR0OnDCTqOsHdS835yDQ5tQeKHLwlZjQF4YexqsrD49yZVkA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-95AnQnzoBbVQSuQVQqWUOiZc43cePOTKXhWpdg5G3Ve65GIdqhBhkV8c5DuHMPMJl4Cr+5PNpiEjmMqn04uTqg==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -13146,7 +13146,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-qmHGIRkfxEpsumb3kK5HiS61itFrmyxboJ5AYdNG8gmprcTfyyZ8GQxQz+yh9JkdCoEE1tI/K0O5PmGnIBtEZg==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-7Y0eayeF8+fcdXu5cybX7y411bbB2aD21zJAhQmui4/1i1x/VS95rRsUd5L0KgZbl9axpafTRqbho/m1W4EphQ==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -13174,7 +13174,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-9iJ3t2A5kZDOfeDbN//2WclIOfqc47Ys6GOkIThF9UrcMcT4T9UKsun8jG9qATAciA98dOUgczW0QAiPH1K8bQ==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-t2kMrMDwxJGkX+Cm5qWFejx4SsnEO34Dmgema+0z3FcNXpawASFceufwbyfWuy4Ub3dTqK8N3x5TW5qWK2sKGw==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -13200,7 +13200,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-se54K80CkdLHAtjR5pbWbWxJnpmHkHvG8/n9d9b5/16ROIXe1IpZzFVO6HAtSEPZgDClzhLwYKcZIBCO+HuS5g==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-7Zzxwb9A/reKClHoux8ig3fRjvmHzNFmAvMYmbz6hc/gK9cbdQ08CeAaT+juiwIdscGYQVaNdWj1ELzhxb37xA==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -13226,7 +13226,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-nAmmiAhrzWJJ8jWgSXh8cWEbGYaHQd6aOnAWjzjK9Tkq2mJ+3JOWDNhuVb0gIWu0dFQl1S7FQ3Vl1gOgI2NEug==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-3nmEXmnL1Uwz8iFOjAlKHXxewcyB4vWwTdjDlgI/pv3getqmbI2iv/kQhv6TQTI6sUeVo4s4+HAho7Dc2+6Eow==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -13253,7 +13253,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Ci2u7IAGUdydHCe2wmCAROKWx7T97dNixQuMMRDfRUNcOqnSaVHljSUcZPtBehVzkzDP+bNsvAhkIdBsjTGzGA==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-d1Amw85hvHEi/fTzEtmnf75J/sbvzr8FTa9dot50CZR1l43/LMX0k0TS0bWsQ7j61uRJNYjGsShJdpu1aSGzzw==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13280,7 +13280,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-IB9vkq0I4UsJ8zRn5BmXyLzCuKzl3cPQIGa/cBw2hRdOrv7RZd3NjArVx5AMlCGli2KZGd1R+yFc3CyRKK+Z8g==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-BhOUzgZYYDM/0qGf0/B2G8VQRK7fvaRdojljK9iRXReGDUrPGGjNDmDEFh3gjHzmjIQllwvOdmatLSf7FmjHyg==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -13306,7 +13306,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-wB8nKJdqPLraKxFYvDlWZWIZSQHuwm0kvnly/tEntmuwJmTx3Z4vYCJyCSvoJ1FXFqsf7A4IrlZXP7E3ynOKQw==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-3xFMt7gl5l4keq9+6rGly8556taKv/ZLgtXzRbcTibxkP/1OiyPEQ/+77Q0P01I/c45VW9NioiyKz9D8W8br6w==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -13333,7 +13333,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-nOFIdKFHWkJiat01An1GtkiOo5zpzhr2q4ZIm8wjPi0rBAVhoMA3pk7iJLacN0DfsSkw2/WWjBpLIReXRoTp9w==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-DLla3k4VcNjF3GugA2DkkwdrqrBU4w+VyNQYn2pNBlsYZFaqnVCtv4dv4lyKf485Y01n+HfcH/Ca5Hatmseudg==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -13359,7 +13359,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-Aj7evbmiifblx0tOWQ7wU1HUeoYcuWE2M+aemxezXhfnFGmyUCMOS2UBbSUJpOToJXH7zuh+LPM0VcLaCBKyfw==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-AB3PZ5K/JTl3MC2yI6ya929462uDf1rcl9TStJ5OAn+lMOGwiMZN2jBbBYZvuzG3827jYUfjS3BglFpE++rd5A==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -13386,7 +13386,7 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-mlkeCAjcXwuHm0TrydOWkbReaCgch+H9eUV6MByE4Fex73ndrHtZ+eH2b4WdtOwxgV9SaIiVilqNbLZ7MqT/eQ==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-bIEvXOy/NdGOKIIjzI8zDrrtBg+Qop15BbWcuEtvThiFjqMmHnVvl+vkwe2atDsGemd5fVxGN1mHh+E/lKgz/Q==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -13412,7 +13412,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-OMj/8g2mHmFPvJ4nvNgV1BK9Rd1Zg1jY9z3rL0iyVGdzMyCXPcM5oWUUALKDGv8o1bdcZzB03PQAQxPHeAdxsA==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-OrQ9rRDwqORmRGVNe6r7BiUadq9NM8FbNVLLLTdeIAdjZsA7iwnIHefGOWfpNwh73E9tSXqqsEfqFEHddi0Ipw==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -13439,7 +13439,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-EAUd2c4BeOeBXQ89uLiqr+PY5EVB2DFZ5PBaRUdUkk+uRa0xQBikVl/SNur7Xv+l29yMfxqnNYc5OSbiAoeolA==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-vmNI5cI19QbV3WiP6J23i7VSh8K+hglsYTvs7l6p9s/sgdSCMobVPvdfCihIfQ2DgGnPYthVVajHhmT1Jm/DYA==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -13467,7 +13467,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-pjBiFum5B8TaJzHGpvGCKvAoOKORPC1LVWvdsNMXjXHMynJOGKP+Ve+W1yI9pOBb6mMLArsYK4kpx4Fzwp5Hgg==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-fWLIetf7dckzxUe5esh6TNETTQ0XfcKoZIqRfRTPq6n/lRjLshLxpSlMNZJri6eBjMZZoVFCCbAMhca9UA6MyA==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -13495,7 +13495,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-CCLqoFVy77SjW2XxQWJkTpISynFVFrdyMhOJAglpXoPkZ/5cDrNTcxGIcsi7TaHVmnEzPpOH3jwr4sGgwuZ8kQ==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-JAaJGD1tnTE0ly7rneoYftcgHWBC64ka+7joqNSggH+TH3XRml7r5pVvhaYfbCAyivAAuIK6YPwrziNFSkW0ew==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13522,7 +13522,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-yGdta9jk/Vv76SSabezPlh12nUpX1Jt3FBfknm7qjO5/58bdTbUOJ7NM+EGKaMxtBTbChFClqJmMueUb/3mcVQ==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-0mmGr7D+JOpiJmS4UXxLghHuH96mMVP+3ad9lHIoIWhmySSHg8KHa218RFech9nrMoH6tE/0ETFsBit0XMbTLg==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -13550,7 +13550,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-6yXtaEcYAXCnPk0yNAQGCfB4NK2NZea1Gbu0UuPWLdHEAcHPzKS3tGvz4NtTj9QsQw02RgTK8QU465Jlf/XVWg==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-K25YK0qmvnTcoNnQ80TAqKTbaGV1kHFLsjH0TF4Ed4UT0kyntsECs/3qRcadj8ODgTxmEl1sQV33khegU1IZoA==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -13577,7 +13577,7 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-fVMZ3HspsXWI4G4RiWvzZ7wzL5eKJKCI3v8px+tJN5FWi4Eoy32qVrjqVtNn77IzE0JyWwe6DugT3sRu9JrkCw==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-9f1c5YSs+FnI8FP18n/TY9yv2Qt9s9yXnLVIOJx4NAbmwCgbSA8qORK+hw9tmKrt8yLKxFg3tRKZXPyqAse4Jw==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -13602,7 +13602,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-mu/7lmKqtBZiHUmLgoRX+DUNMGli60POYBkX/oInW/lhte2lDMpUwT2CfNwaIsa5lIzcmukdPs8pyPCZkFYs9A==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-cxV8lGIc6qBho8Z/P9SDEfvPT7QkEHkcqTrAQBnm7XEyUR90jXUumTais+DGwYd9TuUOaySAE3Cq9TOtsD8n3Q==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -13628,7 +13628,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-izX2d+tCBAsTArlKXWZPE7dC+JZBwf6RzZexfi2O8YH4SEGaWKE7Z5+ufBxxlM03MhE36tvrdZozWb0hjGDICA==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-WiPoeP0wmVQm+wF3/1No2z4+1dhaNHMpIczIEj2lgvSqDZOUg7Vsky2Ypwf6ayRCyWG1xMqxkHn8VSsxSGjhrA==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -13655,7 +13655,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-lVSPNDsTFpmn+0NfABQU2ulAqE1fDBeW4at7Yo+/1dbqblsyiYQxRKsfhMcS3bmcVMo7/F5TLrzcbY3PnSs33A==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-TwgY8kp0XnjxyGXghLjmT7SQTJGtSWEZlccxWvN5Kizah5FW0QaoVFqrT2KGq1efS40TUxbUUJ/wD9fvxq0crw==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -13682,7 +13682,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-HgPgdOYD0GC1VbSniyOKV+k8NQP+Nf4Y8gUcQgmvkpd4GmKGOYWIOJLAGRVkXJcP1JUhHn7XxsR0XGAiWNKu4Q==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-ws5mhvxHYC6HQl5DHRne0d5IWSVunp5PZ10NqYgl0hA+Kx3X4gVPg5/6olxJapbpymXfUAbms09JK56bSdk6Tw==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -13708,7 +13708,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-nA6QiHAbJBIynUYqo4VaqLyU9i5lp3F+yUocs6dmVSuhohHAx7bfe0FAnCDl/UezrO71wAykb5moe276qXWXsw==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-wTxwkOtBLi68wc50lodK3gaUoHAEEDM/UumdXLQJGzV0GzJi2nzWqJvHlDBMuOJ14paiEwYfUeqEwAncAqm4nw==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -13736,7 +13736,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-NPqD1UGqFAN0iiYxgzsD+5UYekqhoKTquGDR/5AlUB2wJYIebyhSzCelZvqbn+xhrBELw+MsVhNYwVJmK+LXyA==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-AC1nlOLofqoFh7fIxslrXKueMzH9NBzsDBagOJirMUvR2561t8SOiZQJ99hOechNEzV9rYi5jL7hMJHU2rc9UA==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -13763,7 +13763,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-MKVqAlcqZxOros4bknf/8NHB4o2X21VtvvBZ0byeh1/Or/OB9rlp0FqUC9A8KEPLWXyV/ddYOhJ/rAyYnbT54w==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-rss20Yb178oeAFD0Se5k6req3ISEo18wahvChMulBOBrxgLuWIe5M0YGHwGAOFPDgF75jyiS6MoKcQylsviBqA==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -13790,7 +13790,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-5FFjCGmPTl6jhVc22w++BvTUb2LwQaR+/exnnJCnQBf7GGRpJOeTcpmBm2rlmS2wbyr1T6Qzih2q9w4eyqxCAw==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-VMLVDqZrBva4XSc96fyZ+yEc6gPnmw3MGVaXEvCQZAtaT+kyOQQfE+QGIIbCFCAUX5UfWk8nHE6wS8QzdT1Dpw==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -13816,7 +13816,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-3DAcFCisgyQlaYSKkCZyYAOLHl51ed8wiK+2FsTcObuCx7Fq7/K86fl2Btoy6/Lhx5TntW74MHB2dSnkknSFxQ==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-yiiLuQ9PmrsGf1M8W+ZROkF2y+egwrM0Cv0Yct9fRk/lE28ZJjVxofNp64nDZBEVULtRy8uexYek5rTIcHERKA==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -13844,7 +13844,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-t6yBBcu+y9ZiyK7+HgWwHELlBzDvihFx3gVys1hfo+5iF3p/DxqYWBVsEwJIEMYl7T27WwzL7ddt5JlKoPeBXA==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-dp7VY5hqr4kKMHm8E8voKdabfPeIvwHqpt3/v2t/hdvnrnNFkAh6e4Ktipn+NGfw4icTjtFjy2ePN5l1SZCoZQ==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -13872,7 +13872,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-UoXd//VD88eyTFXh7pK2KjKfWCN9iJgKuAJpTiJlOPjtNsyGKBKrrBCNFjPpsZ+cbBGJ72C9+03J49tpcXDb6w==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-ei3dXbw0SPBO7472e5Lc2k2U4zGgoVaLnKd3Cj6jTia88sTZW/GkmmZHfRChOthiaU/skOzZ/Nmlvj6DFoah6w==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -13898,7 +13898,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-Sy5p8Gfs1IANvvG1j35dRubNwpi2rK4VlhhlLhXRN6f3Laxxy6f0KR9wz658HF/AOYA/SEkt703waCeBfyYlyw==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-jaQ9mOdgkp1Q0iioQI3CH4Vd96kQQICbN61iuDmabjybD9YDPkkcGsgs9s3k+DLLy2z00nHtugf2NngsUqmCmA==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -13926,7 +13926,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-QhFL8mPuYVp9XnRzSKBav++afPgp0MkdhTaB14//IOFCS6yaY6XOmVKQhshoHk7lPeBw+XcxiMGZvbn9hrlKYw==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-eOGMj0hE798uQgwsFhk07Tlv+X5v3J5CHViZcVkP3T5Q3PDwAGWKImRY5KoNCVRn5OhlNaqP1jfASv75hAsTPg==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -13952,7 +13952,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridnetwork.tgz:
-    resolution: {integrity: sha512-xqfMYQWliSpAFgm11vF2rQSeJhfxgUiTcXSarj2PKbb+IQ+3nH21YDs/ftJuyOOLihLFbmxlQvT8eKuQStRoeQ==, tarball: file:projects/arm-hybridnetwork.tgz}
+    resolution: {integrity: sha512-dgmRfWg1hnBn5L4dbm0/A55CP747c1U6ut/GG2FeUHQ+fiHB94z0CrCknyX6cer3nUI44R1WntdRtR03JG9vPw==, tarball: file:projects/arm-hybridnetwork.tgz}
     name: '@rush-temp/arm-hybridnetwork'
     version: 0.0.0
     dependencies:
@@ -13980,7 +13980,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-jtoCXQudxlOMVFYekAyBSLImoRlpAvAFvXFEgBb/GVXscEzSeDsTd5VCUH1Zvrs8B9CTqy7U2nA0NaveCXa06A==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-EDPsPyOrfkNm5eGS2F0IhirUBQidpeOBlKVDj/uByJzVznz56yxIAuRTRxWbNYUZfC2fLSgRmdgTN+q6ahd6cA==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -14008,7 +14008,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-+d/6wcGG3OeAnrexKwryshVou4efDM5mhgKeICKfzTozbGhN1osPZREFQKN8cBa5X9WATQ7kVyTPyUlIfwv7SQ==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-EzFNFoH25ciLltRS5mTnby6xKHJxrPqArc8bizMXffyEkUioNgMQPehlooRg2YTXa1DwQGeoOBDW1Zr2R16JRw==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -14034,7 +14034,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-WjogQNEjuVkfiAN9gnaphl5L0qQxUQQeHY9TIv1ntiGFcHFuK4X5irE3erwuZa8aBPCE3lBEnFWIGTfk/ix7Jw==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-TVCRaGPO1/PFRav4n7v79oTPfBsAUROLR/IAhd/zuhPM9eVfXFjB2yzPzpbtKEe+GxREpOgCEy4qxpbBTYpE/g==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -14060,7 +14060,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-ndygVizo0cHx1f9cVvkvxX0NSLNi1b03leE9VYaa4ZL6YWG0FcpldvUyWXjXtqnXfT8Gt1pYvxde74aSj/XgOA==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ap+Z6OrBcTh8HXomCKUgo84XPUgrCbp4GSxGaXRqIeU/pT+yjcB8hL+xz3Qy4VODIqnEiGiq5i37BCWxqo9I3g==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14087,7 +14087,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-Fv0lEr32w1wHSr/++mppG8Usw+fDCsdWCd3L3n3nXd05meGuVEjlNbrUGj7orLoFQE5v839JlAUec5uPIGxL7Q==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-IK93gDYqcxLAd5/fprkJBfMYWTwFE+jKSZTY8+CkfWrx8v8sFEUMndDu9C8wkylqpZ9ahvqe560fsI7/WDoTGw==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -14114,7 +14114,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-srfYMkQo+2vzcw1FuYDN4ygHKff8u0p5DmS8/WQme9KmSrnoXSebMFYNfWlLhESHwI3TZoq7jngKYriebz/C/Q==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-lT/DvF/9sFj5AUJnqnxHx13A+C+KGWWdg1oTPTE5YcVSyvCiMANU/0kVsi5llBXbgvjR5iE0ZLNertZGj0bjVg==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14141,7 +14141,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-CxgUmA5b8mNXEHzxim6ap/evv1p6YZIAdfmet9qsbu74tcwSb+ty+Fkit7xwvyqlEZ3XAggzmkuH8g8qUPZjQw==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-5J26dX52OdiglGFO2C5HEYBHJ/cAglmw0+6C0/h5GI0K9i991TwZyhu2drE/InXY0Bye+DafznjMfbworbcHRQ==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -14169,7 +14169,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-FzzUjDedwl6PgApeoOoQPbh9TRWMq5pfolQ3g1C5Xa/VGPz/Qdy0HvFswt00uHSeyuoAi4+aQZvr2VI9M0Wb1w==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-UCuOUS8jLbg9fqrFldv65BoWTCv7zUtY7GcAsPmWjktn5avFyR1CVa25VrzmEwI7Kz3MAe4NQ4kd+5yeSd38tg==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -14196,7 +14196,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-+S9nWXmKnozmTEeevAyzGORODSi4S4kUjzZe+m2101+ualinDLfkkBjRHy635Y0pHmJ1i7ywNv0BcfhMHiH7og==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-ZGcWF+8qoEOWnZt2LVMCrlOAlPkHlWG+icwN+7HgD0GWrhp2aQbk2FQxyXEcM5KZ/xFyC+Usl9YYUbCJRuiibQ==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -14223,7 +14223,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-i64F2+sfyinjeI6+7ZM+hJfYeF075HeRGm43IPoMmYILG/GY06SMB/4oelcoTDd+Ct8eboNVQB3iRCWd3c1NDA==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-5B7F/ARVRCMje4lEBtAYKO2cchl/bCdYxsEe1UzVx2LC9dH5oKFSehKkMBUIb5VVI5lUOZ0WwQ/FeG8O1DOQSg==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -14250,7 +14250,7 @@ packages:
     dev: false
 
   file:projects/arm-largeinstance.tgz:
-    resolution: {integrity: sha512-lO9Q5RIVa9eIxfL1ni3r8h27ysSkSdC+KH9mcgBsRJkhSZywAvepIqnn+aPtnRxyx4L25Ca9FRJTdTHOttlgnA==, tarball: file:projects/arm-largeinstance.tgz}
+    resolution: {integrity: sha512-sdpJjnXZnSAusOEmdMUO8AKVbVh1efEc0pv+nmGJrlqgv5Ky6h+elrHR2FwrAtdZsodoubh0owGBeqCccqA4Kg==, tarball: file:projects/arm-largeinstance.tgz}
     name: '@rush-temp/arm-largeinstance'
     version: 0.0.0
     dependencies:
@@ -14278,7 +14278,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-McQK4lLqTDACdrIbX2PQoRk/AAJDDcFYBzGhsUhPSkhAPXQHJNG3iP3L3kstgzBYfYRlNGPHXMhV9wbn0XMOwg==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-0MrD1N27J/zHy0WuJWhDnH5yigl/7ideSPOq8jvphElPaf63WPsKt/y+zZA6yX85LwTs5xW9dlMTZ1GCHrgHFg==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -14303,7 +14303,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-yYDAiubQWvh5dv2HkaSZkXBnPUGgmu2bppWeY+OctiD0kdWuziv3+dlQJTcsYHJYbIXak8mRgp8D+fOpOIUpUw==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-3mNR1SA2SXx+lyCzHchx0WGoDaGhN0HN/hLwql+FWr0YbBWO38ys0TVsRhJWYyE9Sd+2NkgnSVVLUwINmcDzrg==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -14330,7 +14330,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-aP3BKP6x6VloB97Z64xb5PGsb41pzAHamL8fD6lj2EyKKxoBW1Fo4GgUw6gvRELhSl0KbDg3n7TmAGlu2furgw==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-MM1YQWv+Djqo44GlUOaVms1ry8pZN/XdPPXF1UTnGy5T/Z+rPHHX/9cpSBjKVzdOnhfBnbIDh8BhLamBGvDB6w==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14356,7 +14356,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-3gK+FF8jTwpVOwgkkgdPqTNmFL+txflMo4lPDggW4M0u1vnOqa5+wCoi/RihWA8lhjhPTMwBmqIk1KgCau2P6w==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-NvQ3Z1c6s2jwz+1CCF/Soh6x1iaBCUR3sK6PbLQXyUBOMEAZ0TvjiMrk3SsTq5Ib04nNDnBAGTNECI+/txCtQw==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -14381,7 +14381,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-MOQTVkl5V1eisNyW/TEDd8g2pHY9PdnPxyQ15+cZhdOlVx8JrptUVrgr1UUeEYSUqMK03eT9bouUa71zzipIbQ==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-a/dJxaYa/V4zraMumW+JUERMqiWJRJmCADrtAi8vN534bHzFD2bpOPrnqRs7+IhTtqSpS3y6AHSFry0krduxow==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -14408,7 +14408,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-75hb8WOyINOoDc38e7gYKDr/Sz8SrFz10wxhWkQ7DHoZ9FQLCH3j41TwEBCnuXy27mzedozklcZxVbE189VgZQ==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-R6LzfhCCd2XgsGzXan+Ah1PjWvAVBKrK16boVBCJq0baPh+zamTG8CxBrMrvrY1xsFQfoHh98qnb/7FfpS1O+w==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -14434,7 +14434,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-I9FNymQpc2olKVXL9gws1OZ/MAPvu1IYEnYyEHeTI0PJTUTOaLAimaitGRPvUGS6VSiERUPMP8ZVK8WqwMJw3Q==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-clysHmuJIoRN6GLbav2Ef0LbI/9Kgg+AJbuzndElf6okICaBW709mzH9q95y/kU8xLA1Pv+6VK5+kKGUQs8JQA==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -14460,7 +14460,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-GHFW6M81BuG7EZUBBrSUNvnhiwmu0MonuTL2iBFC4wHOo1FCFrD+zeJzMhb3PGoWqVmjRrwC9XRr4ZXRtLAytw==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-zzTrdQzKuDO7WB7aZSDSj82VDrf4+ampa4FaZIkKjnvXPqZ/8RG5oZUSfhKt6IGu38i/lkFmEw9i5zVT08YeEA==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -14486,7 +14486,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-9dEsnfcOz/nNTOcpaoekSTPdI2wIes9gC7r3dI2xU6LbEx980+RAVnK5hPWgnQ75w9PMbbHEWESKauF1gOEZoQ==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-yuidOEP7AWn1zvqUEAM7WI8rTRCKeQAPmzfZ3NZMRK5SK/kbfHd31ckhcG6FUPQX33lj8QA2d4TI5+1PqMzqGg==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -14509,7 +14509,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-xcC2gXy4yMak1dsAQZ90+L15G7r5c3yFMkyh9OKosi8wG87lhAc55k1jk+nWS2B6WoqIwKWbWdF3xAuQLTjurw==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-x45e4cSI4uAh1K8TZKBjIEBa8ONrS2pndGLkNJALxeCF0WnPfnjnin9ievz0SEn33vCQYHDWhA0mTa9T1j71SA==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -14536,7 +14536,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-p7RcdA+wL3TCKxLeVjpurjFLU7ETSE6NZJbSst/2SDe85kIRjxNa0v9oZL/c6Bwxjk3ABOcxiM87qPXVHhW2Kg==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-UpgMeaPtnHKpfIJveCbCBFBvALedwS5J1ZmylwfWWnVk8Fk4wJkBphLdCbPP9VtJrcG7+7mopGb9gNMuinGdog==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -14563,7 +14563,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-B7O4vAu0ZU9NLnrC+9XEoEnaCqZsofKWeeJBJf4iqLBNpXPyEr9S4vegeinuponSHgkPX7K3VMWoJGl9u52a4Q==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-naErVuF6NP7dUvNRnLnQyQLAxhBrG4vClYWBBeBcue01sG1H+yPsKTMHRWF0FvrNKkhJ2QXJ7cUE3bBfIDwdkw==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -14589,7 +14589,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-RnwjZkNbDxsLU7STx1Wjie0EcbmMzKLQsef/yx5VrilY/pa7kKLerawjMVYn1iM7rOYV/itMxBOzEnXM7Umu+w==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-V/5vfpNX3DzXMWL1Doz+af2hWGrnRM+5vO7FOTK86appRUuPA3CDBza8uYQFsGvTJFdbeDhJNYo7rbYbV2IK9w==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -14615,7 +14615,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-LBFxDOR4MDgM8ER2PIIvO4v48K+xhHLFwr4agj29JVtWGnP+qU3NiUtBIYcCjzF2P9yh3K0l2WVuxOIRcmgX/w==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-iyevSHmaCF3/3r0HnXyLeD+UDAnu0eFFC7l+B+6KS7w6002PbA8qI3wZKIKtkNJ3EjD00Jl/KjiZszXPqLJ4fg==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -14641,7 +14641,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-vE2H9yszk8Fsmt6okk93OVMRjd2TaPLGhVlbQn7MaQiXI2qxQmIN76gmmuTWph50SiWT+FmUNqJniY0aD9M67A==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-MWtCbkD8+NPqz7gEONslSXEIAZistS7cxUuk5IcobtAre+TCY0r5ePIIto9A1J4Ry2E1kI4PgbJoKyzzlo2T8A==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -14667,7 +14667,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-mvbBWVanivDkhML7A+B7Ajhc9viR+MWRsejF0xf3vLJCtHC7uZ8oHUDEc9f6PRf71jnrCdNMe8t7onC4rZpmww==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-BFieCiiReWqBU4Bn90MT/nct9TfLeElIIWVJRvM350z7is07/Zhj7EiKkGL7w/iT+lZhfE9LwiKXd9ooU8WqrQ==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -14693,7 +14693,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-7QLoLg9/16IN1LvSC4Rg4l8ZVz5teMzswqgyy5OXwrTv645DTrO1Uscm3ghbiE6yG6po17T+ElxlwmF3Q5HyQQ==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-CDOlz7BXiXRyWt8iUyf4eVpx3NEErWajEeIQABkPjeIWyoIvv8D0pAMQNzl+niGGkgGLTsBfVKby3Sl+GHP96w==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -14720,7 +14720,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-LsBo7tCSvyNR+fMaTJfJ3+tEm28s2yDvosgL/AcDjZCuxDaEnH8NI1k7NVTmBnXJx+5TuZ3mK3/VjNlSyFZW7A==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-v8R/vweVHlHPNNLDAoQvKfeRVQ7oXpt4YEeV8G7PylAKGAJVG4tKpsiG6Kkg5xAWUwF+5CQjIrsFgyU8SV+23g==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -14746,7 +14746,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-Q+psd8EPbLB0M9BQ0/FhxytuM9rslkjHw0NXLagRgQ0wIIsdOAKtupBgnkaXN/dqu7hRxTMkvkaUqQCFXnakzw==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-sYBluPy2FMEuhw35LFzDGCUBt5tRNZ+s32SdZQ4X4lZxTgyYunBA8u8XOaZNM4fKGdkRFwLg6EjLIvDp4cTwfQ==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -14771,7 +14771,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-vFnMCn9qVBX91fybM9i+Grl1zb9IvgR/SbdqrpsS0K3edmMJVahXhR44CSBI/bD2zrzFlZnCnibVWDIq3Um2fQ==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-szV/QySx5b2H7nf86GrReqVlXdKlnnwJ/I6RYZvbJSC+0m/4VKwjh91uUPls/8lJeKNikrJ9JwSO3dewJREKpA==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -14799,7 +14799,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-HWAbTdMI2a3v/HGSyijai42JPgzaSxRgspUTGnIIxw5f+8w+50s1IyVFQHNJeQKkxg01eu2ue0MHnziLnv37DA==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-cofYNg0UFFy+EfxpFwqzS3po2NIGuMeY5658PhcuwFK4JrF3B6KqtIx5PFFaMiZlnv6nTB9W0yXqKrnnxaQLUA==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14825,7 +14825,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-LGe1iNUoZQYZrNM4/RNoR1/+EF8IbcjoApmtx/watdJQTkPGiiGJoZCf4s6VitBSLdthc+xSJ9+72cKXFvPLEw==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-Efshfh+xTjfC56URQqDUCrE4Uz4CXRgP+O22PnXhrrmtufY52ttt0ChaeKHzhFIcliTi2BIKbWNPc5dBAppl9g==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -14852,7 +14852,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-Lwn16GKLfnJfDlPBpQQ3S7AVMHDUZABIS+e1mWDYgukN4ZPVPn0pXNuc9WoT970JtF8eaVdKJwjzzRLfB+UUXA==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-wdc183yCbS5B1hWay56jl87v8C15ofpipmg/LkjC/96X05HiBgCE6mo0JXtUi01lyqMV55sJshDIan7SCF1U1w==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -14878,7 +14878,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-8ct3yqJVZgtDf4RG5p0cEoWq3Diu67dixpHz/vJT6XppTF9LFC9Eg6phTc2Mdv/R5KqE6fas1XrbhT0YiVsHeQ==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-2OWuTKr2dm2jloyaQUujNd02bDOpBxP/mFFlYz3b9Om6U+6LHk96HbnNawaFE0r/i/ni+JhdedEqx1bgJuUkdQ==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -14905,7 +14905,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-h+BTVXYteK0CeDUVTBqwDmwB1ZpRjOftvYOtLgwwt1K0GU8n0RNNANLYQLCpV3I5QchUFHZDMWpgMzFschmzhw==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-ezWS1P7whjPMUjyfb6m9BSZbKg7kCA874ldLoYbNytscFviQn2p8StF4pBLwxqD6m2GGKQxeaHo38Pn1r0nWmg==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -14931,7 +14931,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-NRbSU4tJHEd86VfwKHMbcal8t80wxgIPUPDqTeSleNgMA45Ri9gMA2nly60ouqM7yEO4OdIF9GTPflKSfSMPIg==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-iOr22rUz3RnnZpiCDvp3RSo4bmPK1WzN4Xu5OF8wdmzW5Yg59oQVQlTOHhwNzvs/cA11omf0ttR4TmNaj/F68Q==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -14959,7 +14959,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-+/uTgvdvzxGR+YCty75Sy6WOIEQArVbrpD6ZzEfrxrRpqW36HQjs72d77+73qPVQ08fpigR5eCASUK5H0DsCGA==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-kcCcRRDpCucKA17wiiYbOvna84m4alTq68FhRTv6QtZa5OGACaE/se+vJokITCz1d5toOujUCyZ6jjkdbrWSPA==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -14987,7 +14987,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-LCineChGQdQRI2T/DTEtrG+i/A+XZrp7h/j8/2CxbveH94qQpxWrqVnCLlPgEEG9jXAlu2Q/unYxGu5o2OK7VQ==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-tSqD3NQBVDjJ+3SxQNTPVkexM1HlO5maMeh7wYvJD42PMPni4uH7ojYnTtDXoUu7KlkQ66laBwSvr/XNDiYHng==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15014,7 +15014,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-JoKUmprfuOrjFxiY68Y8NQlfVMoMGjoxRmQokRHL4mxgPkO1vcm/1o0r5+9JHnN9y+rYta/43v/eluNHt0c2WQ==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-jI23ki0LYxtwy59OFvnMY3sYBbrtpuJZP84Rdyv3R7JzlyB3LVfaoT7PsPkQcdjCs6OfiNBbpI48qMK/DgG95Q==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -15057,7 +15057,7 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-eVa07skT/98o2bwqgqQbEN1y/UwzoFOOIfUg/YWFWz8w7iYzktIN8GyeblJMnmB2J2/Lo8hQdgD8mfK3XVu9AA==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-C379kFhClyqTlThUmNlHIfBUkJ/D7Bpz8FpPPH/VxT9PFHeBOBRugg8DETWzEFhPjgFTB6GbV2YiXE5dGkApkQ==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
@@ -15085,7 +15085,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-NCBJCvly9qFhObxV7wLo7M/LaYkwfSx1Aw4mXzOYDNsukmrH3pHUnwZi80tUh4+oiAVd4NSa9MEiTqDlZd9llQ==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-/jywTEuTPqjudCfBCxEYW/HQdRkNeifVdr4jPMhulVTRwsMRLBRijaAuf2gWNlDb61k5Wwyx3lvLpneaQJy/WQ==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -15112,7 +15112,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-Z34SPZJ2yJ6iyU2XhNtss2so3u9r700aK+jrSIBHDlHUi7SCVr+srrWXHViolEwnARFFTCjkFPcGICjr9S7ccw==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-W0xCa7YjUaJ8KWL48v+dSChszFcpar9VYJkckqzrqqtr+rVpXA+Qlghmmq4UwuFPSKpzdWCQztTz3tMxuTv38A==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -15138,7 +15138,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-OX7qpyv3z9EQxyDSzQt4K0iwOacNu/o0r58CHC8k5kHRHquAVDia5sE6j0tN5Q+odhvdxZKUooXw4LRQC8FG5g==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-fSwUreQRzyD3E2QvkZ7RHVaq++ZpZHYwV4igjsiBXi/xKjbtGOgxjABDnUimkTz5kHjBAGpNmNy1wQG3znpwkw==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -15165,7 +15165,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-LoqehVB1afT29IOfLh7Qk5tO0L+Shm6R2NDTuhARtR741dNCcFgJGvcwfG15h9SoMvNE0r9dToFU1gMloGTLsw==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-UWfk58+Oa2IygrftoJrMt9kBO7RG4+g5qZrjrOz9AU8m2sC8BJFh7NybgRl9wgLy8ESHQR6HuUNpy3X5ef7wwg==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -15193,7 +15193,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-jKI293g20PoBmUCOGlCyMaqSELaMO10wwcclQyqOwdJJrophygB6lLXXFW8APhhlo8DhtAOv1/jIf9OWzodipQ==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-I1FS9xc0y545E4Q8dJFj1uFhkbykV2RJVI61eqy8nL3bh2R0Z8cxMbtd/rYIRdiy/l62QCC8iX7KomAWsO6NSQ==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -15219,7 +15219,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-gxo797QyCyQe7orCyMnvnzy7u436O0VJn71cbCBolurYom8f8ljS0PWt9hfT8NQ+dYvnWncGkHRALMAwaGdm+w==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-uEx7/GpRn6UiRy0iVP38og9AaR6FB9yQES8mDcS21TuazUwMYteEONiHCz5snmQiLTSG8eqD6Q1naHUo7Sq/OA==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -15245,7 +15245,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-Wyb7Eb0ySdtcocGGKaKgFkednNki++RMfltXBtWGvyC097tud2IQz/QxM26dqlIzLkHhgpRR+BbZBzAi0wHvuw==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-LnXw8KN1Xetot9SxduGDGub5SJlIHcZVAfvHYknMEK7laeFsthbDtaJhMLBnDVmuhWSGv0Pp35c91zEdPf+iYQ==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -15272,7 +15272,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-dpgWL0kDJp4/hfPNsEYozAAg6YMwwi6cXfHn7wsmv7R+qktlTa2PEQyuirfoDQIFD1chTEgquQ7WtpwI+KN7nw==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-hXOQDmMAllVkylM7KYMMgtQIZUJ12DH/6RowMWU961RYR1Q/E0ilHMu7Y2tdT/TIzBpS+8ksmF7giXlFsiStpA==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -15298,7 +15298,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-i4wi1IyjC0rtnSs3znILZx+jLnUHejlGb9wB0SGRr8hWCRMhlUqLnYmA19ex923NQwU/Vc53Z6mSNTSe/WeEVQ==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-tXA9+IdDIWnwYyeoe6bUpNT3Q5rcPnA7BsBtGaIsdW6oN+nqpbg9098U6BT5Q8ak36o0TBiT+dx/Tu6dEWhL8w==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -15325,7 +15325,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-+s2/hTPQ+ei20+UDdn8CBJQzWlXSJvPHr3Bg4OuBmN1MVrpQXVDOHYCWWiNTNX2slbijSSYxFj92QWohThNHXQ==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-SaodGf9bzBLZLfAkVcSdAodHHLKlf3LHYIN2WpwkAdXKzm4OPV/+MD7F+IMZmQRDH8jY8pfipka6l5UBUFbLbA==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -15353,7 +15353,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-nwxqfuEt8kAizeFNun74U6uy9qPQRHbNIkGqAIEmcjcw141TAaSdPe5vYH1pyoxaO4WajA1b6cH5FqC5aMV4dQ==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-bMJcA6Z2q0AZlFEFmf3swnCUS9Uh+SzdjCFhkrNbLtb4uhvCUrzzuf5bvfXxR/sDz9Hltv7lHIev3DigcFc8aA==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -15378,7 +15378,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-uvMCb4UDoIroxhOOohR+imdakfekXiJkBk0ltX3gJ7i+as7tkqfauzRGRzpSTJCaEVDXSW50P2nBUFZp63xKtQ==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-CJf33p9Vv7ylIvsbdEzMuXFikIrP2QojqX601qJoHwFanjrU05ADROulvioErYQgMjafcnUV2TaxQRv7e89mbA==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -15406,7 +15406,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Wa8k5UqQgrp4U/+GrOitGrrx3hiG+b8O3t3wc2d1ijEMSyKSyuFYg56HQlGWsbZBIJpz0lQxL5l1nU9nEnAUlQ==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-ScDB/DBpaVYtx/VyVsUvIlGLL38Ob0vFMj6kOdTvwtBz3GBW8YK76hHbwzq5p9UY+3CWNFlGdWBPM3ogPqzU/Q==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15432,7 +15432,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-aB2FSfveainXfLvZI6RowqO90yRj2xCFke52+mVFnXAwv03jGxQ6ewsf+MKp3ALHsSrIDfMcSOX/sWwfbSABaA==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-AEZgoj/i7SNLMWguRNvmLssudvwgZ0S6IiPxj/EKZrFJjIYgQdWuQA2RlzjIIB2jz217+VolAwO9XRXSZfylyA==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -15458,7 +15458,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-KRYQKocGsCeJ+CDRWzkV4vweX0Qxgil7Y7lrTNhsWdBXLYmMIEn4IBmDb6uTOao+klGCGhqZp9R+Sa7EecLJ+Q==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-qvjuosuqlOAfGzKH5kr3XKzeDrE1zmd/u2c0gML81dz3Cah1tSdeZaXED4uziqro4WLTdrn5PSN6m6XvVUDfiA==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -15485,7 +15485,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-OT6lsn37reuBJ5wweEPXg+Sx4K0Q7Vz0qhnzVETQutPDn/h7TzRtc5XW/znrdI1cmelSl+nJaY4FLAxGc4eBSw==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-2/pAo489o9F6JvBw1qjuFgPRxbNqM/LqqvH2N3eCuHF+o6jPWCaFrnUaduvRvITU+90e7wnKy0ma1xpNYHzKug==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -15511,7 +15511,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-l0Hc7dJBOdXsPU6AZ4XQwmwsq9bjfTIm4CLaCTTbS9wrvs3lJn/HshqsF+shfCdRhQPCX9zkLOIhKutTsWr3QQ==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-l0vG6NpEp/wDV8Fotsu59mf16K2gelt+zcA4oj2F0rlCR/LPDYIs29GS0P6hbBz8cvJhbeYGxLENs6r1RVKIXw==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -15539,7 +15539,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-M5ds2idICzu8Gw/+v6o/xYvp+2UaYke3IJtoyy11KRvqmT/DF4v4VZTAw5INVRx5nFbtQN/lp72ZvLWGOI/K5g==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-LBmz0Y4Rka9qVxtNekE7hUZHzSJ1Wak5pvO7qAps4xrRGVJ3D35Q5FUSDQOxtb44FxX5i+z7a2LyfREpI+MhnA==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -15565,7 +15565,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-5Qa8t92V81IOeEsn/1yi4cDf9lxui561+EnV2MezUq247fD8P3UFhb4ocRMIWsQ2AWawtCPvOsBOeAG6FVXWxw==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-ajCMyddRyk4S7o5Dg51r82VCn7kiC7w6CUWJLjceafh+4eU3vkSERS8Gatw9JWS6vyP3quxJzh0J7SiJnH8XAA==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -15592,7 +15592,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-yZSYyun5j0/HNDTHSfmHp6ox5vHB1zRvVfqfKkLUUBay2wVhMbo26tK0dkHUB5easM8bxI9NfrAjp/deGVPg1A==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-dbkP9c/pUaT6jXZOv2usIoT8Vcd6HRfVFu/GzZbGZiMENqRBdMQ/bXMNtPRSExqpP1y6AsNNVUTPSBSNJO4p9A==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -15618,7 +15618,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-iaQLjspd71wTIt4eSsvbIAP45CTozAm5paQyI7fWVcJzWrIGC6mFOTz+OBeeuupKzUcoAR0X8VMCUMWvlde7uw==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-Go/oNw0Y+VzYySaXVplOaAjQ808KKCytP2QRoJoad34bj7SIF1PzpzX0G0nGAQTMimCUD8KjeY5QbKrVXHfYiw==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -15645,7 +15645,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-x+zC/tSdWxGQIAXh4IQtQygsK+VO7Z+ndKNFvHighw+pDeyCOqabJ/EDBfYRiUbKKsHG9cZZ9dHrBpD/8eAldg==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-vGftQJy9mWyJQ/wL92XNBfHK9njHJ1u7FY1UNMBpVIVOF2plh2ueErK3XZZ63AJQKMzJnJ8aKEkUaUjQSLZPGg==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -15671,7 +15671,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-Yyur1awjPnsHv9Pna5PtMZysZFEfci39iDAJdfw4gg7WGdRYjx8HeXocX6MKSiM5/qb544MV98arZAaE+Ar3tA==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-M8kaJltyou+nUeP0MF+p0i3uZX7MWK4VPt/ef5Rck79ikz5R5g1TPJ5ZBQod2Wp2h5NPsFNwaiWFkePrUGImHQ==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -15698,7 +15698,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-g3rgrE9ZtbElbL8Te8fKtmIQAhZWqVTaXEV6FW9vTlCGspjh1zTV7IYIE+Poc12Agg4IOeLKWM/UOVvmyGPNbg==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-GNfb2C0thI6BztiDRxWxekFhaNMrxfr49TUTM6I8FqAcQX3TZ7+Xn6not89GXiMWVathvrFf8TMkoJ7ZGrYKKg==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -15725,7 +15725,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-SliWaIN+Rcv9IO/Jg5OpZ8rxNzffNfZJOa375V45hPzipbZhzW0s+9MaxYzA3zFcbuiL7UMLpoOVYxWMQejEzQ==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-NCB8Nen24P4lV4Wy+a95Sw4HrMVkqcklyfs3HMOb0IxFrpThJiOJhS1rXkvD5Ec1okfBfNPcwzWQLvt3HOEjWA==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -15753,7 +15753,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-oHs4BOulQEkaG3QFPJe0IyomjAZEinjir0bYx2s68YRO+rGj0A+Sv/Qnm8LoB/6BTjUl42nLBCS7eJUpYe4WmQ==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-b/d81K7IFPOaKtope73jrqBUNX3I3gT8DCJD2gFLWxwmkkjD0CJLFOmMUhAxlIO0RSyvOakXpwYaKwsc1BF7nA==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -15781,7 +15781,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-iqNtY8YcvXuQYIeUxhbhCvkji454xHj9UjfVM9r6N3akRvT+oVW7sjpNmm6Gw589QjHwdQgR5EGJnRrTsUrMMg==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-OzGxbqydzboTjE7i/WUZZuPcWWP5hrWN1Y5sz51julbp5mrrCEsbAfLJ77/AcS2C8tjFQjkpoHNXbUkJ3QoJ7A==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -15808,7 +15808,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-CgDiJWEfBie5uPa9+Dm/wsTvLuvtJjhMB41s1uiteo4ApKDyqJhEEaSONEdpQG6LIgfrJiywobzqGUjNIfMEAg==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-vJd7uw+vO2EWOgb4Q2VS1w730vcEK4IKXWEdHKeULLiKQkOMC2R5yv+ScT4W5qLrpPWxofVGdtvlTChaVFuxNQ==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -15836,7 +15836,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-24kYQGbM58lv5R/61dogsGUC0izDyJKrMTR3KWJKYQH76CtODDn71J0E90qeyXrjRuwGqw+b34eZCaUqyUHX5Q==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-+BeQXBTf7kqyP76WWTlQv4QWnH7jTEp5YeFTlLmFPqNmW0Bc/Eo3A1CwWk5vXlax+CluToqUJWWwOlY0t+2djw==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -15863,7 +15863,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-mqMdKd0YceLk1s62hkd4wG7WdHbH+lAHLHvzg27AHCgw24bq2y9C1WuVSkhxVKk1TRx1zBihrxPy8Xb3fzEaYQ==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-4n8ys1OvtE9/Glu+R82iq1RAXAy8bQCdqfKCnmpi/XBBBTQy09gCxa2oaFd2gz2cvWpaQ+9iPEztdy4j/Vi5ng==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -15891,7 +15891,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-sI/vErh7yDc9Oufx+TIXMwNp1EH8DEznIA3832PJ9TeG+Z+dS6e2+b96N86cfm6KrXbRfGHnONJfp6BEH+3B8g==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-s+JbUbQxJxp9Xp8Em9GYV0o7ngPo55Mg97VaiwgBe6l9vu5LMcTTD383xdtwO7UDGkSfXEFUoNbNw+G4jKGtDw==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -15919,7 +15919,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-xnKnpIHxEpsKfRhulihBggq//JkicyBaY7eyKIFi1utQ7H3qO33ZdCaQSVpNULOUdnfwoGhS3lZeMvlrkIYFSw==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-JlXpIV1zrOr+LpiWchISq1AlyNe8NpFmbnd8Us1TNJ5UrYOv942PP25GjqjOTIPt9dfmvx7+WyvxT11YPK+Mag==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -15946,7 +15946,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-3iRs3Rasp6wqQReALavxv1Dyn08akPMzF72PJYYtLT6n9w0h+OhrmqJ93kkZlWbkY/yujmqHGI12z17zVahvuA==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-vasJSz66UVx6WHC/riLzubuHEUXbZjRdSb4tWNUW3Tn6tflQE53bzn1ItzFVZwdGYkIqjAesNhiVIA9tmrogCQ==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -15973,7 +15973,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-B9lagXZTe7K5PZ8NejCd5z8k3+7ZGwbdqlaHPH5RBrX55bV1IS4qhq3AJ6CuXVM8wejBdQYdu8wIdRc4KZsvdw==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-gy7eAtkdZt738VAx8eTfHQa5lc8Fj2FQjAk6W/uUVAAbmXLZ3ASm370F4gVOsRVUzxcZKVMKVgtx79xjiw6YxQ==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -16000,7 +16000,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-zUH7LG2pwzVDPlZCI4VhBJre2Df2c33s7NV+ux4ZRc6MSlt1mcxtXxEYvfMXNf7+Zr+sZBXmfcMiVs8+VuhQCA==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-xQzcEpIRXN7JoZUW1lA8YasKIzAb8R53i9pJxiKq+OKSLqYl5h5Vk6Zbi2+LbPYRM0C+NlHm04r/gpE+eThJdg==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -16025,7 +16025,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-QKYu1rCesMdlYKEKRHiTU1UeDDxNFERyKyXDh2847lxymwPP/D1MRzCP//Ctri6pe2jvXNUIZQ7fGV9ufLdtyQ==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-Z51b5HFcWWH29xEmIXXHHtKVUfQypZzALV6iTjCdD0qXITxApCxJLFse21nYLA48sBUbt088A9GHYCIBD/m2SQ==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -16051,7 +16051,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-GfCk+cFykR+OoOwOAK4sETZulOSenwWMKQFKXow28F1TOsR7nWWRONcKMB0WOqsl4Os0XxMPF5y4uSSnAxx94w==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-k7+ll78u2TfVXKR/W7UCIbPeSxCCrX8KSU+NEvUGgxNK+aygpqTmXUM8meudXQetPCcDa4TgMH/LbYA2ybzthw==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -16078,7 +16078,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-nMgyss1eb62firJEw9NM09/3z5YvqP7giS46NZ5e9ll9yHX4cJ3NWT3wHrNtwDpvb9lrV84laOv1RI5gScxpGQ==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-bmv6pnZKwvc1JpOIRG0VLSIUFOsU3d1X9SzP2+a6PEdaDEHgPQCxT7esdcfW78m788GB2IX+eJAZ7/ftw5Nvpw==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16105,7 +16105,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-ZLi8oi6cLlSk+Oc7Crje7aaZRCpFhQrTIRfH3p9Y0UbxM2uNB2C3DkTw2IYyNqezxrhPZfHg+3OHmm1b+U0qEA==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-aQa+zQmiVvqTjQNxtLs23aDqz6HvjnuhasprXgO/HC3URmZHryBN9B5fFO1RquR5xkgPWdE11518gFpBNu+m0w==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -16131,7 +16131,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-Qmu9lAuw2ebF6CJejpXYRp6msY9Tm80FEOUXCstYv1HTeuMT/XHWE51uiKtlzRX8mXIzEtKWqTLJbnA29HWAsw==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-VcsfgszOelIZOoH/4FhhWsUTtjFl2pvOLcQ3z2njGu5B8zkoIK1M1b7xu8kGp8b0iTnJUzcJHniFpXrb+9Ij7w==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -16158,7 +16158,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-JYfii9hNv1nNo/MVURWinVZLvStXzUhgAFwWGhwda9MEVnGqWxC2chsUZmB4SGjnsIQITuH/ValmCIPrRI6ZhQ==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-lcPYLyrvFVCkBL19YeAJOCcUyfKqX6Nn2gKUsgvy29vISakXeveFY21qqBINa8/VgTCHOURhZ67CP8fDZ1umAQ==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -16185,7 +16185,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-IXoHjgmuDT6lZv//NRYrQorGCNV4qvQZMw3nqZa+TVETc7SXtZ1XUJoChT7hIIFnAbvYBZx+9trbunaB8a7Y3A==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-6dtp0PZjlfSwh/I+Qf/R4nUjW0BF6kY6I4LNSbGSdk+bJoAdZ+6+UXZrUkBfFjv//pNI5Uf2GBF5NhhzpewYgg==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -16212,7 +16212,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-Na4arZcPzswhzF8Fi0O0+dX7HyhCx21d/zu8uDFsqF4t7vhArbxewOFnYfMWGBubDvkRslDDUKWbZOsMI/57Yw==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-g+7Hqxlm3v74YPvirCItNzAfEE+dFVKiZYfUTu8O8SUlJJqtcXWRcRu1XFd5sNrvjuPavzf61c2I1Oy3adkANg==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -16239,7 +16239,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-u2esuhP1W9Bw2VFdjt2PWia9UCncJ4MSKDfRZiBjompPLsoxhK6YzKNjzRlj6xy/D9CRRveQ7tV/1w/Jt7eCkw==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-qACFhnnwBFrThZ7rTUvxpSe+rFOlKRbgGZ/qy5Q6Mnu5ggDk+9p/7abIJG+Yyj8NC5HS09eELEs+K4eM9uB4wQ==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -16266,7 +16266,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-28flvZM982prcnmb138ArBvrXooi85fOQeMoGj3J0okzqkKWjtkmCtO6Xz9tJY3aZ/Fuvg/r5kHvgZbU0kP0dA==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-WFwbxg49BxfXBOH0+8P4kdnuri/AH9oNPKYS9O5Cmi87313R0Eht/Zzgb7/SMY78yo3s5deoJURru8t0DNrh6A==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -16293,7 +16293,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-nmSllrgu/D2fIm0lEg+JBXXZszU/FM4LFJJkZXRDjLQNVUi1Lz/yz4x8b2CvoXsW1a871gTXOi8q1Y8gUpZc9w==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-AQjct2rPlZn1Ru8fQ67UDbfVujDJUTnrHs+2Cv2ufopL6Orv5vVDBmp4kKQMIviKjTgDDyo0AVBtrIeaJCADKQ==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -16320,7 +16320,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-q0aIALRKdXZ7X7EweAexYcIZIZcl1CebIl5ZjMHrAMew2cA1bkpCr9Qt2yejiuO7xEZCDVFREZxCLwQODbagMA==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-OLahXFLD5DfBdbjyUkVzHNRBhKeM8HSPBkkFKSVufIOk+EfPH6E4gAUMGoMXf12nZ5UIsSIDSOZs3CEZ5oe8kg==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -16348,7 +16348,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-i5RTkCVappoHBeA3b3r/hiST+az8+zDEC7CeCvOi8SAlyu58zJewIUn6AioE+ZKQ5g3mKL7vhWvr/VyA9rgTeQ==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-dl5F+DsMnDb26lV4oUQ0JwXTQEZLk8iGTzLHO0XVUYw3WB6wFmeNs3Q5xaij/TbNOq4cn6fDtICW+kl/eLRyPg==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -16373,7 +16373,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-71bEJOwUVHboeY+C685ShbjvT/cdO9NXdlcedl5eSugD32bShnObW3pKZ+Py0NiOxtCT+Xmk/gzZ0f0M0D7FEQ==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-MUuRxRAplWENpyAbZ9YlyNTPoMS6k8LfnfwqCt7g+TFqHTOsD/99ChEBqhB6be+QC9D9jmGy4J7Nw+JODDupvg==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -16400,7 +16400,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-nsxfrZy9e4+uvS0s4SnZVNA49Lmk22yUTB3TZRC00zzoGuTl2/zXgbxjJ/DCRXojTAHPxAj4/enrOMVwNaj9yA==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-2wxThW5vKAnYilJYqr4MdEdcPMPiz0ASVLSR1Jd7AgBAeeS/QhMDD8H4bWnpqs/4WzdxiZk5a+2Qr+NOxy5l8g==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -16428,7 +16428,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-dHSXtV5HilhWtF8WyDnTJ7DgLe4F85DVzVMs8BbN5EDioNrdalZ8tzPk+BiGsyBrtQ/VSPsRC/8EMps7HWY4UQ==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-Co2PAgIlcFoJjZ3WHlg8TGDJCA0sdQLYXihgV0s0/Xd6sB9fXZt6NX1OzB86zQpWwF/ILhqQbUSGBVlhvdZ9eg==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -16471,7 +16471,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-H40bxL/Rk2irrl7vylbxma3yRTJ1CzRHmlbvQEXBpjKFQifkCACxVGP13HAMBcAbZAMlkyqsMDVgH5daiE8TXw==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-hKIFXk5ywgwQf3Z2KxLSVivFg/WlCUf0MNOS4g0/D4nzX68OcGbKEA3veA7QD+HPaPBxfh81JkkjKRvPNGc2ug==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -16497,7 +16497,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-ypfjkL6zxTQCeV1wGnuZ5jp+6xFn8xr3xxpSV7meOUpbK5g/FsPgAp+17VgL72PBWUOs7xXp5IFKYShcLKoX0g==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-gO1Ynv8xmh6gAV292Xg8lRnpIDUuyLER88wTAFfByirhpWhiAA36TevG7igdodB5I7LSJ7wgP6A8mHyEXFSNRQ==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -16524,7 +16524,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-HcGK/ZGbBMFlRmQEjFOHxh2eEAiJD4oOktIWkw7b1ad1VSUayDyqEtyO+kwDD7Cye7+eqnOKK5KXtyq6bpCN/Q==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-5hAvmxN/pYBveHQdAWYkGNFpAzMJKCyt+cjS6CxHnZlxT9jmv0JmqZ4iyxrJY9v0tZJLf5iKpSkldSujFZuSrg==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -16550,7 +16550,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-1xeaplkloqUsU44Ww4L31jRxPXDNeB2vwZ71Vj4IVGThs/bJwAGRTin4AniXTGiI26OXZyNNoGbo7EvqdYOAkw==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-K/vw/qAVpygyid7wTMqoM9xOHEddvU/xstuFkGbC6TWdBHpPHdvpwhgEEZ0Lg/LpUJAAbo/DZRtjX7Tlf235Eg==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -16578,7 +16578,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-ZmMAsux5HFfA9YBrhXDyL1WiehPZSn2EoKESqoG14Zeo7POAxcIkP66kHx05vkfOYLwmfYewI9wbp0tQ990Y2g==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-psByUZapvok/o+/UzSkfOicwB36a/80uOzZNekSWT7gx/yU3DOjzzLJRt4h4EvH1t8K2v1u6EJ5dVqvamis9YA==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -16605,7 +16605,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-FecbO1rrKc54C8B70FYQblM9IMZu3xp+MYvqp1u+9VUoSGFsmkw47mZap9ApSqr2fbzXDFUVwl5faMAOl9iDCw==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-7bB3KNhZkCOV4UuBBjk1eMAWMLgPwabZlacuN3UWTGk4hZipIi+BzbLxq59T8YR2jJVd/RjpbkTNf0EpImLDLA==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -16632,7 +16632,7 @@ packages:
     dev: false
 
   file:projects/arm-springappdiscovery.tgz:
-    resolution: {integrity: sha512-A2tlPSTSESOP8s72ohjMiNNc7W7kN8Pgw9wsV/zDSF35uegD/9bh23qRy8UWHk65fzivRT6677tPfLyYIVrp/A==, tarball: file:projects/arm-springappdiscovery.tgz}
+    resolution: {integrity: sha512-Cvx3054L4wjXLqPYez9k27Kk6jV14PEnCRZQnX3E8JintkVnee/s0LwgDNtaRMcIG0Nwctmp7iJb4zUHdzzDqg==, tarball: file:projects/arm-springappdiscovery.tgz}
     name: '@rush-temp/arm-springappdiscovery'
     version: 0.0.0
     dependencies:
@@ -16660,7 +16660,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-ex3UJHDftkICLCA5doTfowXFXLLV4D2nc4rTG/shZZjNsxDI92pqASoxVQgatsHDeFd4oklXVCoQHIG105bc4g==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-f2JeKbczdfYUglBcV15ua5iQWX0+kQiuANYmKb2jIr33ZvrqI8ITj5nY9wJwwf39VjknNUqG+YYlt+AgLOwzLg==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -16688,7 +16688,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-/lyrMBelmHzvGtPf/WfQd7Ie/3zjXgC4QmkwnRkPtiqCf+0DXIR54w+MYcsmxy/5XXKxbpfDRNOgPQqejCShcQ==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-H3PCZcUj4J8LGTEMYqRtR3rRuqaVZ+J4ntuGONNiBSdDosHkyR2Zb9PCqJ6BpEyD+pY+XGIgO0NrHOf/N+9Fvg==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -16715,7 +16715,7 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-I6N9Dzp45uKP74OaTD+Zz0tsWS4nPf6e4FPs95IgGDCoWzeTDnesgj36U3rf/cq8ZXMtULEM3kf35aoe62QTzQ==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-A/lDTGj63BcUVlKDracjMmjqLnK6BSZYyVww2uvaHizZ1oKkQNPHdrSwy3CsLVZm0jzcM5a5oA47AyxQEGOhEQ==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16742,7 +16742,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-NaCFNQ7Pdl53jqJiSRCyGeftSaEiLOoAViaxVEz0ATYqkQTKX8GQgRtZya02ZjOX6zE7JyPAWTslA+IFTXLJVA==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-IsrRlXy9gZvyVd2b2l1pwItXE0Ny2/KktW1yHAL0SDZQrKdVDIUQl59swXoexqgYTGR5NOPKfXFVv2dd0Wflfg==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -16769,7 +16769,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-BmqN6ugeFzb49BkhF1bWQ6xJ8CD5y0mfAg+d+ZweVu0kjPTKCbhF8+Mh/mLpJ0zp2ha7S0EEE7ePWhTk0CAVpw==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-fM8T5Xb2jI4+F4Qh6yq2mwkfi+pSw781mYwVS9QvZcwoEpSAr779vVEdfdjyHseT5aGvVxMtdHUoSadfFgDSGg==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -16797,7 +16797,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-GHyQElSN8jBqq+5ag5eZrOHi4VeXfOywe2GaORyTnFXTte2XTYSgpMxXfpxt3DPybZej2jieWmxqUG/b6VewqA==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-uiE/VT89Q+7TwXl3eBjcvDT/1gpGCMKWY1mT01K6JHicwGHmYrf5TxAEBw1RXKywwQ1siEk04dtTDIzyJOJVhg==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -16823,7 +16823,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-3PKBf2cm5mX9aivD/2DwLgpn95PyO3thDFjJ0CE58D1UzmwJNUOmhsEZ6ZKy7pFFmh2jYmTFzNIoU+xwg3sh7w==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-MFYVDNTzld7P77u8Ahv4hiPhUR3JYENMX3X+H62gfFzIvea4yswoKJ7k5GlzDG1uJ/grAUz5oIrnNXz3j7ln0A==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -16850,7 +16850,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-joRm8SmJIc86XZEolXZdFUCn5n/lnMynWLeX9dXR24yJxpY8wpO8bwJIKxfCPbUxohHiFq8lIxl63rEwgg1eCg==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-8eSsDVILdgrJHqo9fh3hVqo9OAlTz5gu/mZu6TXBbTon2oAhQ/dVFji/DsmgqTC+Hp0OqGsZT4W1d0b2X8oQOw==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -16876,7 +16876,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-j91FpbfColfGYFcqG/Zdd5iJsHU7m4RzS3ilxSuMneHS277eCwpPlLpx4uLpFQxqTXeU84OJZI4zfMAzUIuc/Q==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-KQePcPFTCqHq+6UQ16uMNhkvwRKVLB8hduJkVh4OfsrA9kfffsPifxvfCRo/SgMg9sxWuhj5bqvSiZD7NLJWXg==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -16902,7 +16902,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-VRQ/YjAU5r/GytNGuxkLQm8dY6DYauU8tEZK4QiuHDKK2PAMi3htlfiG9zgvcZpY5qDhgCS6NG6bXHLIJZ13sA==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-75eXnb9cnIg1faRH4oHjM0+8FtD3vmKtb7oYVhV2gL0O10Cr8UN8yQ8tA6N/cL/Zh+4O4cJDQRJwULKHrGkb7w==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -16928,7 +16928,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-bMBT/aKNcnJEPV/Dsoyly19s7obyxzppiRLG8QPeFpIjI8UarUMpLDlqPc7yYG767tbtOiqsTjQGb3kAE9VPNw==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-lUO5FclctX19VVQ2hjcS9wBbwCjkgS2ruhc/e4slK88hBm6oSsdR5ZFGSGXlIVUaFfoMiDqZkN2DvDeKeIsz8w==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -16956,7 +16956,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-MFbYzgXZkhn0o2uvUgheWdCscLB6BJQRw1bxodgsbgBxOLjl6NAYiG6K8PJgQtjT66Km7/J6TjAZmbnG3fEAGw==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-YRcQwLa7VJXk4rqSbKwvOrLX3P05ASOzFq3Yv/j6kxp7cRd7MOtcWA9Lkio563EHmfSmJ7cBnQGkpaWYQWW8bQ==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16982,7 +16982,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-u7yuFd+M/tLW7d1vgyQalQUSfNPutU1UEbfpuMxRMdzFvzUJdVbxDy6ktk6YXDNg34X6AjDdi0T4usMfip69Fg==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-M7rp04rhDaNUbmRR2V57BZ6GomyX37GVC6vUmtpV+4DLyJADh6Brl+1btNL5EN/0MySAYgcOBjKo+QmeNMWrhA==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -17008,7 +17008,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-3JVcl02aSpUgesD81sxncG7rK0U1nKN1aG2PO76mEizvWZYCtgU7j+UtFaBKr8hQQgnFv5nKUmc2Gg7ixKc/4A==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-XgHePCWuTKjXuSHkZz20+016AqnFYLJ9cVZfFW77mqqU9JfJ9v29bYUXkJroBv3AWSIbRGE16qI+JIyv0nHK9w==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -17035,7 +17035,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-MpXgMplw6Ub2Cq3+wICiu2K434EIL3VHbUY0gQgARXmHqFYb+AK8133N4ARiGI37DIjoGPeQmzSsHVWGZnoKGA==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-kOuS3lRnosyB8YQ3TziUxlUwgwGPCjz1Z7jlvXBMgH8TO8omKadOFQY/9hWQ4v6RARlVolwSHP1GNSvePmbfTQ==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -17062,7 +17062,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-e0UAtbuCrJ+ciKRKtK6GZCxe2ZzA6SnOJwMwkrWGU4oPROxsapRN8p8DjNu+OUAqLZPuMrOIZjrW14Y1It6lnQ==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-EmKy5ke81PZG2w6t/d67Mqza32v/gsJ3/q3qSIfIU63+QCvmfXqcy2o88YsvLNPNRfFjylRJMSTgSwJczc7W6w==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -17087,7 +17087,7 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-snC/fy5M7czA6QMqbhHDAJpOW7t2OUU9K50R3eT/ZExoqsuolkYmYPHV+UGP4H5RqcarIlIxT59+t0IoQnVVcQ==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-XoZWa4Jt0GMYTuSd2qRUglUWPG/sa/ty6703EJX8r/b6x3dd2YKucD5Ke5p/zq7csu8uCEb/klBkduj44vuRXw==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -17114,7 +17114,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-K2hxsxFmVn+tzlhpo+KQzr5gIxRY0CWyQY6rKQJ/kll1ws0Q4f/uKThWAju4uAnr3woVR1UmX4i3GOIyNObABg==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-bg8nHImFEb1ciZRKU956sIjJGBNyqeckeiwaVbHrFtYORI0Sjt/2VNMTtAApCxJ38UASSisSVPUW7njG9sSEJg==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -17140,7 +17140,7 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-brjdBlZByMiKwKgdpxJA0uhCCg73m5NNOffwG5Wfli2JI25oPcnXNk2Vw0mghamnamqOcak/6BDi1/+7opOILg==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-1Y9NsgDZSlN8vWd6LCK0Pem/9NYpSWamCh/bWSGLcs+UtmaUV1GuSwMnzjx/vVE6+ZJimBn+1FreRI198JVD8g==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -17166,7 +17166,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-r9gtrD1gCaCbQ1XH4XSM/LfdE6keWeOaiSbPtb7QRs3f4UYar3/8zOt4uXjVNpnC+ho0o1bChpJ6y0rFsaPe0w==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-zhj2hQWVp2fvoUQhs1HseU6eV84EciqNDRA8j2OUtXtG0APU2XnnC26xb80cWJlk/mfHG5QCjq1arUi2zUeQDA==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -17193,7 +17193,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-3eB17MMGPKdd1mp3nXelGat2GBWw3Xy89Af4xJCFPYXuqs/Clnavu4FhsDr5osCEx+JR+apEIdW8ObjL3KMA4g==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-IxfZerPD/9wJd0cnwIod168ubCV8tbS1XxSR5LUTTnmMErHluo2GID+MzMlH/5UqyAj1vA2m3FgMJr8x7KAaQA==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -17220,7 +17220,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-kjw/v4io7Hov1LS/yzhZpDvnqeubKxwt+hVjxp6FFBW/HUVCOOe4VQAWlhhN3BOBV5KBtokD7G+iT40k74uAaA==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-OkIVPy5PpCCVJsorwfLwI/vvCcnQn0t2UU41O4QRbmosZfwRbF38+Ir0Wax3+s+d0kyRw8vMVX3rnovasBfnRg==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -17247,7 +17247,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-yyBiTNj8d3HVeYHjBlXZmvrzBKEw/uc2HgD/520PCFunarhhGU2aHcM7963avjSKvO5hDKlPFPbCBWnu8m0hnw==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-Bs60yKzm+nOJlATCNhnb8/yHZ6WPQ5UOgPkdayU0nmdXk6FXn4hbM4zdVVeUWu+HjsEjdDjABabvXCXGINrZHQ==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -17273,7 +17273,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-XKudilLFmlEgKCwBkIm8nfpwBGLogLxfz3o5CS3tEm2lFIleiqLxbkT/TqJ3Gmi5D9/XgeYNGI6+2tUEyW0nwA==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-lr5KIJunk0HbSI18EMRZhtKgzxwGjq/Ucy6PrizHnbUjTx+6sNI5KWvzOGCVd3hVBrmgag10dSq7X6abx9qgEA==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -17300,7 +17300,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-kI0Z+inDWhOs2eqg0lqAc4Q/2VhtxMZaIm6Uii4xuyvPkm9B/LRQOTJabYoOdl4rbFZ918sJbA9elNHM3/nd8w==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-L8DySKHpx3B/lB3Eem+ecbloZWvHXe4jSJnJhytVZGYO89/HOM+Acp2NquPbzzRYpHp3geVLQnZu5QqcfvAYLw==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -17325,7 +17325,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-YwIN3qeropX+TPwF8EdEBOidsU00CxgzefGqPUVjIDduG9miM1hTUgN7W+yHW597qvL66APhxN0q5+v6RUiAAg==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-Tyyw19qYotupz4mlS4DmPUF2zB70bpChZno35Q4D+A1PfIgBKI7ao/xnMqrNV0TlcVjq3w5BpI2+IOZeWnck1g==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -17375,7 +17375,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-8yd47IqUf2ma+MaLeDBMpoUUaiJQU8g/vXoZeOzM7aBnIWQZ+pynNBbo1yckG4XJ7HvMVLAhGn/yBT453ko65w==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-294gcuMdC40IF/5CXi/H5JRQOfTEZYLXOoytJS0DxsvUxbCg44Jc7fGIelw5Q5FvF7+UOC7KmvjWEXy5JK+E5w==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -17418,7 +17418,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-LzF6jq2cRdsVswdEp93ACi2iHYunNXUaoyvc7xSDzIMtqQZOBMC3zPUvBz3PoMQPeUTW0gC5wZEPXiJ+SujqQQ==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-GlfaW8LpMQIUhPvcm8hPXAhIFXJm0ya38369m1RHeWxOY0MMGU11jUOYLlv2FLUVEIomHS9Qsj34SLNxiZ5s+w==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -17463,7 +17463,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-zHfAT3Jlmoxh9aAFe7K6Oi5Mk75jpndAi6emM2aNafxxM10wJFiMrKBSMIeo56d1qIDxNiamDRAxgXcA17bAbg==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-AQBomA10nLQB2QRgSfR3gWNrxtHCz+4PEwfy3RIIV+GUzKL+ERsvsaKT1oMe7xtRGPcV6qBvT5wuirJh4Wz8lA==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -17513,7 +17513,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-9ElzIgkR+3Kv6IhNRJt9atGlIZa97gqjXCvVD2WxlrcdM6GODGRtIFS8bNbcUFywbJP3+2I31YE4EMsuxGS6oQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-60J2fhLVxzSYMGCI4mFkiVH6NmTFd0DAhQydqgYbWzdYThUNyBACjHU7eo3hll9Kjun7KtezhJl8V8w+dEmy7A==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -17560,7 +17560,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-KdQRPiGnVECE3zjqt8AiHtvluFeGuZwAHTqWjvbLNGVEfccUh3a+85viGKC34+PLilPpJyxUtjJwQmSgrJOAag==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-82DSQ18aDqMYJztC7/2cR7p9zFQ48gTZVQGR1kABj0OTtI+5LGKPGGGuRWiqiRbf32OJqVIyKgGKIyFrS+CXwQ==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -17600,7 +17600,7 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-zfrzDjBCmfhJBcv9semQ+F5QstOdvioprljAVPNzkCPHRG86PqhliRrVKMd7k33sRMxtc0Fxi+zeIDkntvoGIw==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-n0zbMYfUqfxoIfuoiGKp5zvCB6PgKBTZtg42KCEpo8m4+vw6w5ncYRG+ZGNIZT/BCv8vPh8GkPxNGFH1a1R4Dw==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
@@ -17646,7 +17646,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-+NNoBNG/Bl9XQEy5HX+7uYcxGjOUMNIJowNfJK36J70rFZ0xPY0w1mxYO2IOHgmCDW/nq5EMcKzcSqcEEFA8fw==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-TAYak9UA+YtHtXk9/DRIGhSOWuXv8KOxdPEo9Mxz9G8EsNWGeA18Hi+Qe2AKo6XcxX55wZDxkyJheBVVwRzJJg==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
@@ -17694,7 +17694,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-desk9yMknQZik9abM0PiJhgOyw+Aq3MBTiSFM36lA1c8PGoR8NLXGnoe1rl7KyEnqnPO0CqIs09AAeAs9iIeSg==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-HBXK5G5i/gMmoZH7qaA7KeN+dB01FDAj+v1S6OErZTspJNMSw8Nz+KY75OjHWOLV2XfyIx5endQH1BgPYHewqg==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -17736,7 +17736,7 @@ packages:
     dev: false
 
   file:projects/communication-messages.tgz:
-    resolution: {integrity: sha512-ALfKMarmraBZVs9xT6K7B2sMkt931FOSYzjXc5h3FounSsSuHbWiDbv0Cn4ywQqWpZWb5bUWsJURuhbrEDxRcQ==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-ay8Z7Sikte3gL1nRo6XQGltuZAkclwGt6dkZANAd/bltC4f15OpEcWT1XDqcNlclsCS2QVaPQdAd1iduVPp2Vg==, tarball: file:projects/communication-messages.tgz}
     name: '@rush-temp/communication-messages'
     version: 0.0.0
     dependencies:
@@ -17779,7 +17779,7 @@ packages:
     dev: false
 
   file:projects/communication-network-traversal.tgz:
-    resolution: {integrity: sha512-MlzemQSCkDYbcSrR9XBDhjHi5Z3/asZDkC0qcLpB8cYtx3IKY+ivG6yNseQmN35Vvf4hmVn9LofMFfXnw0Iziw==, tarball: file:projects/communication-network-traversal.tgz}
+    resolution: {integrity: sha512-FYD1FvbT7KM1L10R+soek1v49kycvpzt4hk+Tu/TlkAj/VWnfrv0o/z6Bu0iETelTDJIfaiL4vR4Ju95hsdrgA==, tarball: file:projects/communication-network-traversal.tgz}
     name: '@rush-temp/communication-network-traversal'
     version: 0.0.0
     dependencies:
@@ -17825,7 +17825,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-JzXOayITg3nqzZ27xSySo78kW5/DPgSpLsn0fOWUOtw2sQbv15ZeDnYXb11eQ6ly8Sts//ii1jYhf3yw0+vAFw==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-C/1Aur+M6cFGETSxmpjH1N7viR/S+CPeDL9EoqfnrWLfmrxKSz+3OhVs5MQdZYlxu8X39+oFuh6SVxPcCs1BsA==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -17869,7 +17869,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-hMfurY3Uh2Bs3QmOg4DJ0mzlycC8l37MW8PghNHNgHQWQ61VUVCFYptGewt1p4endsu9oYrLqIgv7UuXD6PSpA==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-mGvSiGEn/LCH/HebBz5bVCwWRnoPNwtRoUZ5vwtMNb7yCPpqpg7sAcg3IZkpJaAbRZjiTw4cTvDlrZfcqiAh2A==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -17915,7 +17915,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-Jp5ZETyt7ubXG5sGlg42nfxPsFPbpsDvA84+5m3kkjnkpc56boFDtJT+2Fc9ZF7AQ3fCzA1diA1MDtSCAEWo/A==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-37laV/u3tPNunKHVlZBx2aDk0c7iJA2isAYHCaDejCapWs5ox47yAiV47jeDqLWfvpLkj24VIfxOZHrJDqq2gg==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -17949,7 +17949,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-c6gu2B7TY1jOjDgjMnncaXR69eRonypm26I++NV1tpuBZWSdZiNqPwkxQv2QcFzPb990Qd5e+8Duw169tn+Ajg==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-SLoCCQkqIbUrmX4CAtH3QLKxm0GM4JXPX24ucoXxP43UNGjI/83x35ZN1ryDQSzTKAZoVj8w6PK0xSpvecyc7g==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -17995,7 +17995,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-AG0uIUZif3jDOmxdY78S9EJbAF1SU9G6pF12/q6hVPmrKPNdND06domPdkp9QX2D4dkJNejEIrKuMQgr96jpRA==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-QH1ojOfspANa/398LyCbgm65fB7oCRClO6dTizPduJp6RLfL6BpNkQ3Z3PfkG6rp6WGQZ1V1hXiV75ExSdFJeg==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -18040,7 +18040,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-C/UipvVfbb9lMrYtG9rZ06v/lSCOuEyENCxu4UMKRtJ9iIbPwTsfPOHQNBGZo6LIlY3hO5AUqrbGcrDB8ueiIg==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-BFGZCZu4YmXn4F9PYNbDzz7iCDFnDsQgsJqZ5q1KbGicMXpKBpC09SfjXZkQA2eiGjAlg6T5f8n9MeRfvYNUXQ==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -18086,7 +18086,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-Lnd58M5AuJ2Y6sNsumMKfkhgnnD1bF02Mn5fthFjm6K4vx+VnFxxLbgaUksMKBMvlrVV/+WnvMRWjNk1GzFYEA==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-guA0GcaKeK5ePDFxXqegPcvAi6bfjF6H+IBcL+H0/hvEve5gPsszaaAHFTe1gnLQP8ISZUJydTQtYHJFQ8iOew==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
@@ -18129,7 +18129,7 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-PS+z+CsVtMitqUn1QCt0cO3URjvFkEq/UfQM2IPZod4x+VRUpYLDqEhysatKa6nXxfF+lg30KewHMOvn8SJ02A==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-9idUUYAK2cpLiiBo0CzOkySEf/VZ0gxKOQVR3Pq3MZ5rAFSqIdIV/7cla5qc4oODAxnoa7YCBVSfYi/vG62R5g==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
@@ -18157,7 +18157,7 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-ii92awiqoHoZc08k2pJO9Q19HWjKA+oUR/42BFtE3HyTtOOODGKG2q3DdfUiPYzNKIfRGVNwBUkPG7mgBe2ZnA==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-3RspgAOXX3qvk3JBFV1rdQYz8ml3jB0RNVF0zoe4Fg8We5BM3ERneXg5GFkvpQWQZpkY3MYfRjb6H7eY5dMqgw==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -18201,7 +18201,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-h6a/mCt2qYR/JfmGNeige8PDCTT3/8Vpkj9FypbqmH3opXycLtaN5Dro1f3ejlV9t3F19A17GrSMW+WD77waLA==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-ICsMjmllReqeC1y07hti4J86Udpgn1BXyJtSWi6lvsPiiHPGM8NlciGqN4QNLvV8lgss6H1+gXwExsxkRWDyAQ==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -18244,7 +18244,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-1LK36hxl/yFX4MHmS5CUf58rso7ZrsDtta31EihcL2mIW0rMVX4dlwG4iu2NvRvl4W1q475ps748uDNjE5Z21w==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-K96YceOVe8qaxhMMzBkZCoFxcj+pj9B1nSfQHQfxy+5DvE/XnGANhIyCZw3pO8uYhmIMZW1gKVTnZTV3ObV1Kg==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -18277,7 +18277,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-OLJyHTL0U4vLGSMZ1Uwm/cbaCSnQpJWNwZxfuqyuHvtF6GoyCXBb9RdB6KZgMhJJgBvEZr3BhxTqM57nciV7lg==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-yrsRgyVw1pJ406mbPES7sVLkTnwYAoJuy5L09RiBVRFG1GTvV5qUlrvL+uAAL7xLWAL8+vetNYYTgZqPFN8KOQ==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -18310,7 +18310,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-J+mQDVAxm/CPhw9yQFUrQt3TLclaYwfzkmNDWVcG3wYLZPyNF6m6Oz5ZyzQpwtQgA1GrZFMtJ6ALGyXqdOYGww==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-38pzXw+IilxQ47iaH8qqQIDKBXJu2dnmz+293f/E3wOoLQbfVnkGMPeM+U9OnsSmUXax5cn7nObnV0nF4CDLDw==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -18343,7 +18343,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-o4+VSa/YjxAuW8meTMp04lfhMav4XhxI2mQBUsgLm6qrsG+UInoYc1XjeoG9dxsSbtoDT8iNguuNKzCXTdAEnA==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-tJPVNWs3bvk80ejwdQWP4r+PL5FO0v6SJ40GugfqBq8vserFyZxRkVq0zDee39eORw1zVDyGp2XfZMY6BBeKxA==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -18375,7 +18375,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-4z+td5KBrB4E4AC1W8sIikhPFggJTtbjtzYitU01rvQe6H97SnwxgSX95X3VYJuuz6FTtaTu8Ygodk7U9AvdUA==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-I2vOznyNVg96o2ndmFcAi2oeJ4sM38eR0ueE6mDKa1DCg02qlf80RxrlRZGUElS19xpWKGbdnERPqCskAMyjSw==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -18408,7 +18408,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-ZSI0Vg4yD2/EK/sq4+YxdzQy9YGswtLd5DeTD397iaMoy0vyp/6BKURyIPiSoBTofFUIV3j7MwaO9tfkyHbT8Q==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-vvZhetkvZ2gG2gxrDKB3AK+6758n4iCXqNQTlWCX2s3JHTGFhkNXQCBzejDjPVyBAA4UxCCsFJca70eX1J2h4A==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -18441,7 +18441,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-SxZK8Sn3iHsCf4SUWs631chCquZR4EoAnGCZIBAN53fzEx7zu7Fn5kMgthrV7k6sZqNh3Gr+2UoTzrdfd96aKA==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-e72dDkqu0Svpxcftt3FqHr1KhLRk8t8Bago/FyrchzuS8WJB2Z4BoU3rA4dWt9GM/7Sa+CQ9V1mn+5t6J0407w==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -18476,7 +18476,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-SQ12AH5WYq1DSw8s4W2KBK4lI0JqidtDTYrSBid8ji11C+5EG6brZOmlEsstwrE4/ou2BRGQZjYOiFhCQASPOw==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-0ulh4nAfDJFxvDkzU3PKjDgRSIUPsB6vMgZ5/U0xPNS7JPPF1q8h3cv/ZcalSTNDdAAuGihR8fEqd/JeaflLAg==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -18510,7 +18510,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-OiN48Pr2CrhzGy/wuAmQKNxNq/JVEDsgVVIbSTMLBh09mRgHVAt1dDP2RiazPOUoVgO+a8sg0lUlT9UuJkbLQA==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-l14HhQTeoS4qlO/6BfJB4/2Z4KTf3qPD3cOGuO1UJIvYfX0mwmwJHiXc7VLPwCL0khQr8f2rhwfxS81pJcPAlg==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -18543,7 +18543,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-m6EGouRXU6ZC5lviRF/UxOy9EcUOR0s05AMbEYkhx9w71Ohu4X8eWea8RiX5kplEaCvQj/Pxpjpk+FqIMiq6tw==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-b1AbMmtrh+KrnMICvIwX44gHMJ8GET4Hof9rl6JAmrc02wDYKa56ZHkHaeQg+ajFIL2tdJnm8Fp8kaDQY5YSUQ==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -18576,7 +18576,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-nHFQ7K/R0RCToo50zrD/m7qx1IwTGRhgSD2sa/u5eP323N1Ekv9SolsTKReAM3bqD1PPirvytI8pP9WC2dvkpg==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-9pzkE3iMmjofYRSecx5G+GoXTBh7IkDfBph8D+Bi89w5fljuGlyAx7dcJL2Bw8+lr/nQEifF9vlu8Rq2WjVw4w==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -18611,7 +18611,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-QvMe4hvJqxGu27gFk9gSt5x0vTeAtrKAv2YfWx1f/lkIeVBhzS4PeFaw9+Gb3cfDLIqB1l9KUkOgoZzWbjgLAQ==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-g2CHsQoYTDcTtSfv9WMBVR9gKsIwtB2TdGfcwsVq8jMZceOIfLt2QwQT4471bxhG4fQ+vGpkQ8oKilKgWtVu9Q==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -18659,7 +18659,7 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-iVIBl8MiXrmlB0wceNOApa29oWDJq6U5IU7Iql2aPWo8Nr/cO35zGNEC4GSLnz9xnk0mPyo/30C+SLc7onJ8DQ==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-3JEF2N6kEpndgHmxC5jqp5wdTeluMOLqER3YoAcGIatApN1jZ9/5jYHQcXN8JuPZqPFBcAIH8g2c6F2hMXSQVA==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -18702,7 +18702,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-cExnd6UJQQIshWTVKi3p43lDS2pAunjd056VzfoZ4auZpdMfZEh1JXWL8a2d8edmRvnLwS7dNRszanFBafh4kA==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-Feg1PWTklRinRbb0fpSl9DlGPs0F+mJPSiPF2pc26+VRmMeYq65b5jUD8EoJI0i8P0ita/XXbL5HMCTzZCSjng==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -18746,7 +18746,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-g2sD7pNnn7rPJrvryHfXFz/s/IGrGDUBZMXOsyAdH2McMYMOPqIY0cfqOxXEAKY89AWo2yr6h6taU6bvywZDQg==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-+bhDzfvPvq4GZ7wsCa2n88wV/biduasOH0FbtwxebJKfG7Br9lefJ0RHB+vpn/S/fN9rv7E1sA0V2j5NB3huKQ==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -18805,8 +18805,6 @@ packages:
       - '@swc/wasm'
       - '@vitest/browser'
       - '@vitest/ui'
-      - bufferutil
-      - debug
       - happy-dom
       - jsdom
       - less
@@ -18816,11 +18814,10 @@ packages:
       - sugarss
       - supports-color
       - terser
-      - utf-8-validate
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-9Row3h2eFyesNCODAS99pVVD0EHWgMj+adg6Xh+HGbuLSKTLzRGmiaiZQ1QydAPjIVfPQN2J6ioWsz4y5lqC0A==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-bfK4GOlAJ9vC+9A95OHPc+JzAJ2eRgLqDfppqIfGV0gFN/GoXTCAp8wjibbr2Byy/SqgSBJrIIQ21DlVNTCYuA==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
@@ -18864,7 +18861,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-WABaWf9yAF6rhuVYZinqJqHzhTAjkcb/wt1nry76qwmZImWlM7zLD2KxSnOeLAr1UMOrZtg6L7i3a82Q/N7F7A==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-7/162x/wY+xN2QTxxexv5jQn+cK6qLdRi1qR6vwr/j7f/CivsHNeo5bZ4juc2qfWT5lQKwo75Kym/cZwTGLnNg==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -18909,7 +18906,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-81LjcHURGDNhd99ICbhwWc+aJH10sWa3J7QjDxFc5WhdewTN9gCHQRLXUlXT5oxBl6VK/7cOt8+MHIZ9Ezq8Xg==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-c2p8g6bTDtMUiM6D02QH5VPifOavw3/sEXQRQhMooIM0SyRU82dZR2qtzOGw9ZGQ2oXOmPPpW7i/N8ifmjSw/A==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -18928,7 +18925,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-QWCQpxYTL732c0p0LhhgoNH+PBuwMeWeCUVO6p/y5HVftrAf1V7fCMuNTH6MkVmX6OhcHY941iWQMGnzskrITw==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-l4Tfx2HM9nIs5nsD8bx1N7Y1zFQ0eGuqbFbyh9loN2Am9X3m2qvsD6Ou8A5+b+kBxd/qFYhmngaESt/dCl+Gnw==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -18966,7 +18963,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-2w5+Fho+ZEbuc8EHMwjZBU8TnU2OLZoZrUXw0svdg6gzQcEuseEC0dzWMyYfYYSpRySwV2jGo/AA5e4XY4KFsQ==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-lnKf3XksF5BrjWw+it3UJehsePqWocTU/zwZtJ1MIYSvQc9UGq4wE9TBH3jjsTf2v3pxCVCNTu98vVdM58sIRg==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -19027,7 +19024,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-n4uul6UnWNvKSlQ++Zs0e5paVpd2DITzP1WZ7WigL+eUTvsSBsfeR35Dviw790NvjuuUiPVhZ/1SL5Ehn7ACPw==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-JA/5o9eLAnSxEpBzxWVIf+fVdRJXv4Ss4K4aLYnsWECtP4XSbzODq20l5BaZQkpO0EWSpxKCTodRmw9G6gGw6A==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -19069,7 +19066,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-9tCkRIV+ana29MG9f705LWm33vr5QP32MQSj2Ugc/FzjJFIo7m7jURJXzUnys8m6Dn4NOCrLa3fNYqzsUq5v2A==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-GZttLKha1yC6gORy3lLWOjzpiVHKORUDKX3goHAJKtbmKnSe+0RJ8O1SX0HJ+NQ/6/mIDzG6eiLNBkPcqqc8vQ==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -19119,7 +19116,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-MNAnVLgZpP2tCpMUYctWUxl1p+RHQswDcdueCxd56pcKq2nmRufWnos6IcR6xbBaJ9i5Rqc5pkFX8matcMwjJQ==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-e2e2OZ9p4QPVXWesw+cp9dIu1L3+GjmB6Y/18qEISNDPYOc8JX1XaWBK7JnX7TSo6/xb0CsebOAQZogMEIX1vA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -19166,7 +19163,7 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-763pAUuz9DAzi7jlsrmynNZo5SWzxx84mSaoRo6Fp5gcbiTl83FaL4IQxDJgSyMbasckrmb0YgsH3Jzs3wpq7g==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-lXoHzjMxtbz8NSmoiT9+c/HUItezv40AHHW3NHLBnKXX6kufB2Gv3He1p4iGCBJoBOGAwKQYiB4dqS4YYtm1WA==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -19210,7 +19207,7 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-8h2H3YNeXGdEGQ+TnUHAsDV6KLvHzLTR+qsSjKocCScNrRdwJBhaSrIo3QtLjBaB7K+iPoPxtsdm3k+lBvKCEQ==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-eYSSKmiQ7PV0CFwAuZR0K9uPivC+fkXFlpbk0iCti0yF4fsAZUkaoMrwfg3lhPZ1F0K5nd1a+lJWdQpP9kRwBA==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
@@ -19254,7 +19251,7 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-R9izTxpyw5PG+oUlt8ZEJwcbNJntRoQUsktQ63K5423Ah7UG1UgDPwIiYIrSrVS+X8OxEIu3DDPo7/oeRVJd3g==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-rc5CIO0faOvOu8tAe26x9g9drWFj41DNzK3xd1P9m6xepSCXy/g0V8hL0ECldsRQemB7icVFOz9debRa02NfbA==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
@@ -19298,7 +19295,7 @@ packages:
     dev: false
 
   file:projects/health-insights-radiologyinsights.tgz:
-    resolution: {integrity: sha512-MgqSqs4TL6lf77N+K1LLcTc0OArMhm7942eyZq4LOE5RQoYx+STFg+wOpncRL0oYlXQ5mLl0XjISd/DmTXb7Hg==, tarball: file:projects/health-insights-radiologyinsights.tgz}
+    resolution: {integrity: sha512-LzShHe5C9t4zZLNVcQO9e9ber1j7KcYsK7AtcQ4Wyy4IcmqqSb3u0cAGnOEddemfOrtdjBA81uLXBFl47FfGUg==, tarball: file:projects/health-insights-radiologyinsights.tgz}
     name: '@rush-temp/health-insights-radiologyinsights'
     version: 0.0.0
     dependencies:
@@ -19342,7 +19339,7 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-pEzSuEC+bJbFJ/bJ0uWL98hxzLq3DrXEkDOnBhOkgXIqsZ/N2i5MkwCpmF1uUtd6c/Jj7GeoBalZRKDp9rb92g==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-RE+YqSTaxxR3bgxMrHGjkuJjywZPJpdr10nDdOkrJ22/So+aW0kisoQEPaQ6WBL7HD6PSN9fWxfTBYsKfBGe2w==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
@@ -19372,7 +19369,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-xjW/usWexAhmcVMN898Kbi+t7A50zceGD22B5femIIF2pIKyExrmUN78+73vvuRWgovG22UHZ5CZwQRm02+PvQ==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-LCwbkL8GhVO0eQEUVYw5NtzezkcIVPHnwXZZ/f0YWGuevw7+KpOVzw+ZptL8VOqaM1+DOFJNfBxemjv/sxx0BA==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -19408,7 +19405,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-vnqh3FnIhswMRabiCjc7s1kUEaRMfrXE643pVnnfrap6XtXLobo/uocB9Rc1XBLwpCUMp4CrgRL93ssVCehxNQ==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-WCE5QHoZnOoqtCgxVpD5cYrQDumqgTNKpzUT/hXeLEkJ8Mu7NmDd8QnIWYd9J6MP0pwZDI2IKRVJRv+Wn6fl+A==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -19443,7 +19440,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-j1761zpFWorjbpu/tWmXQ8wDc6t1/9J0pguRlSl1ibFzo/G3in6FLnG1Cc/8UUcQfvEUbRU3tLf+M0WffpCWdA==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-eWwcHy7qVgJKYZylPZArxZ9mF4TxBqvuDUGf7/I/q/tBRofMWlSm5+epmkPB5EsFWmLE965r5SwyPapJh5lvrw==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -19500,7 +19497,7 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-L6CoANIvkPHd8wxwZtE2GCnmcSnhfq76pfbSFKkRIQxdAovBcUfjGWEqLn+8eefB3FG02REvWxyCFi0KBkBBTA==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-UFNINAFOToP7NJR8stMLUfmepJc8b8YXGZJy5z2ZJYf7Db/xKAvjYOcysmy8lIPB3SyjOWiemD3U3/v0r572og==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -19546,7 +19543,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-RpJ79+50X8ksqxlW0AWqk7c6zVguxpmmP4MhfNkuU44sRaJH96URi9ROItmGIpVRBFbpuuRUOae72ippUgzqew==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-gvMttKI/ZrYHvurbJpfqJcivpEXmmMTOGiLQhMW68m+j1LHsL+3IguNZSffPIox7lRNsDYnpIrLOZ10DbXV+/w==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -19590,7 +19587,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-RLWOSxjyGjR5IK5Zn3K3qhTbssFq8TbHNqWNwm9Mk3SQsUR66+jhDk6lxN6A6lkfSI2p0ACVVIe9gZCGcYTNsg==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-7MJ5EAxk5BnbrztcD9YgCF89aLz3bUNFh1AbWvk5HR0exX5dZ32iKnJVY7wyc5bclBYGJayh+QQlhbPJN3Scyg==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -19621,7 +19618,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-gzE1si0y81RzmpykipQJd3J30EtyRdJafBQ8wL2EO5MmVOr2sGqyFTJiEOW2HivbwCtCn98DsADi2ikdNyyDxA==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-OYVRsqy7v/QmN1pxwJQ5FhKJsWMfzAUELoLvT7XudEVa9wOvBZs6bzkKmNjobcyHAmxYU8zjgpsaRv0IrU8Wfg==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -19666,7 +19663,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-6/RGVMxWL5HA1fMuirrHr6Uppay8SRLhT6XUpKkX7keBA3efjjzpxMBoUweLcAx6wc5i1YzxcRkej8Yc0mp/yQ==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-3eTt0Qa30nw+eIjDezcF8kQ9jFhiFXqTZA6XBNiQAiHrBIeOX4xWXB3kpQ1Xbz2Pqq4G+UnXsc8h3td75Etdgw==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -19696,7 +19693,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-lgL5ctDRRbphGvhYV2vOz4Kg88hszujP2+Jfju1c7ZBa1ipljleDh0Q66uciYRlWa/FftYixCkYGVQiQg++rtw==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-tGzJ200FaETep8Y2lb4/bqtGwstjimWTnepRZwgjrHYFEsjWTfhRGhYKsATCKCKbf8C5NTuQTcNdbgkN8hTLKg==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -19742,7 +19739,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-mcvWWMggYVmLH1lRR2CiE9/PgK4hcDSsjxtlvBR6c2km/1hkTxOGHPsN1vN5ifSOVsw6pYdOxFWjNIObLEGA6Q==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-ceC2UCgZnkE+7/DscilyDhsx9ZVLk1jZR71J7kVXb/JIOQgkyHbQNFAYSQ2EdQRyrq4aYoeeSsKEaJT7k8qXdA==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -19785,7 +19782,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-9KppaB75cGaUL3m1zIWsNuS+d9Xu3ycBx1hlwOmKRXF4q4Eb1FwKd3rog2t8w3+/fJNClCK8zCMpIH+vmXki9Q==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-d8IluGAh4OKdvzXCJSFJmobjvON5nq3IOAfjkafs8Ef4SDTa3QLtA195glf1tVXkfZcJq20Ak5lQ7H2yZracBw==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -19831,7 +19828,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-+9REBcc8JqvPZtrlasULq44Rf/SZCr0g9nSSc62oxWhgQPsk/YBYMbcsfim7y562Vno8uYTFfqAH3xEjznwgnA==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-jUkUA5MVUavt5VKFk1vFVZdC9Qo2YOFYXMcz8lJyUPn9xZNzJ2dIqNbrO15US44xUiLinfcx6W4qr+A7+9pcdA==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -19865,7 +19862,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-MshhAL16Di9s1phne1vgvSkvX9YI1UWTu80q2UYuUxgBHPnwtw5DwXHlGu+WnMKhGS3VbmOkwXanBPJx7AgDTQ==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-3GpElejNNohWM/YZB4HYYpZsbjPr3iXqG2qqlASff6ercwPgzyU/zjmFgZj31zrnOFPNj9l7z0aoxyHhoLJlpQ==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -19883,7 +19880,7 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-0xRLrvXCaJE17JNnFY1oUoejow+942QyefXiTjL/kvTmj4eYQ5HDCOtmOeZP4rSUXT/qadXX60Uzvdwmy+9ucg==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-aSRlzsxpI3DVj260DBALkhBOduoCUT/qMHaTS9AJmFFftrdJ89IPdJOeIRO89WR7BG1SaKR2d3n0gQF54JvH/w==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
@@ -19927,7 +19924,7 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-Mcdw8CbEFcOY5bEc4EpeHsyqXXeNpO1qwyjHbe9mkK3mlUuXymZlzvUEuLGfjVsSDHP0iPqXTXsHRlp4/AuVCQ==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-U65JVg+RhikkPqt810eFVXpZO7scNbuR81bS7dFjeqjqjd4tEUsU6argF1XOsWWQxNOHaUhUp/OGZ1by4Vgbcw==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
@@ -19971,7 +19968,7 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-/zpn44m8aiOTEBEbWXQMnP412K1ihf3w5mfQVfgb6iBJM7IncdDpvsbFQokItVG5AkA6rEgJsi47xF4//Ctoag==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-BoHJHYBKoMovRTG7o3iNC3pxZdk8W+inVFXa/PcdM3qygQuWNA92bv9vP+7aeF5UAkkp5f1OD+6PGor5U7SbCg==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
@@ -20015,7 +20012,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-B4YewDv3JmTWVIMpYJDHR/am1Cr6AP6qIs2IPDNBldh7eRq2NJVYEvGE9mhqKoVwlSmZbsI7mCdb+JGZ0cQzQA==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-YVkCCBVFwS4TRx32GjOuE3qGM3/GKNH64DNYI8l/nrYcNdrO1laeq2hb6uWpvchbgcK3dFE5Nq2/cVii5uc8gw==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
@@ -20059,7 +20056,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-YmEfvYGblBDCX3ShDK6pH5vpYeehwj8YFL82EIKHRC3yOCilxojdnXY6XlWoKlGnR8PmKPacTjyv8ZLbwzm4Sg==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-kyN9szevkPlknBySlT8Pgt46s4O0irEKZcUpNI6K2wU8SQ6oPCKMwSYqJgWB5OGgncPvEDc/F+wi8vH/PYCgmg==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -20101,7 +20098,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-bYue2z4X1o4zb+l9BKAAX0KItEqWIf0HIXwnNjbUB6/qEFpp/emif1nqJO3v5aytxdNQGbrCpKaAeNETsvWfcA==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-Lx5F3/Uhzb8W+K4uDjllDC+El5XrcN3pSZDhsQ+NYBgWmTihXkDm0uOgeIZi5VQMZLOEHNDgegMBZf25W3VJxw==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -20148,7 +20145,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-0iFt6iHLpfCmW64Hgw/dxsQJuhX5FWqOFbYNpztGMMZ5z/EYnJ+0blwPQA47vwp6HRJCs93XGCEo9/PL8RvgUQ==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-cF5biFHCBknMGeAoMtk9cec5IzeT3ABz8tle5SCZMjc1UFO8hOUeOpL26O/SAwfdz97VYr6NeOL6XWL/l/Ng+g==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -20168,7 +20165,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-XTy7LjKs5BRxWuIZxdTaKpNkghCBuYKEdLuU9ax+9I/dc0XwTZ3Ia5pFYk9DYL6bKhK5u+VQIrC6+gD2NUqOyA==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-dfdhur+86HxCJzb09f8aa7lRIZxjhCuZfv2/FA+dhVKsIp+KvZuQuGtbiezUd8Q6nQweFBGYS9hZbTysa5E0iA==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -20216,7 +20213,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-gnhQBJG+kMvERMvZcRGrDRizI+mhiaQqTmbHFfiiXLxi4HBAVmj1Nlx3RXIrUvDcapn8fxK/mOyPvdY0frQ46Q==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-kTOHl9kMbOSOskX+nYUM3Sb7Vk6EgewbgaXKqjz+Brir3IvHoWDSgb+qZM85SeHIjYxEhQI/36jd18HyM4oepg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -20235,6 +20232,7 @@ packages:
       '@types/mocha': 10.0.6
       '@types/node': 18.19.22
       c8: 8.0.1
+      cross-env: 7.0.3
       dotenv: 16.4.5
       eslint: 8.57.0
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
@@ -20250,7 +20248,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-9VxopZ6mNMivF8xrVRfcecWW++p+trx+FNyjcwSWFhQ5jNX3cmmaZB0VRRKxyGtQX03u8Y0DKzRIQDl9mcdQbA==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-oY3JKxapMG5+aFPyq2/ae4IToa2aKOocXo2pcX0O/LBqLry3Hm6fzY302mbH8oW2LjDL7UX/82k5yxXHMXxPgQ==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -20280,6 +20278,7 @@ packages:
       '@types/node': 18.19.22
       '@types/sinon': 17.0.3
       c8: 8.0.1
+      cross-env: 7.0.3
       dotenv: 16.4.5
       eslint: 8.57.0
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
@@ -20295,7 +20294,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-NNfdquPNUyR+6XKI1UpNBijLT7vkqkFXqCVbN6BwNBiKWNVBjVv9y8N9QmcB6fBI1z7vBKBobIaPAuO3mGZotw==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-APfUA0snPDgNqjL0lwKnltwvMRAk88dB212p8rG31+7RU11DlirWZhqEiRdm9yv/SAFl1hBOzFUFkzuyi6tKEQ==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -20338,7 +20337,7 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-wYVvhqm1c9pu0sVGbUmow/+Y1RVDeGgQPeSEXNbxXH5BBO4XS0NUD1rsS0sny/ZuiOyBmH584mTuYPitc27Qww==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-s/yAfCbzDTCZhbHVodYO0Vyrehxkpxk771NPRrphdJznZu8v7t6V5o+Bmxx/ys92RNf36oZf9eA+nT4SgdLjDQ==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
@@ -20379,7 +20378,7 @@ packages:
     dev: false
 
   file:projects/openai-1.tgz:
-    resolution: {integrity: sha512-J+fEGzw/cTpp6pt2s4N3Hrq4O+aJZHiqfiH5zTtD9s9tHiHLvGcwurZPNaNrrqNtvyCHwgS5rVAJa85c5PX63Q==, tarball: file:projects/openai-1.tgz}
+    resolution: {integrity: sha512-nHl5TY8ZI+5uXiQGGDdh3YtcZWRLa365QOqeSypMKKywAkRcrhFnYE+UHqFGY7caOgans8Q+wZJU6OwvjS0rmg==, tarball: file:projects/openai-1.tgz}
     name: '@rush-temp/openai-1'
     version: 0.0.0
     dependencies:
@@ -20423,7 +20422,7 @@ packages:
     dev: false
 
   file:projects/openai-assistants.tgz:
-    resolution: {integrity: sha512-sAmQpau4Yt0j6ZWlakq60s7g0PJlloqpTh3opxH6LgYqH5ZMNQVHFUaoAHVVCEj4y7Al/hF68AfuyOYt8yX2LA==, tarball: file:projects/openai-assistants.tgz}
+    resolution: {integrity: sha512-+Al2BAe9J57+TktRmgFrEC7nr1RV2TdhPDA2qY3+/+7L3+y/KzhH1h8KoHL9SreoEtPM3B1iFni7iryatvuonw==, tarball: file:projects/openai-assistants.tgz}
     name: '@rush-temp/openai-assistants'
     version: 0.0.0
     dependencies:
@@ -20465,7 +20464,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-8k0W5UZO4jYWW3R0sw4J8w/xFEovBBusdYQqIGUMlwGq7t869oE0XXOfahDsZIGDBACj32ci3maBGF8PN/MhUQ==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-obXb6vm/bNL9CLo3VIhpsCeY0v9qbzpa8/iCAGWGHLQCqiKrC38nOBVU86j6McQhLyTeviWOz04ax4b0w2Df8g==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -20483,7 +20482,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-un+vPAwYp1VAxQfyUB4EyC1FceIz943vk6fqY/00ICMtP27Ya0YMbcDF+2AQNwJko5usWdR+Lr75enxF1tQO+g==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-My75scGbzqjp9IkJaEISCLmVKRPW2dc7a369c8s3+uFHMKIzqiz4BjITxqYlI2N7zZ1o+SAW4QV26zY7Tka3EA==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -20527,7 +20526,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-jwvM/uBXz+A91uURcwEDNZj8aaDBn4bQbL/jKk89Kwfd0T9KbivN8gcuAV+cogmZXxukHgRhyPbV8Ha2guuSjw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-nHlDtG65YHF/9vLOzaSVYQAl0uGyfB95ZLConBASNnarAdHdTJuzsJYMH3H6STz3z9UcN9rHw7DhXh4KZsi6kw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -20546,7 +20545,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-zmMlXP481S2leaGbiTPTdoAgWZMmIDLzTjjPgiTqU0qfd9YHtIdaelmqBnwr9F0uRkaKYFR46r97FjSGbsQh3w==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-h5bRfw9HxK0T8exTBPJ0hrJrldRzd4i38FAt8SwD54R8IEJIgZY4hOdMI7SjE+oUSae9ZTt8YIPZujU0TIdFUQ==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -20565,7 +20564,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-1Qj2vbfJQ10Gkhk3ZAx7pWWzVzFHtPEqiQqWwiGfZxErxv8k/flqDznrr0v9L5KBIml+ygYdHMKhyNFjLjAL+A==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-aRLifFK3T0HVAG5f/nS5lnGDJjtrkVIRYvdoFtDq14eoUFTYbKXVblms3mGhTAh2cCaZK4QoBa6R4IPhxO7tHg==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -20583,7 +20582,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-OSuAsD6WyU5XHFVTOIm883IVdqON4sm7COUyxmxP2s/JGz5Nuo0p2jwyFgLl+CkAk7znEvuXA9tcg5wvEE0n5g==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-87DiBf7cu6ukgc1f/3ZsG/JTCeJyIIQ8OaWui2YcKuPIiLPIUCdWztfytciNd49RNCLrnhyiR8UbGFAsLKcudA==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -20602,7 +20601,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-McDuRdZ+MgkgonF+gWWqY2MR3Uu/ZXlzv46lA5/AM2onKI/n+DMyvDai26aDDHrhmgWJ8MG2NNuJXZ8uFOvrKg==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-4VBBoLiknqGY1Pf5W0b3DQXnhOPiTtwRn352YoZUqN0LtfSIl0On7t0o3bkT3wVKV9YOZHBjfKpB5jRqXJlufg==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -20621,7 +20620,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-UknYlNsrzb9/E4tBwf0OT5CZz1Czn1VRG/CbEKG+usukq0711J+rqfaCfQS2yrwPED1r3W3Su6odqBe+MHzPew==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-lKrzqDt/jRSznA+hDQ/YMrYgsNq/WIqlCa0f4/ExOk9WPrFnOH6iVeY/cBCKyRa1lsYa7vUUqcDTZNAXM0f/qQ==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -20639,7 +20638,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-d4G9rQMyMyIAfEwY9p+m6QCM9OTaEjS8/pvg89QnJRW56qqxRwI64iGfApGfQX55YXqdtLM+m4Q+a+dR8Uq/mA==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-1kp1CzvjTJooy5VARRN9YdUO5E9WJV4t8SvHxlnmrr4UPpT1j0gs0Qd0EK0CaQ9NVAlzXfZLHX+EuYhzkFi4bw==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -20662,7 +20661,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-+LFt85LhKL0KYqYvEJfmyUZbv3TX27CM45MC4EI0gnCwuLi23qCSEiQdDwGj4JDtMlCUwdyuWG3y7ijNYfOPmw==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-0JtuW3D7cXwdLvx2QeViId9d5TJDN1yEEYBsd79DLVxpUJOkS7BsKRpYx55rz4YVeYgJwflSkz4lv+THB706Yw==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -20680,7 +20679,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-D+ZExqVjiKJUcmHO44U8xr/kNkvSQed8CEsp6e66LJ4RWNEHVZud6Rsul8LKJe87ETfXepNHUTbWkBfS4waqLA==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-8kFxLUSuT66qoYQwltzcSVmhTNhEQlj35vD0JHeXFcXY537RRLe9ie63OrlBgWU7kLPawf2VTjIINFRNectKzw==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -20701,7 +20700,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-787Mjzr4zBib6gFgA+xA8VgA1TTgiipDgVQEZUd+oWDuPC6jFihrPfXng9ogHgR/CVt0h81BwJmsjQ2If7upWg==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-/bxfs9aM9gkVTPEZcV8kkH9nulqltQe/9UhCc2YFV8qP8RLGBivNsaJzwmq/4nG+5XGx15CJ8oFDRtwuT746kw==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -20719,7 +20718,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-dHYs1Lha6y1+zLOYjV3Ja6AZukV+yf1Js1B0j72wgzEG33F6R7+EuJuUJf1elC/zNqfS/oFHYatfrB9RBEL/Gg==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-4kKWzWkL3zi2Fm6cp3kBwDEnex1v6SHXK0/5dfeBaQi1djJ4kYHo6GFs7WqLiLq3tNhMYysMdUm1po+N7QXuBQ==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -20739,7 +20738,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-cabh08grEft+jxOhMZoXdbZfqdN/yGoCRniuXihWC1+Hq4PzOq22wQrvjXM3n5IR65BWMqd8sOw/bLBONnZ5Ig==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-TkBrpgsbj2qtDnLPvQSyEjJ3Bd7ftehcJN2oiMGQLoP2nPMKh8h/ZA95KBtPSYjZ2fofHw7DIWQKvam0Q3XnZA==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -20760,7 +20759,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-ALF0NZ5LHk6croBUbpAxJmjXHRbDQTXQNo53rwJTq9kQ7YMFtZ8ohtmsR4+D3GsTSVkpAy8HgJzh3zCAHuwqmg==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-Q0ubdUt2FjQKN59273vG/T+Jngcx20FT8qy87CjcOuUYkWLdXC/AQ5DkbMCZMXfmjYHg2TD0BYZXlEfZtqksuw==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -20781,7 +20780,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-ZFa2bHaE3iAI/Wz/4BpDvA34VhYUC2TYJ4jJmaYUFNfVWqdoCSsFjvhVWSFJeVwgBfPD76NraCmoeUvUTkcKmw==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-8ka8qvilTUigrzElOGOAfOz13zfeJyaGrm6rY3hDFjy2R875w/e6twe1CTmyVgZMFf9hS1KVuljf/vCpNLzhSQ==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -20802,7 +20801,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-NGJiYRptN2G5Aa6j0/VCmlCTFRBtboUBFKm5RfYe0odqykbXSmSUlRAHZajR4wgUN1Zc7FsSezkLnWG8pePXKg==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-RXBrhJZ15i6xXfeTJiQsclwIaRDnQlaJkafTNQwofVeIo/GuMECIUG1+inwMV7Ybsj9INqrzhd8k4qppMagZPg==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -20821,7 +20820,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-j7Ky/BPp40IYmh6SzJEe9X/aTt55W1vgfKDQpZLX2hKiAcetAUlk5jue0OPRzTOqmKz1dFQKAIgeHduTL9d1fA==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-CuiiwICnnW5XusZrqq1Cme8qL8cgFMzpcWcdUMt2z7i2enKRuYurcb0R4I2yU6gIq7RAmT3/4ZrJ9tcuuvDZKQ==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -20839,7 +20838,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-aCUoxgLoqo0l8QNC7iTzU70WDorCIA5GGZrLSJhA8NxGGVLfvSi4DeYwL0Zle/5uqbSWt6hUYA+rf4TmjWD/jg==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-XxFW/3sYSD6EP8He4TK6kA/y7A+gmJ+clnkWvEEP8T8vOc0eFx8yLhTWutjHqKAftAV4EwXfR4QSQR9SMJ1E0A==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -20858,7 +20857,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-LQb4g3NZ6t2QvZU9ZKrWJLawDWAt+/o5TivCr080ynesRmFdkwjpIKfQ0/V7Ysz9bs28s5oA32OWOAk9rx+oVA==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-jZlTTBK8TgRGSjDuWJn556aq32zaAiHB9D7dXQdGsMaYkybe6ekJCwl47L7RFAqyEC17TjYLpV7vy0a27C8z2Q==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -20877,7 +20876,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-FVC0hyC2d9huax+dP3bndPGPgF4T+UBKgvzm7fE+ItaWIcvOdL4fmaGDRE6eEe5q+fxGjPiDWwgRKn2dHrr7eA==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-5sk3UwtcDYdV0qXL8+QfzH7+KTyQGDKD5klsIqVTbOf19jO6e7t58aW/uJZlk/Fj5Nw7Zwe6jDcOQrmnOXNjrQ==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -20896,7 +20895,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-Y9OPWqLFNZ7nAuhgpm8AgSbr9mHAgRks7m57FDhbrbGYKSNC0Cluw0TISH2Lq7IflZ1a7PkTf+jGSxzb7ZQ8kg==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-x/dXLp6qDtd0NCXLGGi1g8zNYU5mBegh4EP6JAqOZPKYN5DkO4BVrBbr2cP/6nnqXJc3w4lNCNWEjSl6Lk45zA==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -20916,7 +20915,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-P+LlljVMsRTiuNOETQudyNNf8IKC9+dIMp7DzrCY6Ivg6Lqnvdvr7Fs3tyON7p/bo78dzH9S+4JI4klArw6txA==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-I75PQWgXOw4kRwD4WNMOlc644NER4SPKpyk0l3GE5UW9C3fYpRL4zLkmgyDILHiTaLtHH9P9x8V3kLMte7aB7w==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -20934,7 +20933,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-TUiBoGVM83x0pglCFNA/EyVsCZwrrMJTg5H6Ykx7/8oYhX6JDoT9A1YM1YQHytz5IhdThB4HNuLm3DbQRADhQw==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-UDg47biWhgKXxKxxli0Pjbhm5omIkfJs754EizXDBTRtS00oiMIiLGnZe3wd6BeSbPT7ZKvRichK7WrFs0U2VA==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -20954,7 +20953,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-GRHAAh7r9j3+rjt1IkqzegBHLSo2hI/OZqcCHZvw78r1ff1TlwpH51DkGafS1DiMV57gwygapbK7AlOn/sbmQQ==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-FtcpUKv/bZdTp691/xaBDmi4j/jINmE3PBmqMqPuFjlX85WPapkaM5QGabvSZPzDhOV0cW/1M2V0N4GTTXnz+w==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -20974,7 +20973,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-QECzXzK8cPMGodFUP38hT9EX5C8jPKrGyc7A+qtGd/4pj+3tdapDoBkLwI/i9e7QRwzSa+tEjZoynwNDYWPV2g==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-G2YxZvjCVJOdkhd+Kpkzac+ixyDc3t5zsxgYRjqLMYoVjSogzp+w8guG+RlVJfxGMkQyaSXo0z29zmgTYvb6Hg==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -20994,7 +20993,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-Gi/RDg2fXA+2d06Uy7wYhhrp0z81BlrzuiREg0z//DNGVd8qE+1kMwdpTTOcnyiz78Ko52afaBUDOpkNS0vssg==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-huaMHk3sAyDpT9oL5gA1eVSz3VlmUiWALFdjQeNnFwMPnA3sMi9b9Py+2u+cMMKOR61cdoFQbqt37oU3lLNMZQ==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -21036,7 +21035,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-V9Ewq7Pzce0ceIH/xh81nWVIW9380HAebpPjJ4slzR/K1lRwKIkzaoa+V2zjVAKadlyj6xx1lTNSrFV+0c4FAA==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-xPjDgsD/6hQS8hrfIkUct9AO/g1YoSG6Hig6KoR3n2/5Z36NR7H7iCJx4uWQnvmwdkdHL4Jo1L2tlblGqkBbyg==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -21078,7 +21077,7 @@ packages:
     dev: false
 
   file:projects/purview-datamap.tgz:
-    resolution: {integrity: sha512-jMEVqxCSt9ZMsdYVFwcfhwLLa8sZdkZBEGbrKUi0UqTsmXnp8frn/pkdTrn1qQAMt+zhqbBGs+bnmZR+RoGD5A==, tarball: file:projects/purview-datamap.tgz}
+    resolution: {integrity: sha512-KYZ07b+xDgBmx68jS0Hr0g8M4EJvUCTY1qxA9PanWfe5bPQ2iNlgU3T8SUQKbGOikWijreqebroJNvEjw71GQA==, tarball: file:projects/purview-datamap.tgz}
     name: '@rush-temp/purview-datamap'
     version: 0.0.0
     dependencies:
@@ -21121,7 +21120,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-rvbG0MGCQjGXE+djxJRab7Cz3i8C43p5n6Vnx3KGqA2EqMasoFPzWfcb75aYY08b0ZRu/WKcfPpJDEztOnc6Nw==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-+i9Wn3lF42PuCG9SAFbJAqaUxEne8/0PNj0lj3gwcIzSHoykd38BWeXcsggHWc/sVGp3CwDLC5y2THpsc1hEFg==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -21163,7 +21162,7 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-lc9YhGhZxgTmkzgVi52tC44tHalgQHm33H1Z+yyq54ajqxP7JzFMYv68y8KZ8ce0RrcrfNeGFxkLFGFHis3vlw==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-jGmmE0vpjwO4bm/Z880xzUdesP9iWlKCmpRecy2/j0ZYAR2zA0Fj94xjUre3wVOIdO10pOFE+hzt2ChtiJPWeQ==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
@@ -21207,7 +21206,7 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-Sv3iT2nyU6/cqFlO+PSN1IEq4/EWOCbxVQg52HvEsvw6cgt+Cw3oo4f2KvIMvqzuOaTWWfHIHwmLOt7HWGr4rQ==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-We2FWj+dxhV+6c/q5d+1BXwZJgoAmKlRg1pCvLx6khC6Ij9eFlhDNPJI1gFo+3U6F/17tlpA9iaHfBQvyIUirg==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
@@ -21250,7 +21249,7 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-I1oC934zXF04xfBjYHygauOm9kupQAqX4km7iJdpEsq9PV0RED69nevGTlLCV/AJJ3mYemEtjW6ctLma8KsTxw==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-ynaCHfJXwZY6tCS8I0jED9ghd+ku1+w2PC81cB1Za0+nXaS+PXRBLwH1XSAoxU0l53NZTlfRPpUTTI0EUi2psQ==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -21295,7 +21294,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-2zL4OfTlTEP9f3WbYgvAYRFaQXM1/1/W+/1s0QB4ZdL5ep9Vooq/9e9PutOozOaR13pY+nimzrZVZ8j3WjhFaQ==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-0LhM3eb7FB5sPpxqG/xBYw2f7XjztZsPsMgsdGGfcnLc+0HIK1s48tKAER42W3T3qOombQZisYmpALT+MrroIA==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -21346,7 +21345,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-oS74NCdlVMU/uK7EF7/QQlMyS2OCOCcRmHPxewP/4rPtk3dTQsXYnlC0MkbKF/+cT3kXbGFMJ4DYL7VN7siNGQ==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-doA+TR88iajbBMTcYpjZDeJ10xu0OHHllZv4Wi83kkVQT8aicmqsKWy7NfwAjybH0WxDbgCUv6Bt0VX1MmV9cQ==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -21387,7 +21386,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-0TKcx+XJFiwBwOexpulOoYYFnhZGBfK8UL+gP9BJnNuXRXWMzqlPcsEEV2lsE9klxd/6gHa8+fNAQDzgZZ4H8Q==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-K0Xo2o3mRwcUW+F8BjJjmI+782xykmK46jVth0QaXKaCmvbfzGRk60Wt0tV01ccE0Zvc8IlKE0y7UWdaZUIoAg==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -21426,7 +21425,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-E/8D/cCDKlJ63i4dNk+cENIjJkR/9gaskEfI+P9b88aImnWvg7GR8YZuHytxdPKh4WhBMuu4TIp+A9Jic490hA==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-NCqC4aPSl3n2IZHruv3oxyg2tSowjrXfaXr61yUTCUVaiLVmmSGvQcu0N6nOlSrulyNFkGGJli9Kvs658DSv3g==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -21471,7 +21470,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-q+lVWs4NbjEftlyi7x7dYXNMo0s8h9hgwPaiMQlk2DynzyeZULMeJe6AA88CvCm3Xe+WO2xUUzMUqGCQdkk1Ng==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-reS727hnGbcKISyYBRXqHiSZxtW/W+6K4uTH3qzw1RjYvLLLPTApb0uR3dNWVZxScZYnK3JrNJVGgbph7/+CiA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -21533,7 +21532,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-qcOjqJVfS8HR7rF6r0ThY3Ob7NyFvg/U/9jvDf0DFNgjFAf4VG3CzduflZWPYtNAN+6a7EMyUSZM1HWGgwOiIQ==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-wnWbrl+GSHtXZeB/gqEJhk3dcAYO2hXNIqTFDB4OLNxQv7l2Jyt5YXL6TAcG/R3gs7Kxn4tKrI3k8Yn5rt2pyQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -21583,7 +21582,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-AmvpINVhtD00TjMEeA7RAXuBcrmysnNYASLFmvrRJAC87HO1cngsYC0bUybR99vUJC5APEgE+d/NLYieLqOYGA==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-UbHNdtinQ+ZRDEeVK5218SsLVV6CCmraXC8wJE/XnXArgWc97f+9u2r4iLcm/qjYLy32xQYFWcIF1AmpJrY/Gw==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -21630,7 +21629,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-zpxRN6m+5hZFV/muh/zXAa5G9hQeWHny3j4A3ahxhqvWEY+i4rHwo4uqHQUGftAhEnNiZsSBg0YpYTr3c2ncZg==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-yBtQEOX13UBeIiM5f4+xHS77YgxEaI1RHCvzV+nWKYN4XVDrvtv3yTjK38tZ0P4kZX2mktqypxRi9dAo0VT9cQ==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -21681,7 +21680,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-Qvu7cCuyHzfqt7R6MoYuuUDB0EWwJgHSQdPEW86UtJDXwkbOV9vhgzzKT55QGgKXiwed1hAQqCBN07N3v/eZyQ==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-GdYbPm9Ac4ZNB3MLrVY6t6OGRRdJ3k50yFm7jXroBhBEnkwM0DoNuI7ZPDIQs9U5L0z/VgbrjrUjS4MC0yhY+Q==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -21730,7 +21729,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-/4uvdV8knvoUXWVylxyI2TUGPxYGCLFek8Yh5idIxC2WeJDAdzeTXEcwFcMobMA41J2iBwuVhpwIty8fSMJd/Q==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-CwelXTLp6cMdIXH1QwW5O5Z8MK7iKVTLJ3BlBIfc9l/rwDv8T8Uq4mGo5AUV7f+mo4Q5XZnD9YAVY3n13ELVEA==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -21775,7 +21774,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-5JIX+fXKCwPiySyzoyCJtGPfu4BV6Qxe5u5kbcYb9LkAsJm1pO/g8sEQ+ArQRZdQ4TDVVUGMz3tRO3FdLbpZrw==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-OzmxUl/PYHOS8yGyKUtF3xBu0bjmiS7sP8itZKcF9BrXcy/gUBV13jcThjQJPVdOqosige8PfFAlo+2weP2MMA==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -21821,7 +21820,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-tV8DqnE6Lr8GpmVMbG7GZ3EKN7/jbnwNOvdBGFkYMr/AdF7nLhfUkk5+c67F6vpAV2hcccvBZxTcowLEu9MBWA==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-y9Gw6NsQ6LPFuwFO8oGSrDAAHqS82tjtJq1Dm6qJn22lpz+QiVdSAlv/3VO0SvaNZ9I5LyewwzlwIhkdPM6eJA==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -21865,7 +21864,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-p7lmls5XlMEAkMAanyI4OwaoRXFzQVnHBd5SvPuXyDOiJdv5wEszCuMaLl6HfjpKXAey0QMsyKTxR57K4ttpHA==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-NX2prF/kGaSLwSrS12RsS5hdh4ZqF3wIiEW9cB3dQosMGROwwzAsxWqgqzOEy+QhhWX+++Fhyx4vql29mZbPPQ==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -21911,7 +21910,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-kl1NP0Aly8KJktFBvUrc+XJMgsE9Ude92tavMC2sPKhftN9TTuq3zwHIGEu9GxAItaFsVIPOyBEqaVwZn+Gq7g==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-Ga3erk3RtyoBrEhQzQ2z1/5Sp/8u3KPrPdz2KBE6lshhWhw/5RAUH9HQUgqxlPL6y6s/6Sb3BNFzWO/3C2aVEA==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -21959,7 +21958,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-4c7I4Sx9Qbs7tqcIquGfrBHxglzd7Aay4YlD6lf3nNOoKyqgc8Ssi9GMMCmRP17w6LZnB+P3s3mKDi/WGkqKjQ==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-tSqVosJDzzok10XlJ2YMtVAzc0Hk/wPnRZF989eU9/lAp7QEt2oDUc/NvICRe7XhUPFMcBbLhMFSSNvPtdPdBQ==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -22000,7 +21999,7 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-U33UZ/EkLPoVj/MhhtBw5FeS4Z0hc4BMcQjVjSPvQj75cCgpaU0U/krZ7GTiL/Dphyd/JETYpanzw71jNZnYdw==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-KAaSp+MzUlijvMRwj0RUyIpxTNmj9JRN9WtwHV+iBuFhsYFVYdlqJ8pyf/ix2LrHguwlTJ9vaN8vqjdV6k8rfQ==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
@@ -22036,7 +22035,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-yJd96STpLIo+CTk3UTbQaSd8ldzbNsKxsiXDGFRnmkpVY0SdofAgL8ZHmRQvKR9QP/12qkM/nwtZrXheAgUP3A==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-xHceNRrF53mpk2em5CqubyIkhKWRCywf/QFYMpXlre2L541PJiU4ck/GqVP6Ht3rpm8hXWYq85Zj5B+8Q1DYrQ==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -22077,7 +22076,7 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-cWUJ54rsjIpb9PsE7hkAy4y7fkODWuNSaGjyKtqJNz4bv5GQm2CDUpuVmTMpjkiO/Eo0vhyglw8sqbG+oZGgWg==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-VJ2po8I4sUujbA0IQ4STNJoMJH+NjwDnzPPg4iK3xcLESJ1vdd2j47f3Ef0E4BlC5ItOyMgD4X0U2IDsXvrjEQ==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
@@ -22119,7 +22118,7 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-GhtVBNJOhG2NoJLtD8125wOgW3po9rtn2P4uFJ/OifLK8Yt/Ihh+ObgH5zWxN1OSlHg7xiUHpmxR38dXH8QcWw==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-d7ntz0EHL6il93Owu/txDMufxBB+zTdeou55PJkSAiSNNjyjjgUuGpbxjV4sOx2UiLKjp+2j1z3PGFNYBaE67w==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
@@ -22162,7 +22161,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-DLgL6tmgleuMNJiUw3y0sl3yjzFDRCZUUqU85OiJzzicRNdCjOhx2m85EJ0MassMup+sxWsOumbeV1hdE1WHUA==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-gTRmQq4EwHS+RQz40ZRg+k4l1Uw29zdRiWHTHJsPUGr3zLr9sRMDHpgvHNYNtNvEj/cuk1PecGkctr4Ks0XGRw==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -22180,7 +22179,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-mqd8Rhk6qP95pjgMASERASgaF6QjSBTnupvTA/3ZYA95cigg2OuobQeFdTL+t8MB8T3OWE0YSi2CAqeZYjOSaA==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-j/q/5kY0P7F7LOmefZPLX9jMJeGs3uiOxMcEtzjLbzAPsoOxr/JTQ+o1iB3BO03WfrwJ4542op1G9RPrZvnMQg==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -22220,7 +22219,7 @@ packages:
     dev: false
 
   file:projects/test-utils-perf.tgz:
-    resolution: {integrity: sha512-R/2OafMDrnpOYos4yW4RHmQAZQyxbG0+uNJQYA9jjnbnKuZTInmaAZoU73FOOrjCZBfX7TAYn/tsUBQVS3BL4A==, tarball: file:projects/test-utils-perf.tgz}
+    resolution: {integrity: sha512-WFP5ojdxf3UTanWWi0m66tu0AE+0RSv2q3EQSSKtDpheawdXYirXWwjR/Uf4HSLgFa2N96L4cxs5pA9BS2KO3A==, tarball: file:projects/test-utils-perf.tgz}
     name: '@rush-temp/test-utils-perf'
     version: 0.0.0
     dependencies:
@@ -22248,7 +22247,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-DwBo66ieqQPqfjI3z2waj0OO8do548CVP+PZAICdC5w/Fq8ZOz6dMh09PWYXkpZCvXaFDtl0aaYtAwDmtMAcSw==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-MihJGeJOvpzoOAnTPM3n3aK/NaAMMCk0mXeRigN66YPAtoX7p24DaZuThDcPrAua/uVoClSZHvloJ0NgtroLpQ==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -22284,7 +22283,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-HyGi6Yahjy4aNreOcQN4NWv7LGcax0E/7Rpg+HuM3U022EdzNwaNQ3szWW0F/RMNw8Rph1gDvG41R0SsyELwuQ==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-HPx4nELna/MO9u/GH64GLsaBqwbjM3jJM1lba5Om02nXUwp2JdAwbWS2pt6WPHipxjNhwdqEguzXr85waTIQEQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -22320,7 +22319,7 @@ packages:
     dev: false
 
   file:projects/vite-plugin-browser-test-map.tgz:
-    resolution: {integrity: sha512-8Jg44N2Xy3VsZaSgcBDkWDjjpT8NcU+0TXvb3PCravbYHdMtI8K/XpI6fkpZnisjjl6dEE2MCUX6ecPAoFvvnQ==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
+    resolution: {integrity: sha512-oYyxWJs0yiBuHRK1euUkqJ2WM0LVn+fgnhkQrnjRmvu1kp4+rbmDA3E5UmxKBzxgdFs29chO8Fx/0YipGFMQkA==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
     name: '@rush-temp/vite-plugin-browser-test-map'
     version: 0.0.0
     dependencies:
@@ -22335,7 +22334,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-tW709YZSIRFko8C3hbjhQqgOO/Md5hbJRIxsbauRr9vut9fD4r5AmPP4YrGP7qcyc4OL+zZHzS9V9cVfXzmDDA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-uvpFPo6XIzyHKic6DRBTc//6R6m8n7mhi3CoYLnzEpQMJaiXsEtxXOREBRSdgm+1fz/OaYw1i7BDr9puGy0fAA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -22396,7 +22395,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-XoXsTwBU/quZBvcXcaXviSu92SHndVE8H5SmpPL8MhpjinqmSsx6p1Hi+TK+eyxyP1zUZhS3YYIvKdk38Il3BA==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-c2g3ZI0rWjlkBSH8zaqdqVuxE6p7TU0UlJk1NVn6bOgOgIYXwIrxTRMmmDFMTyoappHgeGLwzusF6lX3eGhXQQ==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -22452,7 +22451,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-WPtvAZ0OsQOolX5WUKH/Z5x3P8CSif43aacM/a8OzBSO/RlGhiRXqxE+rZhGZZ/iWO6GMwNzLQSmO9DAuwbd4g==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-ob7yKXEnCeb+cRYORSYN/N9VeHU+xA9eEppxRdkNTqYFGlQCkA3DrLvqwmYvQYYqvGuCQ5uhfCLMAXl/LBrd0Q==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -22489,7 +22488,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-leLUmqZbSAXmzpkoO5aRtpa2lPnDmKQy2gTBmhpmyRsXnH1GqDV1wGHJ/PauTVzdl7hpq9WRIuYwxwVmLaYj0Q==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-++ibJXG+7uOjChJLGKcUkGLUcqfLXTatj1eTM7TbkJXOhGcdrUYovedIaPV51UFCwgE0yYi3XuiCJs6GvQL4vA==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -89,6 +89,7 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
     "c8": "^8.0.0",
+    "cross-env": "^7.0.2",
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -71,6 +71,7 @@
     "@types/node": "^18.0.0",
     "@types/sinon": "^17.0.0",
     "c8": "^8.0.0",
+    "cross-env": "^7.0.2",
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/monitor-opentelemetry`
`@azure/monitor-opentelemetry-exporter`

### Describe the problem that is addressed by this PR

`cross-env` was removed from the devdeps of monitor-opentelemetry and monitor-opentelemetry-exporter which causes pipeline failures when running the test pipeline since the integration test command uses this binary.
