### PR TITLE
[core-lro] Restore `files` section to package.json

### DIFF
--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -26,6 +26,11 @@
       }
     }
   },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "tags": [


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-lro`

### Describe the problem that is addressed by this PR

In the ESM migration it appears we accidentally removed the `files` section from package.json for this package, so the built and packed package includes everything including the source code. This PR restores the field in line with the other ESMified Core packages.