### PR TITLE
[core] Reinstate "browser" package.json field

### DIFF
--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 2.1.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -13,6 +13,7 @@
   "sideEffects": false,
   "type": "module",
   "main": "./dist/commonjs/index.js",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.7.0 (2024-03-12)
 
 ### Other Changes
@@ -32,6 +34,7 @@
 ### Features Added
 
 - Added `enableCae` option to `GetTokenOptions` to enable Continuous Access Evaluation in [PR #26614](https://github.com/Azure/azure-sdk-for-js/pull/26614).
+
 ## 1.4.0 (2022-08-04)
 
 ### Features Added

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -27,6 +27,7 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "files": [
     "dist/",
     "README.md",

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.3.0 (2024-03-12)
 
 ### Features Added

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.9.0 (2024-03-12)
 
 ### Other Changes
@@ -30,6 +32,7 @@
 ## 1.7.3 (2023-06-01)
 
 ### Other Changes
+
 - remove the validation that credential scopes must be a valid URL [Issue #25881](https://github.com/Azure/azure-sdk-for-js/issues/25881)
 
 ## 1.7.2 (2023-02-23)

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-http-compat/CHANGELOG.md
+++ b/sdk/core/core-http-compat/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 2.1.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 2.7.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -57,10 +57,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "browser": {
-    "os": false,
-    "process": false
-  },
   "license": "MIT",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-lro/README.md",
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -33,6 +33,7 @@
   ],
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "tags": [
     "isomorphic",
     "browser",

--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.6.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.15.0 (2024-03-12)
 
 ### Bugs Fixed

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -5,6 +5,7 @@
   "sdk-type": "client",
   "type": "module",
   "main": "./dist/commonjs/index.js",
+  "browser": "./dist/browser/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/core/core-rest-pipeline/vitest.browser.config.ts
+++ b/sdk/core/core-rest-pipeline/vitest.browser.config.ts
@@ -2,13 +2,11 @@
 // Licensed under the MIT license.
 
 import { defineConfig } from "vitest/config";
-import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 
 export default defineConfig({
   define: {
     "process.env": process.env,
   },
-  plugins: [browserMap()],
   test: {
     reporters: ["basic", "junit"],
     outputFile: {

--- a/sdk/core/core-sse/CHANGELOG.md
+++ b/sdk/core/core-sse/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 2.1.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.1.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.8.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-util/vitest.browser.config.ts
+++ b/sdk/core/core-util/vitest.browser.config.ts
@@ -2,10 +2,8 @@
 // Licensed under the MIT license.
 
 import { defineConfig } from "vitest/config";
-import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 
 export default defineConfig({
-  plugins: [browserMap()],
   define: {
     "process.env": process.env,
   },

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.4.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/logger/CHANGELOG.md
+++ b/sdk/core/logger/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
 ## 1.1.0 (2024-03-12)
 
 ### Other Changes

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
+  "browser": "./dist/browser/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/ts-http-runtime/vitest.browser.config.ts
+++ b/sdk/core/ts-http-runtime/vitest.browser.config.ts
@@ -2,13 +2,11 @@
 // Licensed under the MIT license.
 
 import { defineConfig } from "vitest/config";
-import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 
 export default defineConfig({
   define: {
     "process.env": process.env,
   },
-  plugins: [browserMap()],
   test: {
     reporters: ["basic", "junit"],
     outputFile: {


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

For discussion. Re-adds "browser" field to `package.json` to support older bundlers that do not have support for the more modern "exports" field added in Node 14.
