### PR TITLE
[@azure/eslint-plugin-azure-sdk] Move to vitest

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2096,6 +2096,23 @@ packages:
       - supports-color
     dev: false
 
+  /@eslint/eslintrc@3.0.2:
+    resolution: {integrity: sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@8.1.1)
+      espree: 10.0.1
+      globals: 14.0.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3663,12 +3680,39 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/rule-tester@7.3.0(@eslint/eslintrc@3.0.2)(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-VTyIKtPW9KD3lTjRSkWh5xFatOexprK2kmQM4tRmVm7/ESkUScD1oqXg+uOEd4wWcGdNMZoZHCPtDk3PcQP2rw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@eslint/eslintrc': '>=2'
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint/eslintrc': 3.0.2
+      '@typescript-eslint/typescript-estree': 7.3.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.3.0(eslint@8.57.0)(typescript@5.3.3)
+      ajv: 6.12.6
+      eslint: 8.57.0
+      lodash.merge: 4.6.2
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/scope-manager@5.57.1:
     resolution: {integrity: sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.57.1
       '@typescript-eslint/visitor-keys': 5.57.1
+    dev: false
+
+  /@typescript-eslint/scope-manager@7.3.0:
+    resolution: {integrity: sha512-KlG7xH3J/+nHpZRcYeskO5QVJCnnssxYKBlrj3MoyMONihn3P4xu5jIelrS5YWvBjbytgHmFkzjDApranoYkNA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.3.0
+      '@typescript-eslint/visitor-keys': 7.3.0
     dev: false
 
   /@typescript-eslint/type-utils@5.57.1(eslint@8.57.0)(typescript@5.3.3):
@@ -3696,6 +3740,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
+  /@typescript-eslint/types@7.3.0:
+    resolution: {integrity: sha512-oYCBkD0xVxzmZZmYiIWVewyy/q/ugq7PPm4pHhE1IgcT062i96G0Ww3gd8BvUYpk2yvg95q00Hj2CHRLjAuZBA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dev: false
+
   /@typescript-eslint/typescript-estree@5.57.1(typescript@5.3.3):
     resolution: {integrity: sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3712,6 +3761,28 @@ packages:
       is-glob: 4.0.3
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree@7.3.0(typescript@5.3.3):
+    resolution: {integrity: sha512-UF85+bInQZ3olhI/zxv0c2b2SMuymn3t6/lkRkSB239HHxFmPSlmcggOKAjYzqRCdtqhPDftpsV1LlDH66AXrA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 7.3.0
+      '@typescript-eslint/visitor-keys': 7.3.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -3737,11 +3808,38 @@ packages:
       - typescript
     dev: false
 
+  /@typescript-eslint/utils@7.3.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-7PKIDoe2ppR1SK56TLv7WQXrdHqEiueVwLVIjdSR4ROY2LprmJenf4+tT8iJIfxrsPzjSJGNeQ7GVmfoYbqrhw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.3.0
+      '@typescript-eslint/types': 7.3.0
+      '@typescript-eslint/typescript-estree': 7.3.0(typescript@5.3.3)
+      eslint: 8.57.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/visitor-keys@5.57.1:
     resolution: {integrity: sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.57.1
+      eslint-visitor-keys: 3.4.3
+    dev: false
+
+  /@typescript-eslint/visitor-keys@7.3.0:
+    resolution: {integrity: sha512-Gz8Su+QjOI5qP8UQ74VqKaTt/BLy23IhCCHLbYxhmNzHCGFHrvfgq4hISZvuqQ690ubkD0746qLcWC647nScuQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.3.0
       eslint-visitor-keys: 3.4.3
     dev: false
 
@@ -5557,6 +5655,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
+  /eslint-visitor-keys@4.0.0:
+    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: false
+
   /eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5607,6 +5710,15 @@ packages:
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
+    dev: false
+
+  /espree@10.0.1:
+    resolution: {integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
+      eslint-visitor-keys: 4.0.0
     dev: false
 
   /espree@9.6.1:
@@ -6240,6 +6352,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: false
+
+  /globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
     dev: false
 
   /globalthis@1.0.3:
@@ -8617,6 +8734,7 @@ packages:
 
   /queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
+    requiresBuild: true
     dev: false
 
   /randombytes@2.1.0:
@@ -9617,6 +9735,15 @@ packages:
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+    dev: false
+
+  /ts-api-utils@1.3.0(typescript@5.3.3):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.3.3
     dev: false
 
   /ts-morph@22.0.0:
@@ -19025,10 +19152,11 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-QWCQpxYTL732c0p0LhhgoNH+PBuwMeWeCUVO6p/y5HVftrAf1V7fCMuNTH6MkVmX6OhcHY941iWQMGnzskrITw==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-9DsRQQcKBrvXFMAagOqs3Z0ZEJvjkdlXZ5kzeY5LKaD1+jAPSHngC98wJDCHgf5eKRnJq4oM93y+Gr/jzMLL0w==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
+      '@eslint/eslintrc': 3.0.2
       '@types/chai': 4.3.12
       '@types/eslint': 8.44.9
       '@types/estree': 1.0.5
@@ -19038,7 +19166,9 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/experimental-utils': 5.57.1(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 5.57.1(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/rule-tester': 7.3.0(@eslint/eslintrc@3.0.2)(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.3.3)
+      '@vitest/coverage-istanbul': 1.4.0(vitest@1.4.0)
       chai: 4.3.10
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
@@ -19051,15 +19181,26 @@ packages:
       json-schema: 0.4.0
       mocha: 10.3.0
       prettier: 3.2.5
-      rimraf: 3.0.2
+      rimraf: 5.0.5
       source-map-support: 0.5.21
       ts-node: 10.9.2(@types/node@18.19.24)(typescript@5.3.3)
+      tshy: 1.12.0
       tslib: 2.6.2
       typescript: 5.3.3
+      vitest: 1.4.0(@types/node@18.19.24)(@vitest/browser@1.4.0)
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
       - supports-color
+      - terser
     dev: false
 
   file:projects/event-hubs.tgz:

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/browser"
+  }
+}

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
@@ -1,10 +1,6 @@
 {
   "extends": "./build.json",
-  "include": [
-    "../src/**/*.ts",
-    "../src/**/*.mts",
-    "../src/**/*.tsx"
-  ],
+  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/browser"

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/browser.json
@@ -1,6 +1,10 @@
 {
   "extends": "./build.json",
-  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/browser"

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/build.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [
+    "../src/**/*.mts"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/commonjs"
+  }
+}

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
@@ -1,13 +1,7 @@
 {
   "extends": "./build.json",
-  "include": [
-    "../src/**/*.ts",
-    "../src/**/*.cts",
-    "../src/**/*.tsx"
-  ],
-  "exclude": [
-    "../src/**/*.mts"
-  ],
+  "include": ["../src/**/*.ts", "../src/**/*.cts", "../src/**/*.tsx"],
+  "exclude": ["../src/**/*.mts"],
   "compilerOptions": {
     "outDir": "../.tshy-build/commonjs"
   }

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/commonjs.json
@@ -1,7 +1,13 @@
 {
   "extends": "./build.json",
-  "include": ["../src/**/*.ts", "../src/**/*.cts", "../src/**/*.tsx"],
-  "exclude": ["../src/**/*.mts"],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [
+    "../src/**/*.mts"
+  ],
   "compilerOptions": {
     "outDir": "../.tshy-build/commonjs"
   }

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
@@ -1,6 +1,10 @@
 {
   "extends": "./build.json",
-  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/esm"

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/esm.json
@@ -1,10 +1,6 @@
 {
   "extends": "./build.json",
-  "include": [
-    "../src/**/*.ts",
-    "../src/**/*.mts",
-    "../src/**/*.tsx"
-  ],
+  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/esm"

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/react-native"
+  }
+}

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
@@ -1,10 +1,6 @@
 {
   "extends": "./build.json",
-  "include": [
-    "../src/**/*.ts",
-    "../src/**/*.mts",
-    "../src/**/*.tsx"
-  ],
+  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/react-native"

--- a/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
+++ b/common/tools/eslint-plugin-azure-sdk/.tshy/react-native.json
@@ -1,6 +1,10 @@
 {
   "extends": "./build.json",
-  "include": ["../src/**/*.ts", "../src/**/*.mts", "../src/**/*.tsx"],
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
   "exclude": [],
   "compilerOptions": {
     "outDir": "../.tshy-build/react-native"

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "sdk-type": "utility",
+  "type": "module",
   "private": true,
   "keywords": [
     "eslint",
@@ -31,13 +32,13 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "main": "dist/index.js",
+  "main": "./dist/commonjs/index.js",
   "files": [
     "prettier.json",
     "dist/"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tshy",
     "build:samples": "echo Skipped.",
     "build:test": "echo Skipped.",
     "clean": "rimraf dist/",
@@ -50,7 +51,7 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "unit-test:node": "mocha --require source-map-support/register --require ts-node/register --timeout 10000 --full-trace tests/**/*.ts",
+    "unit-test:node": "vitest",
     "unit-test:browser": "echo skipped",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test": "npm run clean && npm run build:test && npm run unit-test"
@@ -66,7 +67,8 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "eslint-plugin-tsdoc": "^0.2.10"
+    "eslint-plugin-tsdoc": "^0.2.10",
+    "@eslint/eslintrc": "^3.0.2"
   },
   "dependencies": {
     "@typescript-eslint/typescript-estree": "~5.57.0",
@@ -76,24 +78,60 @@
     "glob": "^9.0.0",
     "json-schema": "^0.4.0",
     "typescript": "~5.3.3",
-    "tslib": "^2.2.0"
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.6",
     "@types/json-schema": "^7.0.6",
-    "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "~5.57.0",
     "@typescript-eslint/experimental-utils": "~5.57.0",
     "@typescript-eslint/parser": "~5.57.0",
-    "chai": "^4.2.0",
+    "@typescript-eslint/rule-tester": "^7.3.0",
+    "@vitest/coverage-istanbul": "^1.4.0",
     "eslint": "^8.50.0",
-    "mocha": "^10.0.0",
-    "prettier": "^3.2.5",
-    "rimraf": "^3.0.0",
-    "source-map-support": "^0.5.9",
-    "typescript": "~5.3.3",
     "eslint-plugin-markdown": "~3.0.0",
-    "ts-node": "^10.0.0"
-  }
+    "prettier": "^3.2.5",
+    "rimraf": "^5.0.5",
+    "source-map-support": "^0.5.9",
+    "tshy": "^1.12.0",
+    "typescript": "~5.3.3",
+    "vitest": "^1.4.0"
+  },
+  "tshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "dialects": [
+      "esm",
+      "commonjs"
+    ],
+    "esmDialects": [
+      "browser",
+      "react-native"
+    ],
+    "selfLink": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
+      "react-native": {
+        "types": "./dist/react-native/index.d.ts",
+        "default": "./dist/react-native/index.js"
+      },
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "types": "./dist/commonjs/index.d.ts"
 }

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -6,12 +6,12 @@
  * @author Arpan Laha
  */
 
-import rootConfig from "./azure-sdk-base";
+import rootConfig from "./azure-sdk-base.js";
 
 /**
  * An object containing configurations available for the plugin
  */
-export = {
+export default {
   /**
    * The recommended (default) configuration
    */

--- a/common/tools/eslint-plugin-azure-sdk/src/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/index.ts
@@ -10,9 +10,9 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import configs from "./configs";
-import processors from "./processors";
-import rules from "./rules";
+import configs from "./configs/index.js";
+import processors from "./processors/index.js";
+import rules from "./rules/index.js";
 
 //------------------------------------------------------------------------------
 // Plugin Definition
@@ -21,4 +21,4 @@ import rules from "./rules";
 /**
  * The elements making up the plugin
  */
-export = { configs, processors, rules };
+export default { configs, processors, rules };

--- a/common/tools/eslint-plugin-azure-sdk/src/processors/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/processors/index.ts
@@ -11,7 +11,7 @@ import { Linter } from "eslint";
 /**
  * An object containing processors used by the plugin
  */
-export = {
+export default {
   /**
    * The processor for JSON files
    * Ignores the no-unused-expressions ESLint rule

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -8,7 +8,7 @@
 
 import { Comment, Node } from "estree";
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -24,7 +24,7 @@ function isValid(comments: Comment[]): boolean {
     .every((v) => v.actual.type === "Line" && v.expected === v.actual.value.trim());
 }
 
-export = {
+export default {
   meta: getRuleMetaData(
     "github-source-headers",
     "require copyright headers in every source file",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/index.ts
@@ -6,44 +6,44 @@
  * @author Arpan Laha
  */
 
-import githubSourceHeaders from "./github-source-headers";
-import tsApiExtractorPublicTypes from "./ts-apiextractor-json-types";
-import tsApisurfaceStandardizedVerbs from "./ts-apisurface-standardized-verbs";
-import tsApisurfaceSupportcancellation from "./ts-apisurface-supportcancellation";
-import tsConfigInclude from "./ts-config-include";
-import tsDocInternal from "./ts-doc-internal";
-import tsDocInternalPrivateMember from "./ts-doc-internal-private-member";
-import tsErrorHandling from "./ts-error-handling";
-import tsModulesOnlyNamed from "./ts-modules-only-named";
-import tsNamingDropNoun from "./ts-naming-drop-noun";
-import tsNamingOptions from "./ts-naming-options";
-import tsNamingSubclients from "./ts-naming-subclients";
-import tsNoConstEnums from "./ts-no-const-enums";
-import tsNoWindow from "./ts-no-window";
-import tsPackageJsonAuthor from "./ts-package-json-author";
-import tsPackageJsonBugs from "./ts-package-json-bugs";
-import tsPackageJsonEngineIsPresent from "./ts-package-json-engine-is-present";
-import tsPackageJsonFilesRequired from "./ts-package-json-files-required";
-import tsPackageJsonHomepage from "./ts-package-json-homepage";
-import tsPackageJsonKeywords from "./ts-package-json-keywords";
-import tsPackageJsonLicense from "./ts-package-json-license";
-import tsPackageJsonMainIsCjs from "./ts-package-json-main-is-cjs";
-import tsPackageJsonModule from "./ts-package-json-module";
-import tsPackageJsonName from "./ts-package-json-name";
-import tsPackageJsonRepo from "./ts-package-json-repo";
-import tsPackageJsonRequiredScripts from "./ts-package-json-required-scripts";
-import tsPackageJsonSdkType from "./ts-package-json-sdktype";
-import tsPackageJsonSideEffects from "./ts-package-json-sideeffects";
-import tsPackageJsonTypes from "./ts-package-json-types";
-import tsPaginationList from "./ts-pagination-list";
-import tsUseInterfaceParameters from "./ts-use-interface-parameters";
-import tsUsePromises from "./ts-use-promises";
-import tsVersioningSemver from "./ts-versioning-semver";
+import githubSourceHeaders from "./github-source-headers.js";
+import tsApiExtractorPublicTypes from "./ts-apiextractor-json-types.js";
+import tsApisurfaceStandardizedVerbs from "./ts-apisurface-standardized-verbs.js";
+import tsApisurfaceSupportcancellation from "./ts-apisurface-supportcancellation.js";
+import tsConfigInclude from "./ts-config-include.js";
+import tsDocInternal from "./ts-doc-internal.js";
+import tsDocInternalPrivateMember from "./ts-doc-internal-private-member.js";
+import tsErrorHandling from "./ts-error-handling.js";
+import tsModulesOnlyNamed from "./ts-modules-only-named.js";
+import tsNamingDropNoun from "./ts-naming-drop-noun.js";
+import tsNamingOptions from "./ts-naming-options.js";
+import tsNamingSubclients from "./ts-naming-subclients.js";
+import tsNoConstEnums from "./ts-no-const-enums.js";
+import tsNoWindow from "./ts-no-window.js";
+import tsPackageJsonAuthor from "./ts-package-json-author.js";
+import tsPackageJsonBugs from "./ts-package-json-bugs.js";
+import tsPackageJsonEngineIsPresent from "./ts-package-json-engine-is-present.js";
+import tsPackageJsonFilesRequired from "./ts-package-json-files-required.js";
+import tsPackageJsonHomepage from "./ts-package-json-homepage.js";
+import tsPackageJsonKeywords from "./ts-package-json-keywords.js";
+import tsPackageJsonLicense from "./ts-package-json-license.js";
+import tsPackageJsonMainIsCjs from "./ts-package-json-main-is-cjs.js";
+import tsPackageJsonModule from "./ts-package-json-module.js";
+import tsPackageJsonName from "./ts-package-json-name.js";
+import tsPackageJsonRepo from "./ts-package-json-repo.js";
+import tsPackageJsonRequiredScripts from "./ts-package-json-required-scripts.js";
+import tsPackageJsonSdkType from "./ts-package-json-sdktype.js";
+import tsPackageJsonSideEffects from "./ts-package-json-sideeffects.js";
+import tsPackageJsonTypes from "./ts-package-json-types.js";
+import tsPaginationList from "./ts-pagination-list.js";
+import tsUseInterfaceParameters from "./ts-use-interface-parameters.js";
+import tsUsePromises from "./ts-use-promises.js";
+import tsVersioningSemver from "./ts-versioning-semver.js";
 
 /**
  * An object containing all rules defined by the plugin
  */
-export = {
+export default {
   "github-source-headers": githubSourceHeaders,
   "ts-apiextractor-json-types": tsApiExtractorPublicTypes,
   "ts-apisurface-standardized-verbs": tsApisurfaceStandardizedVerbs,

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
@@ -7,16 +7,16 @@
  * @author Will Temple
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Property } from "estree";
 import { Rule } from "eslint";
-import { stripFileName } from "../utils/verifiers";
+import { stripFileName } from "../utils/verifiers.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-apiextractor-json-types",
     "force api-extractor.json to configure types in a consistent way",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-standardized-verbs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-standardized-verbs.ts
@@ -7,7 +7,7 @@
  */
 
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
-import { getPublicMethods, getRuleMetaData } from "../utils";
+import { getPublicMethods, getRuleMetaData } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
@@ -30,7 +30,7 @@ const bannedPrefixes = [
   "fetch",
 ];
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-apisurface-standardized-verbs",
     "require client methods to use standardized verb prefixes and suffixes where possible",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
@@ -9,8 +9,8 @@
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { Symbol as TSSymbol, Type, TypeChecker, TypeFlags } from "typescript";
-import { getPublicMethods, getRuleMetaData } from "../utils";
-import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { getPublicMethods, getRuleMetaData } from "../utils/index.js";
+import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
@@ -98,7 +98,7 @@ const isValidParam = (
   );
 };
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-apisurface-supportcancellation",
     "require async client methods to accept an AbortSignalLike parameter",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-config-include.ts
@@ -7,14 +7,14 @@
  */
 
 import { ArrayExpression, Literal, Property } from "estree";
-import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-config-include",
     "force tsconfig.json's 'include' value to at least contain 'src/**/*.ts', 'test/**/*.ts', and 'samples-dev/**/*.ts'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal-private-member.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal-private-member.ts
@@ -8,10 +8,10 @@
 
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { Node } from "estree";
-import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options.js";
 import { Rule } from "eslint";
 import { SyntaxKind, canHaveModifiers } from "typescript";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -57,7 +57,7 @@ const reportInternal = (
   }
 };
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-doc-internal-private-member",
     "requires TSDoc comments to not include an '@internal' tag if the object is private",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -7,9 +7,9 @@
  */
 
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
-import { getLocalExports, getRuleMetaData } from "../utils";
+import { getLocalExports, getRuleMetaData } from "../utils/index.js";
 import { Node } from "estree";
-import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options";
+import { ParserWeakMapESTreeToTSNode } from "@typescript-eslint/typescript-estree/dist/parser-options.js";
 import { Rule } from "eslint";
 import { TypeChecker } from "typescript";
 import { globSync } from "glob";
@@ -92,7 +92,7 @@ try {
   exclude = [];
 }
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-doc-internal",
     "require TSDoc comments to include an '@internal' or '@hidden' tag if the object is not public-facing",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
@@ -9,13 +9,13 @@
 import { Identifier, NewExpression, ThrowStatement } from "estree";
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-error-handling",
     "limit thrown errors to ECMAScript built-in error types (TypeError, RangeError, Error)",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
@@ -9,13 +9,13 @@
 import { normalize, relative } from "path";
 import { ExportDefaultDeclaration } from "estree";
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-modules-only-named",
     "force there to be only named exports at the top level",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
@@ -7,7 +7,7 @@
  */
 
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
-import { getPublicMethods, getRuleMetaData } from "../utils";
+import { getPublicMethods, getRuleMetaData } from "../utils/index.js";
 import { Rule } from "eslint";
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 
@@ -15,7 +15,7 @@ import { TSESTree } from "@typescript-eslint/experimental-utils";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-naming-drop-noun",
     "require client methods returning an instance of the client to not include the client name in the method name",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-options.ts
@@ -8,14 +8,14 @@
 
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils";
-import { getPublicMethods, getRuleMetaData } from "../utils";
+import { getPublicMethods, getRuleMetaData } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-naming-options",
     "require client method option parameter type names to be suffixed with Options and prefixed with the method name",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
@@ -7,7 +7,7 @@
  */
 
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
-import { getPublicMethods, getRuleMetaData } from "../utils";
+import { getPublicMethods, getRuleMetaData } from "../utils/index.js";
 import { Rule } from "eslint";
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 
@@ -15,7 +15,7 @@ import { TSESTree } from "@typescript-eslint/experimental-utils";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-naming-subclients",
     "require client methods returning a subclient to have names prefixed suffixed with 'get' and suffixed with 'client'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-no-const-enums.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-no-const-enums.ts
@@ -7,13 +7,13 @@
  */
 
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData("ts-no-const-enums", "forbid usage of TypeScript's const enums", "code"),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
     ({

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-no-window.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-no-window.ts
@@ -7,13 +7,13 @@
  */
 
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData("ts-no-window", "forbid usage of window", "code"),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
     ({

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
@@ -6,14 +6,14 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-author",
     "force package.json's author value to be 'Microsoft Corporation'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
@@ -6,14 +6,14 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-bugs",
     "force package.json's bugs.url value to be 'https://github.com/Azure/azure-sdk-for-js/issues'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
@@ -6,7 +6,7 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 /**

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -7,7 +7,7 @@
  */
 
 import { Literal, Property } from "estree";
-import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { arrayToString, getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ function updateFixRequiredPatterns(currRequiredPatterns: string[]): void {
   }
 }
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-files-required",
     "requires package.json's files value to contain paths to the package contents",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
@@ -7,14 +7,14 @@
  */
 
 import { Literal, Property } from "estree";
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-homepage",
     "force package.json's homepage value to be a URL pointing to your library's readme inside the git repo",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
@@ -6,14 +6,14 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-keywords",
     "force package.json's keywords value to contain at least 'Azure' and 'cloud'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
@@ -6,14 +6,14 @@
  * @license Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-packge-json-license",
     "force package.json's license value to be 'MIT'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -7,14 +7,14 @@
  */
 
 import { Literal, Property } from "estree";
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-main-is-cjs",
     "force package.json's main value to point to a CommonJS or UMD module",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -7,14 +7,14 @@
  */
 
 import { Literal, Property } from "estree";
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-module",
     "force package.json's module value to be the ES6 entrypoint to the application",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
@@ -92,7 +92,7 @@ function getPackageMetadata(node: Property): {
   const nodeValue = node.value as Literal;
   const packageName = nodeValue.value as string;
   // Check if there is a sub scope i.e @azure-rest
-  const [_, subScope] = packageName.match(/^@azure(-[a-z]+)?\//) ?? [];
+  const [, subScope] = packageName.match(/^@azure(-[a-z]+)?\//) ?? [];
 
   return {
     nodeValue,

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
@@ -7,15 +7,15 @@
  */
 
 import { Literal, Property } from "estree";
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
-import { stripFileName } from "../utils/verifiers";
+import { stripFileName } from "../utils/verifiers.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-name",
     "force package.json's name value to be set to @azure/<service>",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -6,14 +6,14 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-repo",
     "force package.json's repository value to be 'github:Azure/azure-sdk-for-js'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
@@ -6,7 +6,7 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Property } from "estree";
 import { Rule } from "eslint";
 
@@ -14,7 +14,7 @@ import { Rule } from "eslint";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-required-scripts",
     "force package.json's scripts value to at least contain build, test, and prepack",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sdktype.ts
@@ -7,7 +7,7 @@
  * @author Ben Zhang
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Property } from "estree";
 import { Rule } from "eslint";
 
@@ -15,7 +15,7 @@ import { Rule } from "eslint";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-sdktype",
     "force package.json's sdk-type to exist and for its value to be 'client' or 'mgmt'",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
@@ -6,14 +6,14 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Rule } from "eslint";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-sideeffects",
     "force package.json's sideEffects value to be false",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
@@ -6,16 +6,16 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Property } from "estree";
 import { Rule } from "eslint";
-import { stripFileName } from "../utils/verifiers";
+import { stripFileName } from "../utils/verifiers.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-package-json-types",
     "force package.json to specify types according to package directory",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
@@ -9,13 +9,13 @@
 import { Identifier, MethodDefinition } from "estree";
 import { Rule } from "eslint";
 import { TSESTree } from "@typescript-eslint/experimental-utils";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-pagination-list",
     "require client list methods to return a PagedAsyncIterableIterator",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -33,9 +33,9 @@ import { ParserServices, TSESTree } from "@typescript-eslint/experimental-utils"
 import {
   ParserWeakMap,
   ParserWeakMapESTreeToTSNode,
-} from "@typescript-eslint/typescript-estree/dist/parser-options";
+} from "@typescript-eslint/typescript-estree/dist/parser-options.js";
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -237,7 +237,7 @@ const evaluateOverloads = (
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData(
     "ts-use-interface-parameters",
     "encourage usage of interfaces over classes as function parameters",

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-use-promises.ts
@@ -8,14 +8,14 @@
 
 import { ParserServices } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
-import { getRuleMetaData } from "../utils";
+import { getRuleMetaData } from "../utils/index.js";
 import { isExternalModule } from "typescript";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData("ts-use-promises", "force usage of built-in promises over external ones"),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const parserServices: ParserServices = context.sourceCode.parserServices;

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-versioning-semver.ts
@@ -6,7 +6,7 @@
  * @author Arpan Laha
  */
 
-import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
+import { getRuleMetaData, getVerifiers, stripPath } from "../utils/index.js";
 import { Property } from "estree";
 import { Rule } from "eslint";
 
@@ -14,7 +14,7 @@ import { Rule } from "eslint";
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = {
+export default {
   meta: getRuleMetaData("ts-versioning-semver", "force adherence to SemVer guidelines"),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
@@ -6,6 +6,6 @@
  * @author Arpan Laha
  */
 
-export { getLocalExports, getPublicMethods, isExternal } from "./exports";
-export { getRuleMetaData } from "./metadata";
-export { arrayToString, getVerifiers, stripPath } from "./verifiers";
+export { getLocalExports, getPublicMethods, isExternal } from "./exports.js";
+export { getRuleMetaData } from "./metadata.js";
+export { arrayToString, getVerifiers, stripPath } from "./verifiers.js";

--- a/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/plugin.ts
@@ -6,9 +6,8 @@
  * @author Arpan Laha
  */
 
-import { describe, it } from "mocha";
-import { assert } from "chai";
-import plugin from "../src";
+import { describe, it, assert } from "vitest";
+import plugin from "../src/index.js";
 
 /**
  * A list of all currently supported rules

--- a/common/tools/eslint-plugin-azure-sdk/tests/ruleTester.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/ruleTester.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vitest from "vitest";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+RuleTester.afterAll = vitest.afterAll;
+
+// If you are not using vitest with globals: true (https://vitest.dev/config/#globals):
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+export { RuleTester };

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/github-source-headers";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/github-source-headers.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apiextractor-json-types.ts
@@ -7,8 +7,8 @@
  * @author Will Temple
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-apiextractor-json-types";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-apiextractor-json-types.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-standardized-verbs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-standardized-verbs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-apisurface-standardized-verbs";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-apisurface-standardized-verbs.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-supportcancellation.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-apisurface-supportcancellation.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-apisurface-supportcancellation";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-apisurface-supportcancellation.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-config-include.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-config-include.ts
@@ -6,8 +6,8 @@
  * @author Wei Jun Tan
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-config-include";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-config-include.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal-private-member.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal-private-member.ts
@@ -6,8 +6,8 @@
  * @author Hamsa Shankar
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-doc-internal-private-member";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-doc-internal-private-member.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-doc-internal.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-doc-internal";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-doc-internal.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-error-handling.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-error-handling.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-error-handling";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-error-handling.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
@@ -29,7 +29,7 @@ ruleTester.run("ts-modules-only-named", rule, {
   valid: [
     // different non-default exports
     {
-      code: 'export default {test: "test"}',
+      code: 'export = {test: "test"}',
       filename: "test.ts",
     },
     {

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-modules-only-named";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-modules-only-named.js";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -29,7 +29,7 @@ ruleTester.run("ts-modules-only-named", rule, {
   valid: [
     // different non-default exports
     {
-      code: 'export = {test: "test"}',
+      code: 'export default {test: "test"}',
       filename: "test.ts",
     },
     {

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-drop-noun.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-drop-noun.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-naming-drop-noun";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-naming-drop-noun.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-options.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-naming-options";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-naming-options.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-subclients.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-naming-subclients.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-naming-subclients";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-naming-subclients.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-const-enums.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-const-enums.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-no-const-enums";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-no-const-enums.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-window.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-no-window.ts
@@ -6,8 +6,8 @@
  * @author Maor Leger
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-no-window";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-no-window.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-author.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-author.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-author";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-author.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-bugs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-bugs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-bugs";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-bugs.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-engine-is-present.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-engine-is-present.ts
@@ -8,8 +8,8 @@
 
 "use strict";
 
-import { RuleTester } from "eslint";
-import rule, { LTS } from "../../src/rules/ts-package-json-engine-is-present";
+import { RuleTester } from "../ruleTester.js";
+import rule, { LTS } from "../../src/rules/ts-package-json-engine-is-present.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-files-required.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-files-required";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-files-required.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-homepage.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-homepage.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-homepage";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-homepage.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-keywords.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-keywords.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-keywords";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-keywords.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-license.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-license.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-license";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-license.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-main-is-cjs.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-main-is-cjs";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-main-is-cjs.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-module.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-module";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-module.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-name.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-name.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-name";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-name.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-repo.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-repo.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-repo";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-repo.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-required-scripts.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-required-scripts.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-required-scripts";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-required-scripts.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sdktype.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sdktype.ts
@@ -6,8 +6,8 @@
  * @author Ben Zhang
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-sdktype";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-sdktype.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sideeffects.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-sideeffects.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-sideeffects";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-sideeffects.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-package-json-types.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-package-json-types";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-package-json-types.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-pagination-list.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-pagination-list.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-pagination-list";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-pagination-list.js";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-use-interface-parameters";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-use-interface-parameters.js";
 
 //------------------------------------------------------------------------------
 // Example class & interface

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-promises.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-promises.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-use-promises";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-use-promises.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-versioning-semver.ts
@@ -6,8 +6,8 @@
  * @author Arpan Laha
  */
 
-import { RuleTester } from "eslint";
-import rule from "../../src/rules/ts-versioning-semver";
+import { RuleTester } from "../ruleTester.js";
+import rule from "../../src/rules/ts-versioning-semver.js";
 
 //------------------------------------------------------------------------------
 // Example files

--- a/common/tools/eslint-plugin-azure-sdk/tsconfig.json
+++ b/common/tools/eslint-plugin-azure-sdk/tsconfig.json
@@ -4,21 +4,27 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "isolatedModules": true,
-    "lib": ["es2017"],
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "./dist",
     "pretty": true,
     "removeComments": true,
     "strict": true,
     "target": "es2017",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "sourceMap": true,
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src", "tests"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/common/tools/eslint-plugin-azure-sdk/tsconfig.json
+++ b/common/tools/eslint-plugin-azure-sdk/tsconfig.json
@@ -13,18 +13,11 @@
     "removeComments": true,
     "strict": true,
     "target": "es2017",
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "sourceMap": true,
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": [
-    "src",
-    "tests"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src", "tests"],
+  "exclude": ["node_modules"]
 }

--- a/common/tools/eslint-plugin-azure-sdk/vitest.config.ts
+++ b/common/tools/eslint-plugin-azure-sdk/vitest.config.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    reporters: ["basic", "junit"],
+    outputFile: {
+      junit: "test-results.xml",
+    },
+    fakeTimers: {
+      toFake: ["setTimeout", "Date"],
+    },
+    watch: false,
+    include: ["tests/**/*.ts"],
+    exclude: ["tests/ruleTester.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: ["vitest*.config.ts"],
+      provider: "istanbul",
+      reporter: ["text", "json", "html"],
+      reportsDirectory: "coverage",
+    },
+  },
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/eslint-plugin-azure-sdk

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Migrates from `mocha` and `eslint` and the `RuleTester` to ESM via `tshy` and `vitest`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
