### PR TITLE
[Azure Monitor OpenTelemetry Exporter] Add support for more Azure Monitor part A/tags

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -3,9 +3,40 @@
 
 import os from "os";
 import {
-  SemanticResourceAttributes,
-  SemanticAttributes,
-  DbSystemValues,
+  SEMRESATTRS_DEVICE_ID,
+  SEMRESATTRS_DEVICE_MODEL_NAME,
+  SEMRESATTRS_SERVICE_VERSION,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  DBSYSTEMVALUES_DB2,
+  DBSYSTEMVALUES_DERBY,
+  DBSYSTEMVALUES_MARIADB,
+  DBSYSTEMVALUES_MSSQL,
+  DBSYSTEMVALUES_ORACLE,
+  DBSYSTEMVALUES_SQLITE,
+  DBSYSTEMVALUES_OTHER_SQL,
+  DBSYSTEMVALUES_HSQLDB,
+  DBSYSTEMVALUES_H2,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_URL,
+  SEMATTRS_HTTP_SCHEME,
+  SEMATTRS_HTTP_TARGET,
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_IP,
+  SEMATTRS_PEER_SERVICE,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_REPLICASET_NAME,
+  SEMRESATTRS_K8S_STATEFULSET_NAME,
+  SEMRESATTRS_K8S_JOB_NAME,
+  SEMRESATTRS_K8S_CRONJOB_NAME,
+  SEMRESATTRS_K8S_DAEMONSET_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+  SEMRESATTRS_TELEMETRY_SDK_NAME,
 } from "@opentelemetry/semantic-conventions";
 import { Tags } from "../types";
 import { getInstance } from "../platform";
@@ -24,9 +55,18 @@ export function createTagsFromResource(resource: Resource): Tags {
   if (resource && resource.attributes) {
     tags[KnownContextTagKeys.AiCloudRole] = getCloudRole(resource);
     tags[KnownContextTagKeys.AiCloudRoleInstance] = getCloudRoleInstance(resource);
-    const endUserId = resource.attributes[SemanticAttributes.ENDUSER_ID];
-    if (endUserId) {
-      tags[KnownContextTagKeys.AiUserId] = String(endUserId);
+    if (resource.attributes[SEMRESATTRS_DEVICE_ID]) {
+      tags[KnownContextTagKeys.AiDeviceId] = String(resource.attributes[SEMRESATTRS_DEVICE_ID]);
+    }
+    if (resource.attributes[SEMRESATTRS_DEVICE_MODEL_NAME]) {
+      tags[KnownContextTagKeys.AiDeviceModel] = String(
+        resource.attributes[SEMRESATTRS_DEVICE_MODEL_NAME],
+      );
+    }
+    if (resource.attributes[SEMRESATTRS_SERVICE_VERSION]) {
+      tags[KnownContextTagKeys.AiApplicationVer] = String(
+        resource.attributes[SEMRESATTRS_SERVICE_VERSION],
+      );
     }
   }
   return tags;
@@ -35,8 +75,8 @@ export function createTagsFromResource(resource: Resource): Tags {
 function getCloudRole(resource: Resource): string {
   let cloudRole = "";
   // Service attributes
-  const serviceName = resource.attributes[SemanticResourceAttributes.SERVICE_NAME];
-  const serviceNamespace = resource.attributes[SemanticResourceAttributes.SERVICE_NAMESPACE];
+  const serviceName = resource.attributes[SEMRESATTRS_SERVICE_NAME];
+  const serviceNamespace = resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE];
   if (serviceName) {
     // Custom Service name provided by customer is highest precedence
     if (!String(serviceName).startsWith("unknown_service")) {
@@ -55,31 +95,27 @@ function getCloudRole(resource: Resource): string {
     }
   }
   // Kubernetes attributes should take precedence
-  const kubernetesDeploymentName =
-    resource.attributes[SemanticResourceAttributes.K8S_DEPLOYMENT_NAME];
+  const kubernetesDeploymentName = resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME];
   if (kubernetesDeploymentName) {
     return String(kubernetesDeploymentName);
   }
-  const kuberneteReplicasetName =
-    resource.attributes[SemanticResourceAttributes.K8S_REPLICASET_NAME];
+  const kuberneteReplicasetName = resource.attributes[SEMRESATTRS_K8S_REPLICASET_NAME];
   if (kuberneteReplicasetName) {
     return String(kuberneteReplicasetName);
   }
-  const kubernetesStatefulSetName =
-    resource.attributes[SemanticResourceAttributes.K8S_STATEFULSET_NAME];
+  const kubernetesStatefulSetName = resource.attributes[SEMRESATTRS_K8S_STATEFULSET_NAME];
   if (kubernetesStatefulSetName) {
     return String(kubernetesStatefulSetName);
   }
-  const kubernetesJobName = resource.attributes[SemanticResourceAttributes.K8S_JOB_NAME];
+  const kubernetesJobName = resource.attributes[SEMRESATTRS_K8S_JOB_NAME];
   if (kubernetesJobName) {
     return String(kubernetesJobName);
   }
-  const kubernetesCronjobName = resource.attributes[SemanticResourceAttributes.K8S_CRONJOB_NAME];
+  const kubernetesCronjobName = resource.attributes[SEMRESATTRS_K8S_CRONJOB_NAME];
   if (kubernetesCronjobName) {
     return String(kubernetesCronjobName);
   }
-  const kubernetesDaemonsetName =
-    resource.attributes[SemanticResourceAttributes.K8S_DAEMONSET_NAME];
+  const kubernetesDaemonsetName = resource.attributes[SEMRESATTRS_K8S_DAEMONSET_NAME];
   if (kubernetesDaemonsetName) {
     return String(kubernetesDaemonsetName);
   }
@@ -88,12 +124,12 @@ function getCloudRole(resource: Resource): string {
 
 function getCloudRoleInstance(resource: Resource): string {
   // Kubernetes attributes should take precedence
-  const kubernetesPodName = resource.attributes[SemanticResourceAttributes.K8S_POD_NAME];
+  const kubernetesPodName = resource.attributes[SEMRESATTRS_K8S_POD_NAME];
   if (kubernetesPodName) {
     return String(kubernetesPodName);
   }
   // Service attributes
-  const serviceInstanceId = resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID];
+  const serviceInstanceId = resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID];
   if (serviceInstanceId) {
     return String(serviceInstanceId);
   }
@@ -103,15 +139,15 @@ function getCloudRoleInstance(resource: Resource): string {
 
 export function isSqlDB(dbSystem: string) {
   return (
-    dbSystem === DbSystemValues.DB2 ||
-    dbSystem === DbSystemValues.DERBY ||
-    dbSystem === DbSystemValues.MARIADB ||
-    dbSystem === DbSystemValues.MSSQL ||
-    dbSystem === DbSystemValues.ORACLE ||
-    dbSystem === DbSystemValues.SQLITE ||
-    dbSystem === DbSystemValues.OTHER_SQL ||
-    dbSystem === DbSystemValues.HSQLDB ||
-    dbSystem === DbSystemValues.H2
+    dbSystem === DBSYSTEMVALUES_DB2 ||
+    dbSystem === DBSYSTEMVALUES_DERBY ||
+    dbSystem === DBSYSTEMVALUES_MARIADB ||
+    dbSystem === DBSYSTEMVALUES_MSSQL ||
+    dbSystem === DBSYSTEMVALUES_ORACLE ||
+    dbSystem === DBSYSTEMVALUES_SQLITE ||
+    dbSystem === DBSYSTEMVALUES_OTHER_SQL ||
+    dbSystem === DBSYSTEMVALUES_HSQLDB ||
+    dbSystem === DBSYSTEMVALUES_H2
   );
 }
 
@@ -119,26 +155,26 @@ export function getUrl(attributes: Attributes): string {
   if (!attributes) {
     return "";
   }
-  const httpMethod = attributes[SemanticAttributes.HTTP_METHOD];
+  const httpMethod = attributes[SEMATTRS_HTTP_METHOD];
   if (httpMethod) {
-    const httpUrl = attributes[SemanticAttributes.HTTP_URL];
+    const httpUrl = attributes[SEMATTRS_HTTP_URL];
     if (httpUrl) {
       return String(httpUrl);
     } else {
-      const httpScheme = attributes[SemanticAttributes.HTTP_SCHEME];
-      const httpTarget = attributes[SemanticAttributes.HTTP_TARGET];
+      const httpScheme = attributes[SEMATTRS_HTTP_SCHEME];
+      const httpTarget = attributes[SEMATTRS_HTTP_TARGET];
       if (httpScheme && httpTarget) {
-        const httpHost = attributes[SemanticAttributes.HTTP_HOST];
+        const httpHost = attributes[SEMATTRS_HTTP_HOST];
         if (httpHost) {
           return `${httpScheme}://${httpHost}${httpTarget}`;
         } else {
-          const netPeerPort = attributes[SemanticAttributes.NET_PEER_PORT];
+          const netPeerPort = attributes[SEMATTRS_NET_PEER_PORT];
           if (netPeerPort) {
-            const netPeerName = attributes[SemanticAttributes.NET_PEER_NAME];
+            const netPeerName = attributes[SEMATTRS_NET_PEER_NAME];
             if (netPeerName) {
               return `${httpScheme}://${netPeerName}:${netPeerPort}${httpTarget}`;
             } else {
-              const netPeerIp = attributes[SemanticAttributes.NET_PEER_IP];
+              const netPeerIp = attributes[SEMATTRS_NET_PEER_IP];
               if (netPeerIp) {
                 return `${httpScheme}://${netPeerIp}:${netPeerPort}${httpTarget}`;
               }
@@ -155,11 +191,11 @@ export function getDependencyTarget(attributes: Attributes): string {
   if (!attributes) {
     return "";
   }
-  const peerService = attributes[SemanticAttributes.PEER_SERVICE];
-  const httpHost = attributes[SemanticAttributes.HTTP_HOST];
-  const httpUrl = attributes[SemanticAttributes.HTTP_URL];
-  const netPeerName = attributes[SemanticAttributes.NET_PEER_NAME];
-  const netPeerIp = attributes[SemanticAttributes.NET_PEER_IP];
+  const peerService = attributes[SEMATTRS_PEER_SERVICE];
+  const httpHost = attributes[SEMATTRS_HTTP_HOST];
+  const httpUrl = attributes[SEMATTRS_HTTP_URL];
+  const netPeerName = attributes[SEMATTRS_NET_PEER_NAME];
+  const netPeerIp = attributes[SEMATTRS_NET_PEER_IP];
   if (peerService) {
     return String(peerService);
   } else if (httpHost) {
@@ -186,9 +222,9 @@ export function createResourceMetricEnvelope(
       if (
         !(
           key.startsWith("_MS.") ||
-          key === SemanticResourceAttributes.TELEMETRY_SDK_VERSION ||
-          key === SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE ||
-          key === SemanticResourceAttributes.TELEMETRY_SDK_NAME
+          key === SEMRESATTRS_TELEMETRY_SDK_VERSION ||
+          key === SEMRESATTRS_TELEMETRY_SDK_LANGUAGE ||
+          key === SEMRESATTRS_TELEMETRY_SDK_NAME
         )
       ) {
         resourceAttributes[key] = resource.attributes[key] as string;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/eventhub.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/eventhub.ts
@@ -3,7 +3,7 @@
 
 import { SpanKind } from "@opentelemetry/api";
 import { hrTimeToMilliseconds } from "@opentelemetry/core";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+import { SEMATTRS_NET_PEER_NAME } from "@opentelemetry/semantic-conventions";
 import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { RemoteDependencyData, RequestData } from "../generated";
 import { TIME_SINCE_ENQUEUED, ENQUEUED_TIME } from "./constants/applicationinsights";
@@ -44,7 +44,7 @@ export const parseEventHubSpan = (
 ): void => {
   const namespace = span.attributes[AzNamespace] as typeof MicrosoftEventHub;
   const peerAddress = (
-    (span.attributes[SemanticAttributes.NET_PEER_NAME] ||
+    (span.attributes[SEMATTRS_NET_PEER_NAME] ||
       span.attributes["peer.address"] ||
       "unknown") as string
   ).replace(/\/$/g, ""); // remove trailing "/"

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -15,7 +15,11 @@ import {
 } from "../generated";
 import { createTagsFromResource, hrTimeToDate } from "./common";
 import { ReadableLogRecord } from "@opentelemetry/sdk-logs";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from "@opentelemetry/semantic-conventions";
 import { Measurements, Properties, Tags } from "../types";
 import { diag } from "@opentelemetry/api";
 import {
@@ -48,10 +52,10 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
 
   if (!log.attributes[ApplicationInsightsBaseType]) {
     // Get Exception attributes if available
-    const exceptionType = log.attributes[SemanticAttributes.EXCEPTION_TYPE];
+    const exceptionType = log.attributes[SEMATTRS_EXCEPTION_TYPE];
     if (exceptionType) {
-      const exceptionMessage = log.attributes[SemanticAttributes.EXCEPTION_MESSAGE];
-      const exceptionStacktrace = log.attributes[SemanticAttributes.EXCEPTION_STACKTRACE];
+      const exceptionMessage = log.attributes[SEMATTRS_EXCEPTION_MESSAGE];
+      const exceptionStacktrace = log.attributes[SEMATTRS_EXCEPTION_STACKTRACE];
       name = ApplicationInsightsExceptionName;
       baseType = ApplicationInsightsExceptionBaseType;
       const exceptionDetails: TelemetryExceptionDetails = {
@@ -124,9 +128,9 @@ function createPropertiesFromLog(log: ReadableLogRecord): [Properties, Measureme
       if (
         !(
           key.startsWith("_MS.") ||
-          key === SemanticAttributes.EXCEPTION_TYPE ||
-          key === SemanticAttributes.EXCEPTION_MESSAGE ||
-          key === SemanticAttributes.EXCEPTION_STACKTRACE
+          key === SEMATTRS_EXCEPTION_TYPE ||
+          key === SEMATTRS_EXCEPTION_MESSAGE ||
+          key === SEMATTRS_EXCEPTION_STACKTRACE
         )
       ) {
         properties[key] = log.attributes[key] as string;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

Add support for AiDeviceId, AiDeviceModel and AiApplicationVer
Fix issue with AiUserId, this is not part of resource attributes
Removed deprecated references from @opentelemetry/semantic-conventions