### PR TITLE
[core-client] Fix issue with Storage bearer challenges

### DIFF
--- a/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
+++ b/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
@@ -79,11 +79,11 @@ function buildScopes(
   challengeOptions: AuthorizeRequestOnChallengeOptions,
   challengeInfo: Challenge,
 ): string[] {
-  if (!challengeInfo.resource_uri) {
+  if (!challengeInfo.resource_id) {
     return challengeOptions.scopes;
   }
 
-  const challengeScopes = new URL(challengeInfo.resource_uri);
+  const challengeScopes = new URL(challengeInfo.resource_id);
   challengeScopes.pathname = Constants.DefaultScope;
   return [challengeScopes.toString()];
 }
@@ -105,7 +105,7 @@ function getChallenge(response: PipelineResponse): string | undefined {
  */
 interface Challenge {
   authorization_uri: string;
-  resource_uri?: string;
+  resource_id?: string;
 }
 
 /**

--- a/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
+++ b/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
@@ -45,7 +45,7 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
 
         return {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_uri=https://storage.azure.com`,
+            "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_id=https://storage.azure.com`,
           }),
           request: req,
           status: 200,
@@ -113,7 +113,7 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
           assert.equal(req.headers.get("authorization"), "Bearer originalToken");
           return {
             headers: createHttpHeaders({
-              "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_uri=https://storage.azure.com`,
+              "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_id=https://storage.azure.com`,
             }),
             request: req,
             status: 401,
@@ -158,7 +158,7 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
           assert.equal(req.headers.get("authorization"), "Bearer originalToken");
           return {
             headers: createHttpHeaders({
-              "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_uri=https://storage.azure.com`,
+              "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_id=https://storage.azure.com`,
             }),
             request: req,
             status: 401,
@@ -245,7 +245,7 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
         assert.equal(req.headers.get("authorization"), "Bearer originalToken");
         return {
           headers: createHttpHeaders({
-            "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_uri=https://storage.azure.com`,
+            "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_id=https://storage.azure.com`,
           }),
           request: req,
           status: 401,


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/core-client`

### Describe the problem that is addressed by this PR

When this logic was ported from a Storage-specific policy, it referenced a field in the challenge called `resource_uri` instead of the actual value which is `resource_id`.

You can see the working value in the storage/stable branch: https://github.com/Azure/azure-sdk-for-js/blob/f7fca7e84dfd0aced888ea5c0d109468a1e2a3a6/sdk/storage/storage-blob/src/policies/StorageBearerTokenChallengeAuthenticationPolicy.ts#L252

I suspect the reason for the confusion is because the documentation page that describes this feature incorrectly gives an example that has `resource_uri` even though the parameter description lists `resource_id`: https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#sample-response-to-bearer-challenge

This wasn't caught previously as Storage had not migrated to CoreV2 and exercised this codepath.