### PR TITLE
[@azure/identity] InteractiveBrowserCredential: allow openBrowser to be passed as options

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `openBrowser` open to `InteractiveBrowserCredentialNodeOptions` to allow overriding the default browser open behavior.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -315,6 +315,7 @@ export interface InteractiveBrowserCredentialInBrowserOptions extends Interactiv
 export interface InteractiveBrowserCredentialNodeOptions extends InteractiveCredentialOptions, CredentialPersistenceOptions, BrowserCustomizationOptions, BrokerAuthOptions {
     clientId?: string;
     loginHint?: string;
+    openBrowser?: (url: string) => Promise<void>;
     redirectUri?: string | (() => string);
     tenantId?: string;
 }

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -74,6 +74,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
             parentWindowHandle: ibcNodeOptions.brokerOptions.parentWindowHandle,
             legacyEnableMsaPassthrough: ibcNodeOptions.brokerOptions?.legacyEnableMsaPassthrough,
           },
+          openBrowser: ibcNodeOptions.openBrowser,
         });
       }
     } else {

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredentialOptions.ts
@@ -47,6 +47,11 @@ export interface InteractiveBrowserCredentialNodeOptions
    * Setting this option skips the account selection prompt and immediately attempts to login with the specified account.
    */
   loginHint?: string;
+
+  /**
+   * Open browser override
+   */
+  openBrowser?: (url: string) => Promise<void>;
 }
 
 /**

--- a/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalOpenBrowser.ts
@@ -23,6 +23,7 @@ export interface MsalOpenBrowserOptions extends MsalNodeOptions {
     errorMessage?: string;
     successMessage?: string;
   };
+  openBrowser?: (url: string) => Promise<void>;
 }
 
 /**
@@ -42,12 +43,14 @@ export class MsalOpenBrowser extends MsalNode {
   private loginHint?: string;
   private errorTemplate?: string;
   private successTemplate?: string;
+  private openBrowser?: (url: string) => Promise<void>;
 
   constructor(options: MsalOpenBrowserOptions) {
     super(options);
     this.loginHint = options.loginHint;
     this.errorTemplate = options.browserCustomizationOptions?.errorMessage;
     this.successTemplate = options.browserCustomizationOptions?.successMessage;
+    this.openBrowser = options.openBrowser;
     this.logger = credentialLogger("Node.js MSAL Open Browser");
   }
 
@@ -57,9 +60,11 @@ export class MsalOpenBrowser extends MsalNode {
   ): Promise<AccessToken> {
     try {
       const interactiveRequest: msalNode.InteractiveRequest = {
-        openBrowser: async (url) => {
-          await interactiveBrowserMockable.open(url, { wait: true, newInstance: true });
-        },
+        openBrowser:
+          this.openBrowser ??
+          (async (url) => {
+            await interactiveBrowserMockable.open(url, { wait: true, newInstance: true });
+          }),
         scopes,
         authority: options?.authority,
         claims: options?.claims,


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/identity`

### Describe the problem that is addressed by this PR

Allow consumer to override `openBrowser` via options for `InteractiveBrowserCredential` in node.

This change would allow scenarios to override the `openBrowser` function. This will be useful in cases where a browser is not available. For example: remote development over ssh in a terminal, the local server for interactive browser can still listen for requests through ssh's port tunneling but won't be a browser in many environments.