### PR TITLE
[Event Hubs] Remove minimum timeout value

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The minimum value of timeout for all operations is no longer 60 seconds. The user can now set the timeout to lower values if needed. The default timeout value is still 60 seconds.
+
 ## 5.11.3 (2023-11-07)
 
 ### Bugs Fixed

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -102,7 +102,7 @@ export enum CloseReason {
  *    - `retryDelayInMs`: Amount of time to wait in milliseconds before making the next attempt. When `mode` is set to `Exponential`,
  *       this is used to compute the exponentially increasing delays between retries. Default: 30000 milliseconds.
  *    - `timeoutInMs`: Amount of time in milliseconds to wait before the operation times out. This will trigger a retry if there are any
- *       retry attempts remaining. Minimum value: 60000 milliseconds.
+ *       retry attempts remaining. Default value: 60000 milliseconds.
  *
  * A simple usage can be `{ "maxRetries": 4 }`.
  *
@@ -162,7 +162,7 @@ export interface EventHubClientOptions {
  *    - `retryDelayInMs`: Amount of time to wait in milliseconds before making the next attempt. When `mode` is set to `Exponential`,
  *       this is used to compute the exponentially increasing delays between retries. Default: 30000 milliseconds.
  *    - `timeoutInMs`: Amount of time in milliseconds to wait before the operation times out. This will trigger a retry if there are any
- *       retry attempts remaining. Minimum value: 60000 milliseconds.
+ *       retry attempts remaining. Default value: 60000 milliseconds.
  *
  * A simple usage can be `{ "maxRetries": 4 }`.
  *

--- a/sdk/eventhub/event-hubs/src/util/retries.ts
+++ b/sdk/eventhub/event-hubs/src/util/retries.ts
@@ -8,9 +8,7 @@ import { Constants, RetryOptions } from "@azure/core-amqp";
  */
 export function getRetryAttemptTimeoutInMs(retryOptions: RetryOptions = {}): number {
   const { timeoutInMs } = retryOptions;
-  return typeof timeoutInMs !== "number" ||
-    !isFinite(timeoutInMs) ||
-    timeoutInMs < Constants.defaultOperationTimeoutInMs
+  return typeof timeoutInMs !== "number" || !isFinite(timeoutInMs)
     ? Constants.defaultOperationTimeoutInMs
     : timeoutInMs;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
One customer is complaining that the minimum wait of 60 seconds is too long and they wish to be able to lower it.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
