### PR TITLE
[core-rest-pipeline] Add support for FormData global in Node

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.15.1 (Unreleased)
+## 1.16.0 (Unreleased)
 
 ### Features Added
+
+- The FormData global is now a supported request body type in Node in addition to the browser.
 
 ### Breaking Changes
 

--- a/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/formDataPolicy.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { stringToUint8Array } from "@azure/core-util";
+import { isNode, stringToUint8Array } from "@azure/core-util";
 import { createHttpHeaders } from "../httpHeaders.js";
 import type {
   BodyPart,
   FormDataMap,
+  FormDataValue,
   PipelineRequest,
   PipelineResponse,
   SendRequest,
@@ -17,6 +18,15 @@ import type { PipelinePolicy } from "../pipeline.js";
  */
 export const formDataPolicyName = "formDataPolicy";
 
+function formDataToFormDataMap(formData: FormData): FormDataMap {
+  const formDataMap: FormDataMap = {};
+  for (const [key, value] of formData.entries()) {
+    formDataMap[key] ??= [];
+    (formDataMap[key] as FormDataValue[]).push(value);
+  }
+  return formDataMap;
+}
+
 /**
  * A policy that encodes FormData on the request into the body.
  */
@@ -24,6 +34,11 @@ export function formDataPolicy(): PipelinePolicy {
   return {
     name: formDataPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      if (isNode && typeof FormData !== "undefined" && request.body instanceof FormData) {
+        request.formData = formDataToFormDataMap(request.body);
+        request.body = undefined;
+      }
+
       if (request.formData) {
         const contentType = request.headers.get("Content-Type");
         if (contentType && contentType.indexOf("application/x-www-form-urlencoded") !== -1) {

--- a/sdk/core/core-rest-pipeline/test/formDataPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/formDataPolicy.spec.ts
@@ -12,7 +12,7 @@ import {
   createFileFromStream,
 } from "../src/index.js";
 import type { BodyPart, FormDataMap, MultipartRequestBody } from "../src/interfaces.js";
-import { stringToUint8Array } from "@azure/core-util";
+import { isNode, stringToUint8Array } from "@azure/core-util";
 
 export async function performRequest(formData: FormDataMap): Promise<PipelineResponse> {
   const request = createPipelineRequest({
@@ -301,5 +301,65 @@ describe("formDataPolicy", function () {
         );
       },
     );
+  });
+
+  describe("FormData request bodies", () => {
+    it.runIf(isNode)("should be processed by formDataPolicy in Node", async () => {
+      const request = createPipelineRequest({
+        url: "https://bing.com",
+        headers: createHttpHeaders({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      });
+      request.body = new FormData();
+      request.body.append("service", "registry.azurecr.io");
+      request.body.append("scope", "repository:library/hello-world:metadata_read");
+
+      const successResponse: PipelineResponse = {
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      };
+      const next = vi.fn<Parameters<SendRequest>, ReturnType<SendRequest>>();
+      next.mockResolvedValue(successResponse);
+
+      const policy = formDataPolicy();
+
+      const result = await policy.sendRequest(request, next);
+
+      assert.isUndefined(result.request.formData);
+      assert.strictEqual(
+        result.request.body,
+        `service=registry.azurecr.io&scope=repository%3Alibrary%2Fhello-world%3Ametadata_read`,
+      );
+    });
+
+    it.runIf(!isNode)("should be passed through in browser", async () => {
+      const request = createPipelineRequest({
+        url: "https://bing.com",
+        headers: createHttpHeaders({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      });
+      const formData = new FormData();
+      formData.append("service", "registry.azurecr.io");
+      formData.append("scope", "repository:library/hello-world:metadata_read");
+      request.body = formData;
+
+      const successResponse: PipelineResponse = {
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      };
+      const next = vi.fn<Parameters<SendRequest>, ReturnType<SendRequest>>();
+      next.mockResolvedValue(successResponse);
+
+      const policy = formDataPolicy();
+
+      const result = await policy.sendRequest(request, next);
+
+      assert.isUndefined(result.request.formData);
+      assert.strictEqual(result.request.body, formData);
+    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-rest-pipeline`

### Issues associated with this PR

- Fixes #28972

### Describe the problem that is addressed by this PR

The global `FormData` is listed as a supported `RequestBodyType`, but is only supported in browser where `fetch` takes care of it. `FormData` was previously not available in Node, but since Node 18 it has been available without a feature This PR makes `formDataPolicy` convert `FormData` bodies into a `FormDataMap` in Node. Our existing pipeline then takes care of converting the `FormData` into the appropriate wire format based on the request content type.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could remove the `isNode` check from this change, which would mean that our pipeline would take care of encoding the `FormData` regardless of whether we're in browser or not. I don't feel strongly either way.

### Are there test cases added in this PR? _(If not, why?)_

Yes, added test cases.
