### PR TITLE
Ensure NPM Task Job is `1es-template`-ized

### DIFF
--- a/eng/pipelines/npm-tasks.yml
+++ b/eng/pipelines/npm-tasks.yml
@@ -45,29 +45,39 @@ parameters:
     type: string
     default: ''
 
-jobs:
-- deployment: 'NPM_Admin'
-  displayName: NPM package management
-  environment: npm
 
-  pool:
-    vmImage: 'windows-2022'
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+  stages:
+    - stage:
+      displayName: NPM Tag
 
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          - task: PowerShell@2
-            displayName: 'Run Task'
-            inputs:
-              targetType: filePath
-              filePath: "eng/scripts/npm-admin-tasks.ps1"
-              arguments: >
-                -taskType ${{parameters.TaskType}}
-                -packageName ${{parameters.PackageName}}
-                -pkgVersion ${{parameters.PkgVersion}}
-                -tagName ${{parameters.TagName}}
-                -npmToken "$(azure-sdk-npm-token)"
-                -reason "${{parameters.Reason}}"
-              pwsh: true
+      jobs:
+      - deployment: 'NPM_Admin'
+        displayName: NPM package management
+        environment: npm
+
+        pool:
+          name: azsdk-pool-mms-win-2022-general
+          image: azsdk-pool-mms-win-2022-1espt
+          os: windows
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                - task: PowerShell@2
+                  displayName: 'Run Task'
+                  inputs:
+                    targetType: filePath
+                    filePath: "eng/scripts/npm-admin-tasks.ps1"
+                    arguments: >
+                      -taskType ${{parameters.TaskType}}
+                      -packageName ${{parameters.PackageName}}
+                      -pkgVersion ${{parameters.PkgVersion}}
+                      -tagName ${{parameters.TagName}}
+                      -npmToken "$(azure-sdk-npm-token)"
+                      -reason "${{parameters.Reason}}"
+                    pwsh: true

--- a/eng/pipelines/npm-tasks.yml
+++ b/eng/pipelines/npm-tasks.yml
@@ -51,7 +51,7 @@ extends:
   parameters:
     stages:
       - stage:
-        displayName: NPM Tag
+        displayName: NPM Task Execute
 
         jobs:
         - deployment: 'NPM_Admin'

--- a/eng/pipelines/npm-tasks.yml
+++ b/eng/pipelines/npm-tasks.yml
@@ -49,35 +49,35 @@ parameters:
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
-  stages:
-    - stage:
-      displayName: NPM Tag
+    stages:
+      - stage:
+        displayName: NPM Tag
 
-      jobs:
-      - deployment: 'NPM_Admin'
-        displayName: NPM package management
-        environment: npm
+        jobs:
+        - deployment: 'NPM_Admin'
+          displayName: NPM package management
+          environment: npm
 
-        pool:
-          name: azsdk-pool-mms-win-2022-general
-          image: azsdk-pool-mms-win-2022-1espt
-          os: windows
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+            image: azsdk-pool-mms-win-2022-1espt
+            os: windows
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-                - task: PowerShell@2
-                  displayName: 'Run Task'
-                  inputs:
-                    targetType: filePath
-                    filePath: "eng/scripts/npm-admin-tasks.ps1"
-                    arguments: >
-                      -taskType ${{parameters.TaskType}}
-                      -packageName ${{parameters.PackageName}}
-                      -pkgVersion ${{parameters.PkgVersion}}
-                      -tagName ${{parameters.TagName}}
-                      -npmToken "$(azure-sdk-npm-token)"
-                      -reason "${{parameters.Reason}}"
-                    pwsh: true
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+                  - task: PowerShell@2
+                    displayName: 'Run Task'
+                    inputs:
+                      targetType: filePath
+                      filePath: "eng/scripts/npm-admin-tasks.ps1"
+                      arguments: >
+                        -taskType ${{parameters.TaskType}}
+                        -packageName ${{parameters.PackageName}}
+                        -pkgVersion ${{parameters.PkgVersion}}
+                        -tagName ${{parameters.TagName}}
+                        -npmToken "$(azure-sdk-npm-token)"
+                        -reason "${{parameters.Reason}}"
+                      pwsh: true

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -1,0 +1,46 @@
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: azure-sdk-build-tools
+      type: git
+      name: internal/azure-sdk-build-tools
+      ref: refs/tags/azure-sdk-build-tools_20230829.1
+
+parameters:
+- name: stages
+  type: stageList
+  default: []
+- name: Use1ESOfficial
+  type: boolean
+  default: true
+
+extends:
+  ${{ if and(parameters.Use1ESOfficial, eq(variables['System.TeamProject'], 'internal')) }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
+    sdl:
+      sourceAnalysisPool:
+        name: azsdk-pool-mms-win-2022-general
+        image: azsdk-pool-mms-win-2022-1espt
+        os: windows
+      sourceRepositoriesToScan:
+        exclude:
+          - repository: azure-sdk-build-tools
+      credscan:
+        suppressionsFile: '$(Build.SourcesDirectory)/eng/CredScanSuppression.json'
+        toolVersion: '2.3.12.23'
+      eslint:
+        enabled: false
+        justificationForDisabling: "ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3556850"
+      psscriptanalyzer:
+        compiled: true
+        break: true
+      policy: M365
+    stages: ${{ parameters.stages }}


### PR DESCRIPTION
See title.

[Test Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3615161&view=results) unpublishing a random manual test release of `@azure/template`.