### PR TITLE
[dev-tool] Fix `--no-test-proxy` option for test run commands

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -11,10 +11,10 @@ export const commandInfo = makeCommandInfo(
   "test:node-js-input",
   "runs the node tests using mocha with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
-    "no-test-proxy": {
-      shortName: "ntp",
+    "test-proxy": {
+      shortName: "tp",
       kind: "boolean",
-      default: false,
+      default: true,
       description: "whether to run with test-proxy",
     },
   },
@@ -35,7 +35,7 @@ export default leafCommand(commandInfo, async (options) => {
     name: "node-tests",
   };
 
-  if (!options["no-test-proxy"]) {
+  if (options["test-proxy"]) {
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -11,11 +11,11 @@ export const commandInfo = makeCommandInfo(
   "test:node-ts-input",
   "runs the node tests using mocha with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
-    "no-test-proxy": {
-      shortName: "ntp",
+    "test-proxy": {
+      shortName: "tp",
       kind: "boolean",
-      default: false,
-      description: "whether to disable launching test-proxy",
+      default: true,
+      description: "whether to enable launching test-proxy",
     },
   },
 );
@@ -41,7 +41,7 @@ export default leafCommand(commandInfo, async (options) => {
     name: "node-tests",
   };
 
-  if (!options["no-test-proxy"]) {
+  if (options["test-proxy"]) {
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTsxTS.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTsxTS.ts
@@ -10,11 +10,11 @@ export const commandInfo = makeCommandInfo(
   "test:node-tsx-ts",
   "runs the node tests using mocha with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
-    "no-test-proxy": {
-      shortName: "ntp",
+    "test-proxy": {
+      shortName: "tp",
       kind: "boolean",
-      default: false,
-      description: "whether to disable launching test-proxy",
+      default: true,
+      description: "whether to enable launching test-proxy",
     },
   },
 );
@@ -34,7 +34,7 @@ export default leafCommand(commandInfo, async (options) => {
     name: "node-tests",
   };
 
-  if (!options["no-test-proxy"]) {
+  if (options["test-proxy"]) {
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -12,11 +12,11 @@ export const commandInfo = makeCommandInfo(
   "test:vitest",
   "runs tests using vitest with the default and the provided options; starts the proxy-tool in record and playback modes",
   {
-    "no-test-proxy": {
-      shortName: "ntp",
+    "test-proxy": {
+      shortName: "tp",
       kind: "boolean",
-      default: false,
-      description: "whether to disable launching test-proxy",
+      default: true,
+      description: "whether to enable launching test-proxy",
     },
     browser: {
       shortName: "br",
@@ -54,7 +54,7 @@ export default leafCommand(commandInfo, async (options) => {
     name: "vitest",
   };
 
-  if (!options["no-test-proxy"]) {
+  if (options["test-proxy"]) {
     return runTestsWithProxyTool(command);
   }
 


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Invert the `no-test-proxy` option in our test run commands, creating a `test-proxy` option instead. The command line parsing library dev-tool uses, `minimist`, special cases CLI options starting with `--no-`, such that passing `--no-test-proxy` sets the `test-proxy` option to `false`, instead of setting the `no-test-proxy` option to `true` as our commands assume. This fix corrects that assumption by inverting the option.

Passing `--no-test-proxy` in to the run command, as many of our package.json scripts do, will work properly after this change.