### PR TITLE
[core-amqp] Update retry

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Update the error thrown after all retries are exhausted to be the last service error received.
+
 ## 4.2.1 (2024-03-04)
 
 ### Other Changes

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Update the error thrown after all retries are exhausted to be the last service error received.
+- Updates the error thrown after all retries are exhausted to be the last service error received.
 
 ## 4.2.1 (2024-03-04)
 

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -285,9 +285,18 @@ function compileErrors(errors: (MessagingError | Error)[]): MessagingError | Err
   if (!errors.length) {
     throw new RangeError("Error array is empty");
   }
-  let i = 0;
-  const str = errors.map((error) => `Error ${i++}: ${error}`).join("\n\n");
-  const lastError = errors[errors.length - 1];
-  lastError.message = str;
+  let message = "";
+  let lastError: MessagingError | Error;
+  for (let i = 0; i < errors.length; i++) {
+    message += `Error ${i}: ${errors[i]}\n\n`;
+    const error = errors[i];
+    // filter out SDK-side errors
+    if ("OperationTimeoutError" !== error.name) {
+      lastError = error;
+    }
+  }
+  message.trimEnd();
+  lastError ??= errors[errors.length - 1];
+  lastError.message = message;
   return lastError;
 }

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -295,8 +295,7 @@ function compileErrors(errors: (MessagingError | Error)[]): MessagingError | Err
       lastError = error;
     }
   }
-  message.trimEnd();
   lastError ??= errors[errors.length - 1];
-  lastError.message = message;
+  lastError.message = message.trimEnd();
   return lastError;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
There're situations where the service decides to close the connection and all subsequent requests will timeout if the first service error is retryable. This PR makes sure to surface the last service error rather than the last SDK timeout error.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Yes.

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
