### PR TITLE
[test-credential] Publish current version to npm

### DIFF
--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.0.2 (2024-03-20)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- The `@azure-tools/test-recorder` dependency has been updated to version `^3.0.0`. This update discontinues the support for `@azure/core-http` in tests.
+- The `@azure/identity` dependency has been upgraded to version `^4.x`.
+- **Additional Updates**: Several other updates have been made to ensure compatibility with the libraries in the Azure SDK for JS repository. These include version updates for `prettier` and `typescript`, as well as an update to the minimum required Node.js version.
 
 ## 1.0.1 (2023-01-23)
 


### PR DESCRIPTION
## What and Why?
- Publishing the current changes in `@azure-tools/test-credential` as version `1.0.2`.
- This allows upgrading to `2.0.0` to consume `@azure-tools/test-recorder@4.0.0` with the newer env settings.
- Added changelog
- Currently blocking the PR #28667 as this package depends on the older `@azure-tools/test-recorder` version `3.x.y`