### PR TITLE
[test-credential] Publish types for `@azure/test-credential`

### DIFF
--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.3 (2024-03-21)
+
+### Features Added
+
+- Add types for the package.
+
 ## 1.0.2 (2024-03-20)
 
 ### Features Added

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/test-credential",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "sdk-type": "utility",
   "description": "Test utilities library that provides the test credential",
   "main": "dist/index.js",

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -34,7 +34,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/src/index.d.ts",
+    "types/latest/src",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
### Packages impacted by this PR
Types for `@azure/test-credential` were not published for `1.0.0` - `1.0.2` versions due to a configuration issue or an oversight during the publishing process. The builds might not have failed before because the missing types did not affect the build process.

Nonetheless, this change is in the right direction in ensuring the types are published correctly.

### Issues associated with this PR
https://dev.azure.com/azure-sdk/public/_build/results?buildId=3625592&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=acc99708-be46-50ff-f197-4ecb2c3cab18&l=444
![image](https://github.com/Azure/azure-sdk-for-js/assets/10452642/0ccdfa49-b97a-4b20-96db-cbbabc7937a9)
