### PR TITLE
[aggregate-reports] Workaround for upload dependency report

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -51,12 +51,7 @@ stages:
               copy eng/common/InterdependencyGraph.html $(Build.ArtifactStagingDirectory)
             displayName: 'Copy static file'
 
-          - pwsh: |
-              azcopy login --identity
-              $Env:AZCOPY_AUTO_LOGIN_TYPE = "MSI"
-            displayName: 'Login to azcopy'
-
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Upload Dependency Report'
             inputs:
               sourcePath: '$(Build.ArtifactStagingDirectory)/*'
@@ -67,7 +62,7 @@ stages:
               blobPrefix: dependencies
               AdditionalArgumentsForBlobCopy: '--exclude-pattern=*data.js*'
 
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Upload Dependency Graph'
             inputs:
               sourcePath: '$(Build.ArtifactStagingDirectory)/*'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -51,6 +51,11 @@ stages:
               copy eng/common/InterdependencyGraph.html $(Build.ArtifactStagingDirectory)
             displayName: 'Copy static file'
 
+          - pwsh: |
+              azcopy login --identity
+              $Env:AZCOPY_AUTO_LOGIN_TYPE = "MSI"
+            displayName: 'Login to azcopy'
+
           - task: AzureFileCopy@4
             displayName: 'Upload Dependency Report'
             inputs:


### PR DESCRIPTION
aggregate report is broken due to azcopy can't do authorization by using AAD Workload Identity. https://github.com/Azure/azure-storage-azcopy/issues/2545
this is a workaround for this known issue