### PR TITLE
[identity] Fix default cache name

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- msal cache files are properly named when the user does not pass in a custom file name [#29039](https://github.com/Azure/azure-sdk-for-js/pull/29039)
+
 ### Other Changes
 
 ## 4.1.0-beta.1 (2024-02-06)

--- a/sdk/identity/identity/src/constants.ts
+++ b/sdk/identity/identity/src/constants.ts
@@ -58,9 +58,17 @@ export const ALL_TENANTS: string[] = ["*"];
 /**
  * @internal
  */
-export const CACHE_CAE_SUFFIX = ".cae";
+export const CACHE_CAE_SUFFIX = "cae";
 
 /**
  * @internal
  */
-export const CACHE_NON_CAE_SUFFIX = ".nocae";
+export const CACHE_NON_CAE_SUFFIX = "nocae";
+
+/**
+ * @internal
+ *
+ * The default name for the cache persistence plugin.
+ * Matches the constant defined in the cache persistence package.
+ */
+export const DEFAULT_TOKEN_CACHE_NAME = "msal.cache";

--- a/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalNodeCommon.ts
@@ -5,7 +5,12 @@ import * as msalNode from "@azure/msal-node";
 
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
 import { AppType, AuthenticationRecord, MsalResult } from "../types";
-import { CACHE_CAE_SUFFIX, CACHE_NON_CAE_SUFFIX, DeveloperSignOnClientId } from "../../constants";
+import {
+  CACHE_CAE_SUFFIX,
+  CACHE_NON_CAE_SUFFIX,
+  DEFAULT_TOKEN_CACHE_NAME,
+  DeveloperSignOnClientId,
+} from "../../constants";
 import { CredentialLogger, formatSuccess } from "../../util/logging";
 import { MsalFlow, MsalFlowOptions } from "../flows";
 import {
@@ -126,12 +131,13 @@ export abstract class MsalNode implements MsalFlow {
 
     // If persistence has been configured
     if (persistenceProvider !== undefined && options.tokenCachePersistenceOptions?.enabled) {
+      const cacheBaseName = options.tokenCachePersistenceOptions.name || DEFAULT_TOKEN_CACHE_NAME;
       const nonCaeOptions = {
-        name: `${options.tokenCachePersistenceOptions.name}.${CACHE_NON_CAE_SUFFIX}`,
+        name: `${cacheBaseName}.${CACHE_NON_CAE_SUFFIX}`,
         ...options.tokenCachePersistenceOptions,
       };
       const caeOptions = {
-        name: `${options.tokenCachePersistenceOptions.name}.${CACHE_CAE_SUFFIX}`,
+        name: `${cacheBaseName}.${CACHE_CAE_SUFFIX}`,
         ...options.tokenCachePersistenceOptions,
       };
       this.createCachePlugin = () => persistenceProvider!(nonCaeOptions);

--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -103,13 +103,13 @@ function generatePluginConfiguration(options: MsalClientOptions): PluginConfigur
       );
     }
 
-    const cacheName = options.tokenCachePersistenceOptions.name ?? DEFAULT_TOKEN_CACHE_NAME;
+    const cacheBaseName = options.tokenCachePersistenceOptions.name || DEFAULT_TOKEN_CACHE_NAME;
     config.cache.cachePlugin = persistenceProvider({
-      name: `${cacheName}.${CACHE_NON_CAE_SUFFIX}`,
+      name: `${cacheBaseName}.${CACHE_NON_CAE_SUFFIX}`,
       ...options.tokenCachePersistenceOptions,
     });
     config.cache.cachePluginCae = persistenceProvider({
-      name: `${cacheName}.${CACHE_CAE_SUFFIX}`,
+      name: `${cacheBaseName}.${CACHE_CAE_SUFFIX}`,
       ...options.tokenCachePersistenceOptions,
     });
   }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -3,7 +3,7 @@
 
 import * as msalNode from "@azure/msal-node";
 
-import { CACHE_CAE_SUFFIX, CACHE_NON_CAE_SUFFIX } from "../../constants";
+import { CACHE_CAE_SUFFIX, CACHE_NON_CAE_SUFFIX, DEFAULT_TOKEN_CACHE_NAME } from "../../constants";
 
 import { MsalClientOptions } from "./msalClient";
 import { NativeBrokerPluginControl } from "../../plugins/provider";
@@ -103,12 +103,13 @@ function generatePluginConfiguration(options: MsalClientOptions): PluginConfigur
       );
     }
 
+    const cacheName = options.tokenCachePersistenceOptions.name ?? DEFAULT_TOKEN_CACHE_NAME;
     config.cache.cachePlugin = persistenceProvider({
-      name: `${options.tokenCachePersistenceOptions.name}.${CACHE_NON_CAE_SUFFIX}`,
+      name: `${cacheName}.${CACHE_NON_CAE_SUFFIX}`,
       ...options.tokenCachePersistenceOptions,
     });
     config.cache.cachePluginCae = persistenceProvider({
-      name: `${options.tokenCachePersistenceOptions.name}.${CACHE_CAE_SUFFIX}`,
+      name: `${cacheName}.${CACHE_CAE_SUFFIX}`,
       ...options.tokenCachePersistenceOptions,
     });
   }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A - noticed in passing

### Describe the problem that is addressed by this PR

When a user does not specify a cache name, we end up stringifying "undefined" as
the cache name. In addition, we prepend a `.` both in the constants and the
cache name. 

The resulting cache name ends up being `undefined..cae` or `undefined..nocae`
which is not what we want.

This PR fixes both of these issues and matches the MSAL cache name to the one
specified in @azure/identity-cache-persistence.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Sharing constants between packages may have been better to ensure consistency;
however, that seemed to be overkill for this. Since we _always_ set the cache
name and pass it into the plugin, the reality is that @azure/identity is the 
source of truth for how the files are named.


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
