### PR TITLE
[personalizer] Fix cloud selection in tests.yml

### DIFF
--- a/sdk/personalizer/ai-personalizer-rest/tests.yml
+++ b/sdk/personalizer/ai-personalizer-rest/tests.yml
@@ -5,7 +5,7 @@ extends:
     parameters:
       PackageName: "@azure-rest/ai-personalizer"
       ServiceDirectory: personalizer
-      Clouds: Canary
+      Clouds: 'Canary'
       EnvVars:
         AZURE_CLIENT_ID: $(PERSONALIZER_CLIENT_ID)
         AZURE_TENANT_ID: $(PERSONALIZER_TENANT_ID)


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/ai-personalizer`

### Describe the problem that is addressed by this PR

With the [recent refactoring of test pipelines](https://github.com/Azure/azure-sdk-for-js/commit/ecdb45e61db7c965ee9aae8a7aa0d12f7b4f5012), some malformed configuration in this file started failing our live test pipelines. Specifically, the `Clouds` parameter, which is expected to be a string, was being passed as a literal causing the pipeline to fail.