### PR TITLE
Add `SimplePollerLike` support in V3 LRO

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 ### Features Added
 
-- Add interface `SimplePollerLike` for poller interface without promise
+- Add interface `SimplePollerLike` for Poller without `Promise` inerface
 - Add a builder function `createInitializedHttpPoller` to create an initialized poller
-
-### Breaking Changes
-
-- Add new parameter `type` in `createHttpPoller` to support creating `PollerLike` and `SimplePollerLike`
+- Add overloads for `createHttpPoller` to support `PollerLike` and `SimplePollerLike` creation
 
 ### Bugs Fixed
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.2 (2023-04-2)
+## 3.0.0-beta.2 (2023-04-02)
 
 Compared with 3.0.0-beta.1 we have following changes:
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.2 (2023-04-02)
+## 3.0.0-beta.2 (2024-04-02)
 
 Compared with 3.0.0-beta.1 we have following changes:
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 3.0.0-beta.2 (Unreleased)
+## 3.0.0-beta.2 (2023-04-2)
+
+Compared with 3.0.0-beta.1 we have following changes:
 
 ### Features Added
 
 - Add interface `SimplePollerLike` for Poller without `Promise` inerface
 - Add a builder function `createInitializedHttpPoller` to create an initialized poller
 - Add overloads for `createHttpPoller` to support `PollerLike` and `SimplePollerLike` creation
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 2.7.1 (2024-03-20)
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Add interface `SimplePollerLike` for poller interface without promise
+- Add a builder function `createInitializedHttpPoller` to create an initialized poller
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -4,11 +4,27 @@
 
 ### Features Added
 
+- Add interface `SimplePollerLike` for poller interface without promise
+
 ### Breaking Changes
+
+- Add new parameter `type` in `createHttpPoller` to support creating `PollerLike` and `SimplePollerLike`
 
 ### Bugs Fixed
 
 ### Other Changes
+
+## 2.7.1 (2024-03-20)
+
+- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
+
+## 2.7.0 (2024-03-12)
+
+### Other Changes
+
+- Migrated the codebase to ESM. This change is internal and should not affect customers.
+- Migrated unit tests to vitest.
+- Export the function `deserializeState` to the public
 
 ## 3.0.0-beta.1 (2024-02-25)
 
@@ -22,18 +38,6 @@ Initial implementation of next-generation for Long Running Operations (LROs) in 
 - Added a new function `serialize` to help serialize the poller
 - Added a new function `submitted` to help wait for the poller submitted succesffully
 - Added a new parameter `TRequest` for `OperationResponse` to accept the raw request
-
-## 2.7.1 (2024-03-20)
-
-- Add top-level `browser` field to `package.json` as fallback for legacy bundlers that do not support the `exports` field.
-
-## 2.7.0 (2024-03-12)
-
-### Other Changes
-
-- Migrated the codebase to ESM. This change is internal and should not affect customers.
-- Migrated unit tests to vitest.
-- Export the function `deserializeState` to the public
 
 ## 2.6.0 (2024-02-01)
 

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -30,7 +30,13 @@ export interface CreateHttpPollerOptions<TResult, TState> {
 }
 
 // @public
-export function createHttpSimplePoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): Promise<SimplePollerLike<TState, TResult>>;
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): Promise<PollerLike<TState, TResult>>;
+
+// @public
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, type: "Poller", options?: CreateHttpPollerOptions<TResult, TState>): Promise<PollerLike<TState, TResult>>;
+
+// @public
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, type: "SimplePoller", options?: CreateHttpPollerOptions<TResult, TState>): Promise<SimplePollerLike<TState, TResult>>;
 
 // @public
 export function deserializeState<TState>(serializedState: string): RestorableOperationState<TState>;

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -105,6 +105,7 @@ export type RestorableOperationState<T> = T & {
 
 // @public
 export interface SimplePollerLike<TState extends OperationState<TResult>, TResult> {
+    readonly [Symbol.toStringTag]: string;
     readonly isDone: boolean;
     readonly isStopped: boolean;
     onProgress(callback: (state: TState) => void): CancelOnProgress;

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -10,10 +10,13 @@ import { AbortSignalLike } from '@azure/abort-controller';
 export type CancelOnProgress = () => void;
 
 // @public
-export function createHttpPoller<TResult, TState extends OperationState<TResult>>(type: "Poller", lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): PollerLike<TState, TResult>;
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): PollerLike<TState, TResult>;
 
-// @public (undocumented)
-export function createHttpPoller<TResult, TState extends OperationState<TResult>>(type: "SimplePoller", lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): SimplePollerLike<TState, TResult>;
+// @public
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, type: "Poller", options?: CreateHttpPollerOptions<TResult, TState>): PollerLike<TState, TResult>;
+
+// @public
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, type: "SimplePoller", options?: CreateHttpPollerOptions<TResult, TState>): SimplePollerLike<TState, TResult>;
 
 // @public
 export interface CreateHttpPollerOptions<TResult, TState> {

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -10,7 +10,10 @@ import { AbortSignalLike } from '@azure/abort-controller';
 export type CancelOnProgress = () => void;
 
 // @public
-export function createHttpPoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): PollerLike<TState, TResult>;
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(type: "Poller", lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): PollerLike<TState, TResult>;
+
+// @public (undocumented)
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(type: "SimplePoller", lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): SimplePollerLike<TState, TResult>;
 
 // @public
 export interface CreateHttpPollerOptions<TResult, TState> {
@@ -60,20 +63,7 @@ export interface OperationState<TResult> {
 export type OperationStatus = "notStarted" | "running" | "succeeded" | "canceled" | "failed";
 
 // @public
-export interface PollerLike<TState extends OperationState<TResult>, TResult> extends Promise<TResult> {
-    readonly isDone: boolean;
-    readonly isStopped: boolean;
-    onProgress(callback: (state: TState) => void): CancelOnProgress;
-    readonly operationState: TState | undefined;
-    poll(options?: {
-        abortSignal?: AbortSignalLike;
-    }): Promise<TState>;
-    pollUntilDone(pollOptions?: {
-        abortSignal?: AbortSignalLike;
-    }): Promise<TResult>;
-    readonly result: TResult | undefined;
-    serialize(): Promise<string>;
-    submitted(): Promise<void>;
+export interface PollerLike<TState extends OperationState<TResult>, TResult> extends Promise<TResult>, SimplePollerLike<TState, TResult> {
 }
 
 // @public
@@ -100,6 +90,23 @@ export type ResourceLocationConfig = "azure-async-operation" | "location" | "ori
 export type RestorableOperationState<T> = T & {
     config: OperationConfig;
 };
+
+// @public
+export interface SimplePollerLike<TState extends OperationState<TResult>, TResult> {
+    readonly isDone: boolean;
+    readonly isStopped: boolean;
+    onProgress(callback: (state: TState) => void): CancelOnProgress;
+    readonly operationState: TState | undefined;
+    poll(options?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<TState>;
+    pollUntilDone(pollOptions?: {
+        abortSignal?: AbortSignalLike;
+    }): Promise<TResult>;
+    readonly result: TResult | undefined;
+    serialize(): Promise<string>;
+    submitted(): Promise<void>;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -30,6 +30,9 @@ export interface CreateHttpPollerOptions<TResult, TState> {
 }
 
 // @public
+export function createHttpSimplePoller<TResult, TState extends OperationState<TResult>>(lro: LongRunningOperation, options?: CreateHttpPollerOptions<TResult, TState>): Promise<SimplePollerLike<TState, TResult>>;
+
+// @public
 export function deserializeState<TState>(serializedState: string): RestorableOperationState<TState>;
 
 // @public

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -20,6 +20,20 @@ import { CreateHttpPollerOptions } from "./models.js";
 import { buildCreatePoller } from "../poller/poller.js";
 
 /**
+ * Create a SimplePoller that will poll the LRO until it is done
+ * Awaitting this would return an initialized poller
+ */
+export async function createHttpSimplePoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): Promise<SimplePollerLike<TState, TResult>> {
+  const poller = createHttpPoller(lro, "SimplePoller", options);
+  // return the poller after it has been initialized
+  await poller.submitted();
+  return poller;
+}
+
+/**
  * The default creation function in which returns poller extending promise interface
  */
 export function createHttpPoller<TResult, TState extends OperationState<TResult>>(

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -20,27 +20,42 @@ import { CreateHttpPollerOptions } from "./models.js";
 import { buildCreatePoller } from "../poller/poller.js";
 
 /**
+ * The default creation function in which returns poller extending promise interface
+ */
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): PollerLike<TState, TResult>;
+/**
+ * Explicitly specify the type of poller as "Poller" to create
+ */
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  type: "Poller",
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): PollerLike<TState, TResult>;
+/**
+ * Explicitly specify the type of poller as "SimplePoller" to create
+ */
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  type: "SimplePoller",
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): SimplePollerLike<TState, TResult>;
+/**
  * Creates a poller that can be used to poll a long-running operation.
- * @param type - the type of poller to create, limited to Poller or SimplePoller
  * @param lro - Description of the long-running operation
+ * @param typeOrOptions - the type of poller or options, type would be limited to Poller or SimplePoller
  * @param options - options to configure the poller
  * @returns an initialized poller
  */
 export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
-  type: "Poller",
   lro: LongRunningOperation,
-  options?: CreateHttpPollerOptions<TResult, TState>,
-): PollerLike<TState, TResult>;
-export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
-  type: "SimplePoller",
-  lro: LongRunningOperation,
-  options?: CreateHttpPollerOptions<TResult, TState>,
-): SimplePollerLike<TState, TResult>;
-export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
-  type: "Poller" | "SimplePoller",
-  lro: LongRunningOperation,
+  typeOrOptions: "Poller" | "SimplePoller" | CreateHttpPollerOptions<TResult, TState> = "Poller",
   options?: CreateHttpPollerOptions<TResult, TState>,
 ): SimplePollerLike<TState, TResult> | PollerLike<TState, TResult> {
+  const type = typeof typeOrOptions === "string" ? typeOrOptions : "Poller";
+  options = typeof typeOrOptions === "string" ? options : typeOrOptions;
   const {
     resourceLocationConfig,
     intervalInMs,

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -5,7 +5,7 @@
 // Licensed under the MIT license.
 
 import { LongRunningOperation, OperationResponse } from "./models.js";
-import { OperationState, PollerLike } from "../poller/models.js";
+import { OperationState, PollerLike, SimplePollerLike } from "../poller/models.js";
 import {
   getErrorFromResponse,
   getOperationLocation,
@@ -21,14 +21,26 @@ import { buildCreatePoller } from "../poller/poller.js";
 
 /**
  * Creates a poller that can be used to poll a long-running operation.
+ * @param type - the type of poller to create, limited to Poller or SimplePoller
  * @param lro - Description of the long-running operation
  * @param options - options to configure the poller
  * @returns an initialized poller
  */
 export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  type: "Poller",
   lro: LongRunningOperation,
   options?: CreateHttpPollerOptions<TResult, TState>,
-): PollerLike<TState, TResult> {
+): PollerLike<TState, TResult>;
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  type: "SimplePoller",
+  lro: LongRunningOperation,
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): SimplePollerLike<TState, TResult>;
+export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
+  type: "Poller" | "SimplePoller",
+  lro: LongRunningOperation,
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): SimplePollerLike<TState, TResult> | PollerLike<TState, TResult> {
   const {
     resourceLocationConfig,
     intervalInMs,
@@ -38,7 +50,8 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
     withOperationLocation,
     resolveOnUnsuccessful = false,
   } = options || {};
-  return buildCreatePoller<OperationResponse, TResult, TState>({
+  return buildCreatePoller<OperationResponse, TResult, TState>(
+    type, {
     getStatusFromInitialResponse,
     getStatusFromPollResponse: getOperationStatus,
     isOperationError,

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -50,8 +50,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
     withOperationLocation,
     resolveOnUnsuccessful = false,
   } = options || {};
-  return buildCreatePoller<OperationResponse, TResult, TState>(
-    type, {
+  return buildCreatePoller<OperationResponse, TResult, TState>(type, {
     getStatusFromInitialResponse,
     getStatusFromPollResponse: getOperationStatus,
     isOperationError,

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -20,8 +20,7 @@ import { CreateHttpPollerOptions } from "./models.js";
 import { buildCreatePoller } from "../poller/poller.js";
 
 /**
- * Create a SimplePoller that will poll the LRO until it is done
- * Awaitting this would return an initialized poller
+ * Create a SimplePoller and awaitting this would return an initialized poller
  */
 export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(
   lro: LongRunningOperation,
@@ -59,7 +58,7 @@ export async function createInitializedHttpPoller<TResult, TState extends Operat
 }
 
 /**
- * The default creation function in which returns poller extending promise interface
+ * Create a PollerLike object and awaitting this would return the final result of polling
  */
 export function createHttpPoller<TResult, TState extends OperationState<TResult>>(
   lro: LongRunningOperation,

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -23,12 +23,37 @@ import { buildCreatePoller } from "../poller/poller.js";
  * Create a SimplePoller that will poll the LRO until it is done
  * Awaitting this would return an initialized poller
  */
-export async function createHttpSimplePoller<TResult, TState extends OperationState<TResult>>(
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(
   lro: LongRunningOperation,
   options?: CreateHttpPollerOptions<TResult, TState>,
-): Promise<SimplePollerLike<TState, TResult>> {
-  const poller = createHttpPoller(lro, "SimplePoller", options);
-  // return the poller after it has been initialized
+): Promise<PollerLike<TState, TResult>>;
+/**
+ * Explicitly specify the type of poller as "Poller" to create
+ */
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  type: "Poller",
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): Promise<PollerLike<TState, TResult>>;
+/**
+ * Explicitly specify the type of poller as "SimplePoller" to create
+ */
+export function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  type: "SimplePoller",
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): Promise<SimplePollerLike<TState, TResult>>;
+export async function createInitializedHttpPoller<TResult, TState extends OperationState<TResult>>(
+  lro: LongRunningOperation,
+  typeOrOptions: "Poller" | "SimplePoller" | CreateHttpPollerOptions<TResult, TState> = "Poller",
+  options?: CreateHttpPollerOptions<TResult, TState>,
+): Promise<SimplePollerLike<TState, TResult> | PollerLike<TState, TResult>> {
+  const type = typeof typeOrOptions === "string" ? typeOrOptions : "Poller";
+  options = typeof typeOrOptions === "string" ? options : typeOrOptions;
+  const poller =
+    type === "Poller"
+      ? createHttpPoller(lro, options)
+      : createHttpPoller(lro, "SimplePoller", options);
   await poller.submitted();
   return poller;
 }

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createHttpPoller } from "./http/poller.js";
+export { createHttpPoller, createHttpSimplePoller } from "./http/poller.js";
 export {
   CancelOnProgress,
   OperationState,

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createHttpPoller, createHttpSimplePoller } from "./http/poller.js";
+export { createHttpPoller, createInitializedHttpPoller } from "./http/poller.js";
 export {
   CancelOnProgress,
   OperationState,

--- a/sdk/core/core-lro/src/index.ts
+++ b/sdk/core/core-lro/src/index.ts
@@ -7,6 +7,7 @@ export {
   OperationState,
   OperationStatus,
   PollerLike,
+  SimplePollerLike,
   RestorableOperationState,
   OperationConfig,
 } from "./poller/models.js";

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -229,7 +229,8 @@ export interface SimplePollerLike<TState extends OperationState<TResult>, TResul
  * A poller interface.
  */
 export interface PollerLike<TState extends OperationState<TResult>, TResult>
-  extends Promise<TResult>, SimplePollerLike<TState, TResult> { }
+  extends Promise<TResult>,
+    SimplePollerLike<TState, TResult> {}
 
 /**
  * A state proxy that allows poller implementation to abstract away the operation

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -177,8 +177,7 @@ export type CancelOnProgress = () => void;
 /**
  * A simple poller interface.
  */
-export interface PollerLike<TState extends OperationState<TResult>, TResult>
-  extends Promise<TResult> {
+export interface SimplePollerLike<TState extends OperationState<TResult>, TResult> {
   /**
    * Returns true if the poller has finished polling.
    */
@@ -226,6 +225,11 @@ export interface PollerLike<TState extends OperationState<TResult>, TResult>
    */
   submitted(): Promise<void>;
 }
+/**
+ * A poller interface.
+ */
+export interface PollerLike<TState extends OperationState<TResult>, TResult>
+  extends Promise<TResult>, SimplePollerLike<TState, TResult> { }
 
 /**
  * A state proxy that allows poller implementation to abstract away the operation

--- a/sdk/core/core-lro/src/poller/models.ts
+++ b/sdk/core/core-lro/src/poller/models.ts
@@ -198,6 +198,10 @@ export interface SimplePollerLike<TState extends OperationState<TResult>, TResul
    */
   readonly result: TResult | undefined;
   /**
+   * A String value that is used in the creation of the default string description of an object.
+   */
+  readonly [Symbol.toStringTag]: string;
+  /**
    * Returns a promise that will resolve once a single polling request finishes.
    * It does this by calling the update method of the Poller's operation.
    */

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -231,7 +231,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
 
         return state;
       },
-      // [Symbol.toStringTag]: "Poller"
+      [Symbol.toStringTag]: "Poller",
     };
     if (type === "SimplePoller") {
       return poller;
@@ -252,7 +252,6 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     ): Promise<TResult> => {
       return poller.pollUntilDone().finally(onfinally);
     };
-    // (poller as PollerLike<TState, TResult>)[Symbol.toStringTag] = "Poller";
     return poller as PollerLike<TState, TResult>;
   };
 }

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -75,13 +75,13 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     const stateProxy = createStateProxy<TResult, TState>();
     const withOperationLocation = withOperationLocationCallback
       ? (() => {
-        let called = false;
-        return (operationLocation: string, isUpdated: boolean) => {
-          if (isUpdated) withOperationLocationCallback(operationLocation);
-          else if (!called) withOperationLocationCallback(operationLocation);
-          called = true;
-        };
-      })()
+          let called = false;
+          return (operationLocation: string, isUpdated: boolean) => {
+            if (isUpdated) withOperationLocationCallback(operationLocation);
+            else if (!called) withOperationLocationCallback(operationLocation);
+            called = true;
+          };
+        })()
       : undefined;
     let statePromise: Promise<TState>;
     let state: RestorableOperationState<TState>;

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -15,7 +15,6 @@ import {
 import { deserializeState, initOperation, pollOperation } from "./operation.js";
 import { POLL_INTERVAL_IN_MS } from "./constants.js";
 import { delay } from "@azure/core-util";
-import { P } from "vitest/dist/reporters-P7C2ytIv.js";
 
 const createStateProxy: <TResult, TState extends OperationState<TResult>>() => StateProxy<
   TState,
@@ -76,13 +75,13 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     const stateProxy = createStateProxy<TResult, TState>();
     const withOperationLocation = withOperationLocationCallback
       ? (() => {
-        let called = false;
-        return (operationLocation: string, isUpdated: boolean) => {
-          if (isUpdated) withOperationLocationCallback(operationLocation);
-          else if (!called) withOperationLocationCallback(operationLocation);
-          called = true;
-        };
-      })()
+          let called = false;
+          return (operationLocation: string, isUpdated: boolean) => {
+            if (isUpdated) withOperationLocationCallback(operationLocation);
+            else if (!called) withOperationLocationCallback(operationLocation);
+            called = true;
+          };
+        })()
       : undefined;
     let statePromise: Promise<TState>;
     let state: RestorableOperationState<TState>;
@@ -108,7 +107,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     const cancelErrMsg = "Operation was canceled";
     let currentPollIntervalInMs = intervalInMs;
 
-    let poller: SimplePollerLike<TState, TResult> = {
+    const poller: SimplePollerLike<TState, TResult> = {
       get operationState(): TState | undefined {
         return state;
       },

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -231,7 +231,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
 
         return state;
       },
-      [Symbol.toStringTag]: "Poller",
+      [Symbol.toStringTag]: type,
     };
     if (type === "SimplePoller") {
       return poller;

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -170,7 +170,7 @@ export function createTestPoller(settings: {
   });
   switch (implName) {
     case "createPoller": {
-      return createHttpPoller(lro, {
+      return createHttpPoller("Poller", lro, {
         intervalInMs: 0,
         resourceLocationConfig: resourceLocationConfig,
         processResult,
@@ -221,11 +221,11 @@ async function runLro<TState>(settings: {
 
 export const createRunLroWith =
   <TState>(variables: { implName: ImplementationName; throwOnNon2xxResponse?: boolean }) =>
-  (settings: {
-    routes: LroResponseSpec[];
-    onProgress?: (state: TState) => void;
-    resourceLocationConfig?: ResourceLocationConfig;
-    processResult?: (result: unknown, state: TState) => Result | Promise<Result>;
-    updateState?: (state: TState, lastResponse: RawResponse) => void;
-  }): Promise<Result> =>
-    runLro({ ...settings, ...variables });
+    (settings: {
+      routes: LroResponseSpec[];
+      onProgress?: (state: TState) => void;
+      resourceLocationConfig?: ResourceLocationConfig;
+      processResult?: (result: unknown, state: TState) => Result | Promise<Result>;
+      updateState?: (state: TState, lastResponse: RawResponse) => void;
+    }): Promise<Result> =>
+      runLro({ ...settings, ...variables });

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -170,7 +170,7 @@ export function createTestPoller(settings: {
   });
   switch (implName) {
     case "createPoller": {
-      return createHttpPoller("Poller", lro, {
+      return createHttpPoller(lro, {
         intervalInMs: 0,
         resourceLocationConfig: resourceLocationConfig,
         processResult,

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -221,11 +221,11 @@ async function runLro<TState>(settings: {
 
 export const createRunLroWith =
   <TState>(variables: { implName: ImplementationName; throwOnNon2xxResponse?: boolean }) =>
-    (settings: {
-      routes: LroResponseSpec[];
-      onProgress?: (state: TState) => void;
-      resourceLocationConfig?: ResourceLocationConfig;
-      processResult?: (result: unknown, state: TState) => Result | Promise<Result>;
-      updateState?: (state: TState, lastResponse: RawResponse) => void;
-    }): Promise<Result> =>
-      runLro({ ...settings, ...variables });
+  (settings: {
+    routes: LroResponseSpec[];
+    onProgress?: (state: TState) => void;
+    resourceLocationConfig?: ResourceLocationConfig;
+    processResult?: (result: unknown, state: TState) => Result | Promise<Result>;
+    updateState?: (state: TState, lastResponse: RawResponse) => void;
+  }): Promise<Result> =>
+    runLro({ ...settings, ...variables });


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.typescript/issues/2230
- Add interface `SimplePollerLike` without promise interface and it will be used for RLC
- Add a builder function `createInitializedHttpPoller` to create an initialized poller
- Add overloading for `createInitializedHttpPoller` and `createHttpPoller` to both return PollerLike and SimplePollerLike

Codegen pr is here: https://github.com/Azure/autorest.typescript/pull/2388.
