### PR TITLE
[notification-hubs] Add builders for other message types

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.2 (Unreleased)
+## 1.2.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added overloads to create notifications for ADM, Baidu, Template, Xiaomi and WebPush accepting either a string or a custom object that is transformed into the JSON notification body.
 
 ## 1.1.1 (2024-03-19)
 

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/notification-hubs",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Azure Notification Hubs SDK for JavaScript",
   "sdk-type": "client",
   "main": "dist/index.cjs",

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -58,7 +58,7 @@ export interface AdmNotification extends JsonNotification {
 // @public
 export interface AdmNotificationParams {
     body: string | AdmNativeMessage;
-    headers?: Record<string, string | undefined>;
+    headers?: Record<string, string>;
 }
 
 // @public
@@ -131,7 +131,7 @@ export interface AppleCriticalSound {
 }
 
 // @public
-export interface AppleHeaders extends Record<string, string | undefined> {
+export interface AppleHeaders extends Record<string, unknown> {
     "apns-collapse-id"?: string;
     "apns-expiration"?: string;
     "apns-id"?: string;
@@ -460,7 +460,7 @@ export interface FcmLegacyNotification extends JsonNotification {
 // @public
 export interface FcmLegacyNotificationParams {
     body: string | FirebaseLegacyNativeMessage;
-    headers?: Record<string, string | undefined>;
+    headers?: Record<string, string>;
 }
 
 // @public
@@ -476,7 +476,7 @@ export interface FcmV1Notification extends JsonNotification {
 // @public
 export interface FcmV1NotificationParams {
     body: string | FirebaseV1NativeMessage;
-    headers?: Record<string, string | undefined>;
+    headers?: Record<string, string>;
 }
 
 // @public
@@ -780,13 +780,13 @@ export type Notification = AppleNotification | AdmNotification | BaiduNotificati
 // @public
 export interface NotificationCommon {
     body: string;
-    headers?: Record<string, string | undefined>;
+    headers?: Record<string, unknown>;
 }
 
 // @public
 export interface NotificationCommonParams {
     body: string | unknown;
-    headers?: Record<string, string | undefined>;
+    headers?: Record<string, unknown>;
 }
 
 // @public
@@ -1014,7 +1014,7 @@ export interface WindowsBadgeNativeMessage {
 export type WindowsContentType = "application/xml" | "application/octet-stream";
 
 // @public
-export interface WindowsHeaders extends Record<string, string | undefined> {
+export interface WindowsHeaders extends Record<string, unknown> {
     "X-WNS-Type"?: WnsTypes;
 }
 

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -223,12 +223,6 @@ export interface BaiduNotification extends JsonNotification {
 }
 
 // @public
-export interface BaiduNotificationParams {
-    body: string | unknown;
-    headers?: Record<string, string | undefined>;
-}
-
-// @public
 export interface BaiduRegistrationChannel {
     baiduChannelId: string;
     baiduUserId: string;
@@ -268,12 +262,6 @@ export interface BrowserInstallationCommon extends InstallationCommon {
 // @public
 export interface BrowserNotification extends JsonNotification {
     platform: "browser";
-}
-
-// @public
-export interface BrowserNotificationParams {
-    body: string | unknown;
-    headers?: Record<string, string | undefined>;
 }
 
 // @public
@@ -346,7 +334,7 @@ export function createAppleTemplateRegistrationDescription(description: AppleTem
 export function createBaiduInstallation(installation: DeviceTokenInstallation): BaiduInstallation;
 
 // @public
-export function createBaiduNotification(notification: BaiduNotificationParams): BaiduNotification;
+export function createBaiduNotification(notification: NotificationCommonParams): BaiduNotification;
 
 // @public
 export function createBaiduNotificationBody(nativeMessage: BaiduNativeMessage): string;
@@ -361,7 +349,7 @@ export function createBaiduTemplateRegistrationDescription(description: BaiduTem
 export function createBrowserInstallation(installation: BrowserInstallationCommon): BrowserInstallation;
 
 // @public
-export function createBrowserNotification(notification: BrowserNotificationParams): BrowserNotification;
+export function createBrowserNotification(notification: NotificationCommonParams): BrowserNotification;
 
 // @public
 export function createBrowserRegistrationDescription(description: BrowserRegistrationDescriptionCommon): BrowserRegistrationDescription;
@@ -403,7 +391,7 @@ export function createFirebaseV1NotificationBody(nativeMessage: FirebaseV1Native
 export function createTagExpression(tags: string[]): string;
 
 // @public
-export function createTemplateNotification(notification: TemplateNotificationParams): TemplateNotification;
+export function createTemplateNotification(notification: NotificationCommonParams): TemplateNotification;
 
 // @public
 export function createWindowsBadgeNotification(notification: WnsNotificationParams): WindowsNotification;
@@ -436,7 +424,7 @@ export function createWindowsToastNotification(notification: WnsNotificationPara
 export function createXiaomiInstallation(installation: DeviceTokenInstallation): XiaomiInstallation;
 
 // @public
-export function createXiaomiNotification(notification: XiaomiNotificationParams): XiaomiNotification;
+export function createXiaomiNotification(notification: NotificationCommonParams): XiaomiNotification;
 
 // @public
 export function createXiaomiRegistrationDescription(description: XiaomiRegistrationDescriptionCommon): XiaomiRegistrationDescription;
@@ -796,6 +784,12 @@ export interface NotificationCommon {
 }
 
 // @public
+export interface NotificationCommonParams {
+    body: string | unknown;
+    headers?: Record<string, string | undefined>;
+}
+
+// @public
 export interface NotificationDetails {
     admOutcomeCounts?: NotificationOutcome[];
     apnsOutcomeCounts?: NotificationOutcome[];
@@ -1003,12 +997,6 @@ export interface TemplateNotification extends JsonNotification {
 }
 
 // @public
-export interface TemplateNotificationParams {
-    body: string | unknown;
-    headers?: Record<string, string | undefined>;
-}
-
-// @public
 export interface TemplateRegistrationDescription {
     bodyTemplate: string;
     templateName?: string;
@@ -1084,12 +1072,6 @@ export interface XiaomiInstallation extends DeviceTokenInstallation {
 // @public
 export interface XiaomiNotification extends JsonNotification {
     platform: "xiaomi";
-}
-
-// @public
-export interface XiaomiNotificationParams {
-    body: string | unknown;
-    headers?: Record<string, string | undefined>;
 }
 
 // @public

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -223,6 +223,12 @@ export interface BaiduNotification extends JsonNotification {
 }
 
 // @public
+export interface BaiduNotificationParams {
+    body: string | unknown;
+    headers?: Record<string, string | undefined>;
+}
+
+// @public
 export interface BaiduRegistrationChannel {
     baiduChannelId: string;
     baiduUserId: string;
@@ -262,6 +268,12 @@ export interface BrowserInstallationCommon extends InstallationCommon {
 // @public
 export interface BrowserNotification extends JsonNotification {
     platform: "browser";
+}
+
+// @public
+export interface BrowserNotificationParams {
+    body: string | unknown;
+    headers?: Record<string, string | undefined>;
 }
 
 // @public
@@ -334,7 +346,7 @@ export function createAppleTemplateRegistrationDescription(description: AppleTem
 export function createBaiduInstallation(installation: DeviceTokenInstallation): BaiduInstallation;
 
 // @public
-export function createBaiduNotification(notification: NotificationCommon): BaiduNotification;
+export function createBaiduNotification(notification: BaiduNotificationParams): BaiduNotification;
 
 // @public
 export function createBaiduNotificationBody(nativeMessage: BaiduNativeMessage): string;
@@ -349,7 +361,7 @@ export function createBaiduTemplateRegistrationDescription(description: BaiduTem
 export function createBrowserInstallation(installation: BrowserInstallationCommon): BrowserInstallation;
 
 // @public
-export function createBrowserNotification(notification: NotificationCommon): BrowserNotification;
+export function createBrowserNotification(notification: BrowserNotificationParams): BrowserNotification;
 
 // @public
 export function createBrowserRegistrationDescription(description: BrowserRegistrationDescriptionCommon): BrowserRegistrationDescription;
@@ -391,7 +403,7 @@ export function createFirebaseV1NotificationBody(nativeMessage: FirebaseV1Native
 export function createTagExpression(tags: string[]): string;
 
 // @public
-export function createTemplateNotification(notification: NotificationCommon): TemplateNotification;
+export function createTemplateNotification(notification: TemplateNotificationParams): TemplateNotification;
 
 // @public
 export function createWindowsBadgeNotification(notification: WnsNotificationParams): WindowsNotification;
@@ -424,7 +436,7 @@ export function createWindowsToastNotification(notification: WnsNotificationPara
 export function createXiaomiInstallation(installation: DeviceTokenInstallation): XiaomiInstallation;
 
 // @public
-export function createXiaomiNotification(notification: NotificationCommon): XiaomiNotification;
+export function createXiaomiNotification(notification: XiaomiNotificationParams): XiaomiNotification;
 
 // @public
 export function createXiaomiRegistrationDescription(description: XiaomiRegistrationDescriptionCommon): XiaomiRegistrationDescription;
@@ -991,6 +1003,12 @@ export interface TemplateNotification extends JsonNotification {
 }
 
 // @public
+export interface TemplateNotificationParams {
+    body: string | unknown;
+    headers?: Record<string, string | undefined>;
+}
+
+// @public
 export interface TemplateRegistrationDescription {
     bodyTemplate: string;
     templateName?: string;
@@ -1066,6 +1084,12 @@ export interface XiaomiInstallation extends DeviceTokenInstallation {
 // @public
 export interface XiaomiNotification extends JsonNotification {
     platform: "xiaomi";
+}
+
+// @public
+export interface XiaomiNotificationParams {
+    body: string | unknown;
+    headers?: Record<string, string | undefined>;
 }
 
 // @public

--- a/sdk/notificationhubs/notification-hubs/src/models/notification.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notification.ts
@@ -26,7 +26,7 @@ export interface NotificationCommon {
   /**
    * The headers to include for the push notification.
    */
-  headers?: Record<string, string | undefined>;
+  headers?: Record<string, unknown>;
 }
 
 /**
@@ -41,7 +41,7 @@ export interface NotificationCommonParams {
   /**
    * The headers to include for the push notification.
    */
-  headers?: Record<string, string | undefined>;
+  headers?: Record<string, unknown>;
 }
 
 /**
@@ -117,7 +117,7 @@ export interface AdmNotificationParams {
   /**
    * The headers to include for the push notification.
    */
-  headers?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
 }
 
 /**
@@ -212,7 +212,7 @@ export interface FcmLegacyNotificationParams {
   /**
    * The headers to include for the push notification.
    */
-  headers?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
 }
 
 /**
@@ -255,7 +255,7 @@ export interface FcmV1NotificationParams {
   /**
    * The headers to include for the push notification.
    */
-  headers?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
 }
 
 /**

--- a/sdk/notificationhubs/notification-hubs/src/models/notification.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notification.ts
@@ -132,13 +132,31 @@ export interface BaiduNotification extends JsonNotification {
 }
 
 /**
+ * Represents a Baidu notification that can be sent to devices.
+ */
+export interface BaiduNotificationParams {
+  /**
+   * The body for the push notification.
+   */
+  body: string | unknown;
+
+  /**
+   * The headers to include for the push notification.
+   */
+  headers?: Record<string, string | undefined>;
+}
+
+/**
  * Creates a notification to send to a Baidu registered device.
  * @param notification - A partial message used to create a message for Baidu.
  * @returns A newly created Baidu.
  */
-export function createBaiduNotification(notification: NotificationCommon): BaiduNotification {
+export function createBaiduNotification(notification: BaiduNotificationParams): BaiduNotification {
+  const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
+
   return {
     ...notification,
+    body,
     platform: "baidu",
     contentType: Constants.JSON_CONTENT_TYPE,
   };
@@ -155,13 +173,33 @@ export interface BrowserNotification extends JsonNotification {
 }
 
 /**
+ * Represents a Web Push notification that can be sent to devices.
+ */
+export interface BrowserNotificationParams {
+  /**
+   * The body for the push notification.
+   */
+  body: string | unknown;
+
+  /**
+   * The headers to include for the push notification.
+   */
+  headers?: Record<string, string | undefined>;
+}
+
+/**
  * Creates a notification to send to a browser.
  * @param notification - A partial message used to create a message for a browser.
  * @returns A newly created Web Push browser.
  */
-export function createBrowserNotification(notification: NotificationCommon): BrowserNotification {
+export function createBrowserNotification(
+  notification: BrowserNotificationParams,
+): BrowserNotification {
+  const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
+
   return {
     ...notification,
+    body,
     platform: "browser",
     contentType: Constants.JSON_CONTENT_TYPE,
   };
@@ -221,7 +259,7 @@ export interface FcmV1Notification extends JsonNotification {
 }
 
 /**
- * Represents an Firebase Legacy notification that can be sent to a device.
+ * Represents an Firebase V1 notification that can be sent to a device.
  */
 export interface FcmV1NotificationParams {
   /**
@@ -262,13 +300,33 @@ export interface XiaomiNotification extends JsonNotification {
 }
 
 /**
+ * Represents a Xiaomi notification that can be sent to devices.
+ */
+export interface XiaomiNotificationParams {
+  /**
+   * The body for the push notification.
+   */
+  body: string | unknown;
+
+  /**
+   * The headers to include for the push notification.
+   */
+  headers?: Record<string, string | undefined>;
+}
+
+/**
  * Creates a notification to send to Xiaomi.
  * @param notification - A partial message used to create a message for Xiaomi.
  * @returns A newly created Xiaomi notification.
  */
-export function createXiaomiNotification(notification: NotificationCommon): XiaomiNotification {
+export function createXiaomiNotification(
+  notification: XiaomiNotificationParams,
+): XiaomiNotification {
+  const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
+
   return {
     ...notification,
+    body,
     platform: "xiaomi",
     contentType: Constants.JSON_CONTENT_TYPE,
   };
@@ -285,13 +343,33 @@ export interface TemplateNotification extends JsonNotification {
 }
 
 /**
- * Creates a notification to send to Firebase.
- * @param notification - A partial message used to create a message for Firebase.
+ * Represents a template notification that can be sent to devices.
+ */
+export interface TemplateNotificationParams {
+  /**
+   * The body for the push notification.
+   */
+  body: string | unknown;
+
+  /**
+   * The headers to include for the push notification.
+   */
+  headers?: Record<string, string | undefined>;
+}
+
+/**
+ * Creates a template notification.
+ * @param notification - A partial message used to be used for a template notification.
  * @returns A newly created Firebase.
  */
-export function createTemplateNotification(notification: NotificationCommon): TemplateNotification {
+export function createTemplateNotification(
+  notification: TemplateNotificationParams,
+): TemplateNotification {
+  const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
+
   return {
     ...notification,
+    body,
     platform: "template",
     contentType: Constants.JSON_CONTENT_TYPE,
   };

--- a/sdk/notificationhubs/notification-hubs/src/models/notification.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notification.ts
@@ -30,6 +30,21 @@ export interface NotificationCommon {
 }
 
 /**
+ * The common notification parameters to accept a string body or JSON body.
+ */
+export interface NotificationCommonParams {
+  /**
+   * The body for the push notification.
+   */
+  body: string | unknown;
+
+  /**
+   * The headers to include for the push notification.
+   */
+  headers?: Record<string, string | undefined>;
+}
+
+/**
  * Represents a JSON notification hub.
  */
 export interface JsonNotification extends NotificationCommon {
@@ -132,26 +147,11 @@ export interface BaiduNotification extends JsonNotification {
 }
 
 /**
- * Represents a Baidu notification that can be sent to devices.
- */
-export interface BaiduNotificationParams {
-  /**
-   * The body for the push notification.
-   */
-  body: string | unknown;
-
-  /**
-   * The headers to include for the push notification.
-   */
-  headers?: Record<string, string | undefined>;
-}
-
-/**
  * Creates a notification to send to a Baidu registered device.
  * @param notification - A partial message used to create a message for Baidu.
  * @returns A newly created Baidu.
  */
-export function createBaiduNotification(notification: BaiduNotificationParams): BaiduNotification {
+export function createBaiduNotification(notification: NotificationCommonParams): BaiduNotification {
   const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
 
   return {
@@ -173,27 +173,12 @@ export interface BrowserNotification extends JsonNotification {
 }
 
 /**
- * Represents a Web Push notification that can be sent to devices.
- */
-export interface BrowserNotificationParams {
-  /**
-   * The body for the push notification.
-   */
-  body: string | unknown;
-
-  /**
-   * The headers to include for the push notification.
-   */
-  headers?: Record<string, string | undefined>;
-}
-
-/**
  * Creates a notification to send to a browser.
  * @param notification - A partial message used to create a message for a browser.
  * @returns A newly created Web Push browser.
  */
 export function createBrowserNotification(
-  notification: BrowserNotificationParams,
+  notification: NotificationCommonParams,
 ): BrowserNotification {
   const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
 
@@ -300,27 +285,12 @@ export interface XiaomiNotification extends JsonNotification {
 }
 
 /**
- * Represents a Xiaomi notification that can be sent to devices.
- */
-export interface XiaomiNotificationParams {
-  /**
-   * The body for the push notification.
-   */
-  body: string | unknown;
-
-  /**
-   * The headers to include for the push notification.
-   */
-  headers?: Record<string, string | undefined>;
-}
-
-/**
  * Creates a notification to send to Xiaomi.
  * @param notification - A partial message used to create a message for Xiaomi.
  * @returns A newly created Xiaomi notification.
  */
 export function createXiaomiNotification(
-  notification: XiaomiNotificationParams,
+  notification: NotificationCommonParams,
 ): XiaomiNotification {
   const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
 
@@ -343,27 +313,12 @@ export interface TemplateNotification extends JsonNotification {
 }
 
 /**
- * Represents a template notification that can be sent to devices.
- */
-export interface TemplateNotificationParams {
-  /**
-   * The body for the push notification.
-   */
-  body: string | unknown;
-
-  /**
-   * The headers to include for the push notification.
-   */
-  headers?: Record<string, string | undefined>;
-}
-
-/**
  * Creates a template notification.
  * @param notification - A partial message used to be used for a template notification.
  * @returns A newly created Firebase.
  */
 export function createTemplateNotification(
-  notification: TemplateNotificationParams,
+  notification: NotificationCommonParams,
 ): TemplateNotification {
   const body = isString(notification.body) ? notification.body : JSON.stringify(notification.body);
 

--- a/sdk/notificationhubs/notification-hubs/src/models/notificationHeaderBuilder.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notificationHeaderBuilder.ts
@@ -18,7 +18,7 @@ export type ApnsPushTypes =
 /**
  * The list of APNs specific headers.
  */
-export interface AppleHeaders extends Record<string, string | undefined> {
+export interface AppleHeaders extends Record<string, unknown> {
   /**
    * The value of this header must accurately reflect the contents of your notification’s payload.
    */
@@ -53,7 +53,7 @@ export type WnsTypes = "wns/toast" | "wns/badge" | "wns/tile" | "wns/raw";
 /**
  * List of WNS specific headers.
  */
-export interface WindowsHeaders extends Record<string, string | undefined> {
+export interface WindowsHeaders extends Record<string, unknown> {
   /**
    * The header specifies whether this is a tile, toast, badge, or raw notification.
    */

--- a/sdk/notificationhubs/notification-hubs/src/utils/constants.ts
+++ b/sdk/notificationhubs/notification-hubs/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.1.2";
+export const SDK_VERSION: string = "1.2.0";
 
 export const JSON_CONTENT_TYPE = "application/json;charset=utf-8";
 export const XML_CONTENT_TYPE = "application/xml";

--- a/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
@@ -38,6 +38,30 @@ describe("createAppleNotification", () => {
     assert.equal(notification.platform, "apple");
     assert.equal(notification.body, `{"aps":{"alert":"Hello"}}`);
   });
+
+  it("should create an apple message with Apple Headers", () => {
+    const notification = createAppleNotification({
+      body: `{"aps":{"alert":"Hello"}}`,
+      headers: {
+        "apns-push-type": "alert",
+        "apns-id": "1234",
+        "apns-expiration": "100",
+        "apns-priority": "10",
+        "apns-topic": "com.example.myapp",
+        "apns-collapse-id": "1234",
+      },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "apple");
+    assert.equal(notification.body, `{"aps":{"alert":"Hello"}}`);
+    assert.equal(notification.headers!["apns-push-type"], "alert");
+    assert.equal(notification.headers!["apns-id"], "1234");
+    assert.equal(notification.headers!["apns-expiration"], "100");
+    assert.equal(notification.headers!["apns-priority"], "10");
+    assert.equal(notification.headers!["apns-topic"], "com.example.myapp");
+    assert.equal(notification.headers!["apns-collapse-id"], "1234");
+  });
 });
 
 describe("createAdmNotification", () => {

--- a/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/unit/notification.spec.ts
@@ -28,17 +28,37 @@ describe("createAppleNotification", () => {
     assert.equal(notification.platform, "apple");
     assert.equal(notification.body, `{"aps":{"alert":"Hello"}}`);
   });
+
+  it("should create an apple message with custom object", () => {
+    const notification = createAppleNotification({
+      body: { aps: { alert: "Hello" } },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "apple");
+    assert.equal(notification.body, `{"aps":{"alert":"Hello"}}`);
+  });
 });
 
 describe("createAdmNotification", () => {
   it("should create an ADM message with defaults", () => {
     const notification = createAdmNotification({
-      body: `{"data":{"message":"Hello}}`,
+      body: `{"data":{"message":"Hello"}}`,
     });
 
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
     assert.equal(notification.platform, "adm");
-    assert.equal(notification.body, `{"data":{"message":"Hello}}`);
+    assert.equal(notification.body, `{"data":{"message":"Hello"}}`);
+  });
+
+  it("should create an ADM message with custom object", () => {
+    const notification = createAdmNotification({
+      body: { data: { message: "Hello" } },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "adm");
+    assert.equal(notification.body, `{"data":{"message":"Hello"}}`);
   });
 });
 
@@ -52,12 +72,32 @@ describe("createBaiduNotification", () => {
     assert.equal(notification.platform, "baidu");
     assert.equal(notification.body, `{"title":"(Hello title)","description":"Hello"}`);
   });
+
+  it("should create a Baidu message with custom object", () => {
+    const notification = createBaiduNotification({
+      body: { title: "(Hello title)", description: "Hello" },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "baidu");
+    assert.equal(notification.body, `{"title":"(Hello title)","description":"Hello"}`);
+  });
 });
 
 describe("createBrowserNotification", () => {
-  it("should create a Baidu message with defaults", () => {
+  it("should create a Web Push message with defaults", () => {
     const notification = createBrowserNotification({
       body: `{"title":"(Hello title)","body":"Hello"}`,
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "browser");
+    assert.equal(notification.body, `{"title":"(Hello title)","body":"Hello"}`);
+  });
+
+  it("should create a Web Push message with custom object", () => {
+    const notification = createBrowserNotification({
+      body: { title: "(Hello title)", body: "Hello" },
     });
 
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
@@ -69,24 +109,44 @@ describe("createBrowserNotification", () => {
 describe("createFcmV1Notification", () => {
   it("should create a Firebase message with defaults", () => {
     const notification = createFcmV1Notification({
-      body: `{"notification":{"title":"TITLE","body":"Hello}}`,
+      body: `{"notification":{"title":"TITLE","body":"Hello"}}`,
     });
 
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
     assert.equal(notification.platform, "fcmv1");
-    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello}}`);
+    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello"}}`);
+  });
+
+  it("should create a Firebase message with custom object", () => {
+    const notification = createFcmV1Notification({
+      body: { notification: { title: "TITLE", body: "Hello" } },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "fcmv1");
+    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello"}}`);
   });
 });
 
 describe("createFcmLegacyNotification", () => {
   it("should create a Firebase message with defaults", () => {
     const notification = createFcmLegacyNotification({
-      body: `{"notification":{"title":"TITLE","body":"Hello}}`,
+      body: `{"notification":{"title":"TITLE","body":"Hello"}}`,
     });
 
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
     assert.equal(notification.platform, "gcm");
-    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello}}`);
+    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello"}}`);
+  });
+
+  it("should create a Firebase message with custom object", () => {
+    const notification = createFcmLegacyNotification({
+      body: { notification: { title: "TITLE", body: "Hello" } },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "gcm");
+    assert.equal(notification.body, `{"notification":{"title":"TITLE","body":"Hello"}}`);
   });
 });
 
@@ -100,17 +160,37 @@ describe("createTemplateNotification", () => {
     assert.equal(notification.platform, "template");
     assert.equal(notification.body, `{"title":"(Hello title)","body":"Hello"}`);
   });
+
+  it("should create a Template message with custom object", () => {
+    const notification = createTemplateNotification({
+      body: { title: "(Hello title)", body: "Hello" },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "template");
+    assert.equal(notification.body, `{"title":"(Hello title)","body":"Hello"}`);
+  });
 });
 
 describe("createXiaomiNotification", () => {
   it("should create a Xiaomi message with defaults", () => {
     const notification = createXiaomiNotification({
-      body: `{"data":{"message":"Hello}}`,
+      body: `{"data":{"message":"Hello"}}`,
     });
 
     assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
     assert.equal(notification.platform, "xiaomi");
-    assert.equal(notification.body, `{"data":{"message":"Hello}}`);
+    assert.equal(notification.body, `{"data":{"message":"Hello"}}`);
+  });
+
+  it("should create a Xiaomi message with custom object", () => {
+    const notification = createXiaomiNotification({
+      body: { data: { message: "Hello" } },
+    });
+
+    assert.equal(notification.contentType, Constants.JSON_CONTENT_TYPE);
+    assert.equal(notification.platform, "xiaomi");
+    assert.equal(notification.body, `{"data":{"message":"Hello"}}`);
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR

- #28243

### Describe the problem that is addressed by this PR

Adds overloads to the notification creation methods so that it accepts both a string of JSON but also an object which will be turned into JSON to allow for a more fluent approach.

```js
// Object
const templateNotification = createTemplateNotification({
  body: { title: "(Hello title)", body: "Hello" },
});

// String
const templateNotification = createTemplateNotification({
  body: `{"title":"(Hello title)","body":"Hello"}`,
});
```

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
