### PR TITLE
[ai-translation-text] fix broken link in README

### DIFF
--- a/sdk/translation/ai-translation-text-rest/README.md
+++ b/sdk/translation/ai-translation-text-rest/README.md
@@ -304,7 +304,7 @@ For more detailed instructions on how to enable logs, you can look at the [@azur
 [translator_resource_create]: https://learn.microsoft.com/azure/cognitive-services/Translator/create-translator-resource
 [translator_auth]: https://learn.microsoft.com/azure/cognitive-services/translator/reference/v3-0-reference#authentication
 [service_errors]: https://learn.microsoft.com/azure/cognitive-services/translator/reference/v3-0-reference#errors
-[translator_client_class]: https://github.com/azure/azure-sdk-for-js/blob/main/sdk/translation/ai-translation-text-rest/src/generated/clientDefinitions.ts
+[translator_client_class]: https://learn.microsoft.com/javascript/api/@azure-rest/ai-translation-text/texttranslationclient
 [languages_doc]: https://learn.microsoft.com/azure/cognitive-services/translator/reference/v3-0-languages
 [translate_doc]: https://learn.microsoft.com/azure/cognitive-services/translator/reference/v3-0-translate
 [transliterate_doc]: https://learn.microsoft.com/azure/cognitive-services/translator/reference/v3-0-transliterate


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/ai-translation-text`

### Describe the problem that is addressed by this PR

Fix a broken link discovered by our pipelines. This was caused by a recent regeneration of this package from TSP as the source file link was no longer valid.