### PR TITLE
Fixed error message check in remote rendering tests

### DIFF
--- a/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
@@ -261,9 +261,10 @@ describe("RemoteRendering functional tests", () => {
       await conversionPoller.pollUntilDone();
       assert.isTrue(false, "Previous call should have thrown an exception.");
     } catch (e: any) {
-      // Invalid input provided. Check logs in output container for details.
-      assert.isTrue(e.message.toLowerCase().includes("invalid input"));
-      assert.isTrue(e.message.toLowerCase().includes("logs"));
+      assert.isTrue(e.code === "InputContainerError");
+      // Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
+      assert.isTrue(e.message);
+      assert.isTrue(e.message.toLowerCase().includes("could not find the asset file in the storage account"));
     }
   });
 
@@ -309,7 +310,7 @@ describe("RemoteRendering functional tests", () => {
     // would carry the earlier maxLeastTimeInMinutes value.
     assert.isTrue(
       readyRenderingSession.maxLeaseTimeInMinutes === 4 ||
-        readyRenderingSession.maxLeaseTimeInMinutes === 5,
+      readyRenderingSession.maxLeaseTimeInMinutes === 5,
     );
 
     assert.equal(readyRenderingSession.status, "Ready");


### PR DESCRIPTION
### Packages impacted by this PR

Only the remote rendering package, but also only the tests, so no changes customers will see in any capacity.

### Issues associated with this PR

Test failures on the remote rendering pipelines.

### Describe the problem that is addressed by this PR

We changed some error message on the remote rendering service side, because the old messages were more confusing than helping. This broke the tests here, because it compared to the old messages still.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could revert the error message changes, but that would leave customers with less helpful information, so I wouldn't do it.

### Are there test cases added in this PR? _(If not, why?)_

No, only changed asserts.

### Provide a list of related PRs _(if any)_

None.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

By hand?

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
