### PR TITLE
[storage blob] Change from isNode to isNodeCompatible

### DIFF
--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -71,6 +71,9 @@ export function isError(e: unknown): e is Error;
 export const isNode: boolean;
 
 // @public
+export const isNodeCompatible: boolean;
+
+// @public
 export function isObject(input: unknown): input is UnknownObject;
 
 // @public

--- a/sdk/core/core-util/src/checkEnvironment.ts
+++ b/sdk/core/core-util/src/checkEnvironment.ts
@@ -75,6 +75,11 @@ export const isNode =
   !isBun;
 
 /**
+ * A constant that indicates whether the environment the code is running is a Node.JS compatible environment.
+ */
+export const isNodeCompatible = isNode || isDeno || isBun;
+
+/**
  * A constant that indicates whether the environment the code is running is in React-Native.
  */
 // https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Core/setUpNavigator.js

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -21,6 +21,7 @@ export {
   isBrowser,
   isBun,
   isNode,
+  isNodeCompatible,
   isDeno,
   isReactNative,
   isWebWorker,

--- a/sdk/storage/storage-blob/src/BlobBatch.ts
+++ b/sdk/storage/storage-blob/src/BlobBatch.ts
@@ -12,7 +12,7 @@ import {
   PipelineResponse,
   SendRequest,
 } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { BlobClient, BlobDeleteOptions, BlobSetTierOptions } from "./Clients";
 import { AccessTier } from "./generatedModels";
@@ -161,7 +161,7 @@ export class BlobBatch {
 
     if (
       typeof urlOrBlobClient === "string" &&
-      ((isNode && credentialOrOptions instanceof StorageSharedKeyCredential) ||
+      ((isNodeCompatible && credentialOrOptions instanceof StorageSharedKeyCredential) ||
         credentialOrOptions instanceof AnonymousCredential ||
         isTokenCredential(credentialOrOptions))
     ) {
@@ -265,7 +265,7 @@ export class BlobBatch {
 
     if (
       typeof urlOrBlobClient === "string" &&
-      ((isNode && credentialOrTier instanceof StorageSharedKeyCredential) ||
+      ((isNodeCompatible && credentialOrTier instanceof StorageSharedKeyCredential) ||
         credentialOrTier instanceof AnonymousCredential ||
         isTokenCredential(credentialOrTier))
     ) {

--- a/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { isNode } from "@azure/core-util";
-import { BlobImmutabilityPolicyMode } from "./generatedModels";
 
+import { isNodeCompatible } from "@azure/core-util";
+import { BlobImmutabilityPolicyMode } from "./generatedModels";
 import {
   BlobDownloadHeaders,
   BlobType,
@@ -500,7 +500,8 @@ export class BlobDownloadResponse implements BlobDownloadResponseParsed {
    * @readonly
    */
   public get readableStreamBody(): NodeJS.ReadableStream | undefined {
-    return isNode ? this.blobDownloadStream : undefined;
+    // TODO: Replace with isNodeCompatible once it's available
+    return isNodeCompatible ? this.blobDownloadStream : undefined;
   }
 
   /**

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { getDefaultProxySettings } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { AbortSignalLike } from "@azure/abort-controller";
 import {
   ServiceGetUserDelegationKeyHeaders,
@@ -360,7 +360,7 @@ export class BlobServiceClient extends StorageClient {
     options = options || {};
     const extractedCreds = extractConnectionStringParts(connectionString);
     if (extractedCreds.kind === "AccountConnString") {
-      if (isNode) {
+      if (isNodeCompatible) {
         const sharedKeyCredential = new StorageSharedKeyCredential(
           extractedCreds.accountName!,
           extractedCreds.accountKey,
@@ -451,7 +451,7 @@ export class BlobServiceClient extends StorageClient {
     if (isPipelineLike(credentialOrPipeline)) {
       pipeline = credentialOrPipeline;
     } else if (
-      (isNode && credentialOrPipeline instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible && credentialOrPipeline instanceof StorageSharedKeyCredential) ||
       credentialOrPipeline instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipeline)
     ) {

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -8,11 +8,10 @@ import {
   TransferProgressEvent,
 } from "@azure/core-rest-pipeline";
 import { isTokenCredential, TokenCredential } from "@azure/core-auth";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { PollOperationState } from "@azure/core-lro";
 import { randomUUID } from "@azure/core-util";
 import { Readable } from "stream";
-
 import { BlobDownloadResponse } from "./BlobDownloadResponse";
 import { BlobQueryResponse } from "./BlobQueryResponse";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
@@ -996,7 +995,8 @@ export class BlobClient extends StorageClient {
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible &&
+        credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
       credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrContainerName)
     ) {
@@ -1027,7 +1027,7 @@ export class BlobClient extends StorageClient {
 
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
+        if (isNodeCompatible) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey,
@@ -1210,7 +1210,7 @@ export class BlobClient extends StorageClient {
             ifTags: options.conditions?.tagConditions,
           },
           requestOptions: {
-            onDownloadProgress: isNode ? undefined : options.onProgress, // for Node.js, progress is reported by RetriableReadableStream
+            onDownloadProgress: isNodeCompatible ? undefined : options.onProgress, // for Node.js, progress is reported by RetriableReadableStream
           },
           range: offset === 0 && !count ? undefined : rangeToString({ offset, count }),
           rangeGetContentMD5: options.rangeGetContentMD5,
@@ -1228,7 +1228,7 @@ export class BlobClient extends StorageClient {
         objectReplicationSourceProperties: parseObjectReplicationRecord(res.objectReplicationRules),
       };
       // Return browser response immediately
-      if (!isNode) {
+      if (!isNodeCompatible) {
         return wrappedRes;
       }
 
@@ -2533,7 +2533,8 @@ export class AppendBlobClient extends BlobClient {
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible &&
+        credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
       credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrContainerName)
     ) {
@@ -2561,7 +2562,7 @@ export class AppendBlobClient extends BlobClient {
 
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
+        if (isNodeCompatible) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey,
@@ -3517,7 +3518,8 @@ export class BlockBlobClient extends BlobClient {
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible &&
+        credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
       credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrContainerName)
     ) {
@@ -3548,7 +3550,7 @@ export class BlockBlobClient extends BlobClient {
 
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
+        if (isNodeCompatible) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey,
@@ -3642,7 +3644,7 @@ export class BlockBlobClient extends BlobClient {
     options: BlockBlobQueryOptions = {},
   ): Promise<BlobDownloadResponseModel> {
     ensureCpkIfSpecified(options.customerProvidedKey, this.isHttps);
-    if (!isNode) {
+    if (!isNodeCompatible) {
       throw new Error("This operation currently is only supported in Node.js.");
     }
 
@@ -3994,7 +3996,7 @@ export class BlockBlobClient extends BlobClient {
     options: BlockBlobParallelUploadOptions = {},
   ): Promise<BlobUploadCommonResponse> {
     return tracingClient.withSpan("BlockBlobClient-uploadData", options, async (updatedOptions) => {
-      if (isNode) {
+      if (isNodeCompatible) {
         let buffer: Buffer;
         if (data instanceof Buffer) {
           buffer = data;
@@ -4783,7 +4785,8 @@ export class PageBlobClient extends BlobClient {
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible &&
+        credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
       credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrContainerName)
     ) {
@@ -4811,7 +4814,7 @@ export class PageBlobClient extends BlobClient {
 
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
+        if (isNodeCompatible) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey,

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -5,7 +5,7 @@ import {
   getDefaultProxySettings,
   RequestBodyType as HttpRequestBody,
 } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
@@ -659,7 +659,8 @@ export class ContainerClient extends StorageClient {
       url = urlOrConnectionString;
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
-      (isNode && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
+      (isNodeCompatible &&
+        credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential) ||
       credentialOrPipelineOrContainerName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrContainerName)
     ) {
@@ -683,7 +684,7 @@ export class ContainerClient extends StorageClient {
 
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
-        if (isNode) {
+        if (isNodeCompatible) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey,

--- a/sdk/storage/storage-blob/src/policies/StorageBrowserPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageBrowserPolicy.ts
@@ -8,8 +8,7 @@ import {
   CompatResponse as HttpOperationResponse,
 } from "@azure/core-http-compat";
 import { BaseRequestPolicy } from "./RequestPolicy";
-import { isNode } from "@azure/core-util";
-
+import { isNodeCompatible } from "@azure/core-util";
 import { HeaderConstants, URLConstants } from "../utils/constants";
 import { setURLParameter } from "../utils/utils.common";
 
@@ -42,7 +41,7 @@ export class StorageBrowserPolicy extends BaseRequestPolicy {
    * @param request -
    */
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
-    if (isNode) {
+    if (isNodeCompatible) {
       return this._nextPolicy.sendRequest(request);
     }
 

--- a/sdk/storage/storage-blob/src/policies/StorageBrowserPolicyV2.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageBrowserPolicyV2.ts
@@ -7,7 +7,7 @@ import {
   SendRequest,
   PipelinePolicy,
 } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { HeaderConstants, URLConstants } from "../utils/constants";
 import { setURLParameter } from "../utils/utils.common";
 
@@ -24,7 +24,7 @@ export function storageBrowserPolicy(): PipelinePolicy {
   return {
     name: storageBrowserPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (isNode) {
+      if (isNodeCompatible) {
         return next(request);
       }
 

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -4,8 +4,7 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 import { TokenCredential } from "@azure/core-auth";
 import { HttpHeaders, createHttpHeaders } from "@azure/core-rest-pipeline";
-import { isNode } from "@azure/core-util";
-
+import { isNodeCompatible } from "@azure/core-util";
 import {
   BlobQueryArrowConfiguration,
   BlobQueryCsvTextConfiguration,
@@ -461,7 +460,7 @@ export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = tru
  * @param content -
  */
 export function base64encode(content: string): string {
-  return !isNode ? btoa(content) : Buffer.from(content).toString("base64");
+  return !isNodeCompatible ? btoa(content) : Buffer.from(content).toString("base64");
 }
 
 /**
@@ -470,7 +469,7 @@ export function base64encode(content: string): string {
  * @param encodedString -
  */
 export function base64decode(encodedString: string): string {
-  return !isNode ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
+  return !isNodeCompatible ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
 }
 
 /**

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -4,7 +4,7 @@
 import * as fs from "fs";
 import { randomUUID } from "@azure/core-util";
 import { AbortController } from "@azure/abort-controller";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { assert } from "@azure/test-utils";
 import {
   bodyToString,
@@ -311,7 +311,7 @@ describe("BlobClient", () => {
       blobContentDisposition: "blobContentDisposition",
       blobContentEncoding: "blobContentEncoding",
       blobContentLanguage: "blobContentLanguage",
-      blobContentMD5: isNode ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
+      blobContentMD5: isNodeCompatible ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
       blobContentType: "blobContentType",
     };
     await blobClient.setHTTPHeaders(headers);
@@ -706,7 +706,7 @@ describe("BlobClient", () => {
       blobContentDisposition: "blobContentDisposition",
       blobContentEncoding: "blobContentEncoding",
       blobContentLanguage: "blobContentLanguage",
-      blobContentMD5: isNode ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
+      blobContentMD5: isNodeCompatible ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
       blobContentType: "blobContentType",
     };
     await blobClient.setHTTPHeaders(headers, { customerProvidedKey: Test_CPK_INFO });
@@ -744,7 +744,7 @@ describe("BlobClient", () => {
   });
 
   it("beginCopyFromURL with rehydrate priority", async function () {
-    if (!isNode && !isLiveMode()) {
+    if (!isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const newBlobURL = containerClient.getBlobClient(
@@ -1551,7 +1551,7 @@ describe("BlobClient - Object Replication", () => {
   });
 
   it("download to file", async function (this: Context) {
-    if (!isNode || !isLiveMode()) {
+    if (!isNodeCompatible || !isLiveMode()) {
       this.skip();
     }
     const srcDownloadedFilePath = recorder.variable(

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./utils/testutils.common";
 import { BlobClient, BlockBlobClient, ContainerClient, BlobBeginCopyFromURLResponse } from "../src";
 import { Context } from "mocha";
-import { isNode } from "@azure/test-utils";
+import { isNodeCompatible } from "@azure/core-util";
 
 describe("BlobClient beginCopyFromURL Poller", () => {
   let containerName: string;
@@ -56,7 +56,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
   });
 
   it("supports automatic polling via pollUntilDone", async function () {
-    if (!isNode && !isLiveMode()) {
+    if (!isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const newBlobClient = destinationContainerClient.getBlobClient(
@@ -92,7 +92,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
   });
 
   it("supports manual polling via poll", async function () {
-    if (!isNode && !isLiveMode()) {
+    if (!isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const newBlobClient = destinationContainerClient.getBlobClient(
@@ -139,7 +139,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
       // these tests will only run with the unit tests with pre-recorded service responses.
       this.skip();
     }
-    if (!isNode && !isLiveMode()) {
+    if (!isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
 
@@ -166,7 +166,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
       // these tests will only run with the unit tests with pre-recorded service responses.
       this.skip();
     }
-    if (!isNode) {
+    if (!isNodeCompatible) {
       this.skip();
     }
 
@@ -188,7 +188,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
   });
 
   it("supports restoring poller state from another poller", async function () {
-    if (!isNode && !isLiveMode()) {
+    if (!isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
 

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "chai";
 import * as fs from "fs";
-import { isNode, delay } from "@azure/core-util";
+import { isNodeCompatible, delay } from "@azure/core-util";
 import {
   getBSU,
   recorderEnvSetup,
@@ -99,14 +99,14 @@ describe("Blob versioning", () => {
     assert.deepStrictEqual(await bodyToString(downloadRes2), "");
     assert.deepStrictEqual(downloadRes2.versionId, uploadRes2.versionId);
 
-    if (isNode) {
+    if (isNodeCompatible) {
       const downloadToBufferRes = await blobVersionClient.downloadToBuffer();
       assert.ok(downloadToBufferRes.equals(Buffer.from(content)));
     }
   });
 
   it("download a version to file", async function (this: Context) {
-    if (!isNode || !isLiveMode()) {
+    if (!isNodeCompatible || !isLiveMode()) {
       // downloadToFile only available in Node.js
       this.skip();
     }
@@ -352,7 +352,7 @@ describe("Blob versioning", () => {
     );
     assert.ok(containerUploadRes.response.versionId);
 
-    if (!isNode) {
+    if (!isNodeCompatible) {
       const uploadBrowserDataRes = await blockBlobClient.uploadBrowserData(new Blob([content]));
       assert.ok(uploadBrowserDataRes.versionId);
     }

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -18,7 +18,7 @@ import { ContainerClient, BlobClient, BlockBlobClient } from "../src";
 import { Test_CPK_INFO } from "./utils/fakeTestSecrets";
 import { BlockBlobTier } from "../src";
 import { Context } from "mocha";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 
 describe("BlockBlobClient", () => {
   let containerName: string;
@@ -143,7 +143,7 @@ describe("BlockBlobClient", () => {
 
     // When in browsers testing with SAS tokens, setAccessPolicy won't work.
     // so only test setAccessPolicy in Node.js environment.
-    if (isNode) {
+    if (isNodeCompatible) {
       await containerClient.setAccessPolicy("container");
     }
 
@@ -164,7 +164,7 @@ describe("BlockBlobClient", () => {
 
     // When in browsers testing with SAS tokens, setAccessPolicy won't work.
     // so only test setAccessPolicy in Node.js environment.
-    if (isNode) {
+    if (isNodeCompatible) {
       await containerClient.setAccessPolicy("container");
     }
 
@@ -277,7 +277,7 @@ describe("BlockBlobClient", () => {
   });
 
   it("can be created with a sas connection string", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const newClient = new BlockBlobClient(
@@ -357,7 +357,7 @@ describe("BlockBlobClient", () => {
 
     // When in browsers testing with SAS tokens, setAccessPolicy won't work.
     // so only test setAccessPolicy in Node.js environment.
-    if (isNode) {
+    if (isNodeCompatible) {
       await containerClient.setAccessPolicy("container");
     }
 

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -4,12 +4,10 @@
 import { assert } from "chai";
 import { readFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
-
 import { AbortController } from "@azure/abort-controller";
 import { TokenCredential } from "@azure/core-auth";
-import { isNode } from "@azure/core-util";
+import { isNodeCompatible } from "@azure/core-util";
 import { delay, isLiveMode, Recorder } from "@azure-tools/test-recorder";
-
 import {
   BlobClient,
   BlobImmutabilityPolicyMode,
@@ -145,7 +143,7 @@ describe("BlobClient Node.js only", () => {
       blobContentDisposition: "blobContentDisposition",
       blobContentEncoding: "blobContentEncoding",
       blobContentLanguage: "blobContentLanguage",
-      blobContentMD5: isNode ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
+      blobContentMD5: isNodeCompatible ? Buffer.from([1, 2, 3, 4]) : new Uint8Array([1, 2, 3, 4]),
       blobContentType: "blobContentType",
     };
     await blobClient.setHTTPHeaders(headers);

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -24,7 +24,7 @@ import { BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES } from "../../src/utils/constants";
 import { Test_CPK_INFO } from "../utils/fakeTestSecrets";
 import { streamToBuffer2 } from "../../src/utils/utils.node";
 import { Context } from "mocha";
-import { isNode } from "@azure/test-utils";
+import { isNodeCompatible } from "@azure/core-util";
 
 describe("Highlevel", () => {
   let containerName: string;
@@ -98,7 +98,7 @@ describe("Highlevel", () => {
   });
 
   it("put blob with maximum size", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const MB = 1024 * 1024;
@@ -118,7 +118,7 @@ describe("Highlevel", () => {
   }).timeout(timeoutForLargeFileUploadingTest);
 
   it("uploadFile should success when blob >= BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     await blockBlobClient.uploadFile(tempFileLarge, {
@@ -141,7 +141,7 @@ describe("Highlevel", () => {
   }).timeout(timeoutForLargeFileUploadingTest);
 
   it("uploadFile should work with tags", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
 
@@ -161,7 +161,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadFile should success when blob < BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     await blockBlobClient.uploadFile(tempFileSmall, {
@@ -184,7 +184,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadFile should success when blob < BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES and configured maxSingleShotSize", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     await blockBlobClient.uploadFile(tempFileSmall, {
@@ -282,7 +282,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadFile should succeed with blockSize = BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const tempFile = await createRandomLocalFile(
@@ -303,7 +303,7 @@ describe("Highlevel", () => {
   }).timeout(timeoutForLargeFileUploadingTest);
 
   it("uploadStream should success", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -341,7 +341,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadStream should work with tags", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
 
@@ -361,7 +361,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadStream should abort", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -378,7 +378,7 @@ describe("Highlevel", () => {
   });
 
   it("uploadStream should update progress event", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -408,7 +408,7 @@ describe("Highlevel", () => {
   it.skip(
     "uploadStream should work when blockSize = BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES",
     async function () {
-      if (isNode && !isLiveMode()) {
+      if (isNodeCompatible && !isLiveMode()) {
         this.skip();
       }
       const tempFile = await createRandomLocalFile(
@@ -432,7 +432,7 @@ describe("Highlevel", () => {
   ).timeout(timeoutForLargeFileUploadingTest);
 
   it("downloadToBuffer should success - without passing the buffer", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -464,7 +464,7 @@ describe("Highlevel", () => {
   });
 
   it("downloadToBuffer should success", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -515,7 +515,7 @@ describe("Highlevel", () => {
   });
 
   it("downloadToBuffer should abort", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileLarge);
@@ -536,7 +536,7 @@ describe("Highlevel", () => {
   }).timeout(timeoutForLargeFileUploadingTest);
 
   it("downloadToBuffer should update progress event", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileSmall);
@@ -586,7 +586,7 @@ describe("Highlevel", () => {
   });
 
   it("blobclient.download should success when internal stream unexpected ends at the stream end", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const uploadResponse = await blockBlobClient.uploadFile(tempFileSmall, {
@@ -625,7 +625,7 @@ describe("Highlevel", () => {
   });
 
   it("blobclient.download should download full data successfully when internal stream unexpected ends", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const uploadResponse = await blockBlobClient.uploadFile(tempFileSmall, {
@@ -665,7 +665,7 @@ describe("Highlevel", () => {
   });
 
   it("blobclient.download should download partial data when internal stream unexpected ends", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const uploadResponse = await blockBlobClient.uploadFile(tempFileSmall, {
@@ -707,7 +707,7 @@ describe("Highlevel", () => {
   });
 
   it("blobclient.download should download data failed when exceeding max stream retry requests", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const uploadResponse = await blockBlobClient.uploadFile(tempFileSmall, {
@@ -747,7 +747,7 @@ describe("Highlevel", () => {
   });
 
   it("blobclient.download should abort after retries", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const uploadResponse = await blockBlobClient.uploadFile(tempFileSmall, {
@@ -792,7 +792,7 @@ describe("Highlevel", () => {
   });
 
   it("download abort should work when still fetching body", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     await blockBlobClient.uploadFile(tempFileSmall, {
@@ -818,7 +818,7 @@ describe("Highlevel", () => {
   });
 
   it("downloadToFile should success", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const downloadedFilePath = recorder.variable(
@@ -848,7 +848,7 @@ describe("Highlevel", () => {
   });
 
   it("downloadToFile should fail when saving to directory", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     const rs = fs.createReadStream(tempFileSmall);
@@ -863,7 +863,7 @@ describe("Highlevel", () => {
   });
 
   it("set tier while upload", async function () {
-    if (isNode && !isLiveMode()) {
+    if (isNodeCompatible && !isLiveMode()) {
       this.skip();
     }
     // single upload


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-util
- @azure/storage-blob

### Issues associated with this PR

- #28101

### Describe the problem that is addressed by this PR

By restricting `isNode` to ensure strict Node compatibility and to exclude Bun and Deno, we have broken existing customers using the Node/npm compat features.  This introduces the `isNodeCompatible` boolean which allows us to determine whether it is either Node, Bun, or Deno through its Node/npm compat.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could have undone the `isNode` to allow for Deno and Bun, but introducing a third option seemed better not to create any unexpected behavior when Node and only Node is expected.  We should migrate as much as possible to the new approach.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
