### PR TITLE
[core-util] Create isNodeLike and isNodeRuntime

### DIFF
--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -67,8 +67,14 @@ export const isDeno: boolean;
 // @public
 export function isError(e: unknown): e is Error;
 
-// @public
+// @public @deprecated
 export const isNode: boolean;
+
+// @public
+export const isNodeLike: boolean;
+
+// @public
+export const isNodeRuntime: boolean;
 
 // @public
 export function isObject(input: unknown): input is UnknownObject;

--- a/sdk/core/core-util/src/checkEnvironment.ts
+++ b/sdk/core/core-util/src/checkEnvironment.ts
@@ -64,15 +64,23 @@ export const isDeno =
 export const isBun = typeof Bun !== "undefined" && typeof Bun.version !== "undefined";
 
 /**
- * A constant that indicates whether the environment the code is running is Node.JS.
+ * A constant that indicates whether the environment the code is running is a Node.js compatible environment.
  */
-export const isNode =
+export const isNodeLike =
   typeof globalThis.process !== "undefined" &&
   Boolean(globalThis.process.version) &&
-  Boolean(globalThis.process.versions?.node) &&
-  // Deno thought it was a good idea to spoof process.versions.node, see https://deno.land/std@0.177.0/node/process.ts?s=versions
-  !isDeno &&
-  !isBun;
+  Boolean(globalThis.process.versions?.node);
+
+/**
+ * A constant that indicates whether the environment the code is running is a Node.js compatible environment.
+ * @deprecated Use `isNodeLike` instead.
+ */
+export const isNode = isNodeLike;
+
+/**
+ * A constant that indicates whether the environment the code is running is Node.JS.
+ */
+export const isNodeRuntime = isNodeLike && !isBun && !isDeno;
 
 /**
  * A constant that indicates whether the environment the code is running is in React-Native.

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -21,6 +21,8 @@ export {
   isBrowser,
   isBun,
   isNode,
+  isNodeLike,
+  isNodeRuntime,
   isDeno,
   isReactNative,
   isWebWorker,

--- a/sdk/core/core-util/test/public/browser/checkEnvironment.spec.ts
+++ b/sdk/core/core-util/test/public/browser/checkEnvironment.spec.ts
@@ -6,6 +6,8 @@ import {
   isBun,
   isDeno,
   isNode,
+  isNodeLike,
+  isNodeRuntime,
   isReactNative,
   isWebWorker,
 } from "../../../src/index.js";
@@ -30,9 +32,27 @@ describe("checkEnvironment (browser)", function () {
     });
   });
 
-  describe("isNode (browser)", function () {
+  describe("isNode(browser)", function () {
     it("should return true", async function () {
       assert.isFalse(isNode);
+    });
+  });
+
+  describe("isNodeRuntime (browser)", function () {
+    it("should return true", async function () {
+      assert.isFalse(isNodeRuntime);
+    });
+  });
+
+  describe("isNodeLike (browser)", function () {
+    it("should return true", async function () {
+      assert.isFalse(isNodeLike);
+    });
+  });
+
+  describe("isNodeRuntime (browser)", function () {
+    it("should return true", async function () {
+      assert.isFalse(isNodeRuntime);
     });
   });
 

--- a/sdk/core/core-util/test/public/node/checkEnvironment.spec.ts
+++ b/sdk/core/core-util/test/public/node/checkEnvironment.spec.ts
@@ -6,6 +6,8 @@ import {
   isBun,
   isDeno,
   isNode,
+  isNodeLike,
+  isNodeRuntime,
   isReactNative,
   isWebWorker,
 } from "../../../src/index.js";
@@ -33,6 +35,18 @@ describe("checkEnvironment (node)", function () {
   describe("isNode (node)", function () {
     it("should return true", async function () {
       assert.isTrue(isNode);
+    });
+  });
+
+  describe("isNodeLike (node)", function () {
+    it("should return true", async function () {
+      assert.isTrue(isNodeLike);
+    });
+  });
+
+  describe("isNodeRuntime (node)", function () {
+    it("should return true", async function () {
+      assert.isTrue(isNodeRuntime);
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-util

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/28101

### Describe the problem that is addressed by this PR

Reverts the behavior of `isNode` checks to ensure that it can still return true for Bun and Deno.  Introducing `isNodeLike` to also have the same behavior as `isNode` so we can deprecate the former function.  We have also added `isNodeRuntime` which then checks for an explicit Node.js runtime.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The previous attempt was to create a `isNodeLike` and be opt-in, versus this PR which gives the old behavior and new opt-in for strict Node runtimes.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- https://github.com/Azure/azure-sdk-for-js/pull/29083

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
