### PR TITLE
[storage] address two issues related to Azure Disk Storage

### DIFF
--- a/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
+++ b/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
@@ -25,6 +25,12 @@ const Constants = {
   },
 };
 
+function isUuid(text: string): boolean {
+  return /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/.test(
+    text,
+  );
+}
+
 /**
  * Defines a callback to handle auth challenge for Storage APIs.
  * This implements the bearer challenge process described here: https://docs.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory#bearer-challenge
@@ -39,6 +45,9 @@ export const authorizeRequestOnTenantChallenge: (
     const challengeInfo: Challenge = parseChallenge(challenge);
     const challengeScopes = buildScopes(challengeOptions, challengeInfo);
     const tenantId = extractTenantId(challengeInfo);
+    if (!tenantId) {
+      return false;
+    }
     const accessToken = await challengeOptions.getAccessToken(challengeScopes, {
       ...requestOptions,
       tenantId,
@@ -62,12 +71,14 @@ export const authorizeRequestOnTenantChallenge: (
  * The tenant id is contained in the authorization_uri as the first
  * path part.
  */
-function extractTenantId(challengeInfo: Challenge): string {
+function extractTenantId(challengeInfo: Challenge): string | undefined {
   const parsedAuthUri = new URL(challengeInfo.authorization_uri);
   const pathSegments = parsedAuthUri.pathname.split("/");
   const tenantId = pathSegments[1];
-
-  return tenantId;
+  if (tenantId && isUuid(tenantId)) {
+    return tenantId;
+  }
+  return undefined;
 }
 
 /**
@@ -85,7 +96,12 @@ function buildScopes(
 
   const challengeScopes = new URL(challengeInfo.resource_id);
   challengeScopes.pathname = Constants.DefaultScope;
-  return [challengeScopes.toString()];
+  let scope = challengeScopes.toString();
+  if (scope === "https://disk.azure.com/.default") {
+    // the extra slash is required by the service
+    scope = "https://disk.azure.com//.default";
+  }
+  return [scope];
 }
 
 /**

--- a/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
+++ b/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
@@ -426,5 +426,4 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
     const lastGetTokenCall = getTokenStub.mock.calls[0];
     assert.equal(lastGetTokenCall[0], quirkScope);
   });
-  //
 });

--- a/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
+++ b/sdk/core/core-client/test/authorizeRequestOnTenantChallenge.spec.ts
@@ -7,6 +7,7 @@ import {
   PipelineResponse,
   bearerTokenAuthenticationPolicy,
   createHttpHeaders,
+  createPipelineRequest,
 } from "@azure/core-rest-pipeline";
 import { authorizeRequestOnTenantChallenge } from "../src/index.js";
 
@@ -383,4 +384,47 @@ describe("storageBearerTokenChallengeAuthenticationPolicy", function () {
     // so we expect 2 calls to refresh the token
     expect(getTokenStub).toBeCalledTimes(2);
   });
+
+  it("should not try to request a token if tenant is invalid", async function () {
+    const request = createPipelineRequest({ url: "https://example.org" });
+    const invalidAuthUri =
+      "https://login.microsoftonline.com/eastasia:/DiskRP-eastasia_2/PoolManagerService/oauth2/authorize";
+    const shouldSendRequest = await authorizeRequestOnTenantChallenge({
+      request,
+      response: {
+        headers: createHttpHeaders({
+          "WWW-Authenticate": `Bearer authorization_uri=${invalidAuthUri}`,
+        }),
+        request,
+        status: 401,
+      },
+      getAccessToken: getTokenStub,
+      scopes: [],
+    });
+    expect(getTokenStub).toBeCalledTimes(0);
+    assert.isFalse(shouldSendRequest);
+  });
+
+  it("should handle disk scope being quirky", async function () {
+    const request = createPipelineRequest({ url: "https://example.org" });
+    // the double forward slash is required
+    const quirkScope = "https://disk.azure.com//.default";
+    const shouldSendRequest = await authorizeRequestOnTenantChallenge({
+      request,
+      response: {
+        headers: createHttpHeaders({
+          "WWW-Authenticate": `Bearer authorization_uri=https://login.microsoftonline.com/${fakeGuid}/oauth2/authorize resource_id=https://disk.azure.com/`,
+        }),
+        request,
+        status: 401,
+      },
+      getAccessToken: getTokenStub,
+      scopes: [],
+    });
+    assert.isTrue(shouldSendRequest);
+    expect(getTokenStub).toBeCalledTimes(1);
+    const lastGetTokenCall = getTokenStub.mock.calls[0];
+    assert.equal(lastGetTokenCall[0], quirkScope);
+  });
+  //
 });


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/storage-blob`

### Describe the problem that is addressed by this PR

As reported by @EmmaZhu there are currently two issues when interacting with Azure Disk Storage.

The first is if you try to access a Storage account that is not properly configured to support bearer challenges. In that case an invalid `authorization_uri` will be returned. Our code currently makes assumptions about `authorization_uri`, specifically that it can 'split' the path part of the URL and reliably get a tenantId. In the case that a valid tenant is not found, the request can end up refreshing in an infinite loop. 

My solution to this problem is to actually check if what we think is a tenant id is a valid guid or not. Now in the case where we don't see the expected `authorization_uri`, we will allow the request to fail with the 401.

The second issue occurs when the initial token scope is set to `https://storage.azure.com/.default`, but the actual required scope is `https://disk.azure.com//.default` -- when calculating the new scope we do not duplicate the forward slash, but since the double forward slash is **required** by the service, a workaround was needed to add it back in.

### Are there test cases added in this PR? _(If not, why?)_

Yes
