### PR TITLE
[notification-hubs] Fix ordering of XML BrowserRegistrationDescription

### DIFF
--- a/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
@@ -805,8 +805,8 @@ export const registrationDescriptionSerializer: RegistrationDescriptionSerialize
     return {
       ...serializeRegistrationDescription(description),
       Endpoint: description.endpoint,
-      Auth: description.auth,
       P256DH: description.p256dh,
+      Auth: description.auth,
     };
   },
 

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -730,6 +730,11 @@ describe("serializeRegistrationDescription", () => {
 
     const xml = registrationDescriptionSerializer.serializeRegistrationDescription(registration);
 
+    // Check for ordering of the fields
+    // Bug: https://github.com/Azure/azure-sdk-for-js/issues/29081
+    assert.isTrue(xml.indexOf("<P256DH>{P256DH}</P256DH><Auth>{Auth Secret}</Auth>") !== -1);
+
+    // Check the fields
     assert.isTrue(xml.indexOf("<BrowserRegistrationDescription") !== -1);
     assert.isTrue(xml.indexOf("<Endpoint>https://www.microsoft.com/</Endpoint>") !== -1);
     assert.isTrue(xml.indexOf("<P256DH>{P256DH}</P256DH>") !== -1);


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR

- #29081

### Describe the problem that is addressed by this PR

The order of fields matter for XML deserialization for the `BrowserRegistrationDescription` as described in the bug.  Adds tests to check for ordering.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
