### PR TITLE
[test-credential] Fix types

### DIFF
--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.0.4 (2024-04-01)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixes "types" for the package.
 
 ## 1.0.3 (2024-03-21)
 

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -34,7 +34,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/latest/src",
+    "types/tools-test-credential.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Listed types in package.json and files included for publishing were not in sync.
`"types": "types/tools-test-credential.d.ts"` vs `"types/latest/src"`

Needed to unblock #28667 
