### PR TITLE
[Perf] [monitor-opentelemetry] Fix perf pipeline

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/perf-tests.yml
+++ b/sdk/monitor/monitor-opentelemetry/perf-tests.yml
@@ -8,6 +8,7 @@ PackageVersions:
 - '@azure/monitor-opentelemetry': 1.1.1
   "@azure/functions": 3.2.0
   "@azure/monitor-opentelemetry-exporter": 1.0.0-beta.18
+  "@opentelemetry/api": 1.7.0
   "@azure/opentelemetry-instrumentation-azure-sdk": 1.0.0-beta.5
 - '@azure/monitor-opentelemetry': source
   "@azure/core-client": source


### PR DESCRIPTION
### Packages impacted by this PR
Perf project for monitor-opentelemetry

### Issues associated with this PR
Perf pipeline for monitor-opentelemetry is failing due to a peer dependency issue.
Pinning `"@opentelemetry/api": 1.7.0`
![image](https://github.com/Azure/azure-sdk-for-js/assets/10452642/010d7992-5d0e-413c-8eb8-7e9d6b8fee8a)

#### Before
<img src="https://github.com/Azure/azure-sdk-for-js/assets/10452642/4361702a-dbd1-4759-82e3-de1bda8cea82" height=300>

### After
<img src="https://github.com/Azure/azure-sdk-for-js/assets/10452642/b6910796-8b99-401f-9b6a-5548a4466c3a" height=300>