### PR TITLE
[test-credential] Cleanup tilde (~) in favor of caret (^) for @azure-tools/test-credential dependency

### DIFF
--- a/sdk/entra/functions-authentication-events/package.json
+++ b/sdk/entra/functions-authentication-events/package.json
@@ -67,7 +67,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.0.1",
     "@azure/test-utils": "^1.0.0",
-    "@azure-tools/test-credential": "~1.0.0",
+    "@azure-tools/test-credential": "^1.0.4",
     "@azure-tools/test-recorder": "^3.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/chai": "^4.1.6",

--- a/sdk/loadtesting/load-testing-rest/package.json
+++ b/sdk/loadtesting/load-testing-rest/package.json
@@ -81,7 +81,7 @@
     "@azure/abort-controller": "^1.1.0"
   },
   "devDependencies": {
-    "@azure-tools/test-credential": "~1.0.0",
+    "@azure-tools/test-credential": "^1.0.4",
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure/identity": "^4.0.1",
     "@microsoft/api-extractor": "^7.31.1",

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -92,7 +92,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure-tools/test-credential": "~1.0.0",
+    "@azure-tools/test-credential": "^1.0.4",
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -6,10 +6,7 @@ import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-auth"
 import { isPlaybackMode, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 import { StorageClient } from "../../src/StorageClient";
 import { Pipeline } from "@azure/core-rest-pipeline";
-import {
-  FindReplaceSanitizer,
-  RegexSanitizer,
-} from "@azure-tools/test-recorder/types/src/utils/utils";
+import { FindReplaceSanitizer, RegexSanitizer } from "@azure-tools/test-recorder";
 
 export const testPollerProperties = {
   intervalInMs: isPlaybackMode() ? 0 : undefined,

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -6,7 +6,10 @@ import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-auth"
 import { isPlaybackMode, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 import { StorageClient } from "../../src/StorageClient";
 import { Pipeline } from "@azure/core-rest-pipeline";
-import { FindReplaceSanitizer, RegexSanitizer } from "@azure-tools/test-recorder";
+import {
+  FindReplaceSanitizer,
+  RegexSanitizer,
+} from "@azure-tools/test-recorder/types/src/utils/utils";
 
 export const testPollerProperties = {
   intervalInMs: isPlaybackMode() ? 0 : undefined,

--- a/sdk/template/template-dpg/package.json
+++ b/sdk/template/template-dpg/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure-tools/test-credential": "^1.0.4",
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure/test-utils": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
@@ -108,8 +109,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.0.0",
     "typescript": "~5.3.3",
-    "util": "^0.12.4",
-    "@azure-tools/test-credential": "~1.0.0"
+    "util": "^0.12.4"
   },
   "dependencies": {
     "@azure-rest/core-client": "^1.1.2",

--- a/sdk/test-utils/test-utils/karma.conf.js
+++ b/sdk/test-utils/test-utils/karma.conf.js
@@ -3,13 +3,6 @@
 
 // https://github.com/karma-runner/karma-chrome-launcher
 process.env.CHROME_BIN = require("puppeteer").executablePath();
-require("dotenv").config();
-const {
-  jsonRecordingFilterFunction,
-  isPlaybackMode,
-  isSoftRecordMode,
-  isRecordMode,
-} = require("@azure-tools/test-recorder");
 
 module.exports = function (config) {
   config.set({
@@ -38,7 +31,7 @@ module.exports = function (config) {
     files: [
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
-    ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
+    ],
 
     // list of files / patterns to exclude
     exclude: [],
@@ -53,13 +46,7 @@ module.exports = function (config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [
-      "TEST_MODE",
-      "ENDPOINT",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_CLIENT_ID",
-      "AZURE_TENANT_ID",
-    ],
+    envPreprocessor: [],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
@@ -85,11 +72,6 @@ module.exports = function (config) {
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
       properties: {}, // key value pair of properties to add to the <properties> section of the report
-    },
-
-    jsonToFileReporter: {
-      filter: jsonRecordingFilterFunction,
-      outputPath: ".",
     },
 
     // web server port
@@ -126,9 +108,6 @@ module.exports = function (config) {
     browserNoActivityTimeout: 60000000,
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
-    browserConsoleLogOptions: {
-      terminal: !isRecordMode(),
-    },
 
     client: {
       mocha: {

--- a/sdk/vision/ai-vision-image-analysis-rest/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/package.json
@@ -81,7 +81,7 @@
     "typescript": "~5.3.3",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure-tools/test-credential": "~1.0.2",
+    "@azure-tools/test-credential": "^1.0.4",
     "@azure/identity": "^4.0.1",
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",


### PR DESCRIPTION
## Minor changes in this PR
- Switch from ~ to ^ for `@azure-tools/test-credential` dependency
- Karma.conf update to `test-utils` package.