### PR TITLE
[Identity] Update IMDS probing logic

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Bugs Fixed
 
 - msal cache files are properly named when the user does not pass in a custom file name [#29039](https://github.com/Azure/azure-sdk-for-js/pull/29039)
-- Allow IMDS probing retry options to be overridden by customers
+- Allow IMDS probing retry options in `ManagedIdentityCredential` to be overridden by customers
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,9 +8,12 @@
 
 ### Breaking Changes
 
+- IMDS probing retry configuration updated for `DefaultAzureCredential`, with `maxRetryCount` increased to 5.
+
 ### Bugs Fixed
 
 - msal cache files are properly named when the user does not pass in a custom file name [#29039](https://github.com/Azure/azure-sdk-for-js/pull/29039)
+- Allow IMDS probing retry options to be overridden by customers
 
 ### Other Changes
 
@@ -27,7 +30,8 @@
 ## 4.0.1 (2024-01-18)
 
 ### Bugs Fixed
-- Initialize Public Client Application in the Interactive Browser Credential, as required by @azure/msal-browser v3 fixed in [#28292](https://github.com/Azure/azure-sdk-for-js/pull/28292). 
+
+- Initialize Public Client Application in the Interactive Browser Credential, as required by @azure/msal-browser v3 fixed in [#28292](https://github.com/Azure/azure-sdk-for-js/pull/28292).
 
 ## 3.4.1 (2023-11-13)
 
@@ -38,9 +42,11 @@
 ## 4.0.0 (2023-11-07)
 
 ### Features Added
+
 - All the features shipped as part of 4.0.0-beta.1 will be GA with this version. The most important features being the browser customization for success/ error messages and the support of brokered authentication on Windows OS, such as WAM.
 
 ### Breaking Changes
+
 - Starting with v4.0.0 of `@azure/identity`, Node.js v20 will be supported and Node.js v16 will no longer be supported.
 
 ## 3.4.0 (2023-11-07)
@@ -52,21 +58,25 @@
 ## 4.0.0-beta.1 (2023-10-26)
 
 ### Features Added
+
 - Added `brokerOptions` in `InteractiveBrowserCredential` for authentication broker support such as WAM. This feature works along with the new `@azure/identity-broker` plugin package. Note that this feature is only available in node.
 - Added support for MSA passthrough in the `brokerOptions` of `InteractiveBrowserCredential`. Note this is only available for legacy 1st party applications.
 - Added `BrowserCustomizationOptions` for success and error messages in the `InteractiveBrowserCredential`.
 
 ### Breaking Changes
+
 - The `redirectUri` is no longer a required option for `InteractiveBrowserCredential` on Node.js. There's no API change, but this is a behavior change.
 
 ## 3.3.2 (2023-10-17)
 
 ### Bugs Fixed
-- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile`  and "-NonInteractive" flag to avoid loading user profiles for more consistent behavior. ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
+
+- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` and "-NonInteractive" flag to avoid loading user profiles for more consistent behavior. ([#27023](https://github.com/Azure/azure-sdk-for-js/pull/27023))
 - Fixed browser bundling for Azure Developer CLI credential. ([Identity] update mapping for browser for azd (#27097))
 - `ManagedIdentityCredential` will fall through to the next credential in the chain in the case that Docker Desktop returns a 403 response when attempting to access the IMDS endpoint.([#27050](https://github.com/Azure/azure-sdk-for-js/pull/27050))
 
 ### Other Changes
+
 - The default IMDS probe request timeout in `ManagedIdentityCredential` has been increased to 1 second from 0.3 seconds to reduce the likelihood of false negatives.
 - Fixed links to documentation.
 - Further improvements to tenant and scope validation.
@@ -74,50 +84,60 @@
 ## 3.3.1 (2023-10-10)
 
 ### Bug Fixes
+
 - Bug fixes for developer credentials
 
 ## 3.3.0 (2023-08-14)
 
 ### Features Added
--  Enabled support for logging [personally identifiable information](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/PII), required for customer support through the `enableUnsafeSupportLogging` option on `loggingOptions` under `TokenCredentialOptions`.
+
+- Enabled support for logging [personally identifiable information](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/PII), required for customer support through the `enableUnsafeSupportLogging` option on `loggingOptions` under `TokenCredentialOptions`.
 - Continuous Access Evaluation (CAE) is now configurable per-request by setting the `enable_cae` keyword argument to `True` in `get_token`. This applies to user credentials and service principal credentials. ([#26614](https://github.com/Azure/azure-sdk-for-js/pull/26614))
 
 ### Breaking Changes
-- CP1 client capabilities for CAE is no longer always-on by default for user credentials. This capability will now be configured as-needed in each `getToken` request by each SDK.  ([#26614](https://github.com/Azure/azure-sdk-for-js/pull/26614))
+
+- CP1 client capabilities for CAE is no longer always-on by default for user credentials. This capability will now be configured as-needed in each `getToken` request by each SDK. ([#26614](https://github.com/Azure/azure-sdk-for-js/pull/26614))
   - Suffixes are now appended to persistent cache names to indicate whether CAE or non-CAE tokens are stored in the cache. This is to prevent CAE and non-CAE tokens from being mixed/overwritten in the same cache. This could potentially cause issues if you are trying to share the same cache between applications that are using different versions of the Azure Identity library as each application would be reading from a different cache file.
   - Since CAE is no longer always enabled for user-credentials, the `AZURE_IDENTITY_DISABLE_CP1` environment variable is no longer supported.
 
 ## 3.2.4 (2023-07-21)
 
 ### Bug Fixes
+
 - Fixed a bug related to [Managed Identity Credential intermixing wrong scopes](https://github.com/Azure/azure-sdk-for-js/pull/26566) for successive `getToken()` calls.
 
 ## 3.2.3 (2023-06-20)
 
 ### Bug Fixes
- - Dependency Upgrades of MSAL libraries to the latest versions for incorporating underlying [bug fix](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4879#issuecomment-1462949837) to resolve [this issue](https://github.com/Azure/azure-sdk-for-js/issues/23331).
+
+- Dependency Upgrades of MSAL libraries to the latest versions for incorporating underlying [bug fix](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4879#issuecomment-1462949837) to resolve [this issue](https://github.com/Azure/azure-sdk-for-js/issues/23331).
+
 ### Other Changes
+
 #### Behavioral breaking change
+
 - Moved `AzureDeveloperCliCredential` to the end of the `DefaultAzureCredential` chain.
 
 ## 3.2.2 (2023-05-15)
 
 ### Bug Fixes
- - Remove console logging in `processMultitenantRequest` for tenant id and resolved tenant.
+
+- Remove console logging in `processMultitenantRequest` for tenant id and resolved tenant.
 
 ## 3.2.1 (2023-05-10)
 
 ### Bug Fixes
- - Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
-   Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).
+
+- Fixed a bug in `WorkloadIdentity Credential`, to incorporate the case where the options can be `undefined` in a conditional check.
+  Related issue [#25827](https://github.com/Azure/azure-sdk-for-js/issues/25827) with the fix [#25829](https://github.com/Azure/azure-sdk-for-js/pull/25829).
 
 ## 3.2.0 (2023-05-09)
 
 ### Breaking Changes
 
- - Renamed `developerCredentialTimeOutInMs` to `processTimeoutInMs` in `DefaultAzureCredentialOptions`.
- - Renamed `federatedTokenFilePath` to `tokenFilePath` under `WorkloadIdentityOptions`.
- 
+- Renamed `developerCredentialTimeOutInMs` to `processTimeoutInMs` in `DefaultAzureCredentialOptions`.
+- Renamed `federatedTokenFilePath` to `tokenFilePath` under `WorkloadIdentityOptions`.
+
 ## 3.2.0-beta.2 (2023-04-13)
 
 ### Features Added
@@ -132,6 +152,7 @@
 ## 3.1.4 (2023-04-11)
 
 ### Bugs Fixed
+
 - Added a workaround of fetching all accounts from token cache to fix the issue of silent authentication not taking place when authenticationRecord is passed. For reference, see [issue](https://github.com/Azure/azure-sdk-for-js/issues/24349).
 
 ## 3.2.0-beta.1 (2023-02-28)
@@ -153,6 +174,7 @@
 ### Bugs Fixed
 
 - Fixed bug in `ManagedIdentity Credential` where "expiresInSeconds" was taking the absolute timestamp instead of relative expiration time period in seconds.
+
 ### Other Changes
 
 - Enable msal logging based on log level specified by user for Azure SDK.
@@ -204,11 +226,12 @@
 
 ### Breaking Changes
 
-- Credential types supporting multi-tenant authentication will now throw an error if the requested tenant ID doesn't match the credential's tenant ID, and is not included in the `additionallyAllowedTenants` option. Applications must now explicitly add additional tenants to the `additionallyAllowedTenants` list, or add `"*"` to list, to enable acquiring tokens from tenants other than the originally specified tenant ID.  See [BREAKING_CHANGES.md](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/BREAKING_CHANGES.md).
+- Credential types supporting multi-tenant authentication will now throw an error if the requested tenant ID doesn't match the credential's tenant ID, and is not included in the `additionallyAllowedTenants` option. Applications must now explicitly add additional tenants to the `additionallyAllowedTenants` list, or add `"*"` to list, to enable acquiring tokens from tenants other than the originally specified tenant ID. See [BREAKING_CHANGES.md](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/BREAKING_CHANGES.md).
 
 ### Bugs Fixed
 
 - Changed the way token expiration for managed identity tokens is calculated to handle different server formats. See [PR #23232](https://github.com/Azure/azure-sdk-for-js/pull/23232)
+
 ## 3.0.0-beta.1 (2022-08-24)
 
 ### Features Added

--- a/sdk/identity/identity/samples-dev/defaultAzureCredential.ts
+++ b/sdk/identity/identity/samples-dev/defaultAzureCredential.ts
@@ -20,7 +20,9 @@ require("dotenv").config();
  */
 
 export async function main(): Promise<void> {
-  const credential = new DefaultAzureCredential();
+  const credential = new DefaultAzureCredential({
+    retryOptions: { maxRetries: 3 },
+  });
 
   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
   const client = new KeyClient(keyVaultUrl, credential);

--- a/sdk/identity/identity/samples-dev/defaultAzureCredential.ts
+++ b/sdk/identity/identity/samples-dev/defaultAzureCredential.ts
@@ -20,9 +20,7 @@ require("dotenv").config();
  */
 
 export async function main(): Promise<void> {
-  const credential = new DefaultAzureCredential({
-    retryOptions: { maxRetries: 3 },
-  });
+  const credential = new DefaultAzureCredential();
 
   const keyVaultUrl = `https://key-vault-name.vault.azure.net`;
   const client = new KeyClient(keyVaultUrl, credential);

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -31,11 +31,15 @@ const logger = credentialLogger("DefaultAzureCredential");
  * @internal
  */
 export function createDefaultManagedIdentityCredential(
-  options?:
+  options:
     | DefaultAzureCredentialOptions
     | DefaultAzureCredentialResourceIdOptions
-    | DefaultAzureCredentialClientIdOptions,
+    | DefaultAzureCredentialClientIdOptions = {},
 ): TokenCredential {
+  options.retryOptions ??= {
+    maxRetries: 5,
+    retryDelayInMs: 800,
+  };
   const managedIdentityClientId =
     (options as DefaultAzureCredentialClientIdOptions)?.managedIdentityClientId ??
     process.env.AZURE_CLIENT_ID;

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -77,12 +77,12 @@ function prepareRequestOptions(
   };
 }
 
-// 800ms -> 1600ms -> 3200ms
-export const imdsMsiRetryConfig = {
-  maxRetries: 3,
-  startDelayInMs: 800,
-  intervalIncrement: 2,
-};
+// // 800ms -> 1600ms -> 3200ms
+// export const imdsMsiRetryConfig = {
+//   maxRetries: 3,
+//   startDelayInMs: 800,
+//   intervalIncrement: 2,
+// };
 
 /**
  * Defines how to determine whether the Azure IMDS MSI is available, and also how to retrieve a token from the Azure IMDS MSI.
@@ -179,8 +179,8 @@ export const imdsMsi: MSI = {
       logger.info(`${msiName}: Using the default Azure IMDS endpoint ${imdsHost}.`);
     }
 
-    let nextDelayInMs = imdsMsiRetryConfig.startDelayInMs;
-    for (let retries = 0; retries < imdsMsiRetryConfig.maxRetries; retries++) {
+    let nextDelayInMs = configuration.retryConfig.startDelayInMs;
+    for (let retries = 0; retries < configuration.retryConfig.maxRetries; retries++) {
       try {
         const request = createPipelineRequest({
           abortSignal: getTokenOptions.abortSignal,
@@ -193,7 +193,7 @@ export const imdsMsi: MSI = {
       } catch (error: any) {
         if (error.statusCode === 404) {
           await delay(nextDelayInMs);
-          nextDelayInMs *= imdsMsiRetryConfig.intervalIncrement;
+          nextDelayInMs *= configuration.retryConfig.intervalIncrement;
           continue;
         }
         throw error;
@@ -202,7 +202,7 @@ export const imdsMsi: MSI = {
 
     throw new AuthenticationError(
       404,
-      `${msiName}: Failed to retrieve IMDS token after ${imdsMsiRetryConfig.maxRetries} retries.`,
+      `${msiName}: Failed to retrieve IMDS token after ${configuration.retryConfig.maxRetries} retries.`,
     );
   },
 };

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -30,7 +30,7 @@ function prepareRequestOptions(
   options?: {
     skipQuery?: boolean;
     skipMetadataHeader?: boolean;
-  },
+  }
 ): PipelineRequestOptions {
   const resource = mapScopesToResource(scopes);
   if (!resource) {
@@ -76,13 +76,6 @@ function prepareRequestOptions(
     headers: createHttpHeaders(rawHeaders),
   };
 }
-
-// // 800ms -> 1600ms -> 3200ms
-// export const imdsMsiRetryConfig = {
-//   maxRetries: 3,
-//   startDelayInMs: 800,
-//   intervalIncrement: 2,
-// };
 
 /**
  * Defines how to determine whether the Azure IMDS MSI is available, and also how to retrieve a token from the Azure IMDS MSI.
@@ -151,7 +144,7 @@ export const imdsMsi: MSI = {
         if (response.status === 403) {
           if (
             response.bodyAsText?.includes(
-              "A socket operation was attempted to an unreachable network",
+              "A socket operation was attempted to an unreachable network"
             )
           ) {
             logger.info(`${msiName}: The Azure IMDS endpoint is unavailable`);
@@ -162,18 +155,18 @@ export const imdsMsi: MSI = {
         // If we received any response, the endpoint is available
         logger.info(`${msiName}: The Azure IMDS endpoint is available`);
         return true;
-      },
+      }
     );
   },
   async getToken(
     configuration: MSIConfiguration,
-    getTokenOptions: GetTokenOptions = {},
+    getTokenOptions: GetTokenOptions = {}
   ): Promise<MSIToken | null> {
     const { identityClient, scopes, clientId, resourceId } = configuration;
 
     if (process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST) {
       logger.info(
-        `${msiName}: Using the Azure IMDS endpoint coming from the environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST=${process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST}.`,
+        `${msiName}: Using the Azure IMDS endpoint coming from the environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST=${process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST}.`
       );
     } else {
       logger.info(`${msiName}: Using the default Azure IMDS endpoint ${imdsHost}.`);
@@ -202,7 +195,7 @@ export const imdsMsi: MSI = {
 
     throw new AuthenticationError(
       404,
-      `${msiName}: Failed to retrieve IMDS token after ${configuration.retryConfig.maxRetries} retries.`,
+      `${msiName}: Failed to retrieve IMDS token after ${configuration.retryConfig.maxRetries} retries.`
     );
   },
 };

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -30,7 +30,7 @@ function prepareRequestOptions(
   options?: {
     skipQuery?: boolean;
     skipMetadataHeader?: boolean;
-  }
+  },
 ): PipelineRequestOptions {
   const resource = mapScopesToResource(scopes);
   if (!resource) {
@@ -144,7 +144,7 @@ export const imdsMsi: MSI = {
         if (response.status === 403) {
           if (
             response.bodyAsText?.includes(
-              "A socket operation was attempted to an unreachable network"
+              "A socket operation was attempted to an unreachable network",
             )
           ) {
             logger.info(`${msiName}: The Azure IMDS endpoint is unavailable`);
@@ -155,18 +155,18 @@ export const imdsMsi: MSI = {
         // If we received any response, the endpoint is available
         logger.info(`${msiName}: The Azure IMDS endpoint is available`);
         return true;
-      }
+      },
     );
   },
   async getToken(
     configuration: MSIConfiguration,
-    getTokenOptions: GetTokenOptions = {}
+    getTokenOptions: GetTokenOptions = {},
   ): Promise<MSIToken | null> {
     const { identityClient, scopes, clientId, resourceId } = configuration;
 
     if (process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST) {
       logger.info(
-        `${msiName}: Using the Azure IMDS endpoint coming from the environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST=${process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST}.`
+        `${msiName}: Using the Azure IMDS endpoint coming from the environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST=${process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST}.`,
       );
     } else {
       logger.info(`${msiName}: Using the default Azure IMDS endpoint ${imdsHost}.`);
@@ -195,7 +195,7 @@ export const imdsMsi: MSI = {
 
     throw new AuthenticationError(
       404,
-      `${msiName}: Failed to retrieve IMDS token after ${configuration.retryConfig.maxRetries} retries.`
+      `${msiName}: Failed to retrieve IMDS token after ${configuration.retryConfig.maxRetries} retries.`,
     );
   },
 };

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsMsi.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { delay, isError } from "@azure/core-util";
-import { GetTokenOptions } from "@azure/core-auth";
+import { MSI, MSIConfiguration, MSIToken } from "./models";
 import {
   PipelineRequestOptions,
   PipelineResponse,
   createHttpHeaders,
   createPipelineRequest,
 } from "@azure/core-rest-pipeline";
-import { credentialLogger } from "../../util/logging";
-import { AuthenticationError } from "../../errors";
-import { tracingClient } from "../../util/tracing";
+import { delay, isError } from "@azure/core-util";
 import { imdsApiVersion, imdsEndpointPath, imdsHost } from "./constants";
-import { MSI, MSIConfiguration, MSIToken } from "./models";
+
+import { AuthenticationError } from "../../errors";
+import { GetTokenOptions } from "@azure/core-auth";
+import { credentialLogger } from "../../util/logging";
 import { mapScopesToResource } from "./utils";
+import { tracingClient } from "../../util/tracing";
 
 const msiName = "ManagedIdentityCredential - IMDS";
 const logger = credentialLogger(msiName);

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -8,7 +8,7 @@ import {
   AuthenticationRequiredError,
   CredentialUnavailableError,
 } from "../../errors";
-import { MSI, MSIToken } from "./models";
+import { MSI, MSIConfiguration, MSIToken } from "./models";
 import { MsalResult, MsalToken, ValidMsalToken } from "../../msal/types";
 import { credentialLogger, formatError, formatSuccess } from "../../util/logging";
 
@@ -70,11 +70,7 @@ export class ManagedIdentityCredential implements TokenCredential {
   private isAvailableIdentityClient: IdentityClient;
   private confidentialApp: ConfidentialClientApplication;
   private isAppTokenProviderInitialized: boolean = false;
-  private msiRetryConfig: {
-    maxRetries: number;
-    startDelayInMs: number;
-    intervalIncrement: number;
-  } = {
+  private msiRetryConfig: MSIConfiguration["retryConfig"] = {
     maxRetries: 3,
     startDelayInMs: 800,
     intervalIncrement: 2,

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -2,29 +2,29 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
-
-import { IdentityClient } from "../../client/identityClient";
-import { TokenCredentialOptions } from "../../tokenCredentialOptions";
+import { AppTokenProviderParameters, ConfidentialClientApplication } from "@azure/msal-node";
 import {
   AuthenticationError,
   AuthenticationRequiredError,
   CredentialUnavailableError,
 } from "../../errors";
-import { credentialLogger, formatError, formatSuccess } from "../../util/logging";
-import { appServiceMsi2017 } from "./appServiceMsi2017";
-import { tracingClient } from "../../util/tracing";
-import { cloudShellMsi } from "./cloudShellMsi";
-import { imdsMsi } from "./imdsMsi";
 import { MSI, MSIToken } from "./models";
-import { arcMsi } from "./arcMsi";
-import { tokenExchangeMsi } from "./tokenExchangeMsi";
-import { fabricMsi } from "./fabricMsi";
-import { appServiceMsi2019 } from "./appServiceMsi2019";
-import { AppTokenProviderParameters, ConfidentialClientApplication } from "@azure/msal-node";
-import { DeveloperSignOnClientId } from "../../constants";
 import { MsalResult, MsalToken, ValidMsalToken } from "../../msal/types";
-import { getMSALLogLevel } from "../../msal/utils";
+import { credentialLogger, formatError, formatSuccess } from "../../util/logging";
+import { imdsMsi, imdsMsiRetryConfig } from "./imdsMsi";
+
+import { DeveloperSignOnClientId } from "../../constants";
+import { IdentityClient } from "../../client/identityClient";
+import { TokenCredentialOptions } from "../../tokenCredentialOptions";
+import { appServiceMsi2017 } from "./appServiceMsi2017";
+import { appServiceMsi2019 } from "./appServiceMsi2019";
+import { arcMsi } from "./arcMsi";
+import { cloudShellMsi } from "./cloudShellMsi";
+import { fabricMsi } from "./fabricMsi";
 import { getLogLevel } from "@azure/logger";
+import { getMSALLogLevel } from "../../msal/utils";
+import { tokenExchangeMsi } from "./tokenExchangeMsi";
+import { tracingClient } from "../../util/tracing";
 
 const logger = credentialLogger("ManagedIdentityCredential");
 
@@ -116,6 +116,9 @@ export class ManagedIdentityCredential implements TokenCredential {
       throw new Error(
         `${ManagedIdentityCredential.name} - Client Id and Resource Id can't be provided at the same time.`,
       );
+    }
+    if (_options?.retryOptions?.maxRetries !== undefined) {
+      imdsMsiRetryConfig.maxRetries = _options.retryOptions.maxRetries;
     }
     this.identityClient = new IdentityClient(_options);
     this.isAvailableIdentityClient = new IdentityClient({

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/models.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/models.ts
@@ -2,12 +2,18 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
+
 import { IdentityClient } from "../../client/identityClient";
 
 /**
  * @internal
  */
 export interface MSIConfiguration {
+  retryConfig: {
+    maxRetries: number;
+    startDelayInMs: number;
+    intervalIncrement: number;
+  };
   identityClient: IdentityClient;
   scopes: string | string[];
   clientId?: string;

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -10,7 +10,6 @@ import {
 } from "../../../src/credentials/managedIdentityCredential/constants";
 import {
   imdsMsi,
-  imdsMsiRetryConfig,
 } from "../../../src/credentials/managedIdentityCredential/imdsMsi";
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "fs";
 import { Context } from "mocha";
@@ -316,9 +315,10 @@ describe("ManagedIdentityCredential", function () {
   });
 
   it("IMDS MSI retries up to a limit on 404", async function () {
+    const credential = new ManagedIdentityCredential("errclient")
     const { error } = await testContext.sendCredentialRequests({
       scopes: ["scopes"],
-      credential: new ManagedIdentityCredential("errclient"),
+      credential: credential,
       insecureResponses: [
         createResponse(200),
         createResponse(404),
@@ -330,7 +330,7 @@ describe("ManagedIdentityCredential", function () {
 
     assert.ok(
       error!.message!.indexOf(
-        `Failed to retrieve IMDS token after ${imdsMsiRetryConfig.maxRetries} retries.`,
+        `Failed to retrieve IMDS token after ${credential["msiRetryConfig"].maxRetries} retries.`,
       ) > -1,
     );
   });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential.spec.ts
@@ -8,9 +8,7 @@ import {
   imdsEndpointPath,
   imdsHost,
 } from "../../../src/credentials/managedIdentityCredential/constants";
-import {
-  imdsMsi,
-} from "../../../src/credentials/managedIdentityCredential/imdsMsi";
+import { imdsMsi } from "../../../src/credentials/managedIdentityCredential/imdsMsi";
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "fs";
 import { Context } from "mocha";
 import { GetTokenOptions } from "@azure/core-auth";
@@ -315,7 +313,7 @@ describe("ManagedIdentityCredential", function () {
   });
 
   it("IMDS MSI retries up to a limit on 404", async function () {
-    const credential = new ManagedIdentityCredential("errclient")
+    const credential = new ManagedIdentityCredential("errclient");
     const { error } = await testContext.sendCredentialRequests({
       scopes: ["scopes"],
       credential: credential,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Fixes https://github.com/Azure/azure-sdk-for-js/issues/28279

### Describe the problem that is addressed by this PR

- IMDS probing retry configuration updated for `DefaultAzureCredential`, with `maxRetryCount` increased to 5.
- Allow IMDS probing retry options in MI Credential to be overridden by customers
- IMDS Probing for error 404 uses the same retry policy for other errors like 408, 500s (exponential retry policy from core)


### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
