### PR TITLE
[Text Translation] Adding support for AAD authentication

### DIFF
--- a/sdk/translation/ai-translation-text-rest/CHANGELOG.md
+++ b/sdk/translation/ai-translation-text-rest/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.2 (Unreleased)
 
 ### Features Added
+- Added support for AAD authentication.
 
 ### Breaking Changes
 

--- a/sdk/translation/ai-translation-text-rest/assets.json
+++ b/sdk/translation/ai-translation-text-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/translation/ai-translation-text-rest",
-  "Tag": "js/translation/ai-translation-text-rest_8b443c94ab"
+  "Tag": "js/translation/ai-translation-text-rest_6dacbcc4a1"
 }

--- a/sdk/translation/ai-translation-text-rest/karma.conf.js
+++ b/sdk/translation/ai-translation-text-rest/karma.conf.js
@@ -61,6 +61,8 @@ module.exports = function (config) {
       "TEXT_TRANSLATION_API_KEY",
       "TEXT_TRANSLATION_REGION",
       "RECORDINGS_RELATIVE_PATH",
+      "TEXT_TRANSLATION_AAD_REGION",
+      "TEXT_TRANSLATION_RESOURCE_ID"
     ],
 
     // test results reporter to use

--- a/sdk/translation/ai-translation-text-rest/karma.conf.js
+++ b/sdk/translation/ai-translation-text-rest/karma.conf.js
@@ -62,7 +62,7 @@ module.exports = function (config) {
       "TEXT_TRANSLATION_REGION",
       "RECORDINGS_RELATIVE_PATH",
       "TEXT_TRANSLATION_AAD_REGION",
-      "TEXT_TRANSLATION_RESOURCE_ID"
+      "TEXT_TRANSLATION_RESOURCE_ID",
     ],
 
     // test results reporter to use

--- a/sdk/translation/ai-translation-text-rest/review/ai-translation-text.api.md
+++ b/sdk/translation/ai-translation-text-rest/review/ai-translation-text.api.md
@@ -40,7 +40,7 @@ export interface CommonScriptModelOutput {
 }
 
 // @public
-function createClient(endpoint: undefined | string, credential?: undefined | TranslatorCredential | KeyCredential | TokenCredential, options?: ClientOptions): TextTranslationClient;
+function createClient(endpoint: undefined | string, credential?: undefined | TranslatorCredential | TranslatorTokenCredential | KeyCredential | TokenCredential, options?: ClientOptions): TextTranslationClient;
 export default createClient;
 
 // @public
@@ -544,6 +544,16 @@ export interface TranslatorCredential {
     key: string;
     // (undocumented)
     region: string;
+}
+
+// @public (undocumented)
+export interface TranslatorTokenCredential {
+    // (undocumented)
+    azureResourceId: string;
+    // (undocumented)
+    region: string;
+    // (undocumented)
+    tokenCredential: TokenCredential;
 }
 
 // @public

--- a/sdk/translation/ai-translation-text-rest/src/custom/authentication.ts
+++ b/sdk/translation/ai-translation-text-rest/src/custom/authentication.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { AzureKeyCredential, TokenCredential } from "@azure/core-auth";
 import {
   PipelinePolicy,
   PipelineRequest,
@@ -11,10 +11,18 @@ import {
 
 const APIM_KEY_HEADER_NAME = "Ocp-Apim-Subscription-Key";
 const APIM_REGION_HEADER_NAME = "Ocp-Apim-Subscription-Region";
+const APIM_RESOURCE_ID = "Ocp-Apim-ResourceId";
+export const DEFAULT_SCOPE = "https://cognitiveservices.azure.com/.default";
 
 export interface TranslatorCredential {
   key: string;
   region: string;
+}
+
+export interface TranslatorTokenCredential {
+  tokenCredential: TokenCredential;
+  region: string;
+  azureResourceId: string;
 }
 
 export class TranslatorAuthenticationPolicy implements PipelinePolicy {
@@ -43,6 +51,22 @@ export class TranslatorAzureKeyAuthenticationPolicy implements PipelinePolicy {
 
   sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
     request.headers.set(APIM_KEY_HEADER_NAME, this.credential.key);
+
+    return next(request);
+  }
+}
+
+export class TranslatorTokenCredentialAuthenticationPolicy implements PipelinePolicy {
+  name: string = "TranslatorTokenCredentialAuthenticationPolicy";
+  credential: TranslatorTokenCredential;
+
+  constructor(credential: TranslatorTokenCredential) {
+    this.credential = credential;
+  }
+
+  sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+    request.headers.set(APIM_REGION_HEADER_NAME, this.credential.region);
+    request.headers.set(APIM_RESOURCE_ID, this.credential.azureResourceId);
 
     return next(request);
   }

--- a/sdk/translation/ai-translation-text-rest/src/custom/customClient.ts
+++ b/sdk/translation/ai-translation-text-rest/src/custom/customClient.ts
@@ -32,8 +32,10 @@ function isTokenCredential(credential: any): credential is TokenCredential {
 }
 
 function isTranslatorTokenCredential(credential: any): credential is TranslatorTokenCredential {
-  return (credential as TranslatorTokenCredential)?.tokenCredential !== undefined
-    && (credential as TranslatorTokenCredential)?.azureResourceId !== undefined;
+  return (
+    (credential as TranslatorTokenCredential)?.tokenCredential !== undefined &&
+    (credential as TranslatorTokenCredential)?.azureResourceId !== undefined
+  );
 }
 
 /**
@@ -44,7 +46,12 @@ function isTranslatorTokenCredential(credential: any): credential is TranslatorT
  */
 export default function createClient(
   endpoint: undefined | string,
-  credential: undefined | TranslatorCredential | TranslatorTokenCredential | KeyCredential | TokenCredential = undefined,
+  credential:
+    | undefined
+    | TranslatorCredential
+    | TranslatorTokenCredential
+    | KeyCredential
+    | TokenCredential = undefined,
   options: ClientOptions = {},
 ): TextTranslationClient {
   let serviceEndpoint: string;
@@ -102,9 +109,9 @@ export default function createClient(
         scopes: DEFAULT_SCOPE,
       }),
     );
-    client.pipeline.addPolicy(new TranslatorTokenCredentialAuthenticationPolicy(
-      credential as TranslatorTokenCredential
-    ));
+    client.pipeline.addPolicy(
+      new TranslatorTokenCredentialAuthenticationPolicy(credential as TranslatorTokenCredential),
+    );
   }
 
   return client;

--- a/sdk/translation/ai-translation-text-rest/src/index.ts
+++ b/sdk/translation/ai-translation-text-rest/src/index.ts
@@ -11,6 +11,6 @@ export * from "./isUnexpected";
 export * from "./models";
 export * from "./outputModels";
 export * from "./serializeHelper";
-export { TranslatorCredential } from "./custom/authentication";
+export { TranslatorCredential, TranslatorTokenCredential } from "./custom/authentication";
 
 export default TextTranslationClient;

--- a/sdk/translation/ai-translation-text-rest/test/public/breakSentenceTest.spec.ts
+++ b/sdk/translation/ai-translation-text-rest/test/public/breakSentenceTest.spec.ts
@@ -39,7 +39,7 @@ describe("BreakSentence tests", () => {
 
     const breakSentences = response.body as BreakSentenceItemOutput[];
     assert.isTrue(breakSentences[0].detectedLanguage?.language === "en");
-    assert.isTrue(breakSentences[0].detectedLanguage?.score === 1.0);
+    assert.isTrue(breakSentences[0].detectedLanguage?.score === 0.98);
     assert.isTrue(breakSentences[0].sentLen[0] === 11);
   });
 

--- a/sdk/translation/ai-translation-text-rest/test/public/translateTest.spec.ts
+++ b/sdk/translation/ai-translation-text-rest/test/public/translateTest.spec.ts
@@ -14,6 +14,7 @@ import {
   createCustomTranslationClient,
   createTranslationClient,
   createTokenTranslationClient,
+  createAADAuthenticationTranslationClient,
   startRecorder,
 } from "./utils/recordedClient";
 import { Context } from "mocha";
@@ -363,6 +364,19 @@ describe("Translate tests", () => {
 
   it("with token", async () => {
     const tokenClient = await createTokenTranslationClient({ recorder });
+    const inputText: InputTextItem[] = [{ text: "This is a test." }];
+    const parameters: TranslateQueryParamProperties & Record<string, unknown> = {
+      to: "cs",
+    };
+    const response = await tokenClient.path("/translate").post({
+      body: inputText,
+      queryParameters: parameters,
+    });
+    assert.equal(response.status, "200");
+  });
+
+  it("with AAD authentication", async () => {
+    const tokenClient = await createAADAuthenticationTranslationClient({ recorder });
     const inputText: InputTextItem[] = [{ text: "This is a test." }];
     const parameters: TranslateQueryParamProperties & Record<string, unknown> = {
       to: "cs",

--- a/sdk/translation/ai-translation-text-rest/test/public/utils/recordedClient.ts
+++ b/sdk/translation/ai-translation-text-rest/test/public/utils/recordedClient.ts
@@ -135,16 +135,14 @@ export async function createAADAuthenticationTranslationClient(options: {
     const tenantId = assertEnvironmentVariable("TEXT_TRANSLATION_TENANT_ID");
     const secret = assertEnvironmentVariable("TEXT_TRANSLATION_CLIENT_SECRET");
 
-    tokenCredential = new ClientSecretCredential(
-      tenantId, clientId, secret
-    );
+    tokenCredential = new ClientSecretCredential(tenantId, clientId, secret);
   }
 
   const translatorTokenCredentials: TranslatorTokenCredential = {
     tokenCredential,
     azureResourceId,
-    region
-  }
+    region,
+  };
   const client = createTextTranslationClient(endpoint, translatorTokenCredentials, updatedOptions);
   return client;
 }

--- a/sdk/translation/ai-translation-text-rest/test/public/utils/recordedClient.ts
+++ b/sdk/translation/ai-translation-text-rest/test/public/utils/recordedClient.ts
@@ -11,17 +11,21 @@ import {
 import { StaticAccessTokenCredential } from "./StaticAccessTokenCredential";
 import createTextTranslationClient, {
   TranslatorCredential,
+  TranslatorTokenCredential,
   TextTranslationClient,
 } from "../../../src";
 import { ClientOptions } from "@azure-rest/core-client";
 import { createDefaultHttpClient, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { TokenCredential } from "@azure/core-auth";
+import { ClientSecretCredential } from "@azure/identity";
 
 const envSetupForPlayback: Record<string, string> = {
   TEXT_TRANSLATION_API_KEY: "fakeapikey",
   TEXT_TRANSLATION_ENDPOINT: "https://fakeEndpoint.cognitive.microsofttranslator.com",
   TEXT_TRANSLATION_CUSTOM_ENDPOINT: "https://fakeCustomEndpoint.cognitiveservices.azure.com",
   TEXT_TRANSLATION_REGION: "fakeregion",
+  TEXT_TRANSLATION_AAD_REGION: "fakeregion",
+  TEXT_TRANSLATION_RESOURCE_ID: "fakeresourceid",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -110,6 +114,38 @@ export async function createTokenTranslationClient(options: {
     credential = new StaticAccessTokenCredential(token);
   }
   const client = createTextTranslationClient(endpoint, credential, updatedOptions);
+  return client;
+}
+
+export async function createAADAuthenticationTranslationClient(options: {
+  recorder?: Recorder;
+  clientOptions?: ClientOptions;
+}): Promise<TextTranslationClient> {
+  const { recorder, clientOptions = {} } = options;
+  const updatedOptions = recorder ? recorder.configureClientOptions(clientOptions) : clientOptions;
+  const endpoint = assertEnvironmentVariable("TEXT_TRANSLATION_ENDPOINT");
+  const region = assertEnvironmentVariable("TEXT_TRANSLATION_AAD_REGION");
+  const azureResourceId = assertEnvironmentVariable("TEXT_TRANSLATION_RESOURCE_ID");
+
+  let tokenCredential: TokenCredential;
+  if (isPlaybackMode()) {
+    tokenCredential = createMockToken();
+  } else {
+    const clientId = assertEnvironmentVariable("TEXT_TRANSLATION_CLIENT_ID");
+    const tenantId = assertEnvironmentVariable("TEXT_TRANSLATION_TENANT_ID");
+    const secret = assertEnvironmentVariable("TEXT_TRANSLATION_CLIENT_SECRET");
+
+    tokenCredential = new ClientSecretCredential(
+      tenantId, clientId, secret
+    );
+  }
+
+  const translatorTokenCredentials: TranslatorTokenCredential = {
+    tokenCredential,
+    azureResourceId,
+    region
+  }
+  const client = createTextTranslationClient(endpoint, translatorTokenCredentials, updatedOptions);
   return client;
 }
 


### PR DESCRIPTION
### Packages impacted by this PR
Text Translation SDK

### Describe the problem that is addressed by this PR
Adding support for AAD authentication using Text Translation endpoints. Those endpoints require use of special header `Ocp-Apim-ResourceId` vs using custom endpoint.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
