### PR TITLE
[ESM] [Recorder] Prep releasing v4 recorder and v2 test-credential

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0 (2024-04-02)
+## 4.0.0 (2024-04-04)
 
 ### Features Added
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -22,11 +22,7 @@
   - The package has been simplified by removing the `dotenv` dependency and the `karma.conf` file, env shims for the browser. This streamlines the package dependencies and configuration files, respectively.
   - These changes introduce a new `env` strategy for all SDKs once they migrate to ESM and depend on `@azure-tools/test-recorder` version 4, as we employ `process.env` through vitest to access environment variables in both Node and browser environments.
 
-### Bugs Fixed
-
-### Other Changes
-
-## 3.1.0 (2023-03-14)
+## 3.1.0 (2024-03-14)
 
 ### Features Added
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0 (Unreleased)
+## 4.0.0 (2024-04-02)
 
 ### Features Added
 

--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (Unreleased)
+## 2.0.0 (2024-04-02)
 
 ### Features Added
 

--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2024-04-02)
+## 2.0.0 (2024-04-04)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure-tools/test-recorder` and `@azure-tools/test-credential` being published to npm.

### Describe the problem that is addressed by this PR
https://github.com/Azure/azure-sdk-for-js/pull/29016 is blocked as vite is unable to pick up the local sources for recorder and instead falling back to the published npm version.

This PR helps publishing the v4 recorder and v2 test-credential, in an attempt to try if vite picks up these dependencies as expected.
