### PR TITLE
[identity] fix transitive dependency

### DIFF
--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -64,11 +64,12 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/logger": "^1.0.4",
-    "@azure/core-util": "^1.6.0",
     "@azure/abort-controller": "^1.1.0",
-    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/core-client": "^1.7.0",
+    "@azure/core-util": "^1.6.0",
     "@azure/dev-tool": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/logger": "^1.0.4",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^3.0.0",
     "@microsoft/api-extractor": "^7.35.1",

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -67,8 +67,9 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/core-client": "^1.7.0",
     "@azure/dev-tool": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/logger": "^1.0.4",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^3.0.0",

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -64,8 +64,9 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/core-client": "^1.7.0",
     "@azure/dev-tool": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/test-utils": "^1.0.0",
     "@azure-tools/test-recorder": "^3.0.0",
     "@microsoft/api-extractor": "^7.31.1",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity-cache-persistence
@azure/identity-broker
@azure/identity-vscode

### Issues associated with this PR

Workaround for #29171 which will be the long term fix

### Describe the problem that is addressed by this PR

Identity CI builds started failing because of build errors in identity-cache-persistence.

This is due to an implicit dependency on @azure/core-client via pulling in of source files from identity directly:

[example1](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity-cache-persistence/src/index.ts#L4)
[example2](https://github.com/Azure/azure-sdk-for-js/blob/1d60a7b672b3be6c51d0a07eafbad36862e6231d/sdk/identity/identity-cache-persistence/test/internal/node/clientSecretCredential.spec.ts#L7-L11)
Because the plugin packages have a runtime dependency on a published version of identity, they pull in source files directly from the source tree. That means that if the version of identity on disk has not been built, core-client will not be built (like when identity in the repo is a major version bump or beta). As a result, trying to build the plugin package causes:

```
../identity/src/client/identityClient.ts(6,31): error TS2307: Cannot find module '@azure/core-client' or its corresponding type declarations.
../identity/src/client/identityClient.ts(75,38): error TS2339: Property 'userAgentOptions' does not exist on type 'TokenCredentialOptions'.
../identity/src/client/identityClient.ts(76,20): error TS2339: Property 'userAgentOptions' does not exist on type 'TokenCredentialOptions'.
../identity/src/client/identityClient.ts(105,33): error TS2339: Property 'sendRequest' does not exist on type 'IdentityClient'.
../identity/src/client/identityClient.ts(262,33): error TS2339: Property 'sendRequest' does not exist on type 'IdentityClient'.
../identity/src/client/identityClient.ts(286,33): error TS2339: Property 'sendRequest' does not exist on type 'IdentityClient'.
../identity/src/credentials/managedIdentityCredential/arcMsi.ts(85,41): error TS2339: Property 'sendRequest' does not exist on type 'IdentityClient'.
../identity/src/credentials/managedIdentityCredential/imdsMsi.ts(138,43): error TS2339: Property 'sendRequest' does not exist on type 'IdentityClient'.
../identity/src/credentials/managedIdentityCredential/index.ts(123,7): error TS2353: Object literal may only specify known properties, and 'retryOptions' does not exist in type 'TokenCredentialOptions'.
../identity/src/tokenCredentialOptions.ts(4,37): error TS2307: Cannot find module '@azure/core-client' or its corresponding type declarations.
```

Rush is not aware of the build dependency so it's not guaranteed that core-client will be built. Having it listed as a
dependency will ensure it gets built before the packages that depend on it do.

