### PR TITLE
[Monitor OpenTelemetry] Revert QuickPulse Endpoint Change

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Bugs Fixed
 
-- Update application inisghts resource endpoint.
-
 ### Other Changes
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/export/sender.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/export/sender.ts
@@ -13,7 +13,7 @@ import {
   QuickpulseClientOptionalParams,
 } from "../../../generated";
 
-const applicationInsightsResource = "https://monitor.azure.com/.default";
+const applicationInsightsResource = "https://monitor.azure.com//.default";
 
 /**
  * Quickpulse sender class


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
Need to revert live metrics endpoint change.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
