### PR TITLE
Mark JS pacakge as shipped in APIView after publishing the package

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -104,6 +104,14 @@ stages:
                                 eng/scripts/cleanup-npm-next-tag.ps1 -packageArtifact $(Package.Archive) -workingDirectory $(System.DefaultWorkingDirectory)/temp -npmToken $(azure-sdk-npm-token)
                               displayName: Cleanup Npm Next Tag
                               condition: and(succeeded(), ne(variables['Skip.RemoveOldTag'], 'true'))
+                            - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+                              parameters:
+                                ArtifactPath: $(Pipeline.Workspace)/packages
+                                Artifacts: ${{parameters.Artifacts}}
+                                ConfigFileDir: $(Pipeline.Workspace)/packages/PackageInfo
+                                MarkPackageAsShipped: true
+                                ArtifactName: ${{parameters.ArtifactName}}
+                                PackageName: ${{artifact.name}}
               - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
                   - deployment: PublishDocs
                     displayName: Docs.MS Release

--- a/eng/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/scripts/Generate-APIView-CodeFile.ps1
@@ -37,7 +37,7 @@ Write-Host "Setting working directory to $($installedPath)"
 Set-Location $installedPath
 npm install
 npm run-script build
-$apiFiles = Get-ChildItem -Path $ArtifactPath -Recurse -Filter "*.api.json"
+$apiFiles = @(Get-ChildItem -Path $ArtifactPath -Recurse -Filter "*.api.json")
 foreach ($apiPkgFile in $apiFiles)
 {
   $apiFilePath = $apiPkgFile.FullName

--- a/eng/scripts/stage-api-review-file.ps1
+++ b/eng/scripts/stage-api-review-file.ps1
@@ -14,16 +14,15 @@ if (!((Test-Path $PackageInfoPath) -and (Test-Path $StagingDirectory)))
 foreach($pkg in (Get-ChildItem -Path $PackageInfoPath "*.json"))
 {
   $info = Get-Content -Path $pkg.FullName | ConvertFrom-Json
-  $apiFilePath = Join-Path $info.DirectoryPath "temp"
-  if (Test-Path $apiFilePath)
+  if (Test-Path $info.DirectoryPath)
   {
-    $apiFile = Get-ChildItem -Path $apiFilePath "*.api.json"
+    $apiFile = @(Get-ChildItem -Path $info.DirectoryPath "*.api.json" -Recurse)
     if ($apiFile)
     {
       if ($apiFile.Count -ne 1)
       {
         # Unlikely, but handling to avoid any issue in the future if more than one api file is present here
-        Write-Error "Detected more than one api extracted file in $apiFilePath"
+        Write-Error "Detected more than one api extracted file in $($info.DirectoryPath)"
         exit 1
       }
       
@@ -45,6 +44,6 @@ foreach($pkg in (Get-ChildItem -Path $PackageInfoPath "*.json"))
   }
   else
   {
-    Write-Host "Directory $($apiFilePath) is not present in package root to search for api-extracted file"
+    Write-Host "Directory $($info.DirectoryPath) is not present in package root to search for api-extracted file"
   }
 }


### PR DESCRIPTION
Send a request to APIView to mark the package version as shipped in APIView after it's shipped from a release pipeline.