### PR TITLE
[Recorder] Recorder upgrade to 3.1.2 - rush update --full

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1180,15 +1180,15 @@ packages:
     resolution: {integrity: sha512-O5wyYiI6bILqO9MOeQ1WhSIcKH6c3DvbpsjMPKYJ+yekmFhFUb/zU/pSKsLvyqZhqUWSACFMNri4cZd4tuW0rw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/core-auth': 1.7.1
-      '@azure/identity': 4.0.1
+      '@azure/identity': 4.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@azure-tools/test-recorder@3.1.0:
-    resolution: {integrity: sha512-qDbZkrhz9OMyH3ijFAJVm1aUN3H1CVgAhW6826U9Pkk0TwcumjtHCx2mPzH8vY8Otl03s8So+Fac00PuyastVw==}
+  /@azure-tools/test-recorder@3.1.1:
+    resolution: {integrity: sha512-ajA2Q36u/ZNKCFUSz8ktTxUQhJwrvhF0Hr/TAG6zle8bfQvV6ZOQf/dQYx3QfP1SIH6wRewfjkX8cCaaay6e1w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/core-auth': 1.7.1
@@ -1477,8 +1477,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/identity@4.0.1:
-    resolution: {integrity: sha512-yRdgF03SFLqUMZZ1gKWt0cs0fvrDIkq2bJ6Oidqcoo5uM85YMBnXWMzYKK30XqIT76lkFyAaoAAy5knXhrG4Lw==}
+  /@azure/identity@4.1.0:
+    resolution: {integrity: sha512-BhYkF8Xr2gXjyDxocm0pc9RI5J5a1jw8iW0dw6Bx95OGdYbuMyFZrrwNw4eYSqQ2BB6FZOqpJP3vjsAqRcvDhw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -4545,7 +4545,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001608
-      electron-to-chromium: 1.4.731
+      electron-to-chromium: 1.4.733
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: false
@@ -5381,8 +5381,8 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
-  /electron-to-chromium@1.4.731:
-    resolution: {integrity: sha512-+TqVfZjpRz2V/5SPpmJxq9qK620SC5SqCnxQIOi7i/U08ZDcTpKbT7Xjj9FU5CbXTMUb4fywbIr8C7cGv4hcjw==}
+  /electron-to-chromium@1.4.733:
+    resolution: {integrity: sha512-gUI9nhI2iBGF0OaYYLKOaOtliFMl+Bt1rY7VmEjwxOxqoYLub/D9xmduPEhbw2imE6gYkJKhIE5it+KE2ulVxQ==}
     dev: false
 
   /emitter-component@1.1.2:
@@ -10815,7 +10815,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-O8YTskEW5isvzVaRXY5QnTJqgqzdLAoaPL2jFLH0Yx/sI8Xs+XjkvFqRF4guFxDSyjGsM2YnqnJxVJtTdOinjg==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-o8AryG5djHP+piuSftD01tKE5GMnlat9J+0cYIfRlYLgHtEZaCFyzLMTsgdhDwsO/KKaYRWPj2MpOTpVp/7ZWQ==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -10848,12 +10848,12 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-GfvGwQe+VrPkfYQ0s/Ej43injMc/EPnxiAkSOOT3XsjmofdSDqKLn5tblfi70GSbwLfrKVSkFfQifXxQ8ousaA==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-iMU3Gu45Y0BA8elROQc/ImmzEHMsQekhocWIdyjepDUUQzGHyJnCLpuHkkV4ExHHhy27EraABONC8S36q6t6fg==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10893,12 +10893,12 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-RS4aHQlRIS8srAwtZyirEzybiPpC340/M7z3YVZg784B1Xsn9WW+pZwHFM3x2cM4Xb12FFGJSAqLcpjbSlSY8Q==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-+9liYSfY0C9Tb/OuBB0zm6Mv5mdvH64sLkukb8Zc7uw0CAA3Xwevhh+iyabGPcwnvC10Ny29tbPuoMkJdX01Pw==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10938,12 +10938,12 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-rqE6UzZqWGS2DZjtSin70zRrb6dnGftZV4iAxbBxeCSagTlbKk0BSK1275BRcARFxIDVAD9f7/hT2g/km9Xyqg==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-PoW+wtv710JYYgo1vdeeJEVBNbyAj5KMQNVEC6+ty2yF8COrZnnRovsR/4PEUaTS5KRgm3gZ9tiR8C5aA3rlBw==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10982,12 +10982,12 @@ packages:
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-wzpGztGymtuh74w15kww5tPE8fNU21xbbE0yHes3qW9j2iMgZkFryBOP9njCB60yUs8WashzOPbztSHsxUHDzg==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-mCoobJ2gmaTXk6xkTXFAQWp1PdvtUw1eZydIVWcKwseifwPQa+HtciVWCWeEehvFzvpVZnddhXrcnBrSM8Ttsg==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11027,12 +11027,12 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-714a+aj3jvAy5r8N7h4/Hcl/TOKI4Y42TZ50rQz3oUgs5AvTza7kgXP1ZH4w1rJEBpVhFiYJIgOrRCeN7A0R6A==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-+IhjM6C7V2sLEVqjA+tpkFShiuK1M7lfBMYjTLqUnCcKd/bbMx1fgoZvYAmoXcF3To+dFllWJNoYIas7vbWhDw==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11071,12 +11071,12 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-0sarobvlcIpkooE1945mIAIfbB/+DJzbhILNijLT63uG/oM+umyJEsqZoerlhAOzz9OqJEmNHeZUV55d+l72lQ==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-yyapMF53kFkruynJZpA8h0JH0Hbzw7c01oN2zWS+0TATRxRicIRrk0qkETg+eg0kj0rHqVcjCuGQVM/QlkSxKA==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.14.1)
@@ -11119,12 +11119,12 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-+ZvsqckEAyGP8o8qCqYQ/c4MlTInPcbLETVd38QcOWCfS1Ka7oOjsZoVrL+7Y66adQYBUsCdutdoyYt3Vmk5hA==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-3Ma7fFPh/+9p2WHvRn2uUuHaJwmidXrFhpkprMij4Wp8+1JZJDNHH5Dv9hT3EI5ZQy6y9nPVKEVZ3S5HT70qBQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11168,12 +11168,12 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-vfJ+eUUj9jmVhuky3ArAl0ZxjNOchd2QTLcQNOUnhVN/o5fnl45kDJCoTJ5aXgVSx4eiAIHFHy76A/BRBfC0kg==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-0tGFMGfV2p0x7P8xVnnTZc3vvqKN8dT7jSBdEnOhlSj+YsRHh8PGBICPcUqYxVtQOqIH7l6Or64zKIJrYvj8KA==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -11216,7 +11216,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-So688SuT8lsbC1LoVQ4/DPqWZPQeVSOD4bELN1x/0Ns/9CKQoIfQj9ivImWlJf9gD7ibidZ8cGUlbYKU+YkbkQ==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-SgHfxPp1wvzZyynCW9P9SwqaPAPnQ7/qUQ7j9a1v4waQ9YtcC0cSHL/Qd+puf1jAtOAXsjZQYWExH1LxRJo31g==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -11241,12 +11241,12 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-WdGBCxAEcry/5DOa8yedeD0nqCE6OfDMc4lla/vhHsgNtCn4eCZt7xZpewgMFSOqQDjH1xI4hY2/YT8a2YhMCA==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-s4BdJGW7RPs/AIITG8nHfqcFZmq2UVVixd9g9C7TLPn4t8TI5EWfRZL1Zew15WVX67oa9Mvn5m4uccsL/e/aPw==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11285,12 +11285,12 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-Ia4Rv1Zhb7e2uxql76vMHR2nTcotbi7Kf/15qNpGBUOJQtzhadtEqpeA/ullceoYoReCAzk6OwC5f5FHMaOhwA==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-dOqV18YLK9FRJSn8iXvFn8sXQ7a2kouY8b0UCYarYbfBM8whGT2B1LgiMnA524Gag+J9B3P+CvUPpWElEmsXGA==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11332,12 +11332,12 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-Rqdrozy9kdR+qxQePI6nKc9K3xJrwRrwFkXiOIbznUUMCDW1AFYs2NTQvWmz1WKGj9Ovn0lcRFGrWlvR5Jsrmw==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-nTxFuZzU8C7fzFUs3OjPkTI5G7VYYO3GC+YIIObiHcyGOPLV6Yiy9CUH16IPRwhxsfXEePrZuSlnUh+lyI13iw==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11376,12 +11376,12 @@ packages:
     dev: false
 
   file:projects/ai-vision-image-analysis.tgz:
-    resolution: {integrity: sha512-xHT2i95o6Y7HbRNYbJRhvF/O9zVFLmooetdFjjS1ozrrRw3vbCJD/pVT17MJdtKy12mmYkDgUc0ODirjJGWnkQ==, tarball: file:projects/ai-vision-image-analysis.tgz}
+    resolution: {integrity: sha512-bXWEYcilc9fkT1q5axp5RlOfAvyq2nIhkCwV5XR2vAHK/5+BM3lc0Ezabz8IdfkTZNAUXZEi+8ahdip56lZncg==, tarball: file:projects/ai-vision-image-analysis.tgz}
     name: '@rush-temp/ai-vision-image-analysis'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.39.5(@types/node@20.10.8)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11420,7 +11420,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-X8BJ1ZNeY9rRDQyKhKhkcZHhxKwEFX7OMBKe1mhXkcY7l4Ho3ExInkCjrjkz/7wIugIj2637vyyP9gauoRCXHA==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-d749ffrOspJbTzY2nT5oH7b5pKLiEy2ev1APSCTsGkYIHPNu5U730wQHThjwex36Clt29GZYl4LMJhGBMjMDAg==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -11462,7 +11462,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-fYGQJAY0yZKEqPk93FA5an7HN4E1Gh2AMynoMtlHI7l+Qhy2lI9YPe9o/yx3myfa+HtHJoHrLZ4nhk13e3Yy4A==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-ZKNSl/mbap8OVZ8phTvKjU50GInYjlUiQ5dzY7tb2Z/AhzPpdgLzdWP8YpEA/73JK4EQLEjYl26HDWinHhhEDA==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -11499,12 +11499,12 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-GyYbYEI4GRrC2f2DOKOisQrkwrlefroxn2hQdQEBqA9iBX8N2QnYBLJzMf++nePBBWoTRyG2Fc4/F6fpPZs0MQ==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-oIXvlM1wl6mKKCEONTSAQkhtCMm0jg04ucXLVdCsINRausGCvHPHr95Z3MfUSjb9D3GPFE4gOKPYtmIKZWatSw==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11539,12 +11539,12 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-wW/dQcwYTpg3bIJMt3xAccGJxdHZU5vpWHwzk46/RB3OUYSs5ZnPPxzrbo6gZUsS4SQLN7WeXDE4+tMxXHzdfA==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-FgfRzO1GJXQVRt0f0UPmuj6GV57rcep1lYcSi5GWX5Sn0J0eKXIG1VwZu5pW+TNyxXDqlZijrRTrkuM+lossXg==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11566,12 +11566,12 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-BuHCRvKQACBFRhp8ljsFWiRNHyGPTeL05BYi30o3QYgo8vjcigXA9Tx//2JhRCB8Z/i5v5zizWAl2UiU7xynjA==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-P1rth3hiil6ewNuwVz1/hVr6xw9tKc2b1NbQ8CYVOaAd7PHfZc0KLAlX1OgmUs2fKSH0JHmOSFxAAx07y8zCKw==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11593,12 +11593,12 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-X8xyuJdYk7mMHfrURVPdjKru45hBQVga2QdftvtSPcuX60EeEb2WKog7SYmF3gt0o0pf/XW+wCoBP9LmVefd6g==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-iJCJ933b8Tf6RffsjuPPBwBRTgbKmfWe40DaCw4QCSlYCb3FECoY7380MWZ4I1Gk/jbjDEgQWtvauT79KD2ejQ==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11620,12 +11620,12 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-nvrtCC0gT5hDrsa7nHU8brD1osiK+rHYBTExA0U8mqoVldZl2gNuemVW64ObLlp/o/wFiSuXkT6Cyh1Sfz2/9A==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-ZcE7yxQWqsOdfKLmxz3GvrotBFgKCc2DjQzi+ZmjDVmzgGxiI8zRuMV27ySVgs3V9OAirfiNS3Dnf7Rkj+jGjg==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11649,12 +11649,12 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-teUmH9aHvrxPKr6hNo/D/tByfI5jeJQkHoT8QVwZ6JW/Mct66oj0vzTU+Inzsz3PUPNWkGq/wAfm2jUWEfIemw==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-E1kKqBdfJrsBmlLhx40l5K5bW69cCRw1drFKUOcR4fhtm9UQMiyYOtWMAdnOyTY3ZUnivK9hgtFo37ivzbPMqw==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11677,12 +11677,12 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-ODxM4tKZ60c0NwZy8Qtl5j7TrVxM8z3mmqYsPfXJNXZmCo7o9t92Atw/M22j+9nWxCgizWs1BoavlE27NVyQ+w==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-zbH538xrIRD2gSN/RQYBcrOQCCBUu6o3keHxj9eJOJsjD3R4/KlkbC7viaCU+Tw+QWP0zZe2nzAQr81mskOw/w==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11704,12 +11704,12 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-1qHzxLwIYxqSsFB4wtimXB0nVKcuPst/y7vaI6BtiAG+rA5j7i0iqCaeRB/KVqWHHEn93V8LgEIwW/XiOC4Jcg==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-RSnkHSTQXihBHqGwR2YdEzgqgcDIjjeW2xrqi2EFi9S28mojWFx35loNAI45I9A8si2m5Tek15V7PJKyakRx2g==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11732,12 +11732,12 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-0VHbVn5spDRoWzWAlFRL09yBJtPRGHSTbf5py4zrx9CO2k0M3Mb5OTXKwIsy2UZ4GoXjM/15aibxLSjig1zInw==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-Agcv0RSMy1m81kMdh23xTTOanZdLqJlU/KL97qBm9Y/tu035SJRy4HYeGHSHAFgctSvJE01sSO3KofaL59IRYw==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11761,12 +11761,12 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-zzyxZ1uXjzfd8r5F+9C010r3Lh4jfSzemUiQLHyuyzWUFQ2cjWO+YCIyveZOfYdoZNtgLHbU/dYxa1NwlQ2HAw==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-NTBrKFSgDwkWau7g3TknfKPtp9SA0ft5+Lhno3iWr2ge8ZjziLPG2hLlDGIe4375pUz1eOzWebgTPNinF0Sf5g==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11787,12 +11787,12 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-MnrSKteJKyNwegElPtyq7xir02/zGRvHBa9Q1rvjHh1bSLQgQJ+R6eQnq+fNX2CVCnB1vZABxz8SyncR0SU6Dw==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-MKvU26OrPKpAlsqulHiLdXVXodppaa5WslnYdGYDq4ytDOrjh5pmjIgI4XtAr7LPnsI9Na0z3BgY5f5Oslf1vA==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11816,12 +11816,12 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-7VIPegrNYSt24czhBUcAXWz9vuaXz4cUFDCltd42h+/JY0lYmVWYl/g69VrKbRLk3lrDbltcfnFd/6Dy4iIROg==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-CM/dH2+ED99ARuQnhrKjwVHEuZDr9OLIvOgqr7Zmf2G+z3jYteGvVyzCHYoYFCkGCC4ZxyL250in1OANa4mnlw==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11845,12 +11845,12 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-5U3hr4Kz2LiWrwllll0CGx2V1LAgqfURZ4swKfxyrsU//oLJ+ZOydn80nGAWm50Y44wspbGTmAsqoCFfeQLQDQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-pqctdxbS2Hr18iy2TQ8fNjJ72kewym87wXf1KFocUNLIn9+FZT4zBD91KQyB6pMH2ol1SEv+rJIDLj/P3n5ODA==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11873,12 +11873,12 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-8kgTka7BV1vtdttLVWajSCmjXtIf5/zIBC/Kp4Gbm2g7sXET7THajZUFgE/OOT1Ohz2xl0X+SlgL0/JSjzMoow==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-B5uLRBMAzRvW2dpkIvNBfZYx2RhSu2g00zHIqaIJGLaasAbWAXSnjIz87ptQG2W1ii1Es8ZLnaA83uvWQ7XBsQ==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11917,12 +11917,12 @@ packages:
     dev: false
 
   file:projects/arm-astro.tgz:
-    resolution: {integrity: sha512-XGak8eZjIxiMZaPr/8xVBJaOH4YTc4YEA7K2S0fyqWhKaT21H7uUx/l7eTkyF3wiLUCxOnWFHPZp0GI6MZDX5w==, tarball: file:projects/arm-astro.tgz}
+    resolution: {integrity: sha512-tG3GDEF47vHC3OCarli+bq46mjlNjumQ2H4JY3pckxMtUC2mFkR+2aEgQ3FEI8nB+d3wgxNfpMzceSrpiq+z8Q==, tarball: file:projects/arm-astro.tgz}
     name: '@rush-temp/arm-astro'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11946,12 +11946,12 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-X8DRDDbvMdLR2meQUfsAIxDXacpIS1vmd0I3KHp1ZEls4sD2NY+qp+2Sj/CGjQqJVGZKiWJ5w+9BXEf73eQYCw==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-NBXw8E1Pus9zHm4ZuP2RnDa527IQeW4TrsYGDdsTgQ2WqcU0Hfs4imLcPgEsCDSlInBZf2jzkCpwh5Z9NnRlpw==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11972,12 +11972,12 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-MhRxk1jdtqn0AdQqP6n7vBarU4bqZtLdew/9AVrFV2hgzPxTAWyRfLXHXzOjmh2G9mz4kTC2n1ryQQhFprBmEQ==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Ci/iCzGcB6xeqKiVCKek2r7C0zpYGjXc+eB7pdmsm3qrWFBAKyDkLt5/fysR6saxoGRGneRrn43ilUSsKmIj/Q==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11999,12 +11999,12 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-j7Xoijk0oeOljdRZeKoMD4SwMhUeTvLMebVSKzFw34jqses+UzdETODziEEaM0E5X/bp1HEG1lEi8Hj9mk4ZWg==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-2blvY+zbxq4U1uk/v3yN3xfR3Q81CkmHIjqTKnU37sP9AClRzJTp02Sl91oQv7G82N51qydw/3jLwzGO5n6rCQ==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12027,12 +12027,12 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-7zrcizqaRNBhTj4XT0q2aEO7NmChramsHfyfdxSGCmCLJRXFkMIyQ0GQ5FNikIunarM0O+RL1ZFAbm9+WdLRgw==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-NMqDiQwuWXD1cfI0vs2sa/UYpH8TZ0dgeyPyjk0hyrcJfN5r3mYTBIMDs8HNm/HJZP7yb+Yq0dnwY4RboRjJjA==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12054,12 +12054,12 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-xQEEYH5n5VwUbGPfzMU3beLYCD84AqTz1TqVK3+9BHFYj0O0RJoHhkqzPdkyjQVAjieBgDLmHVxa+8+z+gQUdA==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-ojW5dioCG6uJXCQjYGJQWOiohfcuT100jHPHah+Pen1nyLlhdLd9Ew7TgbFfKe1uFJPbHtRyfvm0qBNmMDKZrg==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12082,12 +12082,12 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-igWUitcIIs7ugTFe3j84K8uv6920vPgWQlNMj3I/8E3PSHAwDe+6k3P5pHExJmUqYg2MmnAOIlw+gQKcypjSTQ==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-3ACLsJHmG0L6rv1/y0ESEelkUcgG9p+tCtZ7IdEzIgFtaG7LQQWVFXp1AhLsjxkYdrl6tIk5SzTOaPqpiIxWJA==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12110,12 +12110,12 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-bJCa5B23EWAq2A7Zke4R/hL/4LQQiDMI+scAZOXT6YWXKa3b40jH0X6bnvI0/CBHwUd+1U/G45iSuKGLoQd0sg==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-v4jDVCHG3txlb06lCxrovN15MdpIyNabWhW2dvXmRdFvXZv56dKaIl8dKQufcuHQntYNw5sE3NB9K0/UnIQuIg==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12137,12 +12137,12 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-2/IuWtpfuPQv1MDv+IktAxe5+0sTsjQzrCOkANDZCifZLn4scUS+3L66nwXaY5Gdgiz2QSJbVckQNj3ADkLC/g==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-u0whdtTXboWmSkN1tmsn/EWfKqREIecgEThKeLaHcJj2jVuz1jJ7DpD8x28wfvkWLYsi/ruvM9vbnnuwHBoW0w==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12163,12 +12163,12 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-qGDR4HNdLytdqy5zX0a8kew3jTRZxdbIN/AC0sX3FUoSN7De2ln4phdBf4Ned/xMY6rtBkt47NYFZfH/TUYDFQ==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-80s29VTYuDvQQxqaMKro4PVMfo8AVtYoHEoS3kL9uMAVv36yLJcPsGK1niRLHxAdlZOH+9eDELJ/kLPqcFMvqA==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12191,12 +12191,12 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-Tb3N43SpX7PZ7Kwlp1DUEG3KKkutgUAbLa6efMQecDBt0Ikp4WyAeX8btzQulGUYsBVKIlrP3Ae3rmVrw6e+hA==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-WKQquTVtG/ZfSqfHym0CpSbIIOHEQcHJrwm3HiiD2+JSdfbDjMvVsfWbC396Nhf+H883pdYONjjI+rbTQoHX6w==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12220,12 +12220,12 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-1bpVcjcNj8eLsV/ZELn0fJJpK/iIjjc4J2clmjgOMF0CJU+Jzxoavev/Rgl+Qb6lIvyjq2pVOywD5iOStFIz+Q==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-jd0d8opiSO/eldATy+hUW/FgNJJT28a1oTsQ06n791tJM+KZFdHppLv1P73VzFyaGdaIkeYKcjgJ7lYR5KNAvQ==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12249,12 +12249,12 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-82b1JiNgOrxZnQXXYnUvWaos/8jSvPlSuL2hTCtFtnN2X/i45sbXvSJ5GmeIKeaO/+JteKUX2Ya1IXOCO5Evkw==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-Rddk3Dd0Zm9IBATQksslqD5UP2UxiRGw827aHlfD6wLAvJpQZixXzrRXZ3FiO/9ulGkvoe6+EmD875OxYXEMGw==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12276,12 +12276,12 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-P177uuNW5FlFKDWJBZPLbTPaIKmubiMHMR63PtXnYgKfBsyZp0lJ1hoUCjvyW/tLFcRex+J2nYZYZSGWF71v4w==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-AiOKCBkb5VAEvUMjYm8Ar+2UVSR9UeldndaNiYsqtZ/jsFKcDkRVGyTb3XS3feJ4ByFqWMcWZJmtoIpKkUl3SA==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12303,12 +12303,12 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-Y8EXPOI8zrh+YSlBGpK8oOwU+A1akeUIFg0Aae7GJPl3K5CWveJOe1RA7Ob7ywUiBs1JIiUij6cO8T7SV17RQA==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-I0/flO2fM1bt/ZfK4Sw7iZIBe9adFW+I1f5gqB+iI3pmepsAcbsD53cbvXsSFgRnH0BPXUtd4cPm0aow/jQmwg==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12331,12 +12331,12 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-WfDkxGb/1AP1fP0G10jH/uMdunTTfauhuX4gqiGzRFHb7cYFgyepMyp+gYkJWXq1lYWhLXLN74azJksStWiO8Q==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-94XfxcP4BgXhHXL2tNWu08KTky5dWOE+MMZkqKlAHb0OdkY3QwIA/y/uXxSV0WfrazPw3YwlLuTaJzIwVpm8oA==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12359,12 +12359,12 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-+OGGKcl0wtg+SpO5VGHUIiwU7OsRmVNJ0UuapZJHbTlVOGmahfkN6o583SrC9shi3KXIYJro1Eyz8gGVuCMApQ==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-FcPi5rJp4KnlHQc9SBJaXd5fB+7QPp2j+2mW4OVdBm4r3OSJr8q+9+RZEe09/GUThUHJYIjg0eAKtPAmQTPdOQ==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12385,12 +12385,12 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-qnWHTWRyN4kNl8E55WUvZOepvcm3J993lQTC4Ca3Yv0Wu8Gz7t8JsFceXYvnUrkkLDpoq0gDb45u1VBYM2x/iw==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-GLM/wre7xu8cl9Hi5EWMFlCAVAoqEtD/j7uX6VUfeKfu2DYTwy7gTLyLIFScWvYLKdtS8+bgERkI5elF8UAQOQ==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12411,12 +12411,12 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-74+2T0eQMySnOjwFuVFhWFF62IlOER4WFqlmMMGImU888N+mkBpYXVBAA07y/fQgpi+GRq4xX87Natqt/ZZ4kA==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-Vnlr4S0MCYW3+Q/n1esZMrN08ldIYSiQgRdqLdERhs8/JQ2enQwFRaOTyIv7y8oqlyqHsSTslqDci9SJvVD/tw==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/arm-cosmosdb': 16.0.0-beta.6
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -12441,12 +12441,12 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-CgDgK6EOBbiQ+Twt99US1KdfWxsXZQUTjnkwuIueIt6XBKr1XlOgPVCQdtWIWNBc+fSB3gtkQhnQUqYg0ln9ZA==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-hvar2heXZNEhFU6epFa2kLq0qxi9SDz+YwYEUF+L1QS2S7iV0cKaGWJ6hj+iskqgY27UF65AcusWGvsHx+cfBQ==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12469,12 +12469,12 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-aXnmgOdGk9cDTX2n/Db4l9iQyANleZG4H6IpGnIcLEcOJWE2zshAFKkKe+QU1pdDQN7hqn3fGoU6yWmc92ZGxw==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-hfWIzRVT79ofPO1mfS7ScPCL5gYlfN1uK4WQZ+cRwzieRtXwEqBDtCDLh6j7I6wVxsDuCitrRZL0nuB5m6tnPA==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12496,12 +12496,12 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-lCwfWhheIIBjgi3bDrdq0OOlFLeO7bYweuczqOtHDJxsNvTDAPC5a/mWFofmedCaF7Df2p21DK180OP17bF/Tg==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-EOW7BcUe01acgEtug9KSHtY/XHztBzYg9qviD0QT3261CXU20+xyk7J/17I5D3xz5nj/QcaAtWuJmFGgAG2o8w==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12522,12 +12522,12 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-/BM239F5/2Fzux2X0uH86tz+L6u63VF63IksC0Gpc5LsOZ2K9Q9W0FnZkYHp8AyZd30ERrgkNg7iXxscsNA7/Q==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-CksJiFB+INZ+iPW8Uty+d5MTqL+uORqHXi2NWTuglkNhx8xBNvdwnDwZpPrTfcvbSxJSsRgaEIHI4YTk8icNFg==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12548,12 +12548,12 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-AU+rqXmyCKI6DbD9nZwT9ybRtQXckvHzAf8xVumWwDIvePHv9pmh32GFTU7G5dpdCfiTaotQojT6CWa3BWeyrA==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-R1h8zR4GUEIPiVb391CFpUMEL2HTaNaFllq8KZKbJF0eTsNRgbZmxui7tkSNQkPB5IJsx4PCYaR1t8GIqkUNVw==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12577,12 +12577,12 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-Sw7js/mwfJcr9xXFf91D5A1BWYm+2LeoVc+4miwZo9lM4rnbWfRxdBD5JjfDEyB4tDHhcUgQoOaoHOrQY7dotw==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-zXz/tstimh47CQHNZ7Gz6MjDmHtBrS+z04vnHkqHwiINSTGVQQ1/Y3Du2P71PsreoAk+giRlDFHBgoN/ONX7NA==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -12607,12 +12607,12 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-rgHNWsGYLtiKDHhAxntycm/v3sg+BZHVB1pDFQKBoTbJDRhwiZLL0slVpRxnTidIIVQa48Kqij4WJm3mD+RCMg==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-uoxt4TjRRiEFJM7MpMpmvmfTp8rkhHPctuW++vpShfwNIWGD8gz0fIp8+tMVJkoyNDqpj0hFqewGi+GtGEvMIw==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12635,12 +12635,12 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-6XBwpWFuis/26vD8Oc2WnzfhZarucZab3W7AkDphWqtqr8UuTT4LICs0Uo/mJeYX+UzTQELWerXMqSKhQVOn4g==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-UR9WqhDjUmtYRs50KA+TGzCpFFGT30auCqUF3DlgDLXQpeXs86Y1FaohQ/UntlKn/IFiCdj3h50ipelmnQO0iA==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12680,12 +12680,12 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-X+cqSgFY7jg2gO2GHB3LafqRmBXPyxNIAy2FTXWcATH2Lo7EGgGj2GN6ohYTZqexxzBGrxWgNDZv6XNZzX/BhA==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-50yoD+k+60GeyDszj63tECVdDw0mIYMeKytG0DNA8ecHkBGhRw/tvkVBZ+VGBFGZNGatFWdfuZi2n908oyyCQA==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12708,12 +12708,12 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-VKJ0NHSqdx/KhWX4m5GwPWdly05tJjz2NtszstIi3m0TTTXmK4K0+RUseKLAP4H8+g1NTjOg25T52EBIGXfwLw==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-3wnhzXfMHO796iXIqruAFtTZIOa/Z//Icq5w/Ty/JlWsHAGNWOM9VuU8OV4J4ugr04xwPeGm8F6EBsw6HyGbhQ==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12737,12 +12737,12 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-IJ5cjyz3X26qrKcx9ciMBFapnsR+hvlqj3gyjIkj9Vhe5IrvlPuRlBeask6AnuoGpCPKJgEY5KvBTOd9wBzreg==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-FcsK4YYaNfi0NYkPLGCj4L7isG5x8IcdwQ14MiXMBl2kaG5LMr5CVfU+V72ReHnJg3o+wT4+AsqV6k9VqfVCiQ==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12765,12 +12765,12 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-fSEVj7a2ARFYLZNMP5npnGzX2D56JPUnCzNrPZwVQeY5CQ2I4faB6InEVXG5kXbTPJO9I7tvDhBK4FqiCqkTow==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-Kfh92vL6QUKywB73WrhVdZdJ11Rk9MPx2o63vu0LENep7p01QRyZBptwQ4WdCIzA0a+TtNxlPvCWAAoZkmOvJg==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12792,12 +12792,12 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-qpLDe8jdyH9zAnSaQCh0EvQf2WpukSJf5SOMRz8tXdjdBfV/Spr/Rmw0+4X+NFtVGQRwp3w9Nfa/if7NPU4G7w==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-bLValwUei+GFj6RU1QFUgI4SZYs3++0sIoXENNLNyAdCoR+5g2u5f4IjhC1cJKMDdd6GtUPqzrH4kfFLtQJCUQ==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12820,12 +12820,12 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-3nbgahalj8TvXD4Vlp4ekpWFD/ksl+ttZXDmGxu5aBi+qLqQKhkh77tw8BkN/utVSm6vMWtWPOQO9cDhu3Pkyg==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-CffE6ACd5fVMN7LeRvtdf+pCSVf5f48OEmBzm0SWoGZB9XGQ4k34MEwv/EjYQ4ZCk6jtI8yGalB1hSttSN6kkQ==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12849,12 +12849,12 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-y53d083FjFvS5Ylw9I8fa9+hR0XKZj64w9STzaWJZXo5RtETX9ZxgTkqE9Wfk3EEWyzW5DmtmSUpho8DElsiJg==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-NNb8RAIhvQyfr+Ne8C27FMRh3K+r8cLapD4BmH3mrOFVL2m57hXFmqQxvwXg6DRullQI4S3rg2EmSOLi+zYbuA==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12878,12 +12878,12 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-dfEz2X0jOqkg+y4gv/JlFWjALDh+SlBxZ/abyDhQUWu7ucsJpca9FGlYjtKlgPWD+sSbuodH4vi80Se6z4j8PQ==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-alDKm80t0K9EZgejgCLsl7JxMmkOcjYHy0S/b6Eyc6u6Xa1z9BhOISQk+isYd1XHTzjoUcp7JXKWyyzRTm3OBQ==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12922,12 +12922,12 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-dPZIe3+4r7yxODBOy28/vscyxS0jfaGTNGxKPjJ4DDq46Jx2Vdxg7ISeA84+DLTMkQLltMZXGotU/plSpdCFlA==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-Es9+UW2ske5KGapP6QRHBdDyZRDqmvysJWZQ0gloCDFlVoGYDlHMxQ1Lg8MMdCDIOaToPlkyJKOqOmKgFUJu5Q==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12951,12 +12951,12 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-Ys75tw8vGg0nxa4SBrbtnMEB8hZ3lWnRTKOc/Ei/2f8/06rLq2iJ9bNExDoO7j3m17gD0KYDo5EV6CvJHnFzFQ==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-eYG3FyOk/iCLvm0y3dwK5+Td1gD15SazSFUdomrwag7zEvgv5X9u72CAtqAfacf8vcQTADK2F5P9N38CuhA29Q==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12980,12 +12980,12 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-ocN9wPsFz8cFRNaKp0h+pFtka+tvRjbjfzY8ldbmWwoU4KWOB0FOkMDcEBcHmIF8cmB/l5wJhPBp3cuS+3tCpw==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-TPYVsK0KXojam9U5NVcnp9NGpX+Y52OFgRDBwV8uGjKsB+TazalNlH28eGJWLv6DK7PX5Gwsry8XLFzcYhvmbA==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13009,12 +13009,12 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-CqVI41qdLHTtdr/gma80hWApGToYKN2eL8OJRg3s8Gj8WWHhfI8VH2lIpNEAXhNVdMwHog87LFLn808tV0HoTg==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-/EJpILedDtENNb2uGGB1d/YchlS5Tj4ADJK72F8BYjgqZLBsJqLj+DVpIkYqYRs4vt8fC7VdPcUpxUFiEFD7LA==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13037,12 +13037,12 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-JYY+riGwSlbFVw/9vs1zwQ2xuZSfA69NqsypomMznIRShyJQGJox73u9HZAe0p9gcJDs9CvLJtvJ7VvzCT7YSw==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-MGf8I8NToACB/HmUCiawETAH+dxh3be5g3pmlz/Z+EnjwFCKpOc8avUdZLEPorIlRdlR3mm34q+2/GQ4GmpOSQ==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13064,12 +13064,12 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-ZYk02NCJ5Ll/tZsQ/UgXcMIiSJgtY4hxjY01dY9u+PwLQilliCRMrX/O3sDLszBjwFkw/AqlYtweQyX/sgjanw==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-NNtKquEM7RQCkPYK7267E00V/kgXffDCK5N8GGSqMC8HsOsxqVpSw7lNxPpP0XclVTPqxbvXfyxVcFurRtQM7A==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13093,12 +13093,12 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-fwS5LeZzDi+lEbZUjQAZTYytBtsakeS7TxNHXYnGyHWlm2DANXrUvO5fdovHKJwiXGxqQWprzefmcSNFsl9fIw==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-+o18jvH8SmQi8DWf9KvBHXty8key1YNkNB8Ok6ZSgyGoGWFQxXKozU+BusFZ12aNmzKINlHAsV20xSNv+4I32w==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13121,12 +13121,12 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-c859Tjin5UkISsX/xex0wmjp9SGq3YgoxdRNlZnTzlh5YoEGJGtyvTyJi991+w9RORVEebTogGw313guh0HZeA==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-H2NzA+I/AgInprMv4NfnoUJC/iQZXO+6BhZFJ1V81xeG52aC95qLETAGZatOyoOhflUaEUGu0+N63OMTUhOYFQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13149,12 +13149,12 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-XLWm2azN8RXFuvvRRfUEZJjSCllh1pQEV7baCd8qJDVYBoMkJjCLBi3gxb5809gZ2l1ZVWeBWPMnjgm6GaASDQ==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-CnwpFCcLwwjqwNsyz5RjTVcvCmuGiUOrlsWURg/VoiTGAFyPRPUDZO0+9KUvRnLzSJAa+6JU3zIiLpO+6Qx0Iw==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13176,12 +13176,12 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-HXYnpRWbZAc5tYDAK01atqkfeXC/nyrFbcwr7AuB50+v4sQ99BkP0Px/wXwdmI3otinPOkQ6rKtsG4UvQkDjOg==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-LRq5IJasSEtsataIq2XPTgE/n8z8FZh7rzdTH1R5ZRwra1wQmWnJbHvX6Owx2wWo2ljffE0ZAgX69ITDIrfqqA==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13205,12 +13205,12 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-H4L+uA4D/bTZgSFW/VLCD1RIsCQXeMMrAs7A7l4cGzebZOJ/EA2OJyTZdlXO9AzJgtcOGANTC73CezZ6QcGiJA==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-RZWTgsDQu224yqc0lcah1luSm+ivKp1dsowmhRGaHZyykInlSOL8FTzDmfYk0BdGcfoz1PPOpL4f+O1/N3al9w==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13232,12 +13232,12 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-P6a3jufLnQ24DdyYN2wquo1Io5WObns7p8aimTQlMTX/boD7Za1gmXFFmDcXudTHG6/mgn8bULHkPj9ET6UuzA==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-bhqS10D9XDnTWU+HiGWriB6FFoJhyLLJyC/phjmwpAkGeTbvTrzp/vXpMHqYOWohuC+8Mjo/xpd2AC9MR0j4QQ==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13261,12 +13261,12 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-SNGpcpgSM3GMDp0EHwJCKQfjBMfXIpTjSUfe/GI+jhg7gyLrNJucRNZvS3dMQvB91yvSRH+cytuBJ7DKnEeaOw==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-jAZc14aaUmyjmq1tKKqkn4zQcAHlrH86WeseF9RWkuUvn92OcxNn0s2OEJmE2ML+jrj25gF4SFFWGjeA8daFrw==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13290,12 +13290,12 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-XNQF1KeNFuFOrxTyFgagddQ9gUYbKoM9FLVLYo9+g/vtyTwc8SyML745L6X4v5dIFViKUxmHkXddcsyZEXaxBQ==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-1ZIthDvyDMeK8+bUiLk76as/Jh03nVUsje+LOQIfPiEk8qIphz5f01ZZKNn/wMPjnTRZNoOYdfPdkRTsM15zew==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13317,12 +13317,12 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-fFnGaVVstaDjnYcm0BY49UId9IXa7UQJzKtqKqMT7yZT2JJoEvTJ8Dr/CL7G1BnEHfmENDJ9cGZPfvH3J38Zpw==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-wZWvpjb5OKc5hMBFQf9IHrjltEiQ70dEh6WIyTXzAnHssBaOLwTRfgMpg3QUIRq2R/DiY1KS4g3iNjYbGAD31w==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13344,12 +13344,12 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-m/RIyvqKXxnv19eP7as7ifVvP/Dzh+9VdhnWPM/XSmO5JY7INPt9v+vhenKhR+csOqM7vZ/4KL7r0Ssc9t2QtA==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-H9Sske9zt3G3fMUUZi3UKLTM1mFlf6ROLkWdSX1eb9wUZ/XafJ5qnizUM5PugnR2YrlC/PKjBnj+9Ey3DDFPIA==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13373,12 +13373,12 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-5YwEIlv3VBxAn0o6RPrII2A3QOMHAv01nhfzo+LTKieIc8jnJtZJnRlGcbjcDPQbBXvwnXWZOEqs/Jqq74JYQQ==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-yRGFmHsbrUJN3g708M+MVo2G3n2gIakAUmpVzS+Fv2pnBifvUDxzeMHqFzudLyzTmVvA2EEbMlOZPe3C5yKEXA==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13401,12 +13401,12 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-HwJ5x5kleRJk/C/Aqqu9vIasyKqDKnPg5mZ/JKgNWvbR4SPbPw+1FBnP8A6iqrHe2LIEPvBWPmHMd11GCO4ypQ==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-afSQbZE//EfJiNPlt1qP62F6kGRsL+2jalZjoYB5ZQJ0sYzpev4tZ3dVKJapFSWK4SqshWXZGWGo9pZTsjRJ/w==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13428,12 +13428,12 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-SjcO1PU+IxplYla86Nwo/aewA4/hz9NXH8g8swBjv2iW8mvRI26IUm/ydFxfYZUDdTKsiV46vZ8HfH/aStN7sw==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-jne5vaSQuFWwDYGx8qZJoSzbMEaqRhz+/LzJRXXa8vOMqe9Dllvp3FdTDxON+khofnS61Vt9RsYdXHNO8tQeHQ==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13455,12 +13455,12 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-YDWwSMLC4rCQcc/pFT3BllSvXbKhLXG8N7C/5fNADDaxrK29ibzNNDTQ+BhSRODlRlXeU/QsRLg7SQRR3RHq2g==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-qu26Y1vkMROazvU56L07Xxkqf8+A/8lJj8xSqjlWsVYx2HSHvHbETVgDPIJwTGHBRw8ZTRHnOgTXMNjMAke1Jg==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13483,12 +13483,12 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-L2TNwBMWSSNvS8WNuMW6GZp9zehdJchdCNZSvL9Ohe4cvRdqjBoi6m10QsdOPEjhDW4OYFSZl+xpQcpH1uHyAw==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-aO7b6SNbCZMjIqGaXCWiZxTGxM5xhfTBxF0Rn6xRS9Rheb2BLQIcgN0+dp3TGmXXGvDbO1zEY3Xx/lL5Jgkz3g==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13510,12 +13510,12 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-bLZ1MXx1IJbn7buN28bzbKfeT2U53QAslKqzoQXLfWqsNnVxJ75o4FaDfF4/HDvktLK7gg5Hj0iqY0BMEg6dNA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-//KlxIYqb5wuA8zOgYlNXrxDULa3/UpiPgz5xWlGMgqRAi6/1zTa8g0oCUvcqD6/3tjIzyx3frHWyBUu7/oTcA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13538,12 +13538,12 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-elvS89zGI1i+PT7k08+YHzfklvTfgtsh1P4ns4vxSEpA+06xVG6HN0CkisdBG9VLiVDZ4c3RssYRWCJbZvWFGQ==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-jxbXnR9/sOFVCMebjJ/F8NBOG94eJp+YvMh4DR3jBAyorL+MMa9WPbErfEe91CLSQcOTAZKBfgzjkOdg/BeLIA==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13567,12 +13567,12 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-OceweADP6fB71EFAx6FufCGvvGwoEGJ2/JYlhH5soPwk27HwZ3IUyVpOjV7JJjB99BYAEyOg3Tfh9xnvIuJB+w==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-E9LzkbOZ+E7b3HUUncya76sn5y0KsXhQHr/H3+hBk6+cXGytAzBeQkFggWE23dW/yro2la20kjGyypPjcx9boQ==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13594,12 +13594,12 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-aX46lL6I3gM97TObG9LidxpX5I9xE34/Riat2z3T7P+wojfhVAWfSV91a1ptEnps5VCcdNuoPVvYIn6bg8n/pA==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-HaqE1Uw1TQTF0u/iJ/FB0/VX9vheQv8cq8N0StPUSvVjiogatp+VhVZapxuAd1r/f5CUUdLflgluB2bi2LPPSQ==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13621,12 +13621,12 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-/GGh35ftkR5hgeoo5tIxBybPMy3B511CHaXe8qVZeMs0z7kdRI2wo0Mcxu7A2+CNL2ts3k1mef1ooOZtwMFSfA==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-psGIJ4UU7gLomcepBenxeyL5Hdge4HJWoAepqrLlZz/DSbQGBoApQTKLgX7rZ6TVd2pW+dGIR0UT2jnrJFyGjQ==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13649,12 +13649,12 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-oJHIjMIVJV7jBbRH4X/kektX25k2V2u68a2f1tzh7ib53BK4CKzJzT+3kBZY69k8gq0AOzur0YP/7umqqifgWA==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-KV2BUtrdUl6vTYyIMy8aKSYiuJbcj7zkZHfYnGs5HrHVq53IQ+KOK5wGOPBKuGpN3YyLBu5jf/cphOju+uRe/w==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13677,12 +13677,12 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-AHdSJGm9PwGTC1p5v0GcNamfL8oOOrvNRmijGs7AOL19+98P0j4Wwbufdz6v1gMayuafwxZQp9bE12Fl/uYr0g==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-pgAOvWBYyL0pu0u4OMAEbVJ7wciXK+owrDNTb26zzTJZnQpJA8e4a6QfuJ46HOr2f8dx5I793wRwkQrc4aJcMQ==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13704,12 +13704,12 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-+hVod8GU1JfR1AxvP2BLdhf8Ji9+AVhmUfLBc6MpoAwCmIocZd7/a+BsxlYeleFhPWDz86lgMxyir2SM5qYzzg==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-brRXc3k6JOzsm5Az3onhdgXkY5qmCeLSDKlPp8lDjeqOsCnAnQ+Kx005Fw3MbQsTAB4QgwsRvFnBICCFKTc4pQ==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13732,12 +13732,12 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-VGN+Njy920gtjNTOQmwTvLTBwg3+ADWjaUv0O/2Xx/Lm/VzeXypziNkOEP2mAzrrtGAXOTnym7dM/1qhWcO4ew==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-D7roykZpef9xWWZOT3s9/QakRdxX+3QQuCShKEobNuldKw9WcM8XBrimrnOsviv4HAg5evbGhAOdraLFaRQ4eA==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13759,12 +13759,12 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-r62svZ9z5j+VBdiRYg2OKjAOujbmYTz2E3U0zPRKFnhWH+NddkNVbjAXJaAVgDkPCvMk7jxiPPOoK+mz2mH6zA==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-GSNDZH50sfSOsg3aKk5VUWmygBRKGVnk5GIjeuvexycokmOBxQqvXFluekf9k8Yc64r6x/RX3G9heTIhbX2dEA==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13787,12 +13787,12 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-2JY+2QmKtrIkhmf7UKYi1re6BPz7cpC3vTSoClpNkt4qEpDgl9vcdRV3B3Tt0SaCR291XRORKe29ozkASLcuyA==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-C2pSjyXADZsSxrgmtM3zrUhxXdWGyVpdTilRTtcOfEwYzIBRLIh3FcTfIlUUrlGfhDE4Y10LqbWIdJyqS8ejMw==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13814,12 +13814,12 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-lYFE9dZ3w8CAVg2zt1Y9h/zq7hnPbVW23oGEuabfVR+XGQLOTK/txEr0bCdCDH7nkuSu49/reWY9MuSS6GKXEg==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-2G3u5R2pgIQl1PDlYJkg1cwI/glC0DNzoB852ioeSlVnf9YUfO9uu6icmSihFYcC1coIFEIz6p4bzqlpAyUd9A==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13842,12 +13842,12 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-7M9KGcGSUXB4ldovzO8uuGSGYaQd1PbI9zuVnpOqzE3eaLU0UQGMSqjqT7jKt5MyIM2h+MW13/P6t80dbHxX/w==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-jC6ySQ2BA4oJWvEx6os9bGrPTct2nX2ZCL1XlQuHXunrvngEp2b4njEkCXSdAb719qHnQK7LL1aka2MDAoUNFg==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13871,12 +13871,12 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-Hh9pmoyBKfhcPkTarrEpKjpZXFR5pT5Gc3To/aKL1cIMnqLCqojDl3fjEgl5ru0zn4JpnpOWaaWOvtJXwGRkDQ==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-Mih5bJ2xClbZTg4enN/Jbu+Nx5NWWALhbe7km4XitFNP728Jxft6TisHdENcKsTaQA4pnIkhadAVTD0kE4Vigg==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13900,12 +13900,12 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-uj6ZPiqzpbnSIq2Hh3s2C3UJsoVOy0K6FH+HXMcVOffsix3MFbt2YeKg4YLlY0OU036cD0eFoRf0NMbrkpsInw==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Jgd+wb/JPyzhWpejHnjPa8Ocbz5OFT2t0UKuYpDdOsha+rH8kW1vkUOinnj92aT0Tvxe1I6FjCjEUddM1tCQpQ==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13928,12 +13928,12 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-0rRqOKrkEGSSWaBDeTuYNtcqkwp+r+fvD2C+c/i6BesIu61/oYRqoieV7mpo4QGyeALKkbbGJvwMSW8zaDnKQQ==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-/xLdE4thwCx5NruY9xrnJHcrKmtkeUoVYxb7Yj17NR5lixBBSfyLf7duvflidh2DiYqOKQRxiQl3eGbxTc7LOw==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -13957,12 +13957,12 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-SC21QGbnnPx7BJpNcp0PfV5ntHcYjmlvETMyEZLMDQcXU2IuC0Qh94B02FVjH4y7iGeQg2cC+2J9eH94YpxpEw==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-TqGWj1GXe0DtYzys5ZFrVrfi9d6HJEx6fbdvWHjZkaDnPfeQac/iFHh0iNMZWOncVSDim5KTq7PV060h0a+zyQ==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13985,12 +13985,12 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-mWHCK6nOetYir8mdwCkRYXZTbLd5vVbBke/h0Wpf8XIVSWNzmbgN/ts0WwTSRrRbviZsQov1AsvUTOjv986ZTw==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-Q9aKexUiv64lWC2ANL5cHP6VnHnn8Mrc+fHI7z2q1TNPfQBdVSzQjc+cZx6f6mMCp8T00WCrXLPjymxtOW2q2w==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14011,12 +14011,12 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-wrYhhP1ZRKro2EyHyUQY7jZFRv8454FV72Ot27cGmMrQfyaqcjfsqK1Od/jrUdLuSUQWIQLwsbrhftmssyHJ+A==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-mZkFLWBukA089pT4kL/NDfywv+zykn3MUgEI4xMurvbynQw66oQycxFK8JeImVjQhG4ehy8w4Apeyyg5YNpExQ==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14038,12 +14038,12 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-IdgTcu7oawI5XoDyXNbPgKECG9hSA3kk/z17R+LLGDDMt3cRIEul9P/uHdmD2I3vDRZUcxD8m8BfRw6+RmGT9Q==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-L7I7407B8of1nk2yidaCFPYfvyXH6dUgo8A8fUGoUTkF1Xe+z8EEKyJN+rzYhVZmHpsoolMMWCv/kOk0GNCEEg==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14066,12 +14066,12 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-D5EhicmIkhZqVhLD68+jxT0xbXFgTUJeJnxb+JTpDfB81d5yoVp+trwr4QaHf1WY+4rCcUGY2wTzpkbc9e9loA==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-PzAUbTKusXqk9q3sUMedU9K9adXFN8a9rzatJOvp+XeUMxfrHY6nj6a7OjrcOPlUVLsZc3tIoVn5mGY2imzwYQ==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14094,12 +14094,12 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-RXuMxGYneFGjxJOdtHbeFsqz9sNXdgG86lxfwIPZ6Jaw5LVegY7VtZ3jEO9kNkO+4nKYXt/B0Qfr7tV/MMcb/g==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-Z0a5Vv3HJucTxeZufQhyJR57sJNIrQOHJ8YIz0rsBHlQph2jOmhVjYjy6OtD6AhdWqGJ+40ZPazO1oOwH5be+A==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14121,12 +14121,12 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-uRsfhieFZ7swR9Uq+vvTAUNIsvWjs/jU5PLgYm5Ddvq91/GaOsi9J7FLcLFFRJFeRkbsATnVkFTI422JykNpPg==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-OK9DLEwNFNtcOOvJx2Q2Coxkxl3alt1F23CmKlb8jL5ogIyfYclFz9+0IblFqTY43Us7rzRs30Z0ClDwHO0A/A==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14150,12 +14150,12 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-wNAwT2ikZnS2b4+DUVYDhaYuxJjMqoB/m3mBKn2P52RwHw8fP0D+qRAqsUfxHvulHb+1QurgH4WF1L0frDUFRg==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-rByVXfHv3818Mb6kHOdHZs+PLjJhnIYVR3nKFekr3Ogi5UREIYqAKFWJOP/goHc95/gJJlP2nnKJVJ+q4xpYTQ==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14178,12 +14178,12 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-8boxFFFXx2+iRy8J31+aIMFwws3jdUvoefufZ9WtDC+fuVBqjgKQ4oLc6XYS0RnGiqST3ekDIbomiA0HcxG0wA==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-+fIK4OLOaouK2hn6NKkUcTfdcp6AU1Uffo8Y3N9Tg94bZJkPPADWOe/wVOS9/VcwND5bZGi2VTSHZy5hdT6L+w==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14207,12 +14207,12 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-6z2DNvVeAaXOaDJNhOKQOk5xu0DNfMsx7XhQbEBOgTQ7GFBt6V7y7PVkHYxkmDSZoQ575aVQb6NZG+Y641lwGQ==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-CxQKH1b37HBGe2yHXEnQ7YfZQdHraAQpvgKwh4diUJVJXF43/3gvvaIkJb8pn5dFagLVRZY5rbc5BOdvEqSzuA==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14234,12 +14234,12 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-ZPL8+8dhvrqaoDfwRSwhiPiJjKonfiON0V+2UlNscNyQoO8l7bXdmmxp+KqEJJYCD30OzFe5zTvyTNzyD8WbKQ==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-2fw94RRhcxtUpjjCi3ztIFndvnRGtqyp/rV1lHSISO2OjNMMAMzK9mC0v9RGE+c2LAzE0eFO83OdDMTeN11Tmg==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14263,12 +14263,12 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-+ZeWEp0kk8BaZK859yfokXhensQk3SVX5raHH92SQIsWFoNmi6os1SwA7RZVcH8x1fmSZy7W2GbqlPkMGNmkkg==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-rARkl+9Yh5Uogjzj555LZ9D4/H2/7M3HDZym0S8WkD2AQW4fpO6/NjJCca3SowvPXDolOqySrA1n/YHZP5KGHg==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14292,12 +14292,12 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-xrobkfTY9YYxW7AgvjMnQ93cZ3dv+pc9TZNDRcQupRVWA9aI9KY+mbkB7EJFso2D2rmY2Tv7c8gjRhbQyJZJ+A==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-d6kS1PrIIJeLu+18DXrxLEwHcMipXeOY6RCE30eJc9axTn9/zaM3rnTcXmu9+vZ1Pe+nUCdHX9oxmjrKnZY1ew==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14319,12 +14319,12 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-zK3zAW4KHrXa4VraCRuJnVLDvZZk/OVurmO/beaf4OD5m3lEt6C0x9kY/y4Vq+qFohiQHzDOf2YjeREiKe3AFg==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-y+kLfQtGulQ9t/SN3vqdIlCBNBn2la/eaexPJ8xo9kNz+1oiY/m2UFvCYUOu6788lCmM5zCKqu6OYZ9juWj3FA==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14348,12 +14348,12 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-ThhPPomp6ZltKTlOEUT5dpDj/iw20NCN6QvPZ8lqI9lTl4SS9xqn3G6j91/9Thy7aqhXhM7cuK+gXw8jiOKP4Q==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-fKWQWciEP3//9r0ZPU+CKoX4hrWqr2++ctw0iywZJhnyx/C7imDVuobnDPnZBSIkeO78L0YDjpv15mpJNIrFPQ==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14375,12 +14375,12 @@ packages:
     dev: false
 
   file:projects/arm-hybridnetwork.tgz:
-    resolution: {integrity: sha512-RpAqglyx7KG2/agKqlJUweVbeF/eTYdX80PM/ap1+Zs2Lt0IBhR6ooQGw3OOKkLcJPm8w1LxxLMbers5to5RKg==, tarball: file:projects/arm-hybridnetwork.tgz}
+    resolution: {integrity: sha512-JAKX1Gz6PZKsdwgHXskzzRvIhMVa88hWib4JVRfdQ4iFkmJquwcxepFCZRU9n3d69SXHRGf9+ZZ7Mf2gTgRNmg==, tarball: file:projects/arm-hybridnetwork.tgz}
     name: '@rush-temp/arm-hybridnetwork'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14404,12 +14404,12 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-b1xfrrs5IOEd03u1wAPNya4mGZAMxM2Dt0kQo1Yy3PT3lAjzpU1mR9Wot3p96IlO9Vy8WurQkRkm5d/q7HJsBA==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-Umcpvy0s/VOXESolMvquGrWPEizqR0LInVuVKnhZ0pkANzQcbNHItQq/SqSTCVEwH8Vcl4TWrDUXmyh36Ki/KQ==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14433,12 +14433,12 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-hezjJeCbQyg0gCcAY3RzyVaPnwkKBmDESFKvjL+C5Qde+H2A5Kc9rlScWTbma63oWFoP7Rv6fgIPu3SLP87HVg==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-w/4FXY3nna0rZCogKUKsuUFgj9STecfjSnVWEpb85TkXTl3alGQS68mmgNSH60KfjjoBvngY18T/MgqSVF+bKw==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14460,12 +14460,12 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-zaNgJRH6gEt1KmqJ6/tgSFUoniLxWIpy9Jz5v6A/78rUjtffsX9NSGjR+2qM7+zSPFAJK/wr9ref1y7clwiHXQ==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-AtgnSfLehMVF+2FL/14Q5ARTlduDPCrNsOUYkxF6Y4SfxPev5JG4+gNcNogXkSqWsvPIIZLLGJwrepD/ein4pw==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14488,12 +14488,12 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-X0MkDlvBuESkSS3jLvvvn1jSufnjemO/YuufHiSEs2s820LTCux1L21mCE/p7cj0+xXSunGhP2Q5epa58IvLJQ==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Pe46WdNRi4w9ZK1FGbr6EkXfraHOLv0ycfcAIQZYyV2+3hi5PjuiNkzsWj6DWHf5Wncxj05l1nsaLPTg22QCEg==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14516,12 +14516,12 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-pfDXaF56ZpK1yG0UJlUCjiYzLvbG4jUx8+3m8B67ZmD3Nglr1xt3SGyAVFfIUcSBbyOPqLzoRK6QVWLj2FSvHw==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-bZ9xek9c6KMEChYSml+/3RtENCTYZtG4bobsQmwd1oZfKd8v1NuQif2jwFKUjtcSpOiWXD12nXf7kyNo7lahRw==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14544,12 +14544,12 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-QH1FOt9seBZ7DO2L5uBjcMrqsZYSSd3Gv6IQpHjz2K47wyLPscOm64YgDYyUj2P/13uYf59sRFhcTWHUaWK00Q==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-W5rYFfm7uWn73g1yL3kD+vc0VTIH6rwVaY4UaG/jkOsjt49bIVG12Rm8/H6d4G10soGN0Dj/T5k6dHiffSYwBg==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14572,12 +14572,12 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-/3HiRFl1kq/dOgeMPkXwriv0fdg5i3CXLnT+xZRYxPeTzHRTu1V6J6s18l76I2KhdWXSgFakqSCWcDmicOBKiQ==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-iXLmEnxIYKsQzcBib86l6YJhzmj6YYYIgGIHhKlQkuYzNQJatgwFRDUN6xqPjgjTdpZD7GH/hiGeDpHW1GJutQ==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14601,12 +14601,12 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-+Vkki1P9vwjnheakvS3oHgnketup9k2mrAHSgxAg514LG1DeN71GFrmXbFHTZt/2XXCIK7mjHPrgbq2P7UG4ZA==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-m2NRCA12VmXgxqf/BUcNwfShzjy3gvauKqvfwdHfgxyGlx1GXYJiJlAwPDAuMSq6JwxRkHCAS6VgQPJH4glX4w==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14629,12 +14629,12 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-A9YpOztdVkkVkWMN+tKtsmNT6hbfoE/Vdb1MMC6642kfY2YZ2AAf2eVVdX9U2IM9oN/u9J3lZ8k6z+vvqW3yYg==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-rqVbXI7T8l+vHA/OwEnS6LtNZTLba+FxRxxaF4s9TdsTjs0f9sQKC5S7Xkj14CQFuNs41eMl1mEiTH6/cHU3NA==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14657,12 +14657,12 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-6+HXLXcz5mPN+nHklbQaTPVkNYaVJOCahhQXwwKUd59TuebVjuefhGkH8OmHvQhOPzEtZPsDtJVoL3gnwnB0OA==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-J3Z84RSZeWE+VHJsRMdR7gWwfC2n4tZ+svE9RyJhVJ/ypctnnb2BbLtJc5eDeSNvZs/Rk+O85bFiLByu02IDzQ==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14685,12 +14685,12 @@ packages:
     dev: false
 
   file:projects/arm-largeinstance.tgz:
-    resolution: {integrity: sha512-JK2MdXeSTMEcE7vXUkxPz7rW1VaY47aRyWHJvaJ9HMMDY32YNrE4/LTj5M1IB++UgBzW5TJ0HOgXzcWTMsx60g==, tarball: file:projects/arm-largeinstance.tgz}
+    resolution: {integrity: sha512-vHANx78WRHFl0fGV9kw+0WwQvuago6U5Yf96Z0YyRebYLcvHuAXcX3KlWA4nE8HA2x92uu4fz2DXFwvHHg3n+g==, tarball: file:projects/arm-largeinstance.tgz}
     name: '@rush-temp/arm-largeinstance'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14714,12 +14714,12 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-4X7cmOA/odG4/3IHzcmXEmTGMWcyJxUYly9ZBt+yh8f6pcKOJ/OmcFHOz7NKcmDUWlJmkTKERf5VC70vgO4XIw==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-4sMPGtlX1k83v9CNmOiRKMM5Im6pK+kSfu7xTs+4dQ+yrbNh9x2v6C6dK1azpSO+JTJ4SLrfHr8aSs1c9WrdTQ==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14740,12 +14740,12 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-zjpds1T7MZW6j9aTeV4/8t4hN6vATuYQqeeuAr0LsnY70a0CSAOBdUtKnKp0kof+cI2v5hoXpPbB9RJvC5736Q==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-JgT84syj+PBAh1tdcLl5DoiF04R7iACKCcKNmhbIx7HsNU9LeRzNQWZCC3ByEI7yem6QZjdWnXPgFjcaW9YPZQ==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14768,12 +14768,12 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-pt3LXWYELVwrOKh2HIRgzY3FqDZpe2rIPTPpxopl80R9nTXsePwi8l74B8SagaLCt7NhZO6dnP3oCCLCQydYLQ==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-dOXFVgT6rAD6abHF7Q36JKgv/Uc30CNsT+A9tgmIWBHOHaAi/0UVysZVQKFLuOZslIL8PiDiKWqtbsJk0afeaA==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14795,12 +14795,12 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-s+vYI6yqZ42szuMfr/Zc8l2V7xsEHl5MlITDIl9mytEPdWRlnAZXCM/UI8jg1YLmUYI3HHqt1Ad3JSx7aIZVgg==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-c1SJlllemKdtYnhnyCI6U6vAAtnK+1Mfz3xPq/V7ufAsFken3CIgfsqqPDw2yzY70g6ua0+5WykCrffhzEPUUQ==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14821,12 +14821,12 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-z0uavV9NefGsdU4vHjeMPrcrgocgPyjkiBP8iQfHu0hnaO9rHNOjigbPQYHk02qbVsQ0uMNaI1GeNDofkf/olQ==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-nZ3Z/HME1QWvkFdKsFDgPUO1KY5jn8Q9NQJZUufHcvbC/xxp/Firtzjjmp7wdbLDVi2LWHslMGx4KWhFZXArqA==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14849,12 +14849,12 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-w8l+YgbfXzIiuI5VCCHbxvZyi3jprgRbmvatEsZ3WNL+dzddDF1/NaPk/bg4RVQeZ57lVOLmRnvCZ2daQ1TG7g==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-HjcvddN5Qo4JON/POsdV4DI0x5wyoNpaVOy/UvpFfChqUoBLzRcghPazPxM6nlVKKFIKs0NyoPozdlMnUsSLFQ==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14876,12 +14876,12 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-2Fgiyd0vgAZglrTqx39N33mkLT5GTBKuWyWkXqTxO0wphKfBm5Mtrkq0wt5z/+N+bK2SI1nzYW31kEP8P5CV0A==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-EBdUk06m1cEQ+iEIkrC0GgcFJKQLndpiD8EKDKgwYRmNe9IQjtXyL/thVk14RGsEdhaXgJyCAgVqDIu1F2VtKg==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14903,12 +14903,12 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-LyrfSumt71JpylA9GMLk3HKnZvtGv/o4XqiAmuE+xwKQL1NBAIehoKS8/TH62lGWVpN3x/JvceAr9LUO6JjE6w==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-OPAPURC2oVGNNfPEL77ReSONKAj0M/JvwaMsopk/B1oRns1PM6VMkhATU9Ff2NMIVa+2gYciAKKtfGi4wJhHbA==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14930,12 +14930,12 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-PobHylU+9MJJygd5g+RIUQPJqPwOfTH+DpRfsAj0V0gRZiZnacI19SwuGRybAMYVIbV4UOKL0JVoUk8MbMTf5Q==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-Y8H1FSc8bZRoMHd2KsTKLe9wmiYJz0H4GcR7aVNKSo3STJ5aigGxpRmMLAoUeOJT0ley6TuWjiGR5ew4GsKvYw==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14954,12 +14954,12 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-sVLObBOnaoqTKORfSwoxzueptMDXKyDWojBedlz4tvumjOWQqhKGLSg8wR2EBNMiVvcMWJ5NvtAZ8JCkuXy0xw==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-96zp2j62G/2Fq7nImYXWrQKYOnanELCbhJvexr5XpOr8rRBA84THditdFpJDbIYerUeC1oYy4BMl3+RljflVLg==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14982,12 +14982,12 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-ojU4YVkz3jiDeEkr3CJu4CiKrPUK2P3Wj1mbi6vT1RWNT7Wto26hR8Fe+Iil2bJL+lHGfHAgsVolx6qOswE5vw==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-v5AzSH/Y7/PONrIe+GqsAL0quL55ZJJOu31KrCPqThBNxoiKNrdq9o3EA+vrNzh9XCAdW1ZZqRT/n103DgjLNg==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15010,12 +15010,12 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-7BF4zILcNxJnN/sYvg/i3zslKJy7Wg+Lo0tn5dGDvjL/FhoAd1FQWSsyARxwtT9Sdvn5n0+8vNgg3Zl9vfXLmg==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-9z6fV9CYN2h+rSMHqfGuW9EDfcBZM1Amaih4NSRf9ELapVYWj6Lvp3z/s2d0uOIH3KWmEvs9Cx1vzIUcr2Wjmw==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15037,12 +15037,12 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-1OdWF0l9cg0aaNS4oZgSi2Va7FPeELvuISePDByJgwRwZLAx02rp2nWvENFNzzQQ04A6dYtnBF0phv/Gwfm1mw==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-CjrYalV950NLexeqttCrMXhhAWDJtpXVTGFpedh6+Su++ChwGpf31tB8JugP2zbOG1xO4BdeeHpTCNR1EqSHUg==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15064,12 +15064,12 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-X1mR8uJMzc25aekJO29q+S3clqi8SnA6Sp2QiaczLVZ/hqsRjL64s2tHpjGPxsbTtmJArEQjDm8GuJzy164cdA==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-UxVbz+nSLpZ9gyMXI3ZrnBnrydCM9Fa5yEH7lHBa6x/L5TCi/GhIP6tT5sV0y26eMXCynwbkSaImQC7VXl2afQ==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15091,12 +15091,12 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-KZ+Cy9fl6GAPlkrlZUYhvI2s91N9qzVzR/LabwY4gEffcgK/row1cmcMjpwBd3qXs72QyO5W28HzamHP0ulGew==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-pD+xgQrjN5/9yMz5xh8XCo0wNxRS8BWANAzYqKDsfNDQCVyrh+MG/o7TFeFMbqQOUpgkiyl/3jzGfA+PRX5Hkg==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15118,12 +15118,12 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-aTkq3Oe8wso95GfRLDIAzCDwSqaCHQ9LtgUGVzdbVOCkLq3B3dnrD4eq0mTd+l19Ghhh0jeIhC69Gn7GNZamZA==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-AwKxKyAWv9eiRBKcR4EqJE6pAICre4EAcBCaP5Rg+JVKyOLC4ND1wLwpejTa1B3k33c6z6snerO5+dB4j5AdxQ==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15145,12 +15145,12 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-NjiHuwMwG16Vp4f5Y6+QuEsfalT/B84T/jUhE1DW4L3/xxkFNztjn5XfL3XXxOfgKtpdfBlnOsyLBq61PZNwFQ==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-QgrL33qfH97gfgtnxUiIJ3Ro6dct1ziiNcHgp2pkbZSChyPX/ZsgcoMQXGm0nGuQz7j+It6VFeXh5IRCZP1w4g==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15173,12 +15173,12 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-9oT/OMHfdG9QLn4kktf8o4tJIHsdBBOc3zAvIPKvV8KIXIZnDinjCTB3zK7eS2hVNvHYUWtyRrdppnVNcBMdeg==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-/0EiPlO9MYpgvAeH2JgTM3GNF5wc1SpWbdtYImU+TzW37kao1iv2+Tv8bNHRJFEkdW01AUSNlFL8AdpLxE7m8g==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15200,12 +15200,12 @@ packages:
     dev: false
 
   file:projects/arm-migrationdiscoverysap.tgz:
-    resolution: {integrity: sha512-axtgmfLsdmkn/v3YijCqtWB+UJwVDaLurYx1Znz7kkKzvCr/Bjwd+3By9ZkERRfPWg3TGFNYye0+kjqOvnKO4g==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
+    resolution: {integrity: sha512-3Q2KKrAJineyk34hLwlYghNfyf0gnUFWsXcwXQSDI0Vsx+iC6lHxH1I9EZ3tsp3FTlI5xgE+PaK08HaAvgcdhQ==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
     name: '@rush-temp/arm-migrationdiscoverysap'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15229,12 +15229,12 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-qNWr7Xj7muxOzuZ7rkzsDrlnhtf4ocF8ElZLMCjCoTftvykbnT91HV9OaNXbCMVd83tdR63WxJhk4E6Sl7jO9A==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-/q6LMjtM32vI5r7a3N9zAGyKRiCrXQpQIvv6/8h9fXU06KnlRRESyEjiYQ/VTzRR2mbOoiiWgMPS0kjB2YkHkg==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15255,12 +15255,12 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-kf3WyQjSct8WdVXv4zHUzuMZwgZrA8RZnTSaywCbMy6Rwp+ITjKM3K/xEth0plnaOs8M/2xy5dXforMlf8rM8A==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-ZWANZyzw4RZCiOdftFy0aQM7ayj4mwl8/weOrd2fC8MBIu1/7XEedvNquuds6EmPVUI8it6hayZ9jCIyqYY48w==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15284,12 +15284,12 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-Bv9UkR1Jt4LKH9W7GyEP3k5758KUPnU3mJACYECOmBn19QYiPtCDDr0COxrvoc33Bs83Mgna44gtkyADfo8S1g==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-2FaWjx4rDx3McKJRVH3vfTEozAZjEhBdtGoJ2PGKkWFJzxgrved6Cun5P83x2o0mpUVDstgiyc/47hGuU6Acnw==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15311,12 +15311,12 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-We1esoExGFC/Uithy80zsIPDRgy0t+iX6yTf5JG9hqua42XsqjKDPJ68Aw4ZNFmBFPdpD4eabFzBlfAILrxyQg==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-7NTsSupTXf+GEQSaDOWhx4aC8lVg8bTwOXsvxEYs3fVoqtckibZs11cGQZ+axcqnxI9b3443PoHKUjj7BHnoJA==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15340,12 +15340,12 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-HGCKZKx+jvxSgV44cq41oPlb+msz9uJUfJ4gMb6zsT+Fp2t7MJUxWF0W9sTZtNU1oA3KY8KCY+XOoWrnA50Nqw==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-uFHS92AD3+sDExdI1G/pK+ZRARvrddI8P8oCQL+8zmWlgLltAEriUtjOT2P1iKfrHwVDFYW6Ew/l1BZHPE+kSA==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15367,12 +15367,12 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-e8xLSib14Vo44CwPeK9iUeRGxzl5PlNjHwwdVo0qbtdRkl72CF54/lF1Dh5uv8KJkeyzG53CbkPMARqfN4TpKw==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-00fUtqnWrP5G71yj/8sVU0usO4ucTM/4sJdTf8ze9aelKu7+Q702CcYfzcUL+SeSTyiSvFmnLy0eHPQHYkV0+g==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15395,12 +15395,12 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-VlLqDB9CYnVntJyzI6xjvdrxNP685KoX9L/t2mHBCFeUHpbzqZPkzYswoz3SwkdP+NlajcPB4HiSl2m7JSjLPw==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-IzEShkHwQy0iX04+mxpbpVr3HnlOACL8t0EVxrayYD1Q0euF1/Bg7g6ek2ROvGI1VbCJsic/yY3odr7y+rk+Rg==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15422,12 +15422,12 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-QWKmYAhmOzBlzgIDZSQlPUw+Y7l8yvy6fL98VVSKRa7ggzs7fO3EMAXb3T16d/S/eG5k4Kgdg2+PKIscxiPiuA==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-59G+OfOs7CrvIVQTZR1HgFbqu8vy/9MKSszuPB+RUidHVQfoZiAj+Q4meaGmQXgKFQCngIvYjQiCT7i5hh02DQ==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15451,12 +15451,12 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-zvSx/S0MxNP2qntP6ABh3OGVB/sSW5DRHvau33A+xr3S8mZ9uiOhDhejqusdbMSduqUQ7NUDzJ8CKl3sm0LBtw==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-FRYyAFJsPsWHmalWmdynY5ncm7Nqw8BC32tKltoXLBXzqDtiLpD0yFAG63rrkG0M3WDjGvAJeMSr+/VfbRRKjA==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15480,12 +15480,12 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-QAx0ezbgavzHggD3/BPoBxuUhTk+QFALFxwclxstPfpk6vIujS6pTriBPW+pWb4Ru1f90QTJ0FtuiP49sMdu3w==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-n5hEqKBi/tsOfaPGZQc4YrAJu0Xnpudi42Dw90HD4Ml+5+J497uJCt+q2NsEpJfQ7CSOGAXgrYhaIoAw4zazSg==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15508,12 +15508,12 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-5b19d1Z42vF+WHmoPrRsEPixxEBrFYXSX096bASzfJL7xA+5dgUu+MRomjmb1z4SVgBIsOyorMRn3hH+fNGYCw==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-IxNC+WpOdj2rQPXBKTb1PSS+stqZkSRlzkY8ObggHV45/M3A5L6303iw6CaqVjdlBU6jrOBch147t5fNSKVdlQ==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15552,12 +15552,12 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-pKXsuXfh3onUKiGpmFTID6i54AoNR9PWZoTbU43W2G9JLhb1sydXu4IUvw1V0E5ByFgr3a/NEng9bxNPSuFU+g==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-GfXaAX67ErpnS9vO1ueVpNOukxRSw763r6YopznP+NPRq8EuRYXVH8udKuWV8cJ17ag9j5/TYMcsgersCll8eQ==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15581,12 +15581,12 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-IBX9pLKxppR6Cq9Izc2i/aE6IpGMe2SYKq1bXTW+hvJEwJ87ivc9wHYAB8wNSIzJg7YCUfb3Fq+eubik6qRh6A==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-QFVBmkfirccbVH1Lw9pdUNH9cQkxuWfZh6EHkq6V56rQ1swWMU5WjZXpPwnJUH1/z67o8HkfAQrew7VSPWvqDw==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15609,12 +15609,12 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-R4u8HWOaczxmdjHhyqgVJ4f2XxgJTj6Ax8jLo5nnf5s5RX/4tlLu34RUaIIrbV1HyexDi3hSsTw6Yv9QtMqaew==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-WKmTK587//AT/CwgI7rfbKB41W8/cDve3qC2m/HB3KytxfzQf4q8tbKYDFppqfS2NrYve0GBRbs70aVRee82gg==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15636,12 +15636,12 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-GGr7/BL2cwyo8ZZwkhFCbzv/E7gYysvt7v09vlGoAhpQO6/zFISYDo6b6YUGpkMQid5q8xLmFG9lS9LT/sT4TQ==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-FqxGsyXzSR4A02aW4e3rq0UUPYifSNzyE3ra9c+E8qKnk3qmiTujIFD48SfG5hLpz7IakNZTHt4IZRONf2AVRw==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15665,12 +15665,12 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-urM2jG3iY3+o//WGQbCBUQonWqkpFEQUZl6AfrYmi/z1zxt4kCFZLxWGCDWt4rsejk4kZCcYWeZqRJo/9urITg==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-Izw3PprYnNlJtAWXnFDusSpm+YwRB3RHwQhZD5h7A0T+RfsRTGhBup9XpS/Z6y0fwuMz5et59f6KeSlgpNEpGA==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15694,12 +15694,12 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-WKK3NBE8oe/lZ5rz58EpR1M1d3qzcEZvn510Emrjq/A17aJxKJKVndk8O3AvoknZDNZsvoSZLoOt9YXUhxxvqg==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-49uAlO+qbS1+Y6rAgYolwphScrHoecoHODFS8PFOfu9Qp2nIVyH35JE07DuPc9Ol3NSDUslfbFbJJ7BAfzKC4A==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15723,12 +15723,12 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-/yM325AXl23zpMJmbkwTsouOGTy9XJ5SHWYzx/zLOzmcQ2tKXJz4ybwge36taQU2lZ9aDE+XCXheHVkYjZ9/DA==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-h4OltSabuTbTrkw9BZo7gvLOUZNYs2MeXbYLs4S4ljCFS8d4Gl60IkwaqXFQI7f/45tUy+2PnqaCLMFZj409QA==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15750,12 +15750,12 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-4nVbhb1WAzy0re2JTQX0gEbVYBCQtHgXRHMj1112vEX5xyFqJ5Q0fOL0lzPwpxGeDFQqwFQug7cJ61ooQ19uuQ==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-VAqcrxIvEMTjrWjNmQ8Sfc6v6mHAAvLJc66toZ/0VNLaeTFOCvGceXuQjeVuV0Uo+XJ92amb1Nq2rZHNPvWYAg==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15778,12 +15778,12 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-6/zOkwRqsuGtBF1+kRYdC1WcDaUYhHdJG4sYLqmGqTq7YpGXguyPQhiMiKykIJVLRs9/EIqTwptMP0vmdljO9A==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-VLJSw/Ro4ih7iRV3skAL2slXXYuncPfSShLk+1ijq21o7Nd/20IhDhLXtnbIlpJiBXDK91UpPGxVHwifZTYt8g==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15805,12 +15805,12 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-+CtyRbK49Kyt10WPvHxO6yQHJlS4U2V8bdSYuNe5kLgMuq4Z6iB8HL1+VGJR5ijlMnF2XV5SiuizRRNUMfdTHQ==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-fSeTnQGEPu/B1GGs+QGIEcuAk6qhkj7bnX9SAmd4eYGIPhfKvcy++U/zX2ukkAPERQhVxhyXDmdeb3sieBrPCA==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15833,12 +15833,12 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-VZXJ6hrQsAKE1MJLzX6whXB9w1+NzuDec6DBV89+xQ0r0TN95FKUhMlNQh0+t4DdxYAMmmTdh2ZcUwk6TF9Xng==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-AdqB0M4OtlXkH8ym8Gs8JeCa4Bjom8+9R0ANZ321SAOgG2krR0j2G68/B+s9krmM/yQPIQrt5T4vue61+mLssg==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15862,12 +15862,12 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-c4WuGgrEiA1uRnFPFjNe1FsLoxUDa9H5OtVmzoif8g8kDgM4izGZ5hbM3O9jxtpnny60OUNwhOt5DtKU3uw98A==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-TW4pt8loh855GOhKAOcDmZkjmZ34OB9BsJcuTag1G4enztP8KGeJ49aOjq2t1+mE/b3lnC6th//H7ErhUyCqpg==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15888,12 +15888,12 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-a7g7OnS+l85rCj2TyRWVh6Cpsxc3UJhZrWgNptE6HSJVFy/7dK28Ftzm+yB09nz5XQI6kBGSFhtU6aM2i3yMQw==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-VUISwcObamKYGhbMN57f7kpuiiK8Spm8JY5tWB6WnuaquJjHpQ2Y3rQM33b6t+o87mzakbVpvKNP1Zm23oFqBg==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15917,12 +15917,12 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-BiZpniIkgGwMdyD9o/7pR4NIQQkWi3ZZbBz86U14Ety2saXGwjXA4Lr1POUmqDCRnRC7PjNQMi/tmpjauqcumA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-7/15Cbg2E1fOyMrFBhPo35+8GJqzluWD7IIBzxyMiSZNfOHND3/Oubn8dk+cufA6sPGiVtGfI0DvHZwHedr2OA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15944,12 +15944,12 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-/MfIoBCXKZVtisNxZiUfxaecJclRSdCJpzlDMDjjpN2D7X8TvZqwDpXy1m6X4cJ/0z3KbAii81jCwElXDxxEiA==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-4M4aS0vwPQPZouS5wDtsvS6ibXTc9LftVSr26Qu36fu+LZue2Frv5HRS/YwHKBFQW5oIiwPLWyLzQVhFq3rDxg==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15971,12 +15971,12 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-QvcDEqb7437GVfnP3OsIa9sxx41ocgf/ZjY1pHHcEPE49fAhq4R4a1De2jS1rso7U1O8U/nejo4d/1m+EYyZbA==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-G6RPbMDCTxDIzSld4Ksiw9JzoOS5+LtPVGP/ngn6gmJYb5KUA0Tsy7OcJu3A+inb1m/4uMBgc+lhb8MjfgBlxQ==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15999,12 +15999,12 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-MG74TxKY9gs7d6A/tPUto9ksW/0uu1V5nRuKegTmiPir3tp+kmNJUsLNtxExmgnm3Mpie7YJqgsajPneQG4tbQ==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-gKAF0TrpNPx5QR+TL+46YH07LOmIPbtxWtzfriP8zEJIejlGmnWrVzogxXujgXDuwdfoC6LOFJKz8hmemHRXig==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16026,12 +16026,12 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-rpkFlrdN/oOSyE07t7Ha3sdlJ2oFcILqwYdyxpg+rG8jRJjYbnQg4OO1iSRIA7jAK9pemyMQtC0IaXtyRTGzyQ==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-YtSZHxODLOmMgmMVBmFkJ6gzLAsxbGa8HDaUkbJmFvbdzsLNcaS95yKxbwX2i2L/iN9BQv6/h+STWIDprnfGNQ==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16055,12 +16055,12 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-6h7OSqim1QMTenKWFeYpP+bD8t8tMszXP+nQTbxIMh/qPnhiSkPQUJm/96TSGZeOgDTsf9isuVPifZv8sdf9Kg==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-IYlOkEQGWvHcPvU8O8HUNoYH1vfxFDWFjIydmlgy2ShJa5SkMB7NXuC6bmfbNO2g7KqrwPwUQ57v+eawYW8r0w==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16082,12 +16082,12 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-Ev8bCIApThgHN1eo5z47bXgUkal4ijpLJDiFyAGJd9gvPX767u1PSMpN3uTHRPdUpYLV+R1R6BvCfnCUjEJL1Q==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-8sepXf0EMMxBqUthSKZiFbBkk7hms1OQT6rm0o4xAIPXaiMptIFRpXbPNTk2vrzQgaG3kTame59XWFAieF38gg==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16110,12 +16110,12 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-DQRb5a5ZhBbWx91RSd5DBAOTddCxUq1AHczgrGLqz/5UvMn1UGi6r5Ty+5MhSybbMJ5Z+L+Ca31/NFjyvpc1tg==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-+6HtlM4TRWqRvzWJyQxjqQSjxUpL8q2QuK1vuMICnxhF7qvlC8UvgW0JsWmP12Nidqyz5nT8TzO4xxziJTKIDQ==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16137,12 +16137,12 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-OFYDZImAtfX3i8ZFNMAI9Qh1JBvFIAFEg2GW/F3aZw98IBJOASelHvzqrLcB1sAxgBmvYSkLtiRA0oxzdF0pBw==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-gMr+UQNOhZkwttt/or0xmzBc24eAVh4NVI7lupdvcLpt7DLHYuwxWSnR/SY1U2BKO/LHws6lUjfjgQ0er4qF1g==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16165,12 +16165,12 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-7l5ZNLLcaYrSojVBzg0VycXbtfi0ZDHU6rkKNzeGhnhwEir+s+nf/B75tNWlAzDrKbbQI9AsFN/278OP4ZdmMg==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-YQS3kLSfRWH3K4bSKxD0TVe+cGdnbh0/bqcEiVECagxe1g3uYzVa5G9AhcMzN/ylgJY6UQlRessC/BiHsyY+WQ==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16192,12 +16192,12 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-29ViEELhyh6Y9NuLmG0u/ujJJ8T6mmmvSZjqfEV+KzS8E4x+7dwOa0kJdP7hhkJ35gaNU/5YK6A5/8RIkkuQRA==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-UVmzsorx+Xw6e23+F3UTJVlszEtT51bp0WQrUXckzpJQLmA+GYpfL3hH39c86V5L7vDF/Oc6gNelonZO9357AQ==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16221,12 +16221,12 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-dFb0CSFqt0C7wS0WcCdZCG5KOyyz1PgV6BbS5B7d7D9SAduk+8il7TRbGF5eL2G+FKuJF0LXTYqDL6HiPvSwuA==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-d7d0Px7trSmizdTl0gpzQd5H7HADDMHVwxjRj0YrymkNPfX3GDKBM+pHzs4S9G3uvXJusZUnW2URg3HaxzvK1w==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16249,12 +16249,12 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-gNi54AbmkI16+cIqZEwWpvrJsOAuylkPmYJfO6uQzLyVcmDsd7PA+36j32ZhnfN/w0yBMld7fMsrGIdk5CiV8A==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-5fIXcW4ZlIkanWhYTjW59wcoms6Rzz1Bb9Y2AoNfjShiu78xZ7pOg6Wn2w/o9labjWD1x0cxM45hxGdcGwdSlQ==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16278,12 +16278,12 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-iFuHVvYxCZhKwAoH+vjLc/Q9y/fkeFO7/d+e1bD5o+cT7vI4PAjNqGLaU/hHsWk0HmLfjXX8aALCf64aKsXtrQ==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-xeGZ960imLkDizlamNeNq5uwd/kXhPYC+mjzcuk/9mH0PRSfgNDVUfZcAcT+RET4p+dNxyut9Ao8UlbeRmTUGQ==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16307,12 +16307,12 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-3HYIVoqrkJspZGjMAJWyxPJusrE1qNKTojeo2bagvrsKWt0m4mBHnF3Jgonq+DYQasS/1V+xIeLZk0ByvOJqDg==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-YyTSPW1pFyEnSUcnCoLlt/OF3Q5Cii7ySAv5FSxKR3d26xqSYHzEgglIPchIMhZt1svPfwpGPDipALgBuL3ncg==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16335,12 +16335,12 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-w2xvlDZoXNVkbu3+sGBLK/Xg7fJjBQxvYtKHEdCH/t3Okg3/io9tuQQfUNnyNQzAiFEKhnoYY192W6nzAS2PeQ==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-Zv7H5CD0YrtWtz8W92rIQK6cMddOl0AEhK08/amy7aVtW8v//t+/mdQ/QfWOuGHsot5FzFjV8SZ5Iny9a+fLJw==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16364,12 +16364,12 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-Kg5/LLOxamYRgAAmXm2aymWWRONKgNjEEClDmII2kOr268rm3IcujZG5sgq8+YiTppFSrN0OCqtjUnlJQz7scA==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-n7EXBSkVlafYylYFksd9KkrLb3iiUOOO4kysxqfb9fMD91943+3FQI4rM1behA80qXFb0l7zAWeR8e+WUfnP1w==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16392,12 +16392,12 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-W3kHvE0jkHz2tj8DBE4QGuQPpjZh64ozEoWYmLUHpMP2uZM2UXIW9crVl07tuqLRvGbkTjM67Hc7EIyhc/0LPA==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-GjDc8KULxCALKAZPwwpr+CPczFdHAMKSyi4DWKBROmEyjKifCWadFPAaPrCEBGXia9sQPha3PQLMZh8AwJPDJA==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -16421,12 +16421,12 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-IlCWCUYQg1r5vUXljkj6yopmBHMKSnDHzOu2Tt3UYP+w2BxDK1Sryv/JWfc32AZlcUZLkfJNnCU7FFS99tS19g==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-oe37+JBshNUdeLFSGVK8ClbPPJLp5rhDNn3Qe9NXfmM6h689BVMegM5A5Zm0DUzlH3fjCZf5qlSIm/ycheie7w==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16450,12 +16450,12 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-HbmMyrWe+HtUzuIZl51v3P6+xPV/pVdRdVOl5zHrJxR43dQiYQ9zBsF8uG8I28p/M2HSCaRwSJKTY1fmoAqn/w==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-gMhQmRqdrxIi4ZTF4UUEWy+a0zXBq24qp2tK7MWrZZO4Lv1adcMpeXSt95Fd2xubeTHQBteuyfAHeZ7CpW92cw==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16478,12 +16478,12 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-vTLmw0m5Xe/L1zwAU3nie8PtcZClE+dc9gNGHGuHqyUV2DlWweHtTSUO22+sLSkv0TjEYn7TfIr4laRdGQxw2Q==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-+okzw9IU4Lg7g8inzYizCl4TmNNb8x0pm2WDsGtb4BINz36kuoWJ04QeZuu/O8mpzktM2s9u1v+ew8tY18kAgA==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16506,12 +16506,12 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-LxzoBfCpaIJYtEdIj0N7/uaOQEjSe3HUYhc4EdPS4zRkZr94BwtvxlcRNK93tOFM+FssMH2YTT1yyKEF5GKS4g==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-8LnDZbZRmn2KU1oCTTEuvchEfPbq3G/v/+QsLe4egpwiJqdiKSligR8wXQjRgZ+JBR6xYgKkcLBCXFFwTvHYgw==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16534,12 +16534,12 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-i2LP64oFLp5rfKxTLlVZiSGrkx5nN1xjHZQWL4jz/MzcSCUBBYv0bGfWmPQMbwmedCxrxinu7s9WPo6ATlMnYw==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-Dcfidf6A4m57TKfYAHpo1s9rOnt0LC1VB3WO/Ihf4WIxvNrT+mJFFbCVjluNunFq4bevrj1cSbxpbW0fBlxhbQ==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16560,12 +16560,12 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-xo170HoyhEjxJCz+M3qgaSc4XRJRDPgoPpQzwdqCXFeZULKbXBjaoyyTh8CuYKJHAcR1F6AV+tJ8+kpl+rTj4w==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-yz0w0eImMK+FgEeOU6ZqKonhSapbCDkuHCRShNVrrAbfk0LC1M2BRl9fc82nAQm0dze746sgyyQVUAH/DdSYUw==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16587,12 +16587,12 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-qkAoZp5N6nogHZlGDwd+BQm/U0/ZSyZvkFQHu6XUp+qtR6lwNj/IqOwK22wCBtRULX2JfZPA8ySpIEOFKt/bHg==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-7s56ylop3wCXsv2Nyd7QIO0hceFbSvhbX0wOKl/Vl9L0L/VSiFSIii9HpzXbNFPkh7CIaEDFy8sn9HR5StbfCw==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16615,12 +16615,12 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-lH1X4aB5/oOOH+vAcswrpN6rKeGd7MOvCVAWMekHiDwkd+/FulyQBZNJOmeoTcg/l/gSBa0VBZqbkdMjLb2AmQ==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Qj24CXrqJ7uZagFw9S/pDe9iJdtwcG+hA506O5feRuRSxu4mtxyqos1nBkEUAilmuJYnUBBSwALPFBF59c3BPA==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16643,12 +16643,12 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-NUTFjBvQCzWYWMWUDsz/GAVtUWaZaekqEjTAp0uKwcn+lYCaJT4Gvp/8Y7n6C78dgjucG66V16D6mJemHCuJtQ==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-GxyAFTxLv4OY6S7bYR55zV664y3YuIPKypTfcrcdSabebU8oRAR1F2gYkCqg6Txkx4aDR7AutJz+hWt/nLunPQ==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16670,12 +16670,12 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-RRs/fsBvr7u/0P0FHtnIFr6aydzGqSCJU7Lw37YJdwcsfcqrNss9yrXhcJ97mN01q368GQc+B9lqsOq4egIprg==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-G9GHu/Q8Pbz7PeieUKdtpFlI9Z4BBSZ+YI4CV+64esPDaavYN0xJfqCQYA5GopE2E+Rnbt03OXrV2mtxDly7tQ==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16698,12 +16698,12 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-383GAuPc8VHaF+rRkf1gX70XfsPcmmadGSKsen1HKEBDyDcJrSx0hN6tH1KSv/hgVOhN73Ys2lNcp0L1lnsLsw==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-IGTl+oHVkmG6PwFkOZ7mo+ccqx+CDUxgQbi/uQC7Clr8BozDX2/EtdOegUV3/YYakmTDCMkPEnI2COqPuuIkZQ==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16726,12 +16726,12 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-BedxzGniH7OvaJw9q/gsx0cqCrY6rNkh0oMWpR0Hx13tSzzNuA21+PHRznpTDhb0OpfLBBQgIHr6+QFb190hcw==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-8dPoIpzm3NhRpkuNn6mgKkADFiJnK+ItXIamXnR1ItvETAC5ANkKxCE/mKNOydBGsqBp0YEkyUpNVLYd3VF53A==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16754,12 +16754,12 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-oysCkkte5Yut66nN4c92wO3U412viDL1WhWMACmDkPrgpHy72ShTu5XUdMUkSLFjeltIiUg0aCjLLx2N7DcV7Q==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-BMKPKf3aEoqc2lQdIkH3Iv2iMdhOy4K79YRiZFG+63Z7qC1YuTF+UpqOWLhBmfUx9gKVzGMVcna9KpR5QMTJ/A==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16783,12 +16783,12 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-ZBZ/mRqISvYvJs5cRliT2S2HGvsOTU26XcJsaG2b20QDvXFtKxywvucpF4kR53AKVon3l2fir+vQHnlXeOE1nA==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-7c1ZYFM7RyavlyNRBdWRRPErTA45rrFJrQLMlk5OakIRl9wNNcPS16sJA9taQDDJ5C1BVxUwCR/QM6woGkBNBA==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16811,12 +16811,12 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-H158Wluq96jM12Tk0y6uxYDNDoig3RVPMLQrhC7sqwfepEVnoAksUPvE/FLrg+3yT2F6G9FrrRPp9ey5vExVJQ==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-Ovy2kG84EDFXOLIEOveQL+q8Wl6hopwGZ3g2hqMtUN9Sf0E1HWuBLRzV9iIgoDsNSMaBdIzMV6P7et+wQYuvuQ==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16839,12 +16839,12 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-qa3Nq4E+zK+sRnEsHOEJmddYbc6gzG3j9YKg0i14dUuJh7QiR+6PSJBzjuamwEfU7B9qgWEkwqDSST7JZm9xsQ==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-3ewXXYXoJ2LdUl1Zt0xDrdG0qGtNLT6BZ4Jlj7K5w2ADaFmTBcAJ5q8FPgojYnziP38i7/0Hs5AS9fxOkmc7ow==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16867,12 +16867,12 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-cK0HcsNLa01d3wB6vRtRE14s80cEx8+ldhiT+raExMv73IhKBIODDVdRf2qhVF3gpxFfX8uIk8ezy+1dRmGGNQ==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-5/xjqf3/WA6YrZpO1oIN5kDkk+wE2If55zjP7EOKESi4S3FZkRiZpu4QSpE+zqMO7vnSff8IOZLi73pqTIYgIg==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16896,12 +16896,12 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-JpkwYZATXrVRXcg7bFSBX8NEklziInslQnARlN7oqaVXSGajaPCJMr9I4NS0qhhm2/RorWOImpYdCuE19oe6Jw==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-d2qdOfdIwRdtPnF9eYYdI80U3EuGlX3a8gnL58+cikhGchnLREU+Bt2q56wpQjvcq9uzoIaYiYAJbHLnDgKcfA==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16922,12 +16922,12 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-ZI/dwneGES0o/7Ifs6qKSDtaJJn0YL70aZZZswwKaq4PIB/eY/SdMnFnL6OHB9CQsS5U9UOfZrAF3P1/h4NgeQ==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-izz6zcom32t8Cyk7muPRt/rmKw7aklCCnwzJ8NO3swT+sCEm3AimHbGbYXrQsEvAgR68ZIjjwExtK8DsmF0/gA==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16950,12 +16950,12 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-zYolbH4jGu+DR0ijotYA9HpQ5N1MNErvvThr9+Uc+Qu9rMBwyyJNa6Xa4gUhj/ApCcRPhZ77MkKVHqLYC0jjPg==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-g7Ei4j6wQ8FJA1qS8rMlSxjoKk6rRRLoFHT1Bre2ymqaJYWALf0EaUPP9M1avzqUnt4FXxzpGdsS4MBxpm//bA==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16979,12 +16979,12 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-9sav+R+51bIv/nr/Gn1B+AM/WeIz66r2zxlnmthPSDig4nL33kaAMa7lIzxUGnfK74BrvaiLfLVO+6UPg97hug==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-aEUSZ5zwAbNl6p+rVZ3s4gC1l2YpOoTDqXyOlx4nplOwuhr+TakTnRI66MiZJHBzu4p17UU9ySSzTU7JvBdpOw==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17023,12 +17023,12 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-qYzdmk/fttaqL9OnDjTaNPCYhWyxj2qRk8licpZOE7heWnrdureSjowCqHHKxGY1kpv07noplSuDredlshiBzA==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-RIRTRaQkDcehhgJi7S+ALOmPRSc1JbyeqENmtq0sT0nmdEgO/pN//6hawZL3pMrxljj4ke/0UY2i9+MnD9veAw==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17050,12 +17050,12 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-2FsyOs8hbJ2jNfDvGl1f1P0GAK25WIsWqMMe07hTfhhdH11zoz7IjVQwMPu6t7C5NPEN6Md0KmCY5PsJptGzHw==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-BDpsGITOg9ltkJAjfx1FuA8abvbxFO1y69alwshkNcAXxtTIhKGJAYnKaZYq1MaGg60gi0vc/7Fe0zqpkSH2dQ==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17078,12 +17078,12 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-QXPSueg2qD5zObyAC7WAavrv7Mu2PVGJf1R9JHdwlUDP2S3nENozt0+zbCL7DRWYX6gdffG2RuSt3WOA9mnN1A==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-z7W991Lw4803chQS6wBJm07fxqDwxxBsn1ACfV0mcjJffLYxlVNsXzX+v5BTpZhJqAX0EKz6cR4S1IOxR+y89w==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17105,12 +17105,12 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-7rZnn0RMaGMBO9gmV5I+TNOO1CN18Vejc9W5NT4OK9itEu3aFifikY7+7NDcWAKQoYo7C8I+EwhxdjDa5URnYA==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-K1ummDLCcCGE4Zpf8xnM8i7HD6gbbjbMNYylO6yHAHAavNQxX51BoJ6aq0nPW223nE3K8JnCYLjG3vK1RWuc9g==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17134,12 +17134,12 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-vw8q84M9ppxtodEUhQ7POn1Bya5+zyFDUUN3n2qg3NCWKebNvrHXyn4U46IYCmRokJnqbKE+T1mWy4VpwcpW1g==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-DHxkaL8pZXC9AXOQQlW3DEyDyUUUfH1BcrxVv99slsi5wQwcKR25hHqjpLC8EFxNq6S2Un+czlUTepp20zRDwg==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17162,12 +17162,12 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-UR8I/E5HgWTrdMkbT5pGalGIov7KL2/PNvt1yQ1MOJW7d/KO0YKyW++Tok/U+Hx8MhFcxHOHdu5IsgQ6rK1QKQ==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-+IlSxm9KID38QWHGt30aETxycYKTr0mKttw6a47oC2/WLvz4KvPiEbjxXUZEyDc+fHyvpzFzekdZm4JF7wIMoQ==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17191,12 +17191,12 @@ packages:
     dev: false
 
   file:projects/arm-springappdiscovery.tgz:
-    resolution: {integrity: sha512-cOd/tr0nEkG5l2D3Krz3u+t6OkPnCR0luWJlr5mLi0Dd8vPr/i1XRY4+JJrghYUgK6Pn337dn/1EXDCTOReLUQ==, tarball: file:projects/arm-springappdiscovery.tgz}
+    resolution: {integrity: sha512-vzE/N0PW+qmPA1AV/dwGOfF4dpCkMDy2Bi2wMBG8rV2ykCmFSNNsdYN/gYDDoatOSpLIzrD4cclmop3uXPuDWw==, tarball: file:projects/arm-springappdiscovery.tgz}
     name: '@rush-temp/arm-springappdiscovery'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17220,12 +17220,12 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-aALM9z26O8aqbUX5Ow9TUxvgLAf0t1iB0ZD276i3qJ8jAVs17A17kVyTT6p8dQXF+OUyjd/j1eyutcTHvgDcnw==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-sQ0zO4hioyS2R4+iR08ZqWsW/syu3oxc2ITP/oYBobPFVJlK9sbuPLHvNuZ7e4h0KEwKTZVkgTKP98VyY02nFg==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17249,12 +17249,12 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-ZLT3bTkkUG5mbswz2v9DjzKoPokZDpsGOr+ZowDB9zlvD47sthr9xpQgG/TtypUuqfjcshVwYYa7j7j3NaU5NQ==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-rW8CEPCZK3khRkleJizgsluTahN6UdIzT3eef1BHc1pj2qUzE1PEhpJBltmyZlWFHJ+y0jrf/lr539puTKT8HA==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17277,12 +17277,12 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-CkPx39DaeFGJwaUcRxiFc70vTxQMY4PEX1U3FLFaUdAYTO94Z8ffiynhXvtraTAlknILwMwC43BlEOjtAzcRLA==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-wyeAX+y1xeG/uAhVomCMGoPd3qxQk7ca0e6HmAUDNZdvkfC8MLqmL3gMyQ0T2Ton35x3iUw1S4SBrUu5wvPIBg==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17305,12 +17305,12 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-ZLvsrrZJET9rd5M9oyUqzqOkDQehkE6+J+97la0+obI3+zfgCOiTQF/zroDMMDMrElz7CUXnpTZCQsGgXBmS+g==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-9MAmaK1v3jtN46Fu3FCfKdBc1jsvpTdjgLBjA8eZXMF9rs8lud81MDnIhgS9KP2A8Cen8r06xU3no6B5Z38fqQ==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17333,12 +17333,12 @@ packages:
     dev: false
 
   file:projects/arm-storageactions.tgz:
-    resolution: {integrity: sha512-7Wa7kVmAtvFgdYV4eZ4x9fBPhySwdF8nqGaP0rmzH1freSmcQ+pZHHAiuZzlrD1lOrGRIhDcEbGMT2w8QpLjRA==, tarball: file:projects/arm-storageactions.tgz}
+    resolution: {integrity: sha512-IJShP0kFDZj/jtferzKD2I3e2t/IgtB6sdzBpXseGDcKKkUAJte25P0ngurG1hE29lM+ScMYSeYEbjpkEhjtxw==, tarball: file:projects/arm-storageactions.tgz}
     name: '@rush-temp/arm-storageactions'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17362,12 +17362,12 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-vR07r2TNc/q3L7IuUqba17X17s2H4qAHs6rN4JW3w9yGcXtRlKX9OZvShjYwUoEPrYyM6qYcXNg9F2tsE/jfVQ==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-FhX4xO6hdsI7tXKYy4JsQV6RJu3r+xcpg6ASZLH1isOwKPsvSmzG06ZxBM2W43pym8OhAzUWj/e2ZPTsSSROnQ==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17391,12 +17391,12 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-4WU/TmxTdEb5h6pCSma1xt3x7pxBgCCWlnwMrxoeWKfiXCHfD8TY1AdqP9IuebEcMx/jAIp57aUSnBRxZcnTqw==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-FWE+BhoszrSwIxr0Cd3Oe+HjdUF8W8P51bQQjG5CUJdQHV0DV4158TjQua61zEda33I4qxrlHM53idUxP+P0Tg==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17418,12 +17418,12 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-jtxyNYVCulCzdiEQ4Yk7/anngehtPznFZkZ5guFMoQs95NHyZFUCCB48fPsGFyDNH0d3z/KDOqD5q32Emdzgbg==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-UaOU4B8i7xvWvkhi5coLDOCCvVXrPGXdVbVmXrcilIGNCiBEPYzQdBlnD9aDfiA7xaikaLlsaZoVyJSn3nbpIA==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17446,12 +17446,12 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-6c8b4m9JCh1O8j4bwyGoi9Rr94ortf8MRwvmbCE3oVQEl6N2OYxJIKmEPc3oWpwm2ez5Pv1q9eKSBkMDVoaNOw==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-Fo9FSM4ujez2IKQVT730p9e8NMWMHnA6voQMntiFGq8qi3fti9SAxyocJKi+gDkLgRpp00EbkHmrfrDOGChf+g==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17473,12 +17473,12 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-ohVQHM8z4fmNWmMNLLBU9WuhCrnuQzruDb+BT8hKVOfeEUrQn1dwih4MoWaYqNL0EYc2aYwzxhA0ed+YoX0tQg==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-XPnmY5uBkVIK8pDFBWckFVa6jDqr9o2QXX7473syXaGBuodalxSJ0yDzDP4pXDiLTiFd0bMsYWrJWAcg1AL38w==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17500,12 +17500,12 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-zggpBR+higvQ2izb460qLIkBlbT0ac6Ie5qFCqFvxZgS1HTu72uHJ0FfDqSVXapnkXWiqUHGrKspuxMkk5se0A==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-iWCOovPnvi3hersA86MPnSiO62Ka2y3S6bYrfCt0EAzEhGWYpl+48fkSPbAk8t3C32ruaD92bEnVdtxaWszTxg==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17527,12 +17527,12 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-zrYPm4reWt108RgpGv+BR6xySklqJpXwg+DCQkP4FsVBUEgx2qJWJ/Bq/5LydWTV1pBYHfPHUl++f8geN2gysQ==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-QftIiHE9GYvQ9pxv8aH1buSKq8B3hklqgqB6X0/6pOpiRz/lUtFbm2u9fXrHAPDFGxunZ12yAVz7inaDE1ZA0A==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17556,12 +17556,12 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-jeC1ddtD3XHAVz8Ebup+qGKXeBs7BAB/vOGl6hQ4dEvTltkPv4vKTkiSkteKyRQe45orid4kTuDcegjCvQBO5Q==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-6R8vQT8uFdIhm8BtBj2WxUWxx4zrQEifiyvQTmyd2SrSXCvvrqvpVmzKsXrKVhIXCNMnWpLzvYD70VocgRB2xA==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17583,12 +17583,12 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-4B1/jf6h5D0PvhVVBNIGPk4y+qX8GXgyv6RuDgOxPtUbvSH0aywnuV+lqdlfHc9Tp+p/dz9Go6YVBDMm+OfHZg==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-JaC4+MCpd0FKzSH4HByF/yUDNOPm4uHfbZEx5J4f4rVg85E2Q1cdRIBmdLjLDKR+RNVkQa4mlRpCaqO2P/H79Q==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17610,12 +17610,12 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-SFtuGHcex2BNl/xIcNgPo63ov4MTac6LnWyVLjErHFbkW8TdWmWRa1e6M2VYimOnlf9u8WDGLK1Uz5Pu9x0UcA==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-iFtZAAODvg3/NI14Gj/tkNWX1cu4U9Kr15RrEAy7IHRSKHQYGVErHDwSKKRtypJszy56oWsID8XTuKkBNqX1nA==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17639,12 +17639,12 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-GObplutS9G5+IVlltkrE/jfUTMJwrWMmlZTRHOR03lbVl67dRPsCWw0KawO/UXol/BEtiiXIUL5V9VU51C7vbw==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-GxA1bkoJUQGzFDV0tJpgKGIHbusOCq9XoD501CWNhYSBb3NdoEHNCs2T1ZlKmZB4dpP1rTNTnXdlRP3tzPlsGw==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17667,12 +17667,12 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-U5Ly+7kXMWGTSiuIzafta8DxhMyMsDGXhuoVEcUNqahuCP3nsz2Jn9N3N+imaUB/NE+CNCLGJMdMIr20wsLMcw==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-qK9Gd+Kz4B5XiAxSS7Dl1euFQ51pEHfyWw16czI5FkPkys14KNv1rjJ1m7V+akwrsOqL4lq+LD2c00AR9fJ7DQ==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17693,12 +17693,12 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-YFE3zpGAfbZ8XIBK469Ye4yNkkjdsjAdGPYhi5aSGTnqy+VvUbrvrNGfvO6uaq6FevVYEJFgbLyWvw5dNt/oow==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-fCNCe16lZexL7ZGF+yE7MHg1d4UJGxi6wQpQ+cJydvmzDD5EO4pWl+VZOcXNfmQkcoNXfkmicgRedYUGuhe5sw==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17721,12 +17721,12 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-XbWDIzSB5bizRBpak1H19KFnV3FPed0622cyNMCU62YdBoZORcOSNYEKBOjFc3U3C01r3d+xNiyOobZZ3taFhA==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-ILTiGxL9jWtOYIY9XnkDBTil5BftO0baBOhemuXt5kLxz2KQnaNM+xzDYyFcytN9rrSbOW5uR1VUULD0cOsOgg==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17748,12 +17748,12 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-vD0EZkc+3DUESqOLgUDqcYKplsiWYJvrCHdS2VMZxOyYJBP6IYB6DsI/c36DLLrm6RoYvNxkop42oCXjwf4RvA==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-um1UAvdpBVFuGxquAfk3sHyAWY14la309O0y5PtPS5qKoucsoIXXbN8fCHyhA8LJgOZEb3sSSypI1BfGf5nzjQ==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17775,12 +17775,12 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-TDD3O0Gz+SHF8o7BaJ++GqqIGsNCJzVfeN9wEOdobuSm7tGQwC7E5f7AymblqC3dExx9b23+VaV5j2kZb98RfQ==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-A/1p1jFwbBWkPSIPCnkAg8Us0UPFrYk7QOnfzUmXd8VRMGsie3km/4DLXcXH20R0sFLi8ClhoQSpCVy1UleXlw==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17803,12 +17803,12 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-ST+UN7Sx9W3eusoRoprFYW61E5nGHeGXri2WadC8FAIjhry1v2/RTEl/gCNkbkOS3YrIp9XCW4ocDiGN2kxiAg==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-LqSIvWDJrXSVpYSbPy0D1bVmdXSZ9zjjXF2h0S4y86LZ0Yg9GKx0KvDl82iI8EUSD6yIg0KDLUQTA7Afrz37SA==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17831,12 +17831,12 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-rLFm1htm8cM8eeKQtvzj9HEUNC79AkKQPur4HsME3NhVn5B/dymblITc1fxtpF9QcJNjOu2XEeFl380/UG+WAg==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-LSb/EQL0xr04hneitWETIfx2Itvsit6lGvxc+HrXPjDrBT8t2A4FBZmg90L2hwHO3U+41HMq177FpRZS+jT5Ig==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17859,12 +17859,12 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-cl1mPUeIbJqD2qxJJl/3kqm1ocnXupQf4X6eMbeRYfoMZTxjewxclaTI97nvunABGphedwiJmua9PYRQTt5f6g==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-AJcB51RXcyZqkgDLLMTH9OyC/OGaRDeg/dCvxuR72GAGlB6Kk+zAK82egwDwaFbCGNjxeqsrgt7XOQscOjrkQw==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17886,12 +17886,12 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-Pb0P0oCZu4vibDdGerlniSA6wAXHpVIFpInHXp6/vaNAcuTHW/oyilEuc9mZej08kKGd32kmKeMMl7pOQMLulw==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-r6c8uXpkb4ObNjYOkkBwZCMiGNmA22ORU5TJiST04BB6JB8pc8CdKam5ijIdlPeEItoH+J1UO1TIRWu1NTuD9w==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17914,12 +17914,12 @@ packages:
     dev: false
 
   file:projects/arm-workloadssapvirtualinstance.tgz:
-    resolution: {integrity: sha512-ncPcguoNP0mCwLYSIcKMjWss8cQnZTzKJhaDGBDt0vGRi9vJULmghyA9k1IOmhhYNBYGZ85ykeEpUQWfc1SgDw==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
+    resolution: {integrity: sha512-q+47touRZzGm8JdswZDdCX7QQY/iIfULqZY4I3cQ4bUg/s5kgqMFTUSs0VIEr1EaeZF+jYur+6THR3TLKYkJkA==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
     name: '@rush-temp/arm-workloadssapvirtualinstance'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17943,12 +17943,12 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-BIPK90hBKpKFO2rXdmvEkZ5gWvIZEOxp3D10Niwfbb2eEnVdKgLgwOn20CLstrp8v3hvNfrHd34rn2Q37vIU7w==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-+VBJHnXydeqgMA+LREzxoVADNfYMSCpIuCICrWD597kPvFbrUOW4AGj4oYmp9t0yN9y0sCxlwniOJGCjq+Nztg==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17969,12 +17969,12 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-Ur8HQYhWjusDLnXzJdDnF7WxUTLzIjnuIYnY8yFfJYXwN+e3zkuS4vgiyMwZT7ZGvIwedIBrmEtRKwrCwPsyvA==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-Ps+Fyr13/+CQIoopw6HJdjBamauFtAAXx11s8hATqlv2G0qHiTALPUgu45P6si1su/mgpQ1ZQ8Hkxnu4Keudiw==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -18020,11 +18020,11 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-dphSRyMr9ZArQjsv1gks6+br5kznB/CPaQAvG4rkm2l0BPGNCPHoMtS0+SmiJdZpwZN3QsD20kO6P/7xZ+E+Og==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-gb4E0QEv5YUlEHSn4EfoHEJj1neImQZlzvZ2KEjn+UPi3BaWchMJ+bJWEQDoC805ZLVNJx3Y86b7zUyYTJkMSw==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18063,12 +18063,12 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-j7Vv70VMOID2E41qlQtcKstFS+uNWv3kOj37uRyPX/NJ7tabcqz2m4fGCRwdfrEz/LeA3V3vd9Aiq1X3G1//oA==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-fEhM80Ps/3rd/QuRcgJ2yDC+xPSYg4iSjOGLYYw7iGSkmdfEqgy2rm3upXHGoYNkKgz37HR3I4QSemwtsxWHZw==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/communication-phone-numbers': 1.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18111,12 +18111,12 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-Yj6LU84pMBXmnWdLMHGY3/c5hpS0BXvZLotjRnDycrF5Z96xHiz21PULvoVZ6AnUFaBCJ7MqILNHbQ2MN+1AdQ==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-GAFhPIrbddfhhBBo/1A3+10vvMNMTH/P43/f7cCoVCObvrBBqu05JlYwawFEGsBg8eIQ1OtIGxkj4/iSOEA9aw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.22
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18163,7 +18163,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-Vy2LrBRD+OvZuSpTaz0z24OQz7nLfvz2fVzmFTMKvgp6vxbvtvvlx0+HRayfohCrRPn+xdClCrBxFgRnLuv4aA==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-GELlo+mTYOVJs+kqn4BJf5jfPwGNTvXFlKMtVupF4ooR7kFsQWFX4Z0XiIDUKU5377GLyynLUFBp2WcjCJpvYw==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -18210,11 +18210,11 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-PbzM9jMc0fNOE6LlV52gCqrF+ZK66O+6EF3+WcLXimnbX5Y2buPJgMV1w1XMcyIAi4yKq/amcoshMLIwHMFbKA==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-S7ghC5HW9pRSkN9EmUXkcjUgsEgeL8gj5g+TZu/ZRnn3I54ryIx4ocEUkN5MDWl6TgEeKtJEQDLKBZvK+9U7KQ==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18251,12 +18251,12 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-Axo9TAgZ05VQTvAxhnugTY4JrRng6uCvOl2YES8plVZ4BNBarFxa1RK0r9Xh3S7zO4XduFveiAnCqznb5vpTNw==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-d5eYgAX3EnfQ7xtujgxo6uNr7blwquoMBb+r94EyIT8NLU4IaekyiLc2iX8zK+qxdWuowwHojw1ihiC4PVOI1Q==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/msal-node': 1.18.4
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18298,11 +18298,11 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-wsigSzKygdC13jyjLiunIhxKADJ9UnCkYfr8/1CtnaqnJX1VgF3ETAgXQ54K8lzUG9WM1XKPS9iXn521/HQhNw==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-SXhKHDMVmJp4fbypaV95FEVRERYh+DveD3xq9XVITuamKZVy9ScCp33nQaeYVCsOZ1KufHP0Pt+T7eeJ+rMvcw==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18347,12 +18347,12 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-8i+azlrSwzaPfUDididzSEI6ISrBK0asQcYw6HPfbnMWeOQoh6nglIzPSl6GbONN+gv7Eo7ubrNZ1/kV/TUjog==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-JW/STom8zFSovi52WYZ7USsb+MmrJ4xFKmISnWYXGvFawDb7dJ6nERvzi/gKCJEMfV8vzx0FPJwHBFWCkGWMlw==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18390,12 +18390,12 @@ packages:
     dev: false
 
   file:projects/communication-messages.tgz:
-    resolution: {integrity: sha512-1mJy+xtHJVvH/UKbZdLv68m9QyKBFBa26cnkPDEA5yYpgVOj2NVekTRFmrFyzQjmHlB9q/YFFTbj6xW7LbZ0Tg==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-9TQ7r5FtDjJ57AUIrcN1kYBlXKakkpgQ0yjys71dKbHPzQ7FyLe9+lsHg8Fda9b2h6kQccxW5Ahb89NqMYrJGA==, tarball: file:projects/communication-messages.tgz}
     name: '@rush-temp/communication-messages'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/identity': 3.4.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18435,12 +18435,12 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-msS4wvkilxT9IiwNcWzkiYnOj3OKY9ALlWslP8qsaiGy7k4lrLyfrQQ4VDdrli9z50nR4evz5qvO1zCyEX3LNA==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-IReXUgY+bt+ILdVqwbKf/9uHhney2cd1opkXzeEULy3FR7QXHwAcVv6BbDLb0kvHx/mKFcuFxq+swLNJBOsdag==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18480,11 +18480,11 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-UE7NKm7kDbSjmrh5dwJvLNtIu7jPb+aX37s3ltKbtCZwmtnr5TRJkCNO4En7uAj7FKOfVmXIvr7eR50+2UgrXw==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-QR3HkrxjOmt5xNJ4vIMdiBQ2So+Nvvwsu+9m8ecvKJ4fjDwKqBNQuq8BB33Oacl4Bs+K27YOMVBE8iPhBQlBtQ==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18526,12 +18526,12 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-Wo2CGmqMd/dddZMFQZZf8Kb7jtMqiccShkAjHW4RstjQSts5Jsikr5ZRQYmVnLBCTQxcJMpZW5llcE9HExEcrQ==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-z/yJRIUm8fxwfLu/XtvkAAK4GQyP1sfk4znQgzGAh2mmfiDUQz1cSfCo1crvNYf5M54rPRFhtzv9HhV340EysQ==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18562,11 +18562,11 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-69DKvYfFRZG2wcVB/NLnQKkhII8bcNy4rJ6VJdu8WdqnfRkOkfOXyWOVDzDKyaUma+ppQlmfjxxAJz4zCSMdYw==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-53MeJYzoAFBf+aTsVlacJ14EtzEU9Q0t8nEnDELcTsVICjCjjzuOYz3oehNW5QdpkeEI6NkJm3Xb+TXCqknvBQ==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18608,12 +18608,12 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-yMZi18uHFvvQLChPQWIF3A3B2NZcLGA96H71tdhtw9tI8FVaI6OdRXpWKgYSFA7eey4nIn596NEM7A+SV3AuYQ==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-DpeCGbJWMjG3tqlwwm6GBbQn3i5i5q2pPfcXSZb7RiVqaPVKyegfyGNElViGKLQW0wkus+lSkd34z04j/T2b5w==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18654,11 +18654,11 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-VMR2syaebdiuG/nVIgXcDBc2ZHcVPfL+FB4veHZR71zFiLdw8MaIh15OZpwRYqh2WOqeg8We/O6BtDaR6/lT2Q==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-TrjX1fitrvXLy0Scw7fz+LQvoqxbOU/tKbQ1XMyH0JP4DS1t197yqPrOgeiBOLfdWq8ecsjIzjpLaDDJ6DlZTg==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18700,11 +18700,11 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-G66qg4EevaNfPk3qs8ZBLbg11XWEChlw7lA4kFReiiG2n0Z/+yRSVKYMybFnLzsc/c6PRp8w+3TANYkdgSpdVw==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-Y4SKHXVnTq/QPBoog8ceBbKTtQOBNFA0nH17KBowhbKLcCyrbGNoV1XjUJXJGjPxf4QkR8CXUMlkOGT81ceYKg==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18743,12 +18743,12 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-wGKS3X5uOXhzfI602hjlg465aKvOuCl8tpS+Zg059M2Ml19sS1knr3oxgDaEpVRWUwEZmMTblyHXiv+FH+AerQ==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-5TxVZGNsz1nCmhuwFiJpCT/nyjb9B1l6IayDMVJoC+/+NxkVoGfO4MCK9UrEUFLwhHmQDA7OvIgNpAdH6FlCRw==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18772,12 +18772,12 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-i8p3LI2YdSyw2wY/D4Vfwuvt84cEeweiMC7vgiASoohnhSkmucTEk0dhr3E5aFFAARyiU/S2ntYL8Ze7FN7PLg==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-fBJNchkPUWNqE71ya/priSDEfk73jCXrTPz61IPOgD8wfr/9OSBuXimV7zpN0NbyZxqidwYka6T68oR1HirTSQ==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18817,7 +18817,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-CA7shWTzs/QwzgJn1qBvHhHAg5iy2hfAGzUPNZren/bUkP+UzNJ44BO0Vex5G+mmqNhQIi7mDlrodCM7E6X59w==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-IIDg8aiuMRytXjXdpIODRvdXQ7aeXDeiz92A6/HYD51UBKsiazD7F6u3GHdxY4q9jLbQcM9GvHNX3qFzA2NwjQ==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -18859,7 +18859,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-EMvT5vS/uc19Hzb6+jw1hmIF3vgoX+4vyD6iOW9q2VzY+hqK4hpOdUy38JZnMuqaRxwS+V478wzxQIJa2v/Seg==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-kXfJYIJw2iBraGrqxVf0TYACFurW0vrjs9eHCna0AZ+M4k4yNinnKdT+t5Ph5zNd/UwyVRenGVaBKN2z9eO5UQ==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -18892,7 +18892,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-Z3h+vQL5PHTycZWhPQg21spt7xNacqRXRwGmFTjicKdNevkW0Tr+nfwxY8aqh6mvPvd1pqHm1OOww/Vh/R1pKQ==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-Rtg1GBy8Jfm/O7t6wROKbp/4XEWTbnCKm4Q5i8QBq4cpywuZTDLt1b1jskfjzGA9ILLX7ffgGkeL7qa2zEg42g==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -18925,7 +18925,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-aKWPRV4QLBK2kl3nnh2jiVI/FWFRIdsIGSX4Fa+/moOiF/fkEzWym1xpd59SJnEZRwBd82whp5jTHgPf+RYN+w==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-CsAY317JEQnGsW75+x7OlT0dYHSHs42+WbAgP+AoOoCBaBcIbUqvcZXo63ZF2ZZskMpcHH5tzhykDMVOKzRNjA==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -18958,7 +18958,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-gZ2hSW4xspOouq+hB7PWhgD4mgvxAbhBUTZ2RwqSqgHgS1zWM5cTbKjELtetVccm+/W8795Me/Th6EO+M6GoWQ==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-MW32mT515lqZYTtlm7KGjbTCFR6C7dmaQKserF9q79K5v7j26O7vYMCxCaKqnWl/g6M/uICVWWZaK6fiUmzRtA==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -18990,7 +18990,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-CoSBDLPNO8JoLIcbtkYWbqFRd7TgRzIaeK6HTbslkET7xT7MsP2vShd7gQLQi2P49BZBsKson5uzDiLMJgYipw==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-ZzPwcpF7PRSzyQ+1/wgkRjhYJ1FmUWfnNJqXdWGFbBS419g52JQshgTRJM1TaKLrinzRAjHROQmotg5/Alcxig==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -19023,7 +19023,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-xOkdnewn13VbgQvQk2FqAH2aI1yoLb6kk7PWTDFBAkoSNcEZs2vVvGdW9X9Gk+oXrCznPGZFyEH5FkP1EEmtxg==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-UbwXJBeWFo+V/6nd4XxLI6iYz/9Qi44JL2jo3WLoFRAi0iQq88130JxmgzM0zRdtV1GqVjz6+9NpW/3DmEM8MQ==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -19056,7 +19056,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-5O2FHy4jRgdAoofoSg2kzTpwQ2TTRGY+X1+RYLhoQ6SGyjjdm3RcZms0s3jPOu8B0zYSgJi/JS1vgd90DqWIKA==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-cNjUtktNYRcC3t2/ysB2NvM7sXgCysKIhdn/h+FHMg8j7MEqwFgibaGwozfz+HoUzHwJ6RzLt5A3L8+6IS9rLQ==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -19091,7 +19091,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-nY9Bqa/75yzB+e5uV9bswzfytqWKGk3FR93UEeChpnxtpZZhz8DoOeNXXvL/3KOeZIuRnh/6z1kD7h9uV+/x2Q==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-wwbdcyFlGfJLjHbehuiJymzXkZ0MnFxkNiEDY7ItgYELaR6wYzbMMpHVPHKJlB3zZVgX6vytrNWvd/SmGzd16A==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -19125,7 +19125,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-eesVNX3WyWZjXCsD6HeXRix26Frc1oFRr+nC32Z26rZq+Cy+mNeSIfYA5dSNTx4gSEQu0Y8E8zYdX61+FBlfIw==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-HkpVIGdoYYuqbw604sVEog0W0ctDJnxCgmThx+NiGbZ7vucLdzBvMw16phUZVZn/GAKsBLvFLTWJkiPEam5K2w==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -19158,7 +19158,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-LZg5PyjCeJtP58qwT/5LSu409zelMMx8sDVajEO/7Uu/aUgzJu9zRFV7MAMKve/SOy+jsbd3dlO2QabSxJkifQ==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-EsXLMkh3kiAhHnULlTWidL1YwS+i+L197gqqTYFr/FTUOtb3ZJyQOX2X40VjGTkfqGf/U4xws//DR1Gl4ybV/w==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -19191,7 +19191,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-IvtRJ/8+HwBN9gvHr5egr9Ty9ClvvT0eEYAYkSgSSCNHXc9Gi6LN+0smQfABuuxT1ch05rOtExMdaXvwHn2oAw==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-WWyu8Qc+GHKCY1VhpO8Bo+oXlPTriifu4Z6wT89DW0qjX73qsAjfSWQdxvA1kTRk+66cS/tkk/0HEhwRtfrUag==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -19226,7 +19226,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-zi2q0+vySsA8mtMMcjufkKp9cTRINpnIlzjlvWSpzmmrutn/TdhN0b2H/rSWowke6opQQZj2S7gyEyoTn5CzrA==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-dvIdVJAqvos+gSjY1Aj/yNP1iJDbMuogmOCJFbkeh6N8S1cCY0dFJYFfAzwcIIYEBnGJeJ+FwkdfJ1YOgsBCIQ==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -19267,12 +19267,12 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-KktZ4Q8raaFzMZvdJs81DTWTUgwfnh/x+G/FoDilRvdM7E52qd7ZE7mhdDKSL+nc1D8WiBO7rzcfW7DWa0jM9A==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-R+SocPSY+549BuRGPNxoN45fbc0QVehN/4HbLgzaJ7qoO++e49o7JTHEi8RT8b9/xzfji6fodWMyXj9Q0o/WhQ==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19311,12 +19311,12 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-RqJbaDKSXZsm6d55AX62ZKxJTDTmuD/plMNkyDLRQ2u8Qi31eXR8mE1CTgHd4Ro7o7q0ysunf2lQiE+M0tEYNQ==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-a1BCSwk3Ml4ukrkFdyyrBDINY/EE4hENgTZQUv/geiTxagwGyDh9wR4D+lDb8fB4Qe7SAIWPQsdGSTfzCdyQvg==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19356,7 +19356,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-COAzPkDCKpsPZD0iyU3vk8letk0oh0SMzpVHrj2FPDEB6jwtl0PUaHq/9aDqFoaT6E3+HQ7n3BOwMsjM6mDvZg==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-+bhDzfvPvq4GZ7wsCa2n88wV/biduasOH0FbtwxebJKfG7Br9lefJ0RHB+vpn/S/fN9rv7E1sA0V2j5NB3huKQ==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -19419,12 +19419,12 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-Ed/23gg5F1dDnywdkWpHh22xtLRzGHpWYa+gbcF9YHVNYLGBd2K1o4QwzeFju61PvfPxSvTWz4jPixBXpcQJHg==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-huRqaQThzzEupM2r1ClrY8gUblbqTF/WnCtIqhBIFUcFZM9jGmVeYSYxJjsC1psszFgRd+8zGfr2IgKShUefpg==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19464,12 +19464,12 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-avKbrUSJmYVbZDrLcBXNKJ8PpiPG7f0vZCa+fCAbqU+kicjuLKpHC/oEfZn+3IWZQFrMTVEMyyGDdBIN8YGZRQ==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-Tb4TqGkM3MjhGNPIxme/5EFsb1BAiSeuev7CKKEBLvvGPAeT/F/HoLy8vphrxbWI+ku/kb0/Sr8xrQD2wjmVBw==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19510,7 +19510,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-B2OK+KoJAEHvS6dzUXbxKpRc9RaBIFIYhSytptabCPYCEOvTbCernWPQesxZwZLOtOdh6gMjsxg9jbH77N+1ug==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-N2PzTsbZ8MEtggPbRghPAbsODlypa3eXtwoFeN+Hzsj82YmiJ2AtqrrZlxF0nnnRv9CaZSeF2rffI7bv8Src1w==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -19529,7 +19529,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-93THIU29jPMzUdG7ptPcp9dpa1THxhJlgcxtPD3w94hKgG0nuGflkDiTTEerPpOJsRULx59mHm5fM+XUVf6X+Q==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-0FQIXMITEa/l+8zdPHG/zjvtLCN8QoXkFs4k81eUDyBTF10OQMEQs8Kt5LjhmmXoL31Ebk3P7kW2mKKnF7CO+Q==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19576,11 +19576,11 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-sO3Uhvaihvd3Bg7/GP7lNMRBe9RTJK/Y9VN1tbeeZrUUtEzVDRoZ/2HGMMS1i5nochUABaYcTRcs+AIzEUCk9Q==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-eFiey+cSZpRsZhcViH+g58Oml8QhGUHaTsYqkaaPojIaLcb6em2oIzMPdydUIESTC/i7Sz6QdTO9iuhEkTrsbA==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/async-lock': 1.4.2
@@ -19636,11 +19636,11 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-8YAcPbEVX8e6hLTWdKSMc6c3BrAnvMNMD7FmCmzRhAojZJbCj6xFbRJuEZmFmC6RtYRmFShhRTBTKqkEpio2VA==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-YIlzLPpEGlXZWGZo0ApeJK31QBlgMKi/L4m6VylRfAagbZ40y6fOvOldlE15kRGyf3d7CFCdmT+GSUBfQ6XMZg==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -19679,7 +19679,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-ttfzjJUANggDnbJr5HuaUN+ON0YxwYE1Y302VWr0G0CCyKldQif23NfIIPTyWTMvHf4nj9CwYvPg4d6Xb0nhtA==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-PlmpZyF5PjvNrnrDYBEMFsNB/0ufkgm1KzywLyUT4yj7RB2wCBPKF9+MRDNsGYKshse0BF4fyi+U0A8n457oGA==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -19729,7 +19729,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-FNJTfmyg66/SG9viBhukuTAldKR3ndr3v5cwSp08a+V6AaXM1f6pzozXLkV59lkVHCVjAgDE1rXe+o6fyrS6ig==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-DtLkq585iQEEx+wEG/ZLHm+mFmo+1Lqaerd0zeP8/Q6+I3g9bhwIim+lEHnBSq1lW4Bk2NL1B7Cct/RLI0SDMQ==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -19776,12 +19776,12 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-70EQMw7HzIuisq6qjgF9bsqoH584L/RjjSKKfUY7r8WhuObkgDDDIbKsDfmEbP1UIkwxWOkGrSF57+Zep4M5wg==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-qiy5if7EQqItUjbVsfCUWMfscivIT1Hq9PZa8d2/13rcMfEejo2f4fvJV7TOu9/hlVbRWWXzECUZfEqAEB075A==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/functions': 3.5.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19821,12 +19821,12 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-GorEd7D37JqbVs4m/4dvlC4jXDDlPo+yJJxT4HCpJSwyGh/40EB6WbWFAJNeTUBb0JcvdIcX7SWzvadedxTNAg==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-wbleQFWBykza7uzi1mlegUi/ykLBmo5gSqU0UEyzOjZxqiwdim9JjDFKiTcqvyxncbt5xmdaksbDTjCyo+6U6w==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19866,12 +19866,12 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-FC3UFzKmx+hn/25vEm+zDJbn1Z82YZtETEdMtq/0L6ZQYcxZMJlWOO5+8dSZvUppzywl86BztRdMyb+reRD+QA==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-JprObDK4ZIkZVs+dOu1HgeQ77K4XDK8G5rwnLwF8NENn/tDjgqeNas6DIvqtyCiQivTvBWLsWniuu/k7MJxIPA==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19911,12 +19911,12 @@ packages:
     dev: false
 
   file:projects/health-insights-radiologyinsights.tgz:
-    resolution: {integrity: sha512-+4D3zhQz+qZF2D6IzfSG40R9Ufhs+WVpY/Tal08t89K3TsUCx3+SEOjuNrlJ+9HtEEskE7F8FqnFLXWZl0AW5g==, tarball: file:projects/health-insights-radiologyinsights.tgz}
+    resolution: {integrity: sha512-DR/N32EWAwUGnww4p0xXSSy3sq2D5/EUllLRsT7flXAZkojn5piJtiFCJNVJpjRlO//dWQIdJGtQ8MQ7Ss/8MQ==, tarball: file:projects/health-insights-radiologyinsights.tgz}
     name: '@rush-temp/health-insights-radiologyinsights'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19956,11 +19956,11 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-iGuo9l0rEf6PxhxIBtsypSYT2SdwR89LkFXRDPrJlqs4G/jrouIi7g3yZyQ1KZIVv9Y4JPUgKD8s2cVFhHGd8A==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-6np59Jd4HOu8hbLhst32qagIQhLn+LNzJcdbgqxAD/sK6D67aXfc4W52qrrq5IQmKy9Ef4Pnxriayt9CzpBb8w==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/msal-node': 2.6.6
       '@azure/msal-node-extensions': 1.0.14
@@ -19983,11 +19983,11 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-yUEztF6N5aeTpINFup40FH8iL/o4fyLgRGp6i0bVFjMrpXUSZlXwq29Rj8t3FJ5Vefaf+eB2tEqEIYlZ4hv+Xw==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-gzg7dlW+8gRtdtTawjZ4l10SfMs69jFMoS3kfw5QpSsp6r/LRg9NWWiWU90hRqjMj7VfsxrH4puFTt9AKC/+mw==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/msal-node': 2.6.6
       '@azure/msal-node-extensions': 1.0.14
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -20018,11 +20018,11 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-QfQVxnbJ9PmiIKKVZ7Sdnq8xefbQ5HApGrAY9eQm4ZAUM9+5O99prMSr5anv7URwaq4aVnqcfgxNNK0XZ7YRww==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-kRRpADnkNd6vepATKjhzUvjAwpSg61CFueEF1LZviKM5/lNkq+4NsfvkHmztAGhr4ryVSzKbXHlELQ46OL5QVQ==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/jws': 3.2.10
       '@types/mocha': 10.0.6
@@ -20052,11 +20052,11 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-1za66kG/+gpDsfEdYRvG+qdp7QN4XTy4KsUKzyMsObMI//r3sHFHUgX0SCABtzV1oTVy4oJuaJaG0Oktfn8Vjg==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-21s5O2xyc8O4GIPUyAqBuWR2f0EDf/ZB+Ad39kYQb2EWpGWCCIZSXLfgB+FaqQW8Dh8WwQc0mgW+Zmln1DfKMw==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@azure/keyvault-keys': 4.8.0
       '@azure/msal-browser': 3.11.1
@@ -20109,12 +20109,12 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-+0E/hhaVPkG5Bs104IL+cET+qhkkK63nIoJ8AGBNZqilRubN1MF8xU6rxFfY6fFyb/l7rZHHkn/xR4tYGNg0rw==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-eIQM/qy+VJ+yk93oYP1TQKBOftstISOPLp5X1ztt9W4K1bIN/fW9tvC76t47gzYN1oZSERheDntfByAgqA8d3g==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20156,11 +20156,11 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-R5fYuVYCkHjz5x1REx3Z8t8hmVFVDssyrKVvXekFAtA+DMyBbh4J39nUV5lAV6brH0YLgslJX40RR/jd8Jr7lw==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-SRcfyABBDheD6yA2o8khQ644BFhQxIjJq7LXyXGHG4+bB92n8PjVJL+xIgls1xBE93J82sZqovDM2avpMoXn/g==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20201,12 +20201,12 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-mKFg+F6t3e2VYFe6hExejCb4zxB9ljEHIWnKt815eTA1YpBpn4FonsKD5JThzTfsNhwLDvOjZsCQaTGxJrg65Q==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-evSLIiIGa/Adv60K0ORKL4ArZrrxrjCbgwrCexVehoiLGq4mr9uU9OmsJZ6/9SRcP6Mx8MA9Qiztny20LC3n6A==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20233,12 +20233,12 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-AfDzOA4tZFPTtp4eXQH4W9iwTpXgL2ahH0Z/G5h/OzDLeXmOOjmcysB6UvsaaRk2XGHyl2ns8s/SNSPuREZc4Q==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-cNNz477YKMseToPo1b/YBCo5Y5NcUluPofmjpujcVE/vlEbI5YzvI5nPda2QthQ7cdVtYzt/DH8jz+lLR6PH6A==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20278,7 +20278,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-qoZgUcG1tCoEWvr/idduvr/OAj3OdUR0+PaBxlYhDp+4pUBdg3f3eeS4eF/IBxpcofzXuu1R/mE5k9uBiiMr0w==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-CNJKKWgb64bFHgKUX3kG9nlw52Vah32BYCWi/IB6aKLVk2qRgcmvjjESV4XPuEtk2yUQ1HpyrVrwy6MZ/O+DrA==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -20307,12 +20307,12 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-55Z/vimlvR+U+iUkvODSRtQbkXlT1qkhJg3DeRFjYP+ZcfVJ8LSlGLzeP10ZVMkiIj6XRrHKvji/A2E1VC2cPA==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-3py8doRKPABdd8Luh3maQoZem2St0yLhf4z9Y92yocFLPSZ/2qdmyTKouT4NUQYC4Fo1f35y0DeBXkHmbHJtQQ==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20353,12 +20353,12 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-czcr3iWviKbdSmfJBKdyN5mtODJXh3tWGRIf19xC9y2fQSJErB6a0XtSFnTaOI0wQUFLsPlkV3AF90KmEJbW1Q==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-izYG453mDhrkt0YbsFUl87m9pQCPITb29l9OGk+q4zAW9+6npQ1m9MAuCUpc2Y/ywU/vKwhqyNmrapPzMLcCXg==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20396,12 +20396,12 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-2MdsY3e5oXjyVnPeM+9w+ZC52Rb48lJAx/U4sAHooHhf1S3TdxPitqU37b5eNF7r3OkugDGGbouVlcZFO4Jo0Q==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-REB5zdWoRLak1ymtBXB1nk32ZlfNfJH7rjGmRW1Yi1S0GRsU36Fyi9ehozYnZAR4iL98gsxDQL7zp9kFT4UsLQ==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20443,7 +20443,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-Uz2QAi+q3lduBmnVpOusq50H1Wqzy5IRRHVPftrh/SPY/n6v/jOVTh0iD4vlvw1z9ZpiwHdEO1NE7i4w34MFoQ==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-kRR6Sn/ek0zBc9x0gODPxH7dlIOBAbz0Zx8SJorZjmzilpbJQKIWLgisR6Ozf/4VWa9XfeRClPld8xJ8IxLzAw==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -20477,7 +20477,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-MshhAL16Di9s1phne1vgvSkvX9YI1UWTu80q2UYuUxgBHPnwtw5DwXHlGu+WnMKhGS3VbmOkwXanBPJx7AgDTQ==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-3GpElejNNohWM/YZB4HYYpZsbjPr3iXqG2qqlASff6ercwPgzyU/zjmFgZj31zrnOFPNj9l7z0aoxyHhoLJlpQ==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -20495,12 +20495,12 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-wUsvGcJqtM8gFAJQ7CrR9bl5cc9ypYhw2Gy9rbal5p0lOBqCwm6+PmWhecBKFKV8Jj8eCBUtUD4FlJTpGlotfw==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-jHGQj/CT7N8nx/uF3zol96HjXg1KVUn2a2vzGJX3fQyw3neRlv7zBOqzusB7ena1jWAIARVtqr8Ir0OICsQ+Bg==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20540,12 +20540,12 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-dSsN8iEG7KG7FFABwBeyhd4JZEoN3EzcZttz4IDRb4tdjNdTI8ZBVBjV+xZVBmFZH4YFb6jOt31Vyp+W5r4xUQ==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-cf7n5dIx61zDqUwC2fd9BB6RTo1GJ7+2qpZal5MR/SNflYuM07M70g/ZneJ0HGjJ96RdBuDSm+Ruxd3Wk6wPMQ==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20585,12 +20585,12 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-wdaTx6QroFqcCWgUATkgNIAhOQH8EcxDdRdDGrlZDVbstf1Ko6MTaphRoWDrnFvMR55Gl7mDcok3WMglTC7mUw==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-u8Z10jkzEyxMxh8y2nDFWwSLkEpUuKpmwrOhQ0b+TsF5MR0H0i+Go8oQLZrjW1YgJdGUbJ2BS9hbAsOS/LR3dg==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20630,12 +20630,12 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-bNudmsdow29yjiW8cy/Ldn4dsuVlhV/Z0Og9Elhr0T54TF9RC/OdMHCoFnGVvOTVu0sKmr1nyodIygtBGM5Rwg==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-DVBp+9mLHfJZYd+PMAQeNDKgZxczgVvbrgdotgYEeue9Ay8kw8pPIaVHPydB3Sa5myCMyFFD69k78OCjTxlMbA==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20675,12 +20675,12 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-fvP5fJs4x/bgKsUzgzPsQiXG1Nkt9v93irOBUEt965TFkSTgPi+U6Aox4Hir+P3g52drh7OXVpOmKJS7ivMDMQ==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-YHHnGyeoOSte+mO0Rihn4PFNeSmu4r1duUFox35EFCeN0wy7vxz06ALHRd0Uq9NkjbQC7uN7+L8YPJwjl84xsg==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -20719,11 +20719,11 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-t5WjuwwrfMX/hZ4zxuKD8IOUyZtA/9SRRVHeg4DjXccs1EJG6j72vApS+P7voCUisn1cnNOF/q/8t6BywLy68w==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-qERa2sc9ODYfn3WExIULlDEY5GxPOqFUmKcBIZ3/8KUaIaZBHFu5TeeTha7mLUWSxluJgaLym+9U/HkofUF8uw==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20766,7 +20766,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-0iFt6iHLpfCmW64Hgw/dxsQJuhX5FWqOFbYNpztGMMZ5z/EYnJ+0blwPQA47vwp6HRJCs93XGCEo9/PL8RvgUQ==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-cF5biFHCBknMGeAoMtk9cec5IzeT3ABz8tle5SCZMjc1UFO8hOUeOpL26O/SAwfdz97VYr6NeOL6XWL/l/Ng+g==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -20786,12 +20786,12 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-6rCccmqHeXBq+PIDec9u7JG/pSQiPgCQToWJl1WcKKPJutpnZETh6aRbrQc3N+j/TkXMJV1ZiueiM0MMD2gISw==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-pXGNW/Y3XOqNCR69Toj5+dCHvSQrhPkBcTxkwaj80nLiAf5ZwxkZBNi+uZnuRObFlK06UMgQAEYdeomjZIovpQ==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20835,7 +20835,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-tLeqvT+oOPdqagLgotdXnxrY5OXzbp9ESLQTU4s58ZREDdfqX4MH2v3OeU3okiVee0hfqJIzddaanPcAAeX4jg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-xmNkzEDSrL1ejbMXBWgVeMew3KVg5uL7hUqc7OjDW2s5fR4L0LPqQkR1lAJjkshDL9wje+fY/sTeyk0paV0k6w==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -20870,7 +20870,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-8ZgGWmi2k0JV+nDAlTifU83CBynNO0y69qaydnBHtpwuwWJmOc4kLhyqgE+OyEzjsSHP2xZRK/GNpkGBqWuwGQ==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-jeb0N5KN+neI2UruwzfTkBBFjZJO6RidXLSNwq0C3pQRkEPLhHU+e2ZMtu/czYZ1aJNl8zNWzj+gOmkTTnc99w==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -20916,12 +20916,12 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-x/A43vf2U8Z0t6yOUVt2B2KtKp5HlawIWb8HrqGCEZb586ISN9qItAGdTtYSkXSmwy5ppOGGnQaSOtnmlRepzw==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-jSfld+JUQIXg0BYK/2RfXXZYSLZuafRh73lV7lR//mXgYA6SE8Yr3oPDaNe/7kCDCGbFwy1tyI6VtCgabXUM6g==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@opentelemetry/api': 1.8.0
@@ -20960,11 +20960,11 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-8oR3YX6KPtFnqsYNVrktY+IoxPGPG6Se9QfES0nNlUypUQGpXuee+fmkl0JmNGapn5YX+7zaldlEqDXvbldbBg==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-YxQL0A4IE5R842EtcPwwN/fX4MubV9+GuqIF14kZdlIs6XGHtGdn3qlelkUTedNzJTATJ2lhXn3HW3ecxqB+Yw==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20998,12 +20998,12 @@ packages:
     dev: false
 
   file:projects/openai-1.tgz:
-    resolution: {integrity: sha512-/9ALweN0zEGSN5ry5iBg/pEILeK5KRGEWz4jv8cKKsM72GzCEBOD4q5tZkx7d6YlAdFxpaS7dj9jPm89n3KgOg==, tarball: file:projects/openai-1.tgz}
+    resolution: {integrity: sha512-WFZKTPX2NBm5uzODq3Ek9oz6KBRzUFlK3hDOFEWxyk44jIOFFvQsbIAbZkwUluX8uJzI57HmEWf8E5eM3Yfxvg==, tarball: file:projects/openai-1.tgz}
     name: '@rush-temp/openai-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -21042,12 +21042,12 @@ packages:
     dev: false
 
   file:projects/openai-assistants.tgz:
-    resolution: {integrity: sha512-VD3xLnfaCBlNYwqeKtu9DAyOgY4sC/cSjx8+puVsSuhjJx5s1H1B58hX0HOQXlwgCVinYP0sr18yS4uOhYlXTA==, tarball: file:projects/openai-assistants.tgz}
+    resolution: {integrity: sha512-GJVKMOC0tTj2m9vXDYMp2h9zRbTt/qaGIXOQVgKKxqq+072Zuls31uctmGuq2qQWSPUa/0c4SnBgU3EpgwmrHQ==, tarball: file:projects/openai-assistants.tgz}
     name: '@rush-temp/openai-assistants'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -21085,7 +21085,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-8k0W5UZO4jYWW3R0sw4J8w/xFEovBBusdYQqIGUMlwGq7t869oE0XXOfahDsZIGDBACj32ci3maBGF8PN/MhUQ==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-obXb6vm/bNL9CLo3VIhpsCeY0v9qbzpa8/iCAGWGHLQCqiKrC38nOBVU86j6McQhLyTeviWOz04ax4b0w2Df8g==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -21103,7 +21103,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-ODuLXXwjXBHv41+ZrB+tU8kMXQU6XJUrw0Mb3jdVJ1QRluKXuzKTfGdeMCOUUrzappAx3SWTD27bX8E6QeBZJw==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-l0tccY81RwqyVPCKFX4+Sza7l7vKlyXotboqaAm0m1VUj0XRCnjPZZ/L33UrlyVvOnsdkqK2XfcickwgOfieUA==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -21147,7 +21147,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-xd6n6otdsDq+e8q0srZoZ5f856EN7cnYadzqIIZiadhHflDNJViREAEponGzez8Uf9cUHBNLmydVyhRNlgXrzQ==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-rASGQ0G0+fzOYBbIkmsn9sCUvRZOppJ22HvmrrwtbmbniuiUo4gh/FXIdYlzJb2lwcXasQw6VR17/71pPkT0DQ==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -21165,7 +21165,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-uJYrFewXZmkjhxT5Rav6ZlYIYJy2+SblcCCos3v7F/OFzzpUNTjN8WF4hQAHUJm7TCRoK56FUlf5jZuofT1ZBA==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-UIZK9EVBHxhbABl45SjFVdIxQ/9fpLmjapFfWTlrVOAqpNk5xdLhgWac1mj6BQ5j6AIVH9WDG+E3nygvJqBEEg==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -21183,7 +21183,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-8QB6gyIx6315PMO8an0B/QI3KCgYjyWlOE8bdAnYPfR7QuaS3D2qJCgRkATynTMOOlNcmMvAunGYmin8cFwv5w==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-BzLEG5XGTkGNk7zIM0TqunobgSCQqZwhIua4awQszd9KJ7Vs2JmaKdITBXlXqAgSPDWT2LHwSTwnQL2Ba633Kg==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -21201,7 +21201,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-Z9YQn9utvbBe4sTD9hmUhzuMqyV94OjW5qr4WHPt0Q0un1AmKaftHDDi+UyPQ4+ALKM4KZBFOTQgGULkLa/U5A==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-BUNNlM7A23+tmB+5L+TEH12AQd2eBCDhnRyVcIgtcmuTHXJ1/yBv2hvAUhF1in5F4Kodir7xgnPJlLlO0SIayw==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -21219,7 +21219,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-EWyKsHNIlmy4Sk3ggWuIqQpvpOFdo51e951l5CBA6ikUg2n+P6Dho/Kq6K0k+4tJrKYuguU2ylYSKepPIJPinw==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-fHWrf90kOWIYCSkVQLe9CK/5eliInwwpZDtONM3NiLveidPZqb0UtktPSpEXK9AtEZkZMTP/48qXugcQYgAvLw==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -21238,7 +21238,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-uuWmJhbaoaXMibMa6atxi5qX58XBUvOUyi23fWUF4IAURyw5w36DT6OJxYSG5xEUumw0bt6/cOMkMu4hNMbxWQ==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-LTl6Zboh/zFpK2LjSu2QBLNcbsvP0WyTuLGl5H1wZ+alW0tFROc96eZuYJnjreVExYbCy2hAMbJoGeP6NOqnEg==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -21256,7 +21256,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-2P39o1Sgu/Gh0rVZ7mdVKx6Spf/nW3AQB9FTTfMxF37vFx9aPMI5DR9am3gUM0dVodxpvzsMOz5jExdhgBpAQw==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-qfbUCtpzT51U343BdSsF1Xlya/+2ho3Gwd0fOZVAvzdt2WHiLSqDGYfmA1MvrJR2OHa2fxCC/f5UduN9oGeOuA==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -21279,7 +21279,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-Tfbwz8f1hClVmPQnppnVh858FUUyisXzmKondS2JZatax8yaNZoyZIPlXFrtBTzK6L91Px7OC5KiWzLYXDfOvw==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-rjjhVXfHVaxpdwElwGpn3SCex+Ypikjr9TMWqs4CwqUMOF23IWI67HlKf6HdY5GxSCQy2oZdC/bLe11LBVD97A==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -21297,7 +21297,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-1Vw46tqZ0995EATMPhf4JcLRkg50Dr3klTaWww36MnfBhz7bwA86Z7n3bAJueEPfyDPYmOHziY4SMV4qdqATkw==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-63zllJX+oZScSVb9Z5g2X2y+P6zO2RNZaZ3K/dEPN/1fq6pSiP6PiU/+aLhN83ivupPnzMYsNCRb1ur+fNa5cg==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -21318,7 +21318,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-ylDyLkkZ1Re7H5UF7M0LKK4ht1Ji0g8OXjBiVx7QD1JuRsa3ACHGD9xQ0ph4uemlLr5+Cb2/xXQlue292U5d+g==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-y3VWYT642E08TUYDVIXUBxvzBtjaBIbXf7FU3DJa4Mlrv3XEg5HhSfwDLo3b/pD5lfUsoXa1JTlP5b0E/prw2Q==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -21336,7 +21336,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-LanLEqFxVgquWVImjhAFe4t16AIWT3QUpQ9Hxr2KSmAMQ78NIvE4zKWvJLECtYF15hYZ06mzKJO0qvufBHu+hA==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-vk2WpTlPj3AMAYsdru1MTAE44FddlzMjfIkC8XkW/ts7R3txuBIoIGDR6JhkWIlYOjikXuO1rFgXIjVFLoIeIA==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -21355,7 +21355,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-PlENxZotuvjCJuuodILMtn1eQjvKDtWi4kKrcXPENzxY6olKmVqhKiKBjMFe8xcdyUVo6PfsTHymO2Szy+gh+w==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-zOPwz0wU6luYC9uJ0LyBVNsL2P4lJ4PWI3ms9hCbVJClSvHjKbxPzOcMFOQhWhp729AFqSOhlk7B8X7bHqthrw==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -21375,7 +21375,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-3ZSEYLaP78MWJqqlPdTzFnE0dydtGByK08jmphkFj90/Vmi9MRHRC/qijnjX5TqU+n9NDKE+s9kYkkDCpZ3NTA==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-lGZ0RX/a+takGsZIBhSYgYQhHUmfZ9577OcSUzuvizsmzcfgs/6NCauOQITFUr6XcYO4KjADvH3TKXkZ6/NG5Q==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -21395,7 +21395,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-WKDim5ykQMN2z6UkT+WNMVW8k0l3rdhy2jYCDy3leio4s9f7oy0FtnS8D8FdViFxSIYezKhn6ha2Ap1ZU0psDg==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-skFFlPDPRRLvmtdC3YRaEfnSghmIftrfpCYhadDSz4cp1M79dehAuqCDSZhU87chwuZ6CzbSLvClJQDOoS+tLw==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -21415,7 +21415,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-pF02KObcIalrzXBBd1fHuXJk+iSKe/44TkevE+ibf0JlSVEX1zWWIm9cPWCpfJX1cccQGN1Xec1x71z8dP9/2w==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-iwXZlSnU9zrkMHKZxhOC91pH6LDpcDK1AlI+m7YYiYfNTcPY0wT3NzHLwUMQdYkFXGTD3qrGSPgdwdjYvc/LPQ==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -21433,7 +21433,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-tbbPuoK0caAWp0xCggVh6W6+3QY7fC3U9a9/Uasqx6lDvvhCW4i8eZSokJZLRnN3O5QX2gA1xewlZprWOe8AyQ==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-9I04P6ZXeBlGimNqTV3fSLxHIp5qVVxM75CMfLlusEMAsq+MJkQQrySEXkBs7pjcklIlsMUZl3giIleFyU82Ew==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21451,7 +21451,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-l/V+bYT9/DMenAHutNKMww8fXBEn+9BodpsHtx75fPmr4Y5RpW0Ltp1dERblT8Pb0E8RIgBTpgV2UoTC1i/hCA==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-yhGWtVfRdGGWOmfWnnWcm7RtZec2pgWRH9KqsMmWAjRj76m+NY2cbaAWc+HSXt8vAf71hgXzmM2qMqyKkvPj5Q==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -21469,7 +21469,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-Z6AWB9I7hDNHhT1ZcefykWh4jOIqVXWb4nMRi6WtSfOucqQuvbnNI7evPzdyPx1Iw545Z48exyoE8RW7AizYyw==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-pNFAONHtH28dHIpac+1PGmV9YHeKFBmr0kZBjtwdLkwc00ORwZ00IiyiXdpZigeyl+i9oXqeRREDxJ3J5VOXJg==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -21487,7 +21487,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-BE+nuzLuPsOrR2jCtcir1JNIKSZGtZwfwdBYBUA0pIEMIi7wZp4T8/SiiQVdkirlxSuGk2W0SOjKuzKDo/iJMw==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-Pz8Yv1HHdikjRSmbgtkDu139+HdJtglyjMLhlcFaOjqIKpMV3uZlpku6qvzSDeyM1yrFBBwWYzzQb4hk6Ob2Pg==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -21506,7 +21506,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-cwHH48WS85OOIZ1SGphw6/GIV1JZDMjOZP0ocgGTIaR1D1DqIOJUXKrdLVCGgzxv6WcxELIEsQk38lGT+PXBWg==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-ZovRTuFVB9/e6FZzvmlNGbw96rpQHpJTKvdA9RAy/TYI5xcJgb+n9xIs5Ju3zWkYpCn8L46rGM0iDe4QwfcRpg==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -21526,7 +21526,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-V82QX/JQTTRXFyM6INeWcyLpYdKO5SU5PwJ/Y8lOZLK0oN6VrRp4ByPhcznh5TWfI5dOzjqRfAVnVabe+cdE1A==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-615Ezh5eWoSnW/RYkkJnLGOy8PygHk2y2fWisFHwPmMCGkwOhvmc6GpoWXNYulZ3apQcy8OOAuqcMsyujjOnSA==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -21544,7 +21544,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-Q1k5Q5A22jVSdicIOzVuC0Ph3YhV1jZDv4BYXw1QQQUQvXmP3Nczxx/S5R0h8iWDQNo9wrMwhSZCl1rTqmdbDQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-v2d+wPi7KzFZBk+97iTfPQsjd1CAcTkoT06zTlqGaNOyl5Y1Ql+4lw5Yr/2mfD/a5e4EESa3Q98aCSN4BleZBA==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -21564,7 +21564,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-vV+IBBgY1mzop78ZHH0t7A+wN13Nx9dRIY/AC2X+UfsUHMd+h/Hnbf+dzgHfrH69q63rlMVp/yyeP5B50CCb1w==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-3gJOVQ7Nh4CvuHmGSd7w+iftnmNEwoZnSS0jOyQsENBfuHIGyMJIQIKSEV+YnqxJn00DeyEBNI6sB9t4JFatpQ==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -21584,7 +21584,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-el9iCOEMfq0oemoyr1/c3yvxuWILoyWvxVhJHU/zzK9M4McR5psR3xamB0L1sMciyOwOdH9dVaFnAsJC1kbzNQ==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-zE68qE7ZHqws8OoH6W28NpWdZgoes2SZ4un1WnRh8402TmhyskwBVNLRxn1SbXThOUlLy1+F2Jvnk3iDVOyN0w==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -21603,12 +21603,12 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-LKAQLJUQqzpkS6isYcClOUhyClNYSzUG/O7SH+wxsn4Y2gcSUPENd7+a0Wadh2NmeW+WO5Xnc+0WnZnCj3JJVg==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-ESLAOnPa5WN79J4UvIR4feR5/NvBgSw+7jbQ3FuXsLCPbKT6nhmaNBZSnPMZbtzg8H7WmvC+bKmF36owJAgvaQ==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21646,12 +21646,12 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-VyLqhAKHIZHRxTaWtF7x5z76GRSZSWcQw3VNfnumhPkOJE2RAaUsNg9ovkBC20FUzfblrek6vRPOig7ax/iMfA==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-LszLOSXCmEf01D+a+2a6ohM1Bd+OQYB/6hGQCnwygj7HdlUbqmUTcaHfYcGQmNra6bry5uwXLHiPBzAi3072vA==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21689,12 +21689,12 @@ packages:
     dev: false
 
   file:projects/purview-datamap.tgz:
-    resolution: {integrity: sha512-UxdmiF4uOpxNYvaJrOy6XoFoSDCD9AjaU62WVG/OQ3cvhZUcXesZj4UFCLeJ5Ew1AukBRIPadNH+DvmLV5aHLQ==, tarball: file:projects/purview-datamap.tgz}
+    resolution: {integrity: sha512-5qP/6q+0wpk501nP/huk4+KIn6PMwlta044sIRuVQPyV2NUbkHyIA5D9gR59ri2L9y490ekKfIzIutYn/m1cdg==, tarball: file:projects/purview-datamap.tgz}
     name: '@rush-temp/purview-datamap'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21733,12 +21733,12 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-mvd1K80vaIbrpf+h9396uU7AOahn8BQfsJVlVizh4VnZ0LqXMUaCX7L8jOHmt5445ghsCcYvqn51UC8eXeeV7Q==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-nOupcF0tSQAQFdxp9+CklvhCKtJ3CRftGYaPqIZdcals6N+kDK3igYK1i/Jck4vZgAlRRzkeUWv2VBlhHVhRZg==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21776,12 +21776,12 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-goRR6VvI+cYUjVHdLUZ0zdWCimAv2Fo1QUEWx8/s6ebRZ6F/jvJPHrv85w+baKA1dIxVzn7LDHpOqeikVujFqQ==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-PnMhL+gugvrRahnNf5p4wpPioZULoZ7kPETQX3RKQ81I4Wy/GSsEa39Q0wCJH8TY0xEeu3ST0uCX96RIVoXc/g==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21821,12 +21821,12 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-+jV26WeJDEg5xGi7dXTahDatGn9FYpCvmNOtKqwjiNX2AxmNWy6oxIhrvrRjuACiDhHNEFKY75yHWmrCcq4gZw==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-6t/eI/5CUZ+0ttMUlRnhoh2qfiK+7tdSETlh/8ctC7bkbDYvJxV7yNXvduAEmZmJ3a9e/TM0Ok0jLZDKEmleVw==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21865,12 +21865,12 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-wm4HU4iPS1Zgqo1UoaQzC3L3DaL8jH6G28n2R4hKVWnZehoSoX6oTjFC1LjnFngIq3rLEBTux0IXVdDLFKsmcA==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-pdyzHUKwaV83rtmbPI1TxTKCknu3XEwJMraQ75lzaEaqQvnGP4pzGRrr6JczTCNVeTabBxcYUvfLDXMbkwsqOA==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/storage-blob': 12.17.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21911,12 +21911,12 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-kho+Bwuwyc4saljyDYfl7ftWlOEjfx9qMQWUS59Q2Kwr0nB/C7j6sDyPbviV7S6euQvn61bv/DF1d9lKGWfTtA==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-X3VkU520x8CBH5vJdeo29Cty0iP+Z8BfPV8O59QZ+uiDgJW1n0k8qNcULujikHX4rBD8SA8xVmfvBXgP+P5c1w==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/schema-registry': 1.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21963,12 +21963,12 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-zhAgW6R2aDmOAe57pVTMPrLgV2SK6/iy0FS9wGK9sIzIAxNNVbZTNzV0SUbEMUWnaKR8dKmK5OArjsbb7o+4Zg==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-IWN4rF2eOqrksHdxN4K5TfTkvkGHrvwszGptfMtFlj3Lz4Xdk7yaRRey3S1QU5l6ngUTZAqFjsp3BKzY5Ol65A==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22005,12 +22005,12 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-HRwdWQYxvlXH43gYmPjgGeI/Dy23kfa/nOEr1VuWuYMisdrEsAL1KZuXb/Vg1gqS9PjKnhRqGE2IfcMRJ3gRCQ==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-7ja3fJcWuZ/O1aAmLJfI1pSaJ7d2M+C8Pwkdh6L8UwwU95e8F7LMEvHgNi20hCMGd6YrR06EIkvTilywzlummw==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22045,11 +22045,11 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-hcIXqU0YNUHGzXwPM/VtFzULpOkU9v9/L3jEhYk8/ytWLBeSqSjzyl4allwHCKWjI9wZJKy3hXp7vXw4XZa5Iw==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-ijt2RGREy7LgIya8t8CeZHO2yQTN/KG7f8hTg3jClI8zybT9/6wDkAVFFd1mZKcEjq7zcLBKup0ZkOFPleUlVQ==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22091,11 +22091,11 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-cy+g0bhS//gVn22oCSIznS9vMX7bgxhxukSt0YaFuuIp5RQiK0hO+GUF8ayXCFQrt4h2kA3HbJmHnxaFA87eeQ==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-sRFogSf+IF/l0QXL6z2z8MEEDNbrDBRGM/Kz/zFi7Wgye4nb2JVEtvG1LIo2HtYs3jE7OoyWIjeY3mUcB1eSjA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22152,11 +22152,11 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-juSIC1li4GnSMtr52sqeYp2dwVvRbLsukiTXloppEInLQldiOGXtD4nKX2yPQ1PoFKMuxms0LPf9+dDbeAs0ZQ==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-38LygjgH7iPkjeM9Ag1mHMRfNCdwimzAOa6Obngk8PutfoIfnuCOSTd0lyG7CWl/6fQ2g0MVbwZwCYTLJTBaDQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22202,12 +22202,12 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-g4ZWyCNIcabcmZFBiJy51O+gNvI16V5FoCq30QggUlQ/l1WypC1teeDqkIcj22TB0MiexfbeJ3z8YWvAkvE65A==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-7Vrb9dnnYJRxnLDHtH4+U6MSHrl6oYjvkZCXtH4dVD4c0W03baTv5fL9IanRKgjoHHOUTL/mhJu4JVdi3Sw6rg==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22249,12 +22249,12 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-xCg05IZblQAiB7VPW3SeIgzTNV5yCeSV68xTIhmkyUbYJaOUjoLxbnU7PBCAAGx1KJCNhXm5H3LRSbwRaT7Cdg==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-yBxWCs1FeEtb/Rv55nSd5mwHN3GO/MygcD3zZU0ufCULqNzX9GRCITPnuQXC6Kpex2V1rGQCq007gZXTMw9Z4w==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22300,12 +22300,12 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-R7cLavgKqbc/Ic2CeSl175q3UOrRiic2x53irg9bXLaRmb2yz/cnNCcXMFIu35bcLPSYVmHkv60RCDKsFLkGvg==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-hZ2gU3o8T8U7P6IBrrDAjI7+bK0MoqlzdfJd0DaAB39MCEYrJEMyW3e1OzJZe0NhPXB+wgZwzmkff7/SMWzniA==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22349,7 +22349,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-uiRAHlsLtuDep6ebSYIEfXWla6Y7gkfBcP8wLYRfyktHTk/gHmD0UbkQ7GG6KukW1n6EFo+qxASTc208Esjnkg==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-Hy9wsFKwF0sWdBPwDCnuntNDNYEezwLmGLWHl0upQ3rWUr+9HpxV3CDGcChOlH6EhzTpVtO+r7lZ4IAvPRwMqA==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -22393,11 +22393,11 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-ylTL2+88xsieomZKRlb9ZN4w4ZGaZ9tzZ2mxwX/h+J3pibMP1B+IWqomx7hLKnCfrS5NetRIO5l4QDdbLIyw7g==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-CmXOxFgYUJEe9wfWGNHaXTnhi5Y41J++V0K9mIHznTWuRJeFoyToOlqek1Vm4epJgtEi2zoW4mCJ7JUhY2yczQ==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22438,12 +22438,12 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-boeqKD6zOLfRj5L79acHtQGKgbIyG/lKwTW38yGI8xmXzGAnzPkLmgvpg2ij9EsbtujVO8UVRVbBYrlddZMQxQ==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-tDPRrI9fmalwXNqUnPeF8J1WcRyEezMJQNyHaYABWOA20RYBSuIL9a6moz4mrj5DKHPNSRym54GvWHGco+xAkQ==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22484,12 +22484,12 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-U9E1Ea9M8tXn7WrkrauKaEIB/63aDVRSiX48J9Qm6+a7baQvIKPKe3gM7918Fs38E5ee3S57zafKBLUfgBD1qA==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-xGtPat+BInyxrG6YcE+1tNM1sNXb6goccz4tWw9303oCmcxyd1KPwQ9JgCUiQrwoFyAyo9CMoZwbO5jkMI4SaQ==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22531,12 +22531,12 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-ULg7ZdnKwioFLXqpcWoML43yvGjBf239SbLedKOsOXzmSWk6a+ys8jgnMAS8zSPnGImfjmNpYcyUNBxYZ6Zx4A==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-wNJ+binnbpD/VDUnPzOUz+8chiTBIrpswwpr4kap6q216jW4coK/o3funicCEcSUbqFnPdS4QKHT3CJ3KTCtBw==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22580,12 +22580,12 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-pcpThj5mKCAhp4lA9R44AQ4lZz9BU/Jmc9RMd3T7nXwwF5HH9YetLzJINce7fsm10LQmYjPZF24oOcoavO0FMw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-8ajBCeRjgTcC7mDhMskORj2+yZ/NOW+v6Ki2fmcUWzoXzAtKY+hjto91Py6iMLGMd/bsj0bwh6idDSyffhT1pg==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22623,12 +22623,12 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-oJsSLJa+Av2TTYsPjsh1h+0Rl9jVnhoo7OMFo1jvvmW8O6mfmTBhEUrvjvXNtNSE2vV1sTtafBet1Vt/7rPv2w==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-hiKqeA2RzFG0zo9pSgdmd3BkndP6exHD7kLvzaCNcr6Zv1NZI3irDqZNFCu9CuQKiKjiN0K9dSKYfS8B0vx59A==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22661,12 +22661,12 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-lmvowPFgRCfJ9rqb24R/3D+P6Dzm+wzmAWUdpTAmXKSgw67gDY854AshY9BPi0welTObcSKjbDU3Ps6Clt8sEQ==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-lR0t8CPu5zTnVB1YTcaN6LLr5AmiyGlnnANkvsgFwnY/DruxdD1qj+QhTSaUxvdiLrSg3NxHi3TduQ4NE9jhRQ==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22704,12 +22704,12 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-F+DgOl3E7VcTMamXwRw8XPc/GrfOZcHm+GtJ/u4/bxTE79PAjre4phS8WPhk4XdrmT9CbQ+K9Xe2AMWyA5S+1g==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-EXVd5nsFpKxvwGXFXw/IG6JnrgNRhzC/V3uX6AgD1uuMLLK9WVFudPncFyuT3MWWUf2WoINfH063q2dyaQVnPg==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22747,12 +22747,12 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-HNkNyDFnXnUYTqksHKM9+JxxA3i75eDZwVoaspkM2QP+wft+WEtknVgtUA5HPkgByqcNrdo7KJZA/cfNDy9qyw==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-yTmDyGt2RMg2QpvBLn0MUoNOC5jkBVNfazdkwwqKoI+ee6ZuAeVEOgMPvb51ht5DFqS2O/uqdWcazUVMAhZtZQ==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22791,7 +22791,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-Dp2ivvNiSh3YT2rXn66aaH4TwmvUPs0u9hA938JfLF6IGxpOebWCiYU54o5sxEZN/KJnt5+HfLXYrU0vCSytNg==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-2WK/Oo3VDEC2URhwEPcwKIezQJVpervtu929H8iAkpMdHl1E9PwDgKPSLQ1XZa5C4/CLFZAcmlvHtm00xO2t4Q==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -22808,7 +22808,7 @@ packages:
     dev: false
 
   file:projects/test-perf.tgz:
-    resolution: {integrity: sha512-rUvNFA8u6C4yeVj4mefCTGk6kXe8CzG7U4+UqLgyvy6l2Td2CXUBIxE5ASY6V8G7P7ZFnJ4YaS997GlL09WZ3g==, tarball: file:projects/test-perf.tgz}
+    resolution: {integrity: sha512-wrmpiap9iA+/nak2kuwyorrcyAaerobLN/Y0dXCH2kU2CpEvbGtOMRbQDBkz+kHCRGx2ntsL/cYkDL39BavBQg==, tarball: file:projects/test-perf.tgz}
     name: '@rush-temp/test-perf'
     version: 0.0.0
     dependencies:
@@ -22836,7 +22836,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-FLaw6pXVLh04DRS/g3T535oImlsrtgretHHGrqeqBpdYtPWgzOP/0iyB/MwGB4NxksMPXS6KMMWdaGCDZ4n7Jg==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-knW2vdr/GkxxeBG2z0KVs6UwSvteY4OsL35ZJvBlHkbkmFjBTmoYlN0R3P6AEIuMIwLu8g+R6ukp9GluuEZM+A==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -22874,11 +22874,11 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-QH6Hi8Amo03+nhG+1il3yLWHabkrgbxgcfKliXXEO80gHKEtGYApFOu42K2pVgR+7Ho++Ya9G1AVwxVMYUyA2A==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-saXw4i87Ee+oH243a5NdSMq5wH7McXW1i6Dx5nwGkOg5uHPKJtEPS5tFAHFZIQmhJMEh4/pPZ39RIx4voXE4fw==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@opentelemetry/api': 1.8.0
       '@types/chai': 4.3.14
@@ -22911,7 +22911,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-mgYnEo3Po/jE3/DNJAXPS2HObrkhpmCNqueO2JK3DtwzeFly8RMra3zqDx5PUyMj11UnUeYxqXcAZy+K1LE7iw==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-tr8nH9Hv5A1NvJBLOAvetPKGZ43IMNjPxvAIjids5dsC66JQfdcC0i/1NN7dJGRFOZFfX7g2SJI3CUPQvS7qfQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -22947,7 +22947,7 @@ packages:
     dev: false
 
   file:projects/vite-plugin-browser-test-map.tgz:
-    resolution: {integrity: sha512-8Jg44N2Xy3VsZaSgcBDkWDjjpT8NcU+0TXvb3PCravbYHdMtI8K/XpI6fkpZnisjjl6dEE2MCUX6ecPAoFvvnQ==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
+    resolution: {integrity: sha512-oYyxWJs0yiBuHRK1euUkqJ2WM0LVn+fgnhkQrnjRmvu1kp4+rbmDA3E5UmxKBzxgdFs29chO8Fx/0YipGFMQkA==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
     name: '@rush-temp/vite-plugin-browser-test-map'
     version: 0.0.0
     dependencies:
@@ -22962,7 +22962,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-bwCxHezkWnL/Nw/dRRbSgS7oouK66bNQ+cNkd2ql4umt28yri2CSWGaiE6rwuY/9t+0TQo6uMUJXN4XY/uyDyA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-Mr8pfNTdXh7NxONPon6+1Vxo7QMFH0FrslOsDchS5nIZeUwtg1l60/p7s7e7LYsGb1ujANT7f1QgpFmWf43eBw==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -23022,7 +23022,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-SD9OjKfz1eaZ17d3ss9UrwEjFLmNrvmZ7bIFogBQPUBNEJAlSTKXwwM5FoIYq+0zAIZ7cMAvEl3XG/VtqIwqYw==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-MNh1jIeVUgmU8gH015nIVblXcEw2d1LKRP7uE9pBpSKEQZIjeeFqvOM45mzjOdKfA9eKaTwwmYu+++dHc65CUg==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -23077,7 +23077,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-dBtpWJA819NsuRuat/Y5P+uMLOpm6zwDGl0u+8tCdL63BgS2UdCi7RCPmX8ojbzcWJlUJH10EZaAd1SquvEvig==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-RTAtk0J78KaBEhkmjU3a01c2pLD7Y6QZGjVt7Rg24k/mrJz0qQ3srrT624N68yNRTb2ncK4npK56eRnXneoLKQ==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -23113,12 +23113,12 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-4GNEXHgFz0u2KO2v0LaeoskbhQJ5trquUxD6SsXMW5OpI56xRImavkdAbXz4v05Zovm68AtzbPLd6IGVA25WmQ==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-UOt3fCv6guKr9mg0ihMOQADkX5WuKBXZJgr0jzkLRgizTZrxcPxMqlfx+IY3vvZzGCqfT3G9CF5qRdWMYtMgKg==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.0
+      '@azure-tools/test-recorder': 3.1.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/jsonwebtoken': 9.0.6

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1180,15 +1180,15 @@ packages:
     resolution: {integrity: sha512-O5wyYiI6bILqO9MOeQ1WhSIcKH6c3DvbpsjMPKYJ+yekmFhFUb/zU/pSKsLvyqZhqUWSACFMNri4cZd4tuW0rw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/core-auth': 1.7.1
       '@azure/identity': 4.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@azure-tools/test-recorder@3.1.1:
-    resolution: {integrity: sha512-ajA2Q36u/ZNKCFUSz8ktTxUQhJwrvhF0Hr/TAG6zle8bfQvV6ZOQf/dQYx3QfP1SIH6wRewfjkX8cCaaay6e1w==}
+  /@azure-tools/test-recorder@3.1.2:
+    resolution: {integrity: sha512-116XdbMzedsUcVQa7yCm1p/yCNuiq5XHc2vn0Q0P6c7/Tzrjgjo19eq2Lrea2gIo8+n1mDtQcm3zPzLb9C4CoQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/core-auth': 1.7.1
@@ -10853,7 +10853,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10898,7 +10898,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10943,7 +10943,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -10987,7 +10987,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11032,7 +11032,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11076,7 +11076,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.14.1)
@@ -11124,7 +11124,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11173,7 +11173,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -11246,7 +11246,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11290,7 +11290,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11337,7 +11337,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11381,7 +11381,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.39.5(@types/node@20.10.8)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11504,7 +11504,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11544,7 +11544,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11571,7 +11571,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11598,7 +11598,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11625,7 +11625,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11654,7 +11654,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11682,7 +11682,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11709,7 +11709,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11737,7 +11737,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11766,7 +11766,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11792,7 +11792,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11821,7 +11821,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11850,7 +11850,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11878,7 +11878,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11922,7 +11922,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -11951,7 +11951,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -11977,7 +11977,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12004,7 +12004,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12032,7 +12032,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12059,7 +12059,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12087,7 +12087,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12115,7 +12115,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12142,7 +12142,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12168,7 +12168,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12196,7 +12196,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12225,7 +12225,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12254,7 +12254,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12281,7 +12281,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12308,7 +12308,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12336,7 +12336,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12364,7 +12364,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12390,7 +12390,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12416,7 +12416,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/arm-cosmosdb': 16.0.0-beta.6
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -12446,7 +12446,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12474,7 +12474,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12501,7 +12501,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12527,7 +12527,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12553,7 +12553,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12582,7 +12582,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -12612,7 +12612,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12640,7 +12640,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12685,7 +12685,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12713,7 +12713,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12742,7 +12742,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12770,7 +12770,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12797,7 +12797,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12825,7 +12825,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12854,7 +12854,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12883,7 +12883,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -12927,7 +12927,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12956,7 +12956,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -12985,7 +12985,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13014,7 +13014,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13042,7 +13042,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13069,7 +13069,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13098,7 +13098,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13126,7 +13126,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13154,7 +13154,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13181,7 +13181,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13210,7 +13210,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13237,7 +13237,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13266,7 +13266,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13295,7 +13295,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13322,7 +13322,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13349,7 +13349,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13378,7 +13378,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13406,7 +13406,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13433,7 +13433,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13460,7 +13460,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13488,7 +13488,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13515,7 +13515,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13543,7 +13543,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13572,7 +13572,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13599,7 +13599,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13626,7 +13626,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13654,7 +13654,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13682,7 +13682,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13709,7 +13709,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13737,7 +13737,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13764,7 +13764,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13792,7 +13792,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -13819,7 +13819,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13847,7 +13847,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13876,7 +13876,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13905,7 +13905,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13933,7 +13933,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -13962,7 +13962,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -13990,7 +13990,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14016,7 +14016,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14043,7 +14043,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14071,7 +14071,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14099,7 +14099,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14126,7 +14126,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14155,7 +14155,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14183,7 +14183,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14212,7 +14212,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14239,7 +14239,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14268,7 +14268,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14297,7 +14297,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14324,7 +14324,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14353,7 +14353,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14380,7 +14380,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14409,7 +14409,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14438,7 +14438,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14465,7 +14465,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14493,7 +14493,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14521,7 +14521,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14549,7 +14549,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14577,7 +14577,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14606,7 +14606,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14634,7 +14634,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14662,7 +14662,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14690,7 +14690,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14719,7 +14719,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14745,7 +14745,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14773,7 +14773,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14800,7 +14800,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14826,7 +14826,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14854,7 +14854,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14881,7 +14881,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14908,7 +14908,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14935,7 +14935,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -14959,7 +14959,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -14987,7 +14987,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15015,7 +15015,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15042,7 +15042,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15069,7 +15069,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15096,7 +15096,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15123,7 +15123,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15150,7 +15150,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15178,7 +15178,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15205,7 +15205,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15234,7 +15234,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15260,7 +15260,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15289,7 +15289,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15316,7 +15316,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15345,7 +15345,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15372,7 +15372,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15400,7 +15400,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15427,7 +15427,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15456,7 +15456,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15485,7 +15485,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15513,7 +15513,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15557,7 +15557,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15586,7 +15586,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15614,7 +15614,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15641,7 +15641,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15670,7 +15670,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15699,7 +15699,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15728,7 +15728,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15755,7 +15755,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15783,7 +15783,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15810,7 +15810,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15838,7 +15838,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15867,7 +15867,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15893,7 +15893,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -15922,7 +15922,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15949,7 +15949,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -15976,7 +15976,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16004,7 +16004,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16031,7 +16031,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16060,7 +16060,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16087,7 +16087,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16115,7 +16115,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16142,7 +16142,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16170,7 +16170,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16197,7 +16197,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16226,7 +16226,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16254,7 +16254,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16283,7 +16283,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16312,7 +16312,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16340,7 +16340,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16369,7 +16369,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16397,7 +16397,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/arm-network': 32.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -16426,7 +16426,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16455,7 +16455,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16483,7 +16483,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16511,7 +16511,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16539,7 +16539,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16565,7 +16565,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16592,7 +16592,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16620,7 +16620,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16648,7 +16648,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16675,7 +16675,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16703,7 +16703,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16731,7 +16731,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16759,7 +16759,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16788,7 +16788,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16816,7 +16816,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16844,7 +16844,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16872,7 +16872,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16901,7 +16901,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -16927,7 +16927,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16955,7 +16955,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -16984,7 +16984,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17028,7 +17028,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17055,7 +17055,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17083,7 +17083,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17110,7 +17110,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17139,7 +17139,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17167,7 +17167,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17196,7 +17196,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17225,7 +17225,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17254,7 +17254,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17282,7 +17282,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17310,7 +17310,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17338,7 +17338,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17367,7 +17367,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17396,7 +17396,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17423,7 +17423,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17451,7 +17451,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17478,7 +17478,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17505,7 +17505,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17532,7 +17532,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17561,7 +17561,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17588,7 +17588,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17615,7 +17615,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17644,7 +17644,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17672,7 +17672,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17698,7 +17698,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17726,7 +17726,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17753,7 +17753,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17780,7 +17780,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17808,7 +17808,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17836,7 +17836,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17864,7 +17864,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17891,7 +17891,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17919,7 +17919,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -17948,7 +17948,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -17974,7 +17974,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -18024,7 +18024,7 @@ packages:
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18068,7 +18068,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/communication-phone-numbers': 1.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18116,7 +18116,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.22
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18214,7 +18214,7 @@ packages:
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18256,7 +18256,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/msal-node': 1.18.4
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -18302,7 +18302,7 @@ packages:
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18352,7 +18352,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18395,7 +18395,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/identity': 3.4.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18440,7 +18440,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18484,7 +18484,7 @@ packages:
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18531,7 +18531,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18566,7 +18566,7 @@ packages:
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18613,7 +18613,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18658,7 +18658,7 @@ packages:
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18704,7 +18704,7 @@ packages:
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -18748,7 +18748,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18777,7 +18777,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19272,7 +19272,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19316,7 +19316,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19424,7 +19424,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19469,7 +19469,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -19580,7 +19580,7 @@ packages:
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/async-lock': 1.4.2
@@ -19640,7 +19640,7 @@ packages:
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -19781,7 +19781,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/functions': 3.5.1
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19826,7 +19826,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19871,7 +19871,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19916,7 +19916,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -19960,7 +19960,7 @@ packages:
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/msal-node': 2.6.6
       '@azure/msal-node-extensions': 1.0.14
@@ -19987,7 +19987,7 @@ packages:
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/msal-node': 2.6.6
       '@azure/msal-node-extensions': 1.0.14
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
@@ -20022,7 +20022,7 @@ packages:
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/jws': 3.2.10
       '@types/mocha': 10.0.6
@@ -20056,7 +20056,7 @@ packages:
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@azure/keyvault-keys': 4.8.0
       '@azure/msal-browser': 3.11.1
@@ -20114,7 +20114,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20160,7 +20160,7 @@ packages:
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20206,7 +20206,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20238,7 +20238,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20312,7 +20312,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20358,7 +20358,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -20401,7 +20401,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20500,7 +20500,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20545,7 +20545,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20590,7 +20590,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20635,7 +20635,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/maps-common': 1.0.0-beta.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20680,7 +20680,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -20723,7 +20723,7 @@ packages:
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20791,7 +20791,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -20921,7 +20921,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@opentelemetry/api': 1.8.0
@@ -20964,7 +20964,7 @@ packages:
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21003,7 +21003,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
@@ -21047,7 +21047,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -21608,7 +21608,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21651,7 +21651,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21694,7 +21694,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21738,7 +21738,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21781,7 +21781,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21826,7 +21826,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -21870,7 +21870,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/storage-blob': 12.17.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21916,7 +21916,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/schema-registry': 1.2.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -21968,7 +21968,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22010,7 +22010,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22049,7 +22049,7 @@ packages:
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22095,7 +22095,7 @@ packages:
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22156,7 +22156,7 @@ packages:
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22207,7 +22207,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22254,7 +22254,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22305,7 +22305,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22397,7 +22397,7 @@ packages:
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22443,7 +22443,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22489,7 +22489,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22536,7 +22536,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
@@ -22585,7 +22585,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22628,7 +22628,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22666,7 +22666,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/chai-as-promised': 7.1.8
@@ -22709,7 +22709,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22752,7 +22752,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -22878,7 +22878,7 @@ packages:
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@opentelemetry/api': 1.8.0
       '@types/chai': 4.3.14
@@ -23118,7 +23118,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
-      '@azure-tools/test-recorder': 3.1.1
+      '@azure-tools/test-recorder': 3.1.2
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/jsonwebtoken': 9.0.6


### PR DESCRIPTION
### Packages impacted by this PR
Test pipelines have been broken because of the min-max build test failure

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/29232
https://github.com/Azure/azure-sdk-for-js/issues/29246

### Describe the problem that is addressed by this PR
This PR is the followup of the `@azure-tools/test-recorder@3.1.2` release that upgraded the min version of `core-client` to get the needed types https://github.com/Azure/azure-sdk-for-js/pull/29247
