### PR TITLE
[apimanagement] Remove @types/mime

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11462,7 +11462,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-fYGQJAY0yZKEqPk93FA5an7HN4E1Gh2AMynoMtlHI7l+Qhy2lI9YPe9o/yx3myfa+HtHJoHrLZ4nhk13e3Yy4A==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-TwISdXEwl3VcFk8mOckvLvWLThI4G0q9a0D4t9OviV3xzYWAo36Fsl76gvzsd7b5Ksqqbsb7n9QkxZgH5qXCOg==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:

--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -52,7 +52,6 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "^7.43.0",
-    "@types/mime": "^4.0.0",
     "@types/node": "^18.0.0",
     "@vitest/browser": "^1.4.0",
     "@vitest/coverage-istanbul": "^1.4.0",


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/api-management-custom-widgets-tools

### Issues associated with this PR

### Describe the problem that is addressed by this PR

Removes `@types/mime` as the types are now included by default.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
