### PR TITLE
[Test][ServiceBus] react to the retryable error change in core-amqp

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import chai from "chai";
+const expect = char.expect;
 import Long from "long";
 import chaiAsPromised from "chai-as-promised";
 import { ServiceBusMessage, delay, ServiceBusSender, ServiceBusReceivedMessage } from "../../src";
@@ -794,7 +795,7 @@ describe("Batching Receiver", () => {
           });
           throw new Error(`Test failure`);
         } catch (err: any) {
-          err.message.should.equal(StandardAbortMessage);
+          expect(err.message).includes(StandardAbortMessage);
         }
       },
     );
@@ -811,7 +812,7 @@ describe("Batching Receiver", () => {
           });
           throw new Error(`Test failure`);
         } catch (err: any) {
-          err.message.should.equal(StandardAbortMessage);
+          expect(err.message).includes(StandardAbortMessage);
         }
       },
     );
@@ -973,10 +974,8 @@ describe("Batching Receiver", () => {
           await receiver.receiveMessages(10);
           throw new Error(testFailureMessage);
         } catch (err: any) {
-          assert.deepNestedInclude(err, {
-            name: "Error",
-            message: "Test: fake connection failure",
-          });
+          assert.ok(err.name === "Error");
+          assert.ok(err.message.match(/Test: fake connection failure/));
         }
 
         await onDetachedCalledPromise;
@@ -1247,10 +1246,8 @@ describe("Batching Receiver", () => {
           await sessionReceiver.receiveMessages(10);
           throw new Error(testFailureMessage);
         } catch (err: any) {
-          assert.deepNestedInclude(err, {
-            name: "Error",
-            message: "Test: fake connection failure",
-          });
+          assert.equal(err?.name, "Error");
+          expect(err?.message).includes("Test: fake connection failure");
         }
 
         await drainRequestedPromise;

--- a/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchReceiver.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import chai from "chai";
-const expect = char.expect;
 import Long from "long";
 import chaiAsPromised from "chai-as-promised";
 import { ServiceBusMessage, delay, ServiceBusSender, ServiceBusReceivedMessage } from "../../src";
@@ -32,6 +31,7 @@ import { testLogger } from "./utils/misc";
 const should = chai.should();
 chai.use(chaiAsPromised);
 const assert = chai.assert;
+const expect = chai.expect;
 
 const noSessionTestClientType = getRandomTestClientTypeWithNoSessions();
 const withSessionTestClientType = getRandomTestClientTypeWithSessions();

--- a/sdk/servicebus/service-bus/test/internal/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/retries.spec.ts
@@ -79,7 +79,15 @@ describe("Retries - ManagementClient", () => {
       await func();
     } catch (error: any) {
       errorThrown = true;
-      should.equal(error.message, "Hello there, I'm an error", "Unexpected error thrown");
+      should.equal(
+        error.message,
+        `Error 0: ServiceBusError: Hello there, I'm an error
+
+Error 1: ServiceBusError: Hello there, I'm an error
+
+Error 2: ServiceBusError: Hello there, I'm an error`,
+        "Unexpected error thrown",
+      );
       should.equal(
         numberOfTimesManagementClientInvoked,
         defaultMaxRetries + 1,
@@ -240,7 +248,15 @@ describe("Retries - MessageSender", () => {
       await func();
     } catch (error: any) {
       errorThrown = true;
-      should.equal(error.message, "Hello there, I'm an error", "Unexpected error thrown");
+      should.equal(
+        error.message,
+        `Error 0: MessagingError: Hello there, I'm an error
+
+Error 1: MessagingError: Hello there, I'm an error
+
+Error 2: MessagingError: Hello there, I'm an error`,
+        "Unexpected error thrown",
+      );
       should.equal(numberOfTimesInitInvoked, defaultMaxRetries + 1, "Unexpected number of retries");
     }
     should.equal(errorThrown, true, "Error was not thrown");
@@ -370,7 +386,15 @@ describe("Retries - Receive methods", () => {
       await func();
     } catch (error: any) {
       errorThrown = true;
-      should.equal(error.message, "Hello there, I'm an error", "Unexpected error thrown");
+      should.equal(
+        error.message,
+        `Error 0: MessagingError: Hello there, I'm an error
+
+Error 1: MessagingError: Hello there, I'm an error
+
+Error 2: MessagingError: Hello there, I'm an error`,
+        "Unexpected error thrown",
+      );
       should.equal(numberOfTimesTried, defaultMaxRetries + 1, "Unexpected number of retries");
     }
     should.equal(errorThrown, true, "Error was not thrown");

--- a/sdk/servicebus/service-bus/test/internal/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/retries.spec.ts
@@ -241,7 +241,10 @@ describe("Retries - MessageSender", () => {
     (sender as ServiceBusSenderImpl)["_sender"]["open"] = fakeFunction;
   }
 
-  async function mockInitAndVerifyRetries(func: () => Promise<void>): Promise<void> {
+  async function mockInitAndVerifyRetries(
+    func: () => Promise<void>,
+    expectedErrorType: string = "MessagingError",
+  ): Promise<void> {
     mockInitToThrowError();
     let errorThrown = false;
     try {
@@ -250,11 +253,11 @@ describe("Retries - MessageSender", () => {
       errorThrown = true;
       should.equal(
         error.message,
-        `Error 0: MessagingError: Hello there, I'm an error
+        `Error 0: ${expectedErrorType}: Hello there, I'm an error
 
-Error 1: MessagingError: Hello there, I'm an error
+Error 1: ${expectedErrorType}: Hello there, I'm an error
 
-Error 2: MessagingError: Hello there, I'm an error`,
+Error 2: ${expectedErrorType}: Hello there, I'm an error`,
         "Unexpected error thrown",
       );
       should.equal(numberOfTimesInitInvoked, defaultMaxRetries + 1, "Unexpected number of retries");
@@ -274,7 +277,7 @@ Error 2: MessagingError: Hello there, I'm an error`,
     await beforeEachTest(TestClientType.UnpartitionedQueue);
     await mockInitAndVerifyRetries(async () => {
       await sender.sendMessages(TestMessage.getSample());
-    });
+    }, "ServiceBusError");
   });
 
   it("Unpartitioned Queue: createBatch", async function (): Promise<void> {
@@ -299,7 +302,7 @@ Error 2: MessagingError: Hello there, I'm an error`,
     await beforeEachTest(TestClientType.UnpartitionedQueue);
     await mockInitAndVerifyRetries(async () => {
       await sender.sendMessages(TestMessage.getSample());
-    });
+    }, "ServiceBusError");
   });
 
   it("Unpartitioned Queue with Sessions: createBatch", async function (): Promise<void> {

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
@@ -3,6 +3,7 @@
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+const expect = chai.expect;
 import {
   ServiceBusReceivedMessage,
   delay,
@@ -24,7 +25,7 @@ import {
 import { getDeliveryProperty } from "./utils/misc";
 import { verifyMessageCount } from "../public/utils/managementUtils";
 import sinon from "sinon";
-import { isNode } from "@azure/core-util";
+import { isNodeLike } from "@azure/core-util";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -491,7 +492,11 @@ describe("Streaming Receiver Tests", () => {
     });
 
     const testError = (err: Error): void => {
-      should.equal(err.message, MessageAlreadySettled, "ErrorMessage is different than expected");
+      expect(
+        err.message,
+
+        "ErrorMessage is different than expected",
+      ).includes(MessageAlreadySettled);
       errorWasThrown = true;
     };
 
@@ -994,7 +999,7 @@ export function createOnDetachedProcessErrorFake(): sinon.SinonSpy & {
     // websocket platforms this can manifest as a CloseEvent).
     const expectedErrors = [];
 
-    if (isNode) {
+    if (isNodeLike) {
       if (errors.length > 0) {
         expectedErrors.push("read ECONNRESET");
       }

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiverSessions.spec.ts
@@ -29,6 +29,7 @@ import { getDeliveryProperty } from "./utils/misc";
 import { singleMessagePromise } from "./streamingReceiver.spec";
 import { defer } from "./unit/unittestUtils";
 const should = chai.should();
+const expect = chai.expect;
 const assert = chai.assert;
 chai.use(chaiAsPromised);
 
@@ -509,7 +510,9 @@ describe("Streaming with sessions", () => {
       });
 
       const testError = (err: Error): void => {
-        should.equal(err.message, MessageAlreadySettled, "ErrorMessage is different than expected");
+        expect(err.message, "ErrorMessage is different than expected").includes(
+          MessageAlreadySettled,
+        );
         errorWasThrown = true;
       };
 

--- a/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/invalidParameters.spec.ts
@@ -65,10 +65,11 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         errorCaught = error.message;
       }
-      should.equal(
+      expect(
         errorCaught,
-        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
         "Did not throw error if created a client with invalid receiveMode.",
+      ).includes(
+        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
       );
     });
 
@@ -119,31 +120,29 @@ describe("invalid parameters", () => {
       });
     });
 
-    it("PeekBySequenceNumber: Wrong type sequenceNumber in SessionReceiver", async function (): Promise<void> {
+    it("PeekBySequenceNumber: Wrong type fromSequenceNumber in SessionReceiver", async function (): Promise<void> {
       let caughtError: Error | undefined;
       try {
         await receiver.peekMessages(1, { fromSequenceNumber: "somestring" as any });
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "fromSequenceNumber" should be of type "Long"`,
       );
     });
 
     [false, 0, -0, "", NaN].forEach((falsyValue) => {
-      it("PeekBySequenceNumber: Wrong type sequenceNumber in SessionReceiver when passing falsy value that is not undefined or null", async function (): Promise<void> {
+      it("PeekBySequenceNumber: Wrong type fromSequenceNumber in SessionReceiver when passing falsy value that is not undefined or null", async function (): Promise<void> {
         let caughtError: Error | undefined;
         try {
           await receiver.peekMessages(1, { fromSequenceNumber: falsyValue as any });
         } catch (error: any) {
           caughtError = error;
         }
-        should.equal(caughtError && caughtError.name, "TypeError");
-        should.equal(
-          caughtError && caughtError.message,
+        should.equal(caughtError?.name, "TypeError");
+        expect(caughtError?.message).includes(
           `The parameter "fromSequenceNumber" should be of type "Long"`,
         );
       });
@@ -156,8 +155,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Invalid "MessageHandlers" provided.`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Invalid "MessageHandlers" provided.`);
     });
 
     it("RegisterMessageHandler: Wrong type for onMessage in SessionReceiver", async function (): Promise<void> {
@@ -167,20 +166,20 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Invalid "MessageHandlers" provided.`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Invalid "MessageHandlers" provided.`);
     });
 
-    it("ReceiveDeferredMessages: Wrong type sequenceNumber in SessionReceiver", async function (): Promise<void> {
+    it("ReceiveDeferredMessages: Wrong type sequenceNumbers in SessionReceiver", async function (): Promise<void> {
       let caughtError: Error | undefined;
       try {
         await receiver.receiveDeferredMessages("somestring" as any);
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      console.log(caughtError?.message);
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be of type "Long"`,
       );
     });
@@ -192,8 +191,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "sequenceNumbers"`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Missing parameter "sequenceNumbers"`);
     });
 
     it("ReceiveDeferredMessages: Wrong type sequenceNumber array in SessionReceiver", async function (): Promise<void> {
@@ -203,9 +202,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be an array of type "Long"`,
       );
     });
@@ -225,10 +223,11 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         errorCaught = error.message;
       }
-      should.equal(
+      expect(
         errorCaught,
-        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
         "Did not throw error if created a client with invalid receiveMode.",
+      ).includes(
+        `Invalid receiveMode '123' provided. Valid values are 'peekLock' and 'receiveAndDelete'`,
       );
     });
 
@@ -240,10 +239,11 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         errorCaught = error.message;
       }
-      should.equal(
+      expect(
         errorCaught,
-        `Invalid subQueueType '123' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`,
         "Did not throw error if created a client with invalid subQueue.",
+      ).includes(
+        `Invalid subQueueType '123' provided. Valid values are 'deadLetter' and 'transferDeadLetter'`,
       );
     });
 
@@ -301,9 +301,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "fromSequenceNumber" should be of type "Long"`,
       );
     });
@@ -316,9 +315,8 @@ describe("invalid parameters", () => {
         } catch (error: any) {
           caughtError = error;
         }
-        should.equal(caughtError && caughtError.name, "TypeError");
-        should.equal(
-          caughtError && caughtError.message,
+        should.equal(caughtError?.name, "TypeError");
+        expect(caughtError?.message).includes(
           `The parameter "fromSequenceNumber" should be of type "Long"`,
         );
       });
@@ -331,8 +329,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Invalid "MessageHandlers" provided.`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Invalid "MessageHandlers" provided.`);
     });
 
     it("RegisterMessageHandler: Wrong type for onMessage in Receiver", async function (): Promise<void> {
@@ -342,8 +340,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Invalid "MessageHandlers" provided.`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Invalid "MessageHandlers" provided.`);
     });
 
     it("ReceiveDeferredMessages: Wrong type sequenceNumber in Receiver", async function (): Promise<void> {
@@ -353,9 +351,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be of type "Long"`,
       );
     });
@@ -367,8 +364,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "sequenceNumbers"`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Missing parameter "sequenceNumbers"`);
     });
 
     it("ReceiveDeferredMessages: Wrong type sequenceNumber array in Receiver", async function (): Promise<void> {
@@ -378,9 +375,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be an array of type "Long"`,
       );
     });
@@ -399,11 +395,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
-        `Missing parameter "scheduledEnqueueTimeUtc"`,
-      );
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Missing parameter "scheduledEnqueueTimeUtc"`);
     });
 
     it("ScheduledMessages: Missing messages in Sender", async function (): Promise<void> {
@@ -413,8 +406,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "messages"`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Missing parameter "messages"`);
     });
 
     it("CancelScheduledMessages: Wrong type sequenceNumber in Sender", async function (): Promise<void> {
@@ -424,9 +417,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be of type "Long"`,
       );
     });
@@ -438,8 +430,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "sequenceNumbers"`);
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(`Missing parameter "sequenceNumbers"`);
     });
 
     it("CancelScheduledMessages: Wrong type sequenceNumbers array in Sender", async function (): Promise<void> {
@@ -449,9 +441,8 @@ describe("invalid parameters", () => {
       } catch (error: any) {
         caughtError = error;
       }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(
-        caughtError && caughtError.message,
+      should.equal(caughtError?.name, "TypeError");
+      expect(caughtError?.message).includes(
         `The parameter "sequenceNumbers" should be an array of type "Long"`,
       );
     });

--- a/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sendAndSchedule.spec.ts
@@ -4,6 +4,7 @@
 import chai from "chai";
 import Long from "long";
 const should = chai.should();
+const expect = chai.expect;
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import { ServiceBusMessage, delay } from "../../src";
@@ -463,7 +464,7 @@ describe("Sender Tests", () => {
         });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal(StandardAbortMessage);
+        expect(err.message).includes(StandardAbortMessage);
       }
     },
   );
@@ -478,7 +479,7 @@ describe("Sender Tests", () => {
         await sender.cancelScheduledMessages([Long.ZERO], { abortSignal: controller.signal });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal(StandardAbortMessage);
+        expect(err.message).includes(StandardAbortMessage);
       }
     },
   );
@@ -592,7 +593,9 @@ describe("ServiceBusMessage validations", function (): void {
         actualErrorMsg = err.message;
       });
 
-      should.equal(actualErrorMsg, testInput.expectedErrorMessage, "Error not thrown as expected");
+      expect(actualErrorMsg, "Error not thrown as expected").includes(
+        testInput.expectedErrorMessage,
+      );
     });
 
     // sendBatch(<Array of messages>) - Commented
@@ -603,11 +606,8 @@ describe("ServiceBusMessage validations", function (): void {
     //     await sender.sendBatch([testInput.message, { body: "random" }]).catch((err) => {
     //       actualErrorMsg = err.message;
     //     });
-    //     should.equal(
-    //       actualErrorMsg,
-    //       testInput.expectedErrorMessage,
-    //       "Error not thrown as expected"
-    //     );
+    //     expect(actualErrorMsg, "Error not thrown as expected")
+    //       .includes(testInput.expectedErrorMessage);
     //   }
     // );
 
@@ -618,11 +618,8 @@ describe("ServiceBusMessage validations", function (): void {
     //     await sender.sendBatch([{ body: "random" }, testInput.message]).catch((err) => {
     //       actualErrorMsg = err.message;
     //     });
-    //     should.equal(
-    //       actualErrorMsg,
-    //       testInput.expectedErrorMessage,
-    //       "Error not thrown as expected"
-    //     );
+    //     expect(actualErrorMsg, "Error not thrown as expected")
+    //       .includes(testInput.expectedErrorMessage);
     //   }
     // );
 
@@ -633,7 +630,7 @@ describe("ServiceBusMessage validations", function (): void {
         actualErr = err;
         actualErrorMsg = err.message;
       });
-      should.equal(actualErrorMsg, testInput.expectedErrorMessage, actualErr);
+      expect(actualErrorMsg, actualErr).includes(testInput.expectedErrorMessage);
     });
   });
 });

--- a/sdk/servicebus/service-bus/test/public/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/sessionsTests.spec.ts
@@ -6,6 +6,7 @@ import Long from "long";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
+import { StandardAbortMessage } from "@azure/core-amqp";
 import {
   ServiceBusReceivedMessage,
   delay,
@@ -29,6 +30,7 @@ import sinon from "sinon";
 import { ServiceBusSessionReceiverImpl } from "../../src/receivers/sessionReceiver";
 
 let unexpectedError: Error | undefined;
+const abortMsgRegex = new RegExp(StandardAbortMessage);
 
 async function processError(args: ProcessErrorArgs): Promise<void> {
   unexpectedError = args.error;
@@ -267,7 +269,7 @@ describe("session tests", () => {
         await receiver.getSessionState({ abortSignal: controller.signal });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal("The operation was aborted.");
+        err.message.should.match(abortMsgRegex);
         err.name.should.equal("AbortError");
       }
     });
@@ -280,7 +282,7 @@ describe("session tests", () => {
         await receiver.setSessionState("why", { abortSignal: controller.signal });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal("The operation was aborted.");
+        err.message.should.match(abortMsgRegex);
         err.name.should.equal("AbortError");
       }
     });
@@ -293,7 +295,7 @@ describe("session tests", () => {
         await receiver.renewSessionLock({ abortSignal: controller.signal });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal("The operation was aborted.");
+        err.message.should.match(abortMsgRegex);
         err.name.should.equal("AbortError");
       }
     });
@@ -306,7 +308,7 @@ describe("session tests", () => {
         await receiver.receiveDeferredMessages([Long.ZERO], { abortSignal: controller.signal });
         throw new Error(`Test failure`);
       } catch (err: any) {
-        err.message.should.equal("The operation was aborted.");
+        err.message.should.match(abortMsgRegex);
         err.name.should.equal("AbortError");
       }
     });


### PR DESCRIPTION
PR #28751 updates the message of thrown error from retry to include messages of all the retried errors. This PR fixes affected Service Bus tests.