### PR TITLE
[core] Use isNodeLike

### DIFF
--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -92,7 +92,7 @@
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-auth": "^1.4.0",
     "@azure/core-tracing": "^1.0.1",
-    "@azure/core-util": "^1.3.0",
+    "@azure/core-util": "^1.9.0",
     "@azure/logger": "^1.0.0",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.0",

--- a/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
+++ b/sdk/core/core-rest-pipeline/src/createPipelineFromOptions.ts
@@ -10,7 +10,7 @@ import { multipartPolicy, multipartPolicyName } from "./policies/multipartPolicy
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy.js";
 import { defaultRetryPolicy } from "./policies/defaultRetryPolicy.js";
 import { formDataPolicy } from "./policies/formDataPolicy.js";
-import { isNode } from "@azure/core-util";
+import { isNodeLike } from "@azure/core-util";
 import { proxyPolicy } from "./policies/proxyPolicy.js";
 import { setClientRequestIdPolicy } from "./policies/setClientRequestIdPolicy.js";
 import { tlsPolicy } from "./policies/tlsPolicy.js";
@@ -78,7 +78,7 @@ export interface InternalPipelineOptions extends PipelineOptions {
 export function createPipelineFromOptions(options: InternalPipelineOptions): Pipeline {
   const pipeline = createEmptyPipeline();
 
-  if (isNode) {
+  if (isNodeLike) {
     if (options.tlsOptions) {
       pipeline.addPolicy(tlsPolicy(options.tlsOptions));
     }
@@ -95,7 +95,7 @@ export function createPipelineFromOptions(options: InternalPipelineOptions): Pip
   pipeline.addPolicy(multipartPolicy(), { afterPhase: "Deserialize" });
   pipeline.addPolicy(defaultRetryPolicy(options.retryOptions), { phase: "Retry" });
   pipeline.addPolicy(tracingPolicy(options.userAgentOptions), { afterPhase: "Retry" });
-  if (isNode) {
+  if (isNodeLike) {
     // Both XHR and Fetch expect to handle redirects automatically,
     // so only include this policy when we're in Node.
     pipeline.addPolicy(redirectPolicy(options.redirectOptions), { afterPhase: "Retry" });

--- a/sdk/core/core-rest-pipeline/src/util/file.ts
+++ b/sdk/core/core-rest-pipeline/src/util/file.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "@azure/core-util";
+import { isNodeLike } from "@azure/core-util";
 import { isNodeReadableStream } from "./typeGuards.js";
 
 /**
@@ -153,7 +153,7 @@ export function createFile(
   name: string,
   options: CreateFileOptions = {},
 ): File {
-  if (isNode) {
+  if (isNodeLike) {
     return {
       ...unimplementedMethods,
       type: options.type ?? "",

--- a/sdk/core/core-rest-pipeline/test/defaultLogPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/defaultLogPolicy.spec.ts
@@ -7,7 +7,7 @@ import { assert, describe, it, vi } from "vitest";
 import { createHttpHeaders } from "../src/httpHeaders.js";
 import { createPipelineFromOptions } from "../src/createPipelineFromOptions.js";
 import { createPipelineRequest } from "../src/pipelineRequest.js";
-import { isNode } from "@azure/core-util";
+import { isNodeLike } from "@azure/core-util";
 
 describe("defaultLogPolicy", function () {
   it("should be invoked on every retry", async function () {
@@ -30,7 +30,7 @@ describe("defaultLogPolicy", function () {
 
     const orderedPolicies = pipeline.getOrderedPolicies();
 
-    const expectedOrderedPolicies = isNode ? ["proxyPolicy", "decompressResponsePolicy"] : [];
+    const expectedOrderedPolicies = isNodeLike ? ["proxyPolicy", "decompressResponsePolicy"] : [];
     expectedOrderedPolicies.push(
       "formDataPolicy",
       "userAgentPolicy",
@@ -39,7 +39,7 @@ describe("defaultLogPolicy", function () {
       "defaultRetryPolicy",
       "tracingPolicy",
     );
-    if (isNode) {
+    if (isNodeLike) {
       expectedOrderedPolicies.push("redirectPolicy");
     }
     expectedOrderedPolicies.push("testSignPolicy", "logPolicy");

--- a/sdk/core/core-rest-pipeline/test/node/multipartPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/node/multipartPolicy.spec.ts
@@ -3,13 +3,13 @@
 
 import { describe, it, assert } from "vitest";
 import { createHttpHeaders } from "../../src/httpHeaders.js";
-import { isNode, stringToUint8Array } from "@azure/core-util";
+import { isNodeLike, stringToUint8Array } from "@azure/core-util";
 import { Readable } from "stream";
 import { performRequest } from "../multipartPolicy.spec.js";
 import { assertBodyMatches } from "../util.js";
 
 describe("multipartPolicy (node-only)", function () {
-  it.runIf(isNode)("supports Node ReadableStream body", async function () {
+  it.runIf(isNodeLike)("supports Node ReadableStream body", async function () {
     const body = Readable.from(Buffer.from("part1", "utf-8"));
 
     const request = await performRequest({

--- a/sdk/core/ts-http-runtime/src/createPipelineFromOptions.ts
+++ b/sdk/core/ts-http-runtime/src/createPipelineFromOptions.ts
@@ -10,7 +10,7 @@ import type { ProxySettings } from "./index.js";
 import { decompressResponsePolicy } from "./policies/decompressResponsePolicy.js";
 import { defaultRetryPolicy } from "./policies/defaultRetryPolicy.js";
 import { formDataPolicy } from "./policies/formDataPolicy.js";
-import { isNode } from "./util/checkEnvironment.js";
+import { isNodeLike } from "./util/checkEnvironment.js";
 import { proxyPolicy } from "./policies/proxyPolicy.js";
 import { tlsPolicy } from "./policies/tlsPolicy.js";
 import { tracingPolicy } from "./policies/tracingPolicy.js";
@@ -78,7 +78,7 @@ export interface InternalPipelineOptions extends PipelineOptions {
 export function createPipelineFromOptions(options: InternalPipelineOptions): Pipeline {
   const pipeline = createEmptyPipeline();
 
-  if (isNode) {
+  if (isNodeLike) {
     if (options.tlsOptions) {
       pipeline.addPolicy(tlsPolicy(options.tlsOptions));
     }
@@ -94,7 +94,7 @@ export function createPipelineFromOptions(options: InternalPipelineOptions): Pip
   pipeline.addPolicy(multipartPolicy(), { afterPhase: "Deserialize" });
   pipeline.addPolicy(defaultRetryPolicy(options.retryOptions), { phase: "Retry" });
   pipeline.addPolicy(tracingPolicy(options.userAgentOptions), { afterPhase: "Retry" });
-  if (isNode) {
+  if (isNodeLike) {
     // Both XHR and Fetch expect to handle redirects automatically,
     // so only include this policy when we're in Node.
     pipeline.addPolicy(redirectPolicy(options.redirectOptions), { afterPhase: "Retry" });

--- a/sdk/core/ts-http-runtime/src/util/file.ts
+++ b/sdk/core/ts-http-runtime/src/util/file.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isNode } from "./checkEnvironment.js";
+import { isNodeLike } from "./checkEnvironment.js";
 import { isNodeReadableStream } from "./typeGuards.js";
 
 /**
@@ -153,7 +153,7 @@ export function createFile(
   name: string,
   options: CreateFileOptions = {},
 ): File {
-  if (isNode) {
+  if (isNodeLike) {
     return {
       ...unimplementedMethods,
       type: options.type ?? "",

--- a/sdk/core/ts-http-runtime/test/defaultLogPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/defaultLogPolicy.spec.ts
@@ -7,7 +7,7 @@ import { PipelinePolicy } from "../src/pipeline.js";
 import { createHttpHeaders } from "../src/httpHeaders.js";
 import { createPipelineFromOptions } from "../src/createPipelineFromOptions.js";
 import { createPipelineRequest } from "../src/pipelineRequest.js";
-import { isNode } from "../src/util/checkEnvironment.js";
+import { isNodeLike } from "../src/util/checkEnvironment.js";
 
 describe("defaultLogPolicy", function () {
   it("should be invoked on every retry", async function () {
@@ -30,7 +30,7 @@ describe("defaultLogPolicy", function () {
 
     const orderedPolicies = pipeline.getOrderedPolicies();
 
-    const expectedOrderedPolicies = isNode ? ["proxyPolicy", "decompressResponsePolicy"] : [];
+    const expectedOrderedPolicies = isNodeLike ? ["proxyPolicy", "decompressResponsePolicy"] : [];
     expectedOrderedPolicies.push(
       "formDataPolicy",
       "userAgentPolicy",
@@ -38,7 +38,7 @@ describe("defaultLogPolicy", function () {
       "defaultRetryPolicy",
       "tracingPolicy",
     );
-    if (isNode) {
+    if (isNodeLike) {
       expectedOrderedPolicies.push("redirectPolicy");
     }
     expectedOrderedPolicies.push("testSignPolicy", "logPolicy");


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-rest-pipeline`
- `@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

Use `isNodeLike` in favor of the deprecated `isNode` in Core packages that depend on `core-util`.

Eventually we should remove the deprecated `isNode` property from the unbranded Core. I have added this to the [unbranded breaking change wishlist](https://loop.microsoft.com/p/eyJ3Ijp7InUiOiJodHRwczovL21pY3Jvc29mdC5zaGFyZXBvaW50LmNvbS8%2FbmF2PWN6MGxNa1ltWkQxaUlWcElZeko0WVc1ZloxVjFUWE4wUkU5RFIya3pTakkyUkVOUFoxWk9SVVpNYlV3NE9GRkRiR1ZLY0dwSldHbzRjMDFwUlVoVVdWUXRObTAwUmxkaVpEVW1aajB3TVVSSFJqSlBSVFJVUlUxUk5EZFNSa0UzV2tVeVQwWk9RMFEwVmxnMk5ESkZKbU05Sm1ac2RXbGtQVEUlM0QiLCJyIjpmYWxzZX0sInAiOnsidSI6Imh0dHBzOi8vbWljcm9zb2Z0LnNoYXJlcG9pbnQuY29tLzpmbDovci9zaXRlcy82MTU1NGI1Ni1jOTBiLTQ5NjEtYmE3Yy02MWNhYWUyMzUzMzUvU2hhcmVkJTIwRG9jdW1lbnRzL0xvb3BBcHBEYXRhL1VudGl0bGVkLmxvb3A%2FZD13NmE1NTMzNmU0MzEwNDllZmJjMjliYzhjNjJhMzMyOGMmY3NmPTEmd2ViPTEmbmF2PWN6MGxNa1p6YVhSbGN5VXlSall4TlRVMFlqVTJMV001TUdJdE5EazJNUzFpWVRkakxUWXhZMkZoWlRJek5UTXpOU1prUFdJaFdraGpNbmhoYmw5blZYVk5jM1JFVDBOSGFUTktNalpFUTA5blZrNUZSa3h0VERnNFVVTnNaVXB3YWtsWWFqaHpUV2xGU0ZSWlZDMDJiVFJHVjJKa05TWm1QVEF4UkVkR01rOUZNMDlIVGt0WFZVVkRSRFUxUlROWlMwNDBVbEpTUzBkTlZVMG1ZejBsTWtZbVpteDFhV1E5TVNaaFBVeHZiM0JCY0hBbWNEMGxOREJtYkhWcFpIZ2xNa1pzYjI5d0xYQmhaMlV0WTI5dWRHRnBibVZ5Sm5nOUpUZENKVEl5ZHlVeU1pVXpRU1V5TWxRd1VsUlZTSGgwWVZkT2VXSXpUblphYmxGMVl6Sm9hR050Vm5kaU1teDFaRU0xYW1JeU1UaFphVVpoVTBkTmVXVkhSblZZTW1SV1pGVXhlbVJGVWxCUk1HUndUVEJ2ZVU1clVrUlVNbVJYVkd0V1IxUkhNVTFQUkdoU1VUSjRiRk51UW5GVFZtaHhUMGhPVG1GVlZrbFdSbXhWVEZSYWRFNUZXbGhaYlZFeFprUkJlRkpGWkVkTmF6bEdUa1pTUmxSV1JUQk9NVXBIVVZSa1lWSlVTbEJTYXpWRVVrUlNWMWRFV1RCTmExVWxNMFFsTWpJbE1rTWxNakpwSlRJeUpUTkJKVEl5TUdJMU1XVTRNV0V0WXpOaE1TMDBPVEpoTFdGa05XSXROemhoWWpNMFpqQTBNekl3SlRJeUpUZEUiLCJyIjpmYWxzZX0sImkiOnsiaSI6IjBiNTFlODFhLWMzYTEtNDkyYS1hZDViLTc4YWIzNGYwNDMyMCJ9fQ%3D%3D).

### Provide a list of related PRs _(if any)_

- https://github.com/Azure/azure-sdk-for-js/pull/29086
