### PR TITLE
Add jsdelivr support

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/package.json
+++ b/sdk/web-pubsub/web-pubsub-client/package.json
@@ -16,14 +16,15 @@
     "./dist-esm/src/websocket/websocketClient.js": "./dist-esm/src/websocket/websocketClient.browser.js",
     "events": "eventemitter3"
   },
+  "jsdelivr": "./dist-browser/index.browser.js",
   "types": "types/web-pubsub-client.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:browser": "tsc -p . && dev-tool run bundle",
+    "build:browser": "tsc -p . && dev-tool run bundle && webpack-cli --mode=production",
     "build:node": "tsc -p . && dev-tool run bundle",
     "build:samples": "dev-tool samples publish -f",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && api-extractor run --local && webpack-cli --mode=production",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf --glob dist dist-esm test-dist temp types *.tgz *.log",
@@ -114,7 +115,9 @@
     "mock-socket": "^9.1.5",
     "util": "^0.12.1",
     "@types/ws": "^7.4.5",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.0.0",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
   },
   "//sampleConfiguration": {
     "productName": "Azure Web PubSub Client",

--- a/sdk/web-pubsub/web-pubsub-client/webpack.config.js
+++ b/sdk/web-pubsub/web-pubsub-client/webpack.config.js
@@ -1,0 +1,16 @@
+const path = require("path");
+
+module.exports = {
+  entry: "./dist-esm/src/index.js",
+  output: {
+    filename: "index.browser.js",
+    library: 'WebPubSubClient',
+    path: path.resolve(__dirname, "dist-browser")
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+    fallback: {
+      "events": require.resolve("events/")
+    }
+  }
+};


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-client

### Describe the problem that is addressed by this PR
Our package is auto published to [jsdelivr](https://www.jsdelivr.com/package/npm/@azure/web-pubsub-client). As this library is usually used by browser, the CDN version implies this can be directly reference in HTML for usage. However, it can't as the content in package needs webpack, which really confuses our customer. This PR add a single file for jsdelivr and it can be directly refer in HTML

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
