### PR TITLE
[docs] Use correct unit for expiresOn examples

### DIFF
--- a/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
@@ -143,7 +143,7 @@ export interface BlobSASSignatureValues {
  *     containerName, // Required
  *     permissions: ContainerSASPermissions.parse("racwdl"), // Required
  *     startsOn: new Date(), // Optional
- *     expiresOn: new Date(new Date().valueOf() + 86400), // Required. Date type
+ *     expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Required. Date type
  *     ipRange: { start: "0.0.0.0", end: "255.255.255.255" }, // Optional
  *     protocol: SASProtocol.HttpsAndHttp, // Optional
  *     version: "2016-05-31" // Optional
@@ -161,7 +161,7 @@ export interface BlobSASSignatureValues {
  * await containerClient.setAccessPolicy(undefined, [
  *   {
  *     accessPolicy: {
- *       expiresOn: new Date(new Date().valueOf() + 86400), // Date type
+ *       expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Date type
  *       permissions: ContainerSASPermissions.parse("racwdl").toString(),
  *       startsOn: new Date() // Date type
  *     },
@@ -187,7 +187,7 @@ export interface BlobSASSignatureValues {
  *     blobName, // Required
  *     permissions: BlobSASPermissions.parse("racwd"), // Required
  *     startsOn: new Date(), // Optional
- *     expiresOn: new Date(new Date().valueOf() + 86400), // Required. Date type
+ *     expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Required. Date type
  *     cacheControl: "cache-control-override", // Optional
  *     contentDisposition: "content-disposition-override", // Optional
  *     contentEncoding: "content-encoding-override", // Optional


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/storage-blob`

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The docs comments uses the value 86400 i.e. number of seconds in a day, to add on the expiresOn example, which could incorrectly lead the reader (_totally not speaking from experience 👀_) to believe that they should just add however many seconds into the future they want, when instead they should be adding milliseconds.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
