### PR TITLE
[core-amqp] Handle case of ErrorEvent being passed as Error to rhea

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Handle translation of ErrorEvent properly [PR #29297](https://github.com/Azure/azure-sdk-for-js/pull/29297)
+
 ### Other Changes
 
 ## 4.2.1 (2024-03-04)

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -634,7 +634,7 @@ function isBrowserWebsocketError(err: any): boolean {
  * Checks whether a object is an ErrorEvent or not. https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
  * @param err - object that may contain error information
  */
-function isErrorEvent(err: any): err is { message: string; error: any }{
+function isErrorEvent(err: any): err is { message: string; error: any } {
   let result: boolean = false;
   if (typeof err.error === "object" && typeof err.message === "string") {
     result = true;

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -631,6 +631,19 @@ function isBrowserWebsocketError(err: any): boolean {
 
 /**
  * @internal
+ * Checks whether a object is an ErrorEvent or not. https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
+ * @param err - object that may contain error information
+ */
+function isErrorEvent(err: any): err is { message: string; error: any }{
+  let result: boolean = false;
+  if (typeof err.error === "object" && typeof err.message === "string") {
+    result = true;
+  }
+  return result;
+}
+
+/**
+ * @internal
  */
 const rheaPromiseErrors = [
   // OperationTimeoutError occurs when the service fails to respond within a given timeframe.
@@ -657,19 +670,22 @@ export function translate(err: unknown): MessagingError | Error {
     // The error is a scalar type, make it the message of an actual error.
     return new Error(String(err));
   }
+
+  const errObj = isErrorEvent(err) ? err.error : err;
+
   // Built-in errors like TypeError and RangeError should not be retryable as these indicate issues
   // with user input and not an issue with the Messaging process.
-  if (err instanceof TypeError || err instanceof RangeError) {
-    return err;
+  if (errObj instanceof TypeError || errObj instanceof RangeError) {
+    return errObj;
   }
 
-  if (isAmqpError(err)) {
+  if (isAmqpError(errObj)) {
     // translate
-    const condition = err.condition;
-    const description = err.description!;
+    const condition = errObj.condition;
+    const description = errObj.description!;
     const error = new MessagingError(description);
-    if ((err as any).stack) error.stack = (err as any).stack;
-    error.info = err.info;
+    if ((errObj as any).stack) error.stack = (errObj as any).stack;
+    error.info = errObj.info;
     if (condition) {
       error.code = ConditionErrorNameMapper[condition as keyof typeof ConditionErrorNameMapper];
     }
@@ -687,16 +703,16 @@ export function translate(err: unknown): MessagingError | Error {
     return error;
   }
 
-  if (err instanceof Error && err.name === "MessagingError") {
+  if (errObj instanceof Error && errObj.name === "MessagingError") {
     // already translated
-    return err;
+    return errObj;
   }
 
-  if (isSystemError(err)) {
+  if (isSystemError(errObj)) {
     // translate
-    const condition = err.code;
-    const description = err.message;
-    const error = new MessagingError(description, err);
+    const condition = errObj.code;
+    const description = errObj.message;
+    const error = new MessagingError(description, errObj);
     let errorType = "SystemError";
     if (condition) {
       const amqpErrorCondition =
@@ -711,7 +727,7 @@ export function translate(err: unknown): MessagingError | Error {
     return error;
   }
 
-  if (isBrowserWebsocketError(err)) {
+  if (isBrowserWebsocketError(errObj)) {
     // Translate browser communication errors during opening handshake to generic ServiceCommunicationError
     const error = new MessagingError("Websocket connection failed.");
     error.code = ConditionErrorNameMapper[ErrorNameConditionMapper.ServiceCommunicationError];
@@ -721,9 +737,9 @@ export function translate(err: unknown): MessagingError | Error {
 
   // Some errors come from rhea-promise and need to be converted to MessagingError.
   // A subset of these are also retryable.
-  if (isError(err) && rheaPromiseErrors.indexOf(err.name) !== -1) {
-    const error = new MessagingError(err.message, err);
-    error.code = err.name;
+  if (isError(errObj) && rheaPromiseErrors.indexOf(errObj.name) !== -1) {
+    const error = new MessagingError(errObj.message, errObj);
+    error.code = errObj.name;
     if (error.code && retryableErrors.indexOf(error.code) === -1) {
       // not found
       error.retryable = false;
@@ -731,7 +747,7 @@ export function translate(err: unknown): MessagingError | Error {
     return error;
   }
 
-  return isError(err) ? err : new Error(String(err));
+  return isError(errObj) ? errObj : new Error(String(errObj));
 }
 
 /**

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -635,11 +635,7 @@ function isBrowserWebsocketError(err: any): boolean {
  * @param err - object that may contain error information
  */
 function isErrorEvent(err: any): err is { message: string; error: any } {
-  let result: boolean = false;
-  if (typeof err.error === "object" && typeof err.message === "string") {
-    result = true;
-  }
-  return result;
+  return typeof err.error === "object" && typeof err.message === "string";
 }
 
 /**

--- a/sdk/core/core-amqp/test/errors.spec.ts
+++ b/sdk/core/core-amqp/test/errors.spec.ts
@@ -66,8 +66,9 @@ describe("Errors", function () {
           errno: "-3008",
           syscall: "getaddrinfo",
           message: "getaddrinfo ENOTFOUND example.invalid",
-          stack: "'Error: getaddrinfo ENOTFOUND example.invalid\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)'",
-        }
+          stack:
+            "'Error: getaddrinfo ENOTFOUND example.invalid\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)'",
+        },
       };
       const translatedError = Errors.translate(testError) as Errors.MessagingError;
       translatedError.message.should.equal(testError.error.message);
@@ -78,7 +79,6 @@ describe("Errors", function () {
       translatedError.stack!.should.equal(testError.error.stack);
       translatedError.retryable.should.equal(false);
     });
-
 
     it("Sets retryable to true, if input is custom error and name is OperationTimeoutError", function () {
       const err = new Error("error message");

--- a/sdk/core/core-amqp/test/errors.spec.ts
+++ b/sdk/core/core-amqp/test/errors.spec.ts
@@ -58,6 +58,28 @@ describe("Errors", function () {
       translatedError.should.deep.equal(testError);
     });
 
+    it("handles an ErrorEvent", function () {
+      const testError = {
+        message: "getaddrinfo ENOTFOUND example.invalid",
+        error: {
+          code: "ENOTFOUND",
+          errno: "-3008",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid",
+          stack: "'Error: getaddrinfo ENOTFOUND example.invalid\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)'",
+        }
+      };
+      const translatedError = Errors.translate(testError) as Errors.MessagingError;
+      translatedError.message.should.equal(testError.error.message);
+      should.equal(translatedError.name, "MessagingError");
+      should.equal(translatedError.code, "ENOTFOUND");
+      translatedError.code!.should.equal(testError.error.code);
+      translatedError.message.should.equal(testError.error.message);
+      translatedError.stack!.should.equal(testError.error.stack);
+      translatedError.retryable.should.equal(false);
+    });
+
+
     it("Sets retryable to true, if input is custom error and name is OperationTimeoutError", function () {
       const err = new Error("error message");
       err.name = "OperationTimeoutError";


### PR DESCRIPTION
Rhea expects an Error object

https://github.com/amqp/rhea/blob/2.0.8/lib/connection.js#L591 but some times it

gets an ErrorEvent instead from certain packages, ws for example

https://github.com/websockets/ws/blob/8.16.0/lib/event-target.js#L224

while rhea may be changed to unwrap the error from an ErrorEvent instance, this PR handles the ErrorEvent case in our code base since we have more control here.

### Packages impacted by this PR
`@azure/core-amqp`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/29294
