### PR TITLE
[api management tool] fix "main" entry in package.json

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -94,6 +94,6 @@
       }
     }
   },
-  "main": "dist/index.js",
+  "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts"
 }


### PR DESCRIPTION
This change is the result of running build. Looks the current path is incorrect
as the CJS build output is under ./dist/commonjs