### PR TITLE
[ACR][Test] fix failure in test resource deployment

### DIFF
--- a/sdk/containerregistry/test-resources-post.ps1
+++ b/sdk/containerregistry/test-resources-post.ps1
@@ -9,7 +9,8 @@ Import-AzContainerRegistryImage `
     -ResourceGroupName $DeploymentOutputs['CONTAINERREGISTRY_RESOURCE_GROUP'] `
     -RegistryName $DeploymentOutputs['CONTAINER_REGISTRY_NAME'] `
     -SourceImage 'library/busybox' -SourceRegistryUri 'registry.hub.docker.com' `
-    -Mode 'Force'
+    -Mode 'Force' `
+    -TargetTag 'library/busybox:latest'
 
 Import-AzContainerRegistryImage `
     -ResourceGroupName $DeploymentOutputs['CONTAINERREGISTRY_RESOURCE_GROUP'] `


### PR DESCRIPTION
Likely the Import-AzContainerRegistryImage powershell command now requires the TargetTag parameter.

