### PR TITLE
remove communication network traversal from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,10 +103,6 @@
 # ServiceLabel: %Communication - Phone Numbers
 /sdk/communication/communication-phone-numbers/ @miguhern @whisper6284 @RoyHerrod @danielav7
 
-# PRLabel: %Communication - Network Traversal
-# ServiceLabel: %Communication - Network Traversal
-/sdk/communication/communication-network-traversal/ @ajpeacock0 @nathpete-msft
-
 # PRLabel: %Communication - Rooms
 # ServiceLabel: %Communication - Rooms
 /sdk/communication/communication-rooms/ @anujissarMS @minnieliu @paolamvhz @shwali-msft @allchiang-msft


### PR DESCRIPTION
remove communication network traversal from codeowners to resolve ci failure https://dev.azure.com/azure-sdk/public/_build/results?buildId=3705411&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4&l=23