### PR TITLE
[EngSys] Remove esm from default ts-node

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -20,6 +20,7 @@
     "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
+    "integration-test": "echo skipped",
     "lint:fix": "eslint --no-eslintrc -c ../../../sdk/.eslintrc.internal.json package.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint --no-eslintrc -c ../../../sdk/.eslintrc.internal.json package.json src test --ext .ts",
     "pack": "npm pack 2>&1",

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -24,9 +24,7 @@ export default leafCommand(commandInfo, async (options) => {
   const isModuleProj = await isModuleProject();
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
-  const defaultMochaArgs = `${
-    isModuleProj ? "--loader=ts-node/esm " : "-r esm "
-  }-r ts-node/register ${reporterArgs} --full-trace`;
+  const defaultMochaArgs = `--loader=ts-node -r ts-node/register ${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
   );

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -60,7 +60,7 @@
     "extract-api": "npm run check:src:strict && npm run build:src && api-extractor run --local",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples-dev/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "cross-env NODE_OPTIONS='--dns-result-order=ipv4first' mocha -r test/mocha.env.ts -r ts-node/register -r esm -r dotenv/config -r ./test/public/common/setup.ts --reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\"  --timeout 100000",
+    "integration-test:node": "cross-env NODE_OPTIONS='--dns-result-order=ipv4first' mocha --loader=ts-node -r test/mocha.env.ts -r ts-node/register -r dotenv/config -r ./test/public/common/setup.ts --reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml \"./test/internal/**/*.spec.ts\" \"./test/public/**/*.spec.ts\"  --timeout 100000",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",


### PR DESCRIPTION
### Packages impacted by this PR

All via dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

esm is still being required in our test:node-ts-input and I don't believe it is
necessary. I'm removing it, but PLEASE do let me know what I'm missing - I don't
know much about mocha config to be honest.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
