### PR TITLE
[dev-tool] Resolve linter errors

### DIFF
--- a/common/tools/dev-tool/src/commands/about.ts
+++ b/common/tools/dev-tool/src/commands/about.ts
@@ -31,7 +31,7 @@ export default leafCommand(commandInfo, async (options) => {
     console.log(chalk.blueBright(`  Name/Version:\t${packageInfo.name}@${packageInfo.version}`));
     console.log(chalk.blueBright(`  Location:\t${packageInfo.path}`));
     console.log();
-  } catch (error: any) {
+  } catch (error: unknown) {
     log.error("Could not locate dev-tool package.");
     log.error("Unable to display dev-tool version information.");
   }

--- a/common/tools/dev-tool/src/commands/admin/list/packages.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/packages.ts
@@ -22,8 +22,10 @@ export const commandInfo = makeCommandInfo("packages", "list packages defined in
   },
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _rushJson: any = undefined;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getRushJson(): Promise<any> {
   if (_rushJson) return _rushJson;
 

--- a/common/tools/dev-tool/src/commands/package/resolve.ts
+++ b/common/tools/dev-tool/src/commands/package/resolve.ts
@@ -40,7 +40,7 @@ export default leafCommand(commandInfo, async (options) => {
         log.info(`Version specifier: ${currentPackage.name}@${currentPackage.version}`);
         log.info(`Location: ${path.resolve(dir, currentPackage.path)}`);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       log.error("Could not find package starting from", dir);
       log.error(error);
     }

--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -39,6 +39,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   let moduleField = info.packageJson.module;
   if (!moduleField) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultExport = info.packageJson.exports?.["."]?.import as any;
     if (defaultExport) {
       moduleField = defaultExport?.default;
@@ -52,6 +53,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   // Read the imports
   const importMap = new Map<string, string>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const importField = (info.packageJson as any)?.imports;
   if (importField) {
     const keys = Object.keys(importField);

--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -75,6 +75,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   let moduleField = info.packageJson.module;
   if (!moduleField) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultExport = info.packageJson.exports?.["."]?.import as any;
     if (defaultExport) {
       moduleField = defaultExport?.default;
@@ -117,7 +118,7 @@ export default leafCommand(commandInfo, async (options) => {
         exports: "named",
         esModule: true,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       log.error(error);
       return false;
     }
@@ -180,7 +181,7 @@ export default leafCommand(commandInfo, async (options) => {
     };
 
     try {
-      const browserBundle = await rollup.rollup(browserTestConfig as any);
+      const browserBundle = await rollup.rollup(browserTestConfig);
 
       await browserBundle.write({
         file: `dist-test/index.browser.js`,
@@ -195,7 +196,7 @@ export default leafCommand(commandInfo, async (options) => {
         // inlined.
         inlineDynamicImports: true,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       log.error(error);
       return false;
     }

--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -100,7 +100,9 @@ export default leafCommand(commandInfo, async (options) => {
       };
 
       // Place the subpath export rollup file in the directory from which it is exported
-      let publicTrimmedFilePath = path.parse(extractorConfigObject.dtsRollup.publicTrimmedFilePath);
+      const publicTrimmedFilePath = path.parse(
+        extractorConfigObject.dtsRollup.publicTrimmedFilePath,
+      );
       const newPublicTrimmedPath = path.join(
         publicTrimmedFilePath.dir,
         exportPath,

--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -140,7 +140,7 @@ function createDockerContextDirectory(
     try {
       new URL(s);
       return true;
-    } catch (err: any) {
+    } catch (err: unknown) {
       return false;
     }
   };

--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -49,7 +49,7 @@ export default leafCommand(commandInfo, async (options) => {
 
     // This is where the actual magic of creating the output from the template happens
     await factory(basePath);
-  } catch (ex: any) {
+  } catch (ex: unknown) {
     log.error((ex as Error).message);
     return false;
   }

--- a/common/tools/dev-tool/src/commands/samples/run.ts
+++ b/common/tools/dev-tool/src/commands/samples/run.ts
@@ -37,7 +37,7 @@ async function runSingle(name: string, accumulatedErrors: Array<[string, string]
       const { main: sampleMain } = await import(name);
       await sampleMain();
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
     const truncatedError: string = (err as Error).toString().split("\n")[0].slice(0, 100);
     accumulatedErrors.push([path.basename(name), truncatedError]);
     log.warn(`Error in ${name}:`);

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -169,7 +169,7 @@ export function sourcemaps() {
         return { code, map: null };
       } catch (e) {
         // eslint-disable-next-line no-inner-declarations
-        function toString(error: any): string {
+        function toString(error: unknown): string {
           return error instanceof Error ? error.stack ?? error.toString() : JSON.stringify(error);
         }
         this.warn({ message: toString(e), id });

--- a/common/tools/dev-tool/src/util/customization/customize.ts
+++ b/common/tools/dev-tool/src/util/customization/customize.ts
@@ -61,8 +61,8 @@ async function directoryExists(path: string) {
   try {
     const stats = await stat(path);
     return stats.isDirectory();
-  } catch (error: any) {
-    if (error.code === "ENOENT") {
+  } catch (error: unknown) {
+    if (error instanceof Object && (error as Record<string, unknown>).code === "ENOENT") {
       return false; // Directory does not exist
     } else {
       throw error; // Other error occurred, propagate it

--- a/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
+++ b/common/tools/dev-tool/src/util/customization/helpers/preformat.ts
@@ -27,6 +27,7 @@ export function sortSourceFileContents(sourceFile: SourceFile) {
   const enums = sourceFile.getEnums();
 
   // Sort elements by exported status
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sortExportedFirst = (a: any, b: any) => (b.isExported() ? 1 : 0) - (a.isExported() ? 1 : 0);
   const variableStructures = variableStatements
     .sort(sortExportedFirst)

--- a/common/tools/dev-tool/src/util/pathUtil.ts
+++ b/common/tools/dev-tool/src/util/pathUtil.ts
@@ -3,8 +3,10 @@
 
 import path from "node:path";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toPosixWrapper<T extends (...args: any[]) => any>(f: T): T {
   const wrapped = (...args: Parameters<T>): ReturnType<T> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const newArgs = args.map((arg: any) =>
       typeof arg === "string" ? arg.replace(/\\/g, "/") : arg,
     ) as Parameters<T>;

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -169,7 +169,7 @@ export async function makeSampleGenerationInfo(
 
         try {
           contents = fs.readFileSync(path.resolve(projectInfo.path, file));
-        } catch (ex: any) {
+        } catch (ex: unknown) {
           fail(`Failed to read custom snippet file '${file}'`, ex);
         }
         return {

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -292,7 +292,7 @@ export async function isProxyToolActive(): Promise<boolean> {
       }\n`,
     );
     return true;
-  } catch (error: any) {
+  } catch (error: unknown) {
     return false;
   }
 }
@@ -313,7 +313,7 @@ async function getTargetVersion() {
 
     log.info(`Image tag obtained from the powershell script => ${tag}\n`);
     return tag;
-  } catch (_: any) {
+  } catch (_: unknown) {
     log.warn(
       `Unable to get the image tag from the powershell script, trying "latest" tag instead\n`,
     );

--- a/common/tools/dev-tool/test/customization/classes.spec.ts
+++ b/common/tools/dev-tool/test/customization/classes.spec.ts
@@ -236,7 +236,7 @@ class MyClass {}
         parameters: [{ name: "foo", type: "string" }],
       });
       augmentConstructor(customConstructor, originalClass!);
-      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors()
+      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors();
       assert.isDefined(constructorDeclarations);
       if (constructorDeclarations) assert.lengthOf(constructorDeclarations, 1);
     });
@@ -250,14 +250,12 @@ class MyClass {}
       });
       augmentConstructor(customConstructor, originalClass!);
 
-      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors()
+      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors();
       assert.isDefined(constructorDeclarations);
-      if (!constructorDeclarations) assert.fail("constructorDeclarations is undefined")
+      if (!constructorDeclarations) assert.fail("constructorDeclarations is undefined");
       assert.lengthOf(constructorDeclarations, 1);
       assert.isDefined(constructorDeclarations[0].getParameter("foo"));
-      assert.isUndefined(
-        constructorDeclarations[0].getParameter("bar"),
-      );
+      assert.isUndefined(constructorDeclarations[0].getParameter("bar"));
     });
 
     it("should augment constructor with original constructor", () => {
@@ -289,36 +287,17 @@ class MyClass {}
 
       augmentConstructor(customConstructor, originalClass!);
 
-      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors()
-      if (!constructorDeclarations) assert.fail("constructorDeclarations is undefined")
+      const constructorDeclarations = originalFile.getClass("MyClass")?.getConstructors();
+      if (!constructorDeclarations) assert.fail("constructorDeclarations is undefined");
       assert.lengthOf(constructorDeclarations, 1);
       assert.equal(constructorDeclarations[0].getJsDocs().length, 1);
-      assert.equal(
-        constructorDeclarations[0].getJsDocs()[0].getDescription(),
-        "Customized docs",
-      );
-      assert.isDefined(
-        constructorDeclarations[0].getParameter("endpoint"),
-      );
-      assert.isUndefined(
-        constructorDeclarations[0].getParameter("baseUrl"),
-      );
-      assert.include(
-        constructorDeclarations[0].getText(),
-        "console.log('custom');",
-      );
-      assert.include(
-        constructorDeclarations[0].getText(),
-        "console.log('original');",
-      );
-      assert.notInclude(
-        constructorDeclarations[0].getText(),
-        "// @azsdk-constructor-end",
-      );
-      assert.include(
-        constructorDeclarations[0].getText(),
-        "console.log('finish custom');",
-      );
+      assert.equal(constructorDeclarations[0].getJsDocs()[0].getDescription(), "Customized docs");
+      assert.isDefined(constructorDeclarations[0].getParameter("endpoint"));
+      assert.isUndefined(constructorDeclarations[0].getParameter("baseUrl"));
+      assert.include(constructorDeclarations[0].getText(), "console.log('custom');");
+      assert.include(constructorDeclarations[0].getText(), "console.log('original');");
+      assert.notInclude(constructorDeclarations[0].getText(), "// @azsdk-constructor-end");
+      assert.include(constructorDeclarations[0].getText(), "console.log('finish custom');");
     });
   });
 });

--- a/common/tools/dev-tool/test/customization/interfaces.spec.ts
+++ b/common/tools/dev-tool/test/customization/interfaces.spec.ts
@@ -39,8 +39,8 @@ describe("Interfaces", () => {
     augmentInterface(customInterface, originalInterface, originalFile);
 
     assert.isDefined(originalFile.getInterface("myInterface"));
-    const props = originalFile.getInterface("myInterface")?.getProperties()
-    if (!props) assert.fail("myInterface#getProperties() is undefined")
+    const props = originalFile.getInterface("myInterface")?.getProperties();
+    if (!props) assert.fail("myInterface#getProperties() is undefined");
     assert.lengthOf(props, 2);
     assert.isDefined(originalFile.getInterface("myInterface")?.getProperty("foo"));
     assert.equal(
@@ -70,7 +70,7 @@ describe("Interfaces", () => {
 
     assert.isDefined(originalFile.getInterface("myInterface"));
     const props = originalFile.getInterface("myInterface")?.getProperties();
-    if (!props) assert.fail("myInterface#getProperties() is undefined")
+    if (!props) assert.fail("myInterface#getProperties() is undefined");
     assert.lengthOf(props, 2);
     assert.isDefined(originalFile.getInterface("myInterface")?.getProperty("foo"));
     assert.isDefined(originalFile.getInterface("myInterface")?.getProperty("baz"));


### PR DESCRIPTION
- use `unknown` for catch variable type
- suppress error where `any` is desired
