### PR TITLE
[communication-identity] upgrade dependency @azure/msal-node to ^2.7.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1555,11 +1555,6 @@ packages:
       '@azure/msal-common': 14.9.0
     dev: false
 
-  /@azure/msal-common@13.3.1:
-    resolution: {integrity: sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==}
-    engines: {node: '>=0.8.0'}
-    dev: false
-
   /@azure/msal-common@14.9.0:
     resolution: {integrity: sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==}
     engines: {node: '>=0.8.0'}
@@ -1578,16 +1573,6 @@ packages:
   /@azure/msal-node-runtime@0.13.6-alpha.0:
     resolution: {integrity: sha512-Tu5e4wBFiaiBLrOu7bsJF7FYknFH9XIOvUyCqCnmLJFMMOUnYULZ7fOFYuintFFcNPMOT2u8BVfSCPxETri5ng==}
     requiresBuild: true
-    dev: false
-
-  /@azure/msal-node@1.18.4:
-    resolution: {integrity: sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==}
-    engines: {node: 10 || 12 || 14 || 16 || 18}
-    deprecated: A newer major version of this library is available. Please upgrade to the latest available version.
-    dependencies:
-      '@azure/msal-common': 13.3.1
-      jsonwebtoken: 9.0.2
-      uuid: 8.3.2
     dev: false
 
   /@azure/msal-node@2.7.0:
@@ -10809,7 +10794,7 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-SVz9hB6zZzJbFy/JcR8ffDbQxflZ7Y8T85K1Tm2xMaVv9DzdsyylVGz3tMLTmmBuzN9wAIHqv2xHbXzYhrAEkg==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-v/xJ+RkdJi2WRugVOl3vV+wWrAlQPU2dlDE/zUvcmrKIvkJe+gL1NdVy0M5BCtwOaC992GAJRJ5kkL3eRtOwRg==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
@@ -10842,7 +10827,7 @@ packages:
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-rmRo4g03tSJmKEfAl9EXYb6iPTCyLPzx6mv6gb/RZ9QDu4bIMZBZ1Sgx6K7vqUsvEhiMazQ2c3ZVnhGCQK7Q+w==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-jsIFNt2WTaDYtJ5lSWUff5ulNGlpSOPe5J1CLpUaxQvufa1p0RSH1d2oXjD81B99t+jVkmeL+kARGSj7NXVXCg==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -10887,7 +10872,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-HWu9F0vYD/MZEwXxSstWMR4wIGq01dUOrnvgVU/0/jNtFqYZmNn5OFXapV5WSL6GfZ7EZWvKI1jc6MAg1s0fKQ==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-mF1kwH2xyPjpDH4wy1DWVQ6a7rcWhUeS3BX9kBBe+h7PDI27S+lDI/rtyvBD4paysdJJf7mwIyviJnCBQfx8Kw==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -10932,7 +10917,7 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-i/dnTDtZGRJcM3qHum6NnxGJOyX+kDlGly3uUw5ufpKihCX7AL1Z+JymLUR5tr2gwFgrVH8zJjVwon/0kVooEQ==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-xdO7vzrx8IlDZh0NGXnSum/b27xOfW3lKcEVAmygRlOcTFWKcRJbGnWl/pamffOqS96HOz4GTDiK1OwpwTFOuA==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
@@ -10976,7 +10961,7 @@ packages:
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-ErXLetJ7RzF1fs68qD0ihMPFrGBBIlfrzrupXeUwKL/bXUMAPF+1U6YPe99nm0fVUO9TdielJSBK/btdiOdRfg==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-hc9i7POE3metk+arzOmstWEGPP+458zEYpIKXaG5j8WfwA/LFkzV9kpy7jg74KUOKJOMP5Py6M80uN/kVrsXEQ==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
@@ -11021,7 +11006,7 @@ packages:
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-qJzfjhzPKrRJBqqkdiJ/juf95YOeOkWr2mnray1o0dYiraTSYPmaevR91O7zoSuxJXDxeQ08i2NeFNTS8L2kfA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-VkKFjj2jBuulv6nYUrBzWkpOHvi+gD7kJc3vfpZMfHaZxNyF3mxrlFAtfLura5oqEhN1kgreL1Cx4uE6Jys66g==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
@@ -11065,7 +11050,7 @@ packages:
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-4h4TigOA1O43D6YyrYtOOiY/8o9Ou6eoqpmyHFHdoqe7N05hOJpC8w7NN0bE/VgMkTkJXgIpdLrmiw+H1jcAag==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-/ZinWuNeaNRHJcilVpfZw4OsWtOlipzu7By0FhzSri/7ygL9Qrv0TdQxoy73CY1vc/E/tRTQplcErmekHj4NnA==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -11113,7 +11098,7 @@ packages:
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-FawM+tiF9gD/CIVRZPiZ7BnaKY5Ml7MNWmdNzjHA+YqJ+tMyq+IxB7Q0wR7XwbCoJmZSEC/JQKQFIT/o6cYT7A==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-NvgvCdcBXO6ikF+Ea1juGhLmU366JUZ9S3x97gp1s9aOyaWeE4XiNpvMPE+j/EgrlTulKTHz6gXkyMcaaft3HQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -11162,7 +11147,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-wgxnOrEgyzPHC+mN8Uleu9exrIzfm5Ui4rVQKhZ6dKw+0QjEMpA+gcW+s98km1iB9sLmXljao15SjJb1u7nI9A==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-oLu2Iu8f0wklBHpBQWzMi/J/s7NWiLntGAaH/tSP+Zf4aqK4aydiap5MZz49NSirlCmhMYna80Eu5YNCY2k2dw==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -11210,7 +11195,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-D/84iHmJgj21O67hrx/hwvRvZYC6D4lR9B01/Xck0h42/as/gzXuKHKaqsl1citSGPI97kPHDqUNgDQvMCAWGw==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-RN88v3ItwxCkgtxPUN6vPdCR+kGwiHOa/j5yKMR+EjusYsFEvyL4FZcBQF3GRCbl4fFiDzqyTv77x3s4bMu2TQ==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -11235,7 +11220,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-rAEoVNIgvj2iq+EP9Hibm4vmGgifyqm/q4HGWepiDC85Fhc3hKF5yp8xBdR2P61MQGonR9Q5JKylLYHI+7YW0A==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-3Kky2+bfR4oU1fWej/8bZ0WruLDZFPfG1NPholhVxvR6TFJtn2QxaKSmgYY/8bsjglkdx/1F8Telg/aGeUYyVA==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -11279,7 +11264,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-9x5amujpyclwK8+CeMk3iD5rvSIlPWfJZZks0eQb0fd/mo7jjf0FXYDAXWv+wvW+kLNuRgIPivJ6QQHF7f/NHA==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-5O/XDI9yQolzQsV9WIZVL9qjqPEChjLrz96LwXZWMrakIo6+qpzWE745XV9/h6smIbEdrisQ11qqo2PT5NVihQ==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -11326,7 +11311,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-jKRiAJx5CKjvXkzaZF+KwnLVZmCkdNnniaJljVr4iIuFpePga5QdEeTDyPKQxgKhwiW4zcVvh/ll8OJUcLPO5A==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-b6RssFRLCUcuXug/3UQMIxRxDtvOJBibMJfVmHDnWSbu0T+ATvcydQI8w63VsJPTIYu1AJviYd3p7b+dstU6Pw==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
@@ -11370,7 +11355,7 @@ packages:
     dev: false
 
   file:projects/ai-vision-image-analysis.tgz:
-    resolution: {integrity: sha512-2gCshDRE6yulTuM/ipgrnE8z6/3w0xmfH9wZtV3B/LdRsuHV1hfX96s66OysqLQXLZl3+j0LZAkpnTPJL9WbCg==, tarball: file:projects/ai-vision-image-analysis.tgz}
+    resolution: {integrity: sha512-0Apqo6mWV25tJcPWtdqEoIjwHgTKGbwFlYIF0MFuzRX1QnTfC9f0wuOnDXJHd49OxW4AD4gf+fZvlDOK++wetA==, tarball: file:projects/ai-vision-image-analysis.tgz}
     name: '@rush-temp/ai-vision-image-analysis'
     version: 0.0.0
     dependencies:
@@ -11414,7 +11399,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-JenVN3xgkSYCMRfzLcMqc03nvJZpOUurl+iKhOya4dLzzRGrMxbtECrgfMzoNk2zWUJtPaWB4EeTW0Z7Yf1+lw==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-dwYLdpNRkcf5t1x+RofEhJ60AfQTyfVcgllNcD0qpnlBc4RsaZbbFaZFE6dV22SbabE66Pu2StoY1aWP4Mh9gA==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -11456,7 +11441,7 @@ packages:
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-SLovIyo+bE0sRgMnphSx58mqjPvV0Skoj7RE/vkVKBtPBY22bUNi9sCIJRyZ01rkX4RvFjpYpVNugcKS+d8rCQ==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-H0V5oKg1LUH8IDYvJI1UXj3NwWTgEPTgGR8ubj4EUZrvoY9DzYOs0LYV01h9vlikOo+bP/B36PTuddHTwc2gBg==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
@@ -11492,7 +11477,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-Y1PFxDGCkQcD0qudEsYbFjuOwl7UxA1eaaHR4raeMxcLhtVO/2e3p84v119LKAXXHJSmCV834h7z6YVXi75Kwg==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-NmowUeKGi7yeDUMMjrMyL5P8xY9EZVSzWLWNVUYRCWwGljt7VBDy9rNK6cKMCT2LHwx8ppkGmjJvPkNOlRhP9g==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -11532,7 +11517,7 @@ packages:
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-PcMFElry6HUBzY4nh5RMkD4jzFxRDxh5qxqvSz05imtUdm5vWIISmOuI8c8e3YaRy3MnSev6OEMzBxptC9b1Cw==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-zyuVmvXs6ZyN+8sxCfudmpRTW3FZXHUDxSaUbhtd0kKDlm27fLfwvLzAyF1R8ld0Nw/MIGIPNxLBmHawNWN3Dg==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -11559,7 +11544,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-w/Aeh0PZB7ip9nXj7vTzeGbTg0QDYTkf+4MHP9PBRw+g7TOo002DAMbMmZ/7dQKCn6PNvY/kUY+iPoUWTfy9zA==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-xV/s7pjqexSpW/ZGXFKAoLumz4Mr3ikrh3JPRcE4WB2mW+bIZP7BkZD0oLvbyjr5PdRktbVa9f4/olF/AFbrSQ==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -11586,7 +11571,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-f4QFIRC4DyUWrctIsYWB9dAKyZGUoApakNBQDv2o4oA7cYu1DU41uWClO0a+oA00Wxuuz0VsjX8baxZ0GgvGnQ==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-eD4TBS4ovQ2Us2sxKsXoRtAO4NnRT0zRXYTM5KgaCW3uB9otCMd0VVQblFCKPPwgCYx1YXygH7/5I73h3B97Xw==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -11613,7 +11598,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-Jon2zDGUxbKvhXq7Zf2OCRlqN72XPkZgX2Q6jGV6KSY6bCCrCwNhqel9pUVtOPh/rLoe9JTyebu4ysIAR7M5aA==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-Ku1KVbAO4KSIhkkNPNLUGAgSnaqQSXFgH+86XKnZdX724ZatHXNNlXkvVoS1xl9PLdriKueoM6wm3C++pQMLPg==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -11642,7 +11627,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-o5qHYag0Pi0Or+ww9DJpO5RD/pK8Bv9DUSvdYOlfK75MgP77b26bA7wnBta3IFTI7oiOm+X/8pxPFhgehvwP0g==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-rcixPMQuP30AVFDnA4WB8j49ym60Je/4sU//j8WEFP00NInx6J+O+KuGqjSxl3KW0mElNzzA+30BfrumnYXvQg==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -11670,7 +11655,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-E9djO/4zbVzcy9UB8D0+7V8KNedgX1IG6itEinuoi33vZm0w0nC+7EXm16PrUEEOJUu1WL/YmN+1NLfZZSwLZA==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-zE9obcrTHbnYrgC6SDTM1QP0k2IWmYcgusg4qzbKWTPFH1n4swXecVZBN1ZElB641cdGHFLaZgHSntoO9Bcl2A==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -11697,7 +11682,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-UnE60Qd2BXV8iV/oJT6bAc9XbwLs6zCumqlzDSdEmzoOEMjAZf356DjqmBxstqHLLqDoKTIA/O3DOh+S/+tZtQ==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-X3oLsmTFbzT+t/qnj9dpmp5pLbAiZEM+tzub+0kyQoKeG1qRFqoHT1w/HMpr+eBX3YxOq67PnwKvodB69ExQaQ==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -11725,7 +11710,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-42rV7Hf370i+LMgkh8/IGzAcgczKw/IqhbCKlrhXcUM8ZT5QCfI91igeWZwkTii7Q98PcagclV57+QL2ImcfoA==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-Wofx+axN4ukE66NnpV+uO37gGltPdU7YELDRgKkX0IKbfbhLSzOG6oziZcWUTR+kKclFt2D+ffybnhI56aTimw==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -11754,7 +11739,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-FebFb5HB9RW6ORb6z7ZddUkpCifAytXHLi6xrRvUlMKZF973Z6ai/crCEJyiT4QmntXRgfh0+Hz6kCOcrCb6Wg==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-yjy/76f2JIgGJtqAnskFaZxQj6ZxRwDoG6oxl2XSiZws+Z2KeWEJx1+W6xpdMX6KDvKw85u7Id0KHd+nQBuyhQ==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -11780,7 +11765,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-5/oD21d7b+C+E8kE/gqg4r1RgeW2/Bi/coEM+lQrh0opS49Da1cRVPQHQcJe06SPkNpYJesdktCvuTrD6Qb8GQ==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-QCqMM8XvQUxE6L7xzxK2YaJDSepx8wDS98FeKoqiJ4lyAm66OPPHITw1W0Z3ZIa2l4APzkMmK1oEbgwkH1JBVg==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -11809,7 +11794,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-7XB/gHY6/pmLwiYld/T6uMYco1DxYRMIpW6goj59+g2D6muUjR+b/ylMHH+T4fBOeP50sj5gmnnQWMh8g4aL1A==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-p/q1EAu9eh7YD/7ywZYiUh1E0lukwWmT1V/d8Q/94x4bpQ/VoiTiPuWl4ESekYysio++AG+zh+XsBnHiIvZMdw==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -11838,7 +11823,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-ocCACETGCsIvZilBjUXaOMYMO/7aaUCnP0MGoQ0FT85JcLxZq4IzuqEUQ66cBLi0DC7hN9K9FJPhSBxYQcYC4w==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-NivqyR/7N82rpBVDvO5pb6cjSNvbOWa8uxe1DxlMdalVpdlvcaaUgD20pv1vCJ79BdlsFMeNMHzZfiw0F7MDUQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11866,7 +11851,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-4RQqpf0A1o2iFEnl4tcfibsV4ZYXzjFoFaO+xidfrbbu2YqoxdPZ0dzJ5Q7SmjEByhwjMEdtJ2MZ1kjQ8cmA4w==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-uDGbHcaWOnrwnVQFXQqknNtkRGM1Gsb6rDifkhcIaEScvvXpp8AJRDgZPeA/EDgW/cNTNh1ipWxMYDXy2l8zkg==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -11910,7 +11895,7 @@ packages:
     dev: false
 
   file:projects/arm-astro.tgz:
-    resolution: {integrity: sha512-9F9IujbuoRYDeilwxH37CFdI/jn/TqMU8nuz3WJX6FbkQim9HKYwj209lgxvCYlwLzLFsdbYwG0xERhn9BaWZA==, tarball: file:projects/arm-astro.tgz}
+    resolution: {integrity: sha512-m1PbY+rTfK3aoyxFvAtysnhTbBvqlj9kbApEOUBSMyjFdKQTTzBle+fZaDK4YXz4d7G/Q4GPJFt5A5OdEeFS6w==, tarball: file:projects/arm-astro.tgz}
     name: '@rush-temp/arm-astro'
     version: 0.0.0
     dependencies:
@@ -11939,7 +11924,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-inqZ2S2lGVhcBtMjmiddECcMbBvyqZ845W2KHgWSNBiu2m2oVAGClndg8iPZz5/3cbPMjdEuQnCKtjFRvUUsug==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-LX9ASV1ZKwYUtOiIrr6u4zlyAwGzivDVe/mYHtD3e9nyyDXLrKAivZM/TgICJgh3l0iCaU+HBZ5KG6CfB182Kg==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -11965,7 +11950,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-kDAI4aC2MrAwEgabZr64LF3znxwpNWsz04WhuoKSQ/HxFF5VOW5ACNK3KMjLVHBPBTBLcJ4CUlfJ34R9PUNbOA==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-m9qateyXBx6akGfdZjYXAtox/9he8wA9jytnmDVUATPlwJQe86PeLabX9ebq7D0sj4yegk8m9bziuuSsNiZhZg==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -11992,7 +11977,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-xzM5NbGj+zfBdHwXYEbRX53g4nC6KCS/kKx/FF28txaKgA6zvFurNoTppjapnl9/w4Pxs2HIUOTPoXCigDSMPw==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-67wEe/WRT68oEhrKtZ+Y1MeFv/vXG9KdFtH39jSBcRpBsfIi/x8j22SfS0j8l0Xj1dw5Sv9EPfZVViDy11GJcA==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -12020,7 +12005,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-7JmMDXOSkkODSBpD7+wCY4A/5GPJ88EfO8/3gsh9v2xs50IOjjMaJymfIV9o0r7OCvof8RJKyiHJebGo9U/QeQ==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-WGtfg0dDi6jkNh/Ri+uXy8/gQjRis0we3YkCeibk+k8JdcRcnYg2iGTLHIZpQJnS8cQC8XQGQxeuY2X/ObovFQ==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -12047,7 +12032,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-BDM6lZ3nVi8avbL2a6ZDRMX9+TJcGDdjy1gVHEHo5MBnMERYaszuoYYZTj7PV1QNRwInZ1+b4jQunzkknXCoBw==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-LkCVMYNYoREqLgdsRkEFk53t4P0lcupKBQAqpA5PsTT5iYAHZbp4qNFsA4AYm6WswcvBOILQlj0NWtjib4y0ug==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -12075,7 +12060,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-tB4JRi2ho7ieaJeBlBArubiak5ZmvV/gddcKjyMEvYfz4wM9zbgngoLpHFGm+ogq7tHv4RS1oBhOcHgU1V009w==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-JVgCzBZ1CZVhidxWm5jBurQEoF0VJHDh75O43kpL9fOiUTbZkVZcQoPYUWLb3UMxgdhyziL/0T4++vVY1Dxtow==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -12103,7 +12088,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-frx3qAmxB/grwY6lMMwAmnu2P+2bzlpmsfn3YJ+7BkB4aWfB5h6d505PbEvTUlO4k4IDc88LuL2+uJVi91dNgQ==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-SPyaQzWcW2YAIL6rtPJ6M5/9h0uLABlc+TntAkw1JdoNgbKzqeloNp6yHpb43NAbYPVwHWCrJ+hP1bNmgwmzlw==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -12130,7 +12115,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-z6quddidd1O5M0UneDKFjRctQ/MHF90qeo7pUsE68GLBaRXv0kOdX/GuZGcFbeaKf+yyqKY+04REyquanIt7+Q==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-AECWQnFsG8NLdEBLPiBqHb1uJckCkcBKWxaj9L6AS4wFVPqsGlRZ5o1CPGn0DetPHOCjDvDGwFtRjVRdR2wx+g==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -12156,7 +12141,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-0c4fbJhbe8mcJruAjwCJ0f2ch/Jns7s4OTDjd9CBnH1/8msCTRxBVeGoLuVwzl+e63+R353YNt3sgBtSF8+VLA==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-BmJwWMzZEuz+9kEe0boitvxgP+UZXowLbShpBFbVeVXL9w2qmPVt+SVoMYDNxa18Np1zGV+f2rMuYojTiLpRAA==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -12184,7 +12169,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-ueAwCJdb4g3zCu5I1GjLyohH/yBAmzKYsPq/vRADkXzIcG5oBcB40rdb2hel+1T6HlmS8ccN9jM4x09gboaoFw==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-nhbpr6xe3GHNXTfOR3FTPow53RGvZDWy+Zy1Y3y8LXr1DPsuXSd3jjYiVOJmqU6/5GTmp7vqeUJ/oNZVvlX6cg==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -12213,7 +12198,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-PEFF1xoihZUbyqYsAFC4brctf7ZnYDOaJo90Chnz5tKMpebitLX+ZVCaakX7sOCfQWtde+ZUg57tA/Yj8Ab7yg==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-p432qy+oWn+fse5jMb7qDgh+0VeWYET5TD6bLzWg6t3egRRcHmqpvY9aHeXAJcHjYH9McY6y7rD7VJ2M53U1pQ==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -12242,7 +12227,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-Fn1YLQTZasXmzCMNqgxvb2HtLm5axJKM4YS3cSJx2npcoukBAXJVu9fOjUpA+Uuqp+GLbSiuh4/LJvUE609Jmw==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-uVGmF6bNlF/A7n9qeGKAjZ1n3/VnOBC8rD5s5W7VISgYkii9P5MSCGT2kHfk0nDLNeGzzrWDNdHoFQx1TNzSQA==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -12269,7 +12254,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-nnWIpKps6iWfNzqcHE7HzxDsIe35DGDMvokRYe6iL7NeWvrHGdy2QsGcCgkyv39+KmqqDPXFpXY8M9Oe97AGHA==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-EvJ9wt0LIzjR/RPIJCl3+ZsUwT/WZwySrvDQDoubZdba086LZIYFPMJKmc4oHSJz0kmlR7V1biB/1pGEaaATzw==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -12296,7 +12281,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-147xXSwgZaTrVjH56KouUjgso03Z6u0SNJo5q0clHJxLYRNg1Qx/8I3vYUh17iX3ZhL2sF1TF63DqsjnctogYg==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-ldp80vXRReW2KaOixkkFuZrJRT/+d5In2pZ+hhlgQiurNRd6mwpiWT9uQxpC6e2wpj0EBRJ57LEwcVcWcNiizA==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -12324,7 +12309,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-qPFtnItAzw6rrvpa2uLUffSfwTrN26NSeo1p+UyGsS1vbJbyNsoyUgwJUaA5JVr86fPBCvtfL7ubGnoXE8pX6A==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-mlKGuq6sVDAUW+rnrbMUWESxNSNHj7XYqbOJ26fKtmgdiotFBI9axB/JTxyqYW+YyZbhhl3Gpn/UnOXjbzw23w==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -12353,7 +12338,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-4p3KydGWdmzEAl5LvLJP4hiztkgPTGXLK8oP5xzmmau15B/bxx14Jr9u/OX2oPXF0Re6x+LjU99MusUUF1Qoyg==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-TFO0oIjzso4/pF6iYCv9xLGGIreaxmywsD/NuOJ+CcCaj8fpPapo4xdyGUvD2WdIfBbmFbGc6Jcv4DlFZi+Odw==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -12379,7 +12364,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-fpKq9xzl6S1nz2jtGtsy7N0Oc/iWgSSxy528Lq/J4xhI8jI/+BjrGPkxH7GFgGB/t8YzHZwgnDtb+h6xOKDrdw==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-QqrenayrvPlOcFomQ5GNwaCyj/NMbsD+9fMJEbKAJe26tN2EIjjig5anRHe9YA5aD6a89nydYl99cEZRtOGMrw==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -12405,7 +12390,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-kDwaCpo/Ax1gskBL4wAOdGlT8xq1uyp8jkfaXgSdyycoxnSI0iMQpoMlh/Oz7CC5Xzozyf2Lv0X14/G6lUUXVw==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-NfuhL42A6rJqhIjKwPNf9L0g9x+IuumdnBrVpzgMlccsLrtAnE0/8px6/uYyi3TylMFc8eJEjUF0rR92GgUNMA==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -12435,7 +12420,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-chTH1KiO4ZsPf6I1VhvSMjsCgYdCd3rAY7I9LbzNkDFgzu4ChVvpb/it4ZpaOKBSO0GNU9rXVAClwcNF/ln8hA==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-Kh8zlyqhpyH2SzAWOkzFFY1iJv8yr+WVlqrHb6gL/3LY2SAC6v8/yt1uoDPHQsDSaQoZATXypZwZqVNNSPWqXA==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -12463,7 +12448,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-I7yRUd0ERqsRYJv/qachlu7CL6EIQyu02Iu8GO8f4XfUlcbpyicmLbMKgTuGZ6WpDh532a6uVpN/xBoTOhzJ4A==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-8Oy7QLqQEJxxQmu5PiiMHM+UpbvNIKpYH1+iN7JsaKSc93Fcrt4RWsbJ5GoytFHaUcdlpQm5YjRd6eBUAqzpLw==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12490,7 +12475,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-9HjUf6anYFR41WUOoaO0SrDbdaTC/PAbQeJVht0rX0AIgUjbGlppvGck4zphNUzB0NI6ebrEEbJbstlBNyLXeQ==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-coz+x1+dMhYbo76Hrb8OUhv4/vB6G4O2b2d5yr8A+oSM+prh+wmfN4lbd9T5GgghoEWKldSNPfOEZbRZ2UEqRA==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -12516,7 +12501,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-PGUh0U+C4Ylvj8rV1aL/hIn/i7UUU57RK3lHVSgc6lR3SGHUB/CM07zqh3E64k1IyGrpqtEfDO0VY8bEeAJdxg==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-HKf5ps3CLSrAy9v83HhgcE/TaOrfUjs7h205iL6pFwOejeU2p2nxQeb7RvEcUPgHAziVs2+BqiJD45NXlOTOKw==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -12542,7 +12527,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-+VO3h0VyUCjugKOo3C9lVQ9rczFNs1LD57DqJXkk1EzRB1OoPQVI8qs7UuIrI52w8qfBgpUjUesxmIUy+56m2A==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-SZwQTTbliqwpEqVmyQrPRR2FLdaB+JNMj2UxzMMu0mm0n3awsWGhWM+Q6CrO1EiYaCuOz4bT5QZDM5qJ9PZAQg==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -12571,7 +12556,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-T6NsKdpACodrWINP3YTSuX4XQNwbFq2kc76yA1BJOysP6l9LHGzk9Ke6/XewQEfZi8/ZCzgWrOrHac6QchLliA==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-MtVaJb7FdzJ1OJ+VSxIhCEts4kuNvHaytOf84xb5zwMEpRvDRB0xzLFRukJi4Onc09yIsFYV/9jLojJHy55DaQ==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -12601,7 +12586,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-ve2cqjcowlBqDhoQ8nUC0mpdGeWyiwlfAs9GAF3uuj4yBhooV+P5Ssky7Rft+sjYcljy1+cxJkOLzgN5mjMkfg==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-/eqUl6unRexbZ31IBYGFr9aUQxhBBpebjgswaVdB6rP7SDYJ64gG9tcxiL854PHt9M7hl0Gn+ZXX++DQIOqy7g==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12629,7 +12614,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-KUXvKkLcY/cmqNM7A3sbC34Vyc65DWkWlmEQyfOPDMUFDoNXFRugAnJf4VlCA+ndZ+kuzmEvOwOR4QfEdRDtTw==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-cvbza8JHohowCT9THKTrRE8cM4h7VbAwh7/4gbZjFA170eewAqTIp+1f89Ph59gmcPtZGzeu4n2j69I8zTY/JQ==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -12674,7 +12659,7 @@ packages:
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-GeQ/R0V9XY03jKdNIARebWNHV8JruQuMeEBvqmy4Su3WmQqIn8F73UTCOUjPRUEj1YbVIQC04tfRV6883HOS/A==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-q2B73OWxu31kNy6b6nuvQ+5WkX17wMcxSwCJX9qksekbLXfwux9Af7kR+FBoQIpBKmEBcxHRRlZvC+2Q6mhI6Q==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -12702,7 +12687,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-xPZdMSSAQVIcmRkoUCafCf0dp5qhZypVuQbni8k9sU7DweM+zlaqAbFyaXjhBH0msVNhWi0qUKmPKbOB3m8Bqw==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-jYt2pYjACNWvcr/PY5TbHuOies5FWCFb/YVJvklx+Ws1zeAhuEpa19G1MhlwOgZIYs3VeeILk6IFMhvnYSI2zg==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -12731,7 +12716,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-U9K19akJPCpL33ri+mf8BRcrv1A38NcwJW9SVQ+zi7H8mwF9DcwgeRx4toHbE/heYi5tePiB/Y+P/aVaM8EP4Q==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-8LqC0hnmAgEvXVfTI88hM6WSDNenrkldS6W1Mn7OkolVRMXuTMUTMa/1367EbEK4wIZRQBdnAjx01gizUYciRg==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -12759,7 +12744,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-Y7RcYCr4rWxXcv9wwKX1dTBlu9/7jNvIWJjBgc+4J5MZ7jI1KIL95bJ7NJgfE6Fy3FQHXL+WHKHtLw+tT/6TXA==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-TYVD0Abqik6+IeRkKLj9a2y8Q9XFSn1A9G1ZebebEMyHwHYJN3AEcNaW05KX+fX82EGYUQWPpd++/GJQ0zXxHA==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -12786,7 +12771,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-l64sIIEY9QChUwFd3PrIZ8ifrgXarDmwL2STUpYZWKCYxB9/NXXqPtmHt6t8u99ERWS0mJPwfDrD4a1sZwESrQ==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-ShuykTgPAcXE84nH7XD+Fjq3njy/24mwcF1dj3pBP6VukEfTFH2N20466YET9jASMl3sAqNus7j/dEVRO6d6ug==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -12814,7 +12799,7 @@ packages:
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-bZNuhSJxkW8PFG0RO+nxPwPG/li/sdfJ/vx3oxWoLNV92V1FV70BDr14SVIob/wxfYP2M4kA7+2zjba0HMyOvA==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-hMk4EakGl6qtnJSGh5/7bdo6LcSAKzX05XJpWdTeZ+YzuyP6+e9qFPNdxK+aTxYAFVqkDYmnq5iAHpDYOyCWfw==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -12843,7 +12828,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-TesM/t7N1xfp2v0Jw0tf8vPHI52GzDtHYBNF11NaXSy5UcOD685vBHVF0RJutiyHp3eTlTj69qoB5N+LbYpAOA==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-g0uv8GRxWzJpsuJKltZetVZX1mg8bVzMl4coaSqlWWEiWIArMb6VMjrOmdLC/+qKoIevJx9SJVFxqdxStFweRQ==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -12872,7 +12857,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-rIDCdJttMEuS7oS45NQgQ07PA1pQLPhS3Axwyt3RoN7TKFFPh/QScN20USte4HRT2vQE8b5fMTHoMKDElicPGQ==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-mz8DIuXMKNhOCKveeeXmLjqHQ18/3xrK5vGvlAVqh8dYWU/rIj+bdIREzAvAKb6OG0z9eVjXot8//2POTohqeA==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -12916,7 +12901,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-YklM0m3u7k/HLS1W87ta1XBixmA+hFPZIuaw+rOhV7jcBmiyWH8BQTNhenSjoOyIulDQL8ui7oMADMJhQFn5ag==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-kC8B7PqbN7XesSPA0mwrxDOWfzeTVMDevB2w4DlvGX79kzfpITklunVENqtsdC1C0Cl3e9nkZXPaDwip4cN1xw==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -12945,7 +12930,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-2O0kuux1SDlIeSiiaOghFaPynK0Y1B6tl8Mrm6dNcBHPdUCXscMSXVMQyQfAfFxp+NKFl4CA+52fAMNtdZbNFQ==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-zBigAR/J44FbZtuU0gTz7zEuYVt9uzovy3yUXLC/Pmz9tS3Y3QH88jbIlKvXsxtMnN2uy7W/ayrsfrCGHdocqg==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -12974,7 +12959,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-aFMVwzONoRUhpBewFQLVnRdNIzEasaFxsDVeAQpF/RnaO4bLIL3i8qnnzBB+q1Wky9a1kS7wxRhjMebygz3CiQ==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-/71myXqmqfuabq1qHV9kq+HMQHrn4X4tlRqoYdxHXlRap2CCqAvRS7UkwbU4wcpry2pvrZ7hgLB5u+6g178jWA==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -13003,7 +12988,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-wpHdQSdFigfpAEj99bgwXAJYfL1MwkrakM5qyVFp8A/+MjvdIB46ATjjUucfozRE9XtCydezPmKns4cfGdhfHw==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-HLboQSLLKBWHoS9m9JcXWYyx1LkE9IZo/YaNyekIBkJRCB3wlhKQIFfJDSVtOI0nljnH7ksSRokfHXIMEub6tw==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -13031,7 +13016,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-8aiwIJD5LwQTAbT1XxyBdRmJSPvBcRuLq3eNZ4vDnCr6jD+HP0zKLdhhWdXLVO/DnIIAaYF7Q+9uj3xfYYReCQ==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-0Xa3dAzWurK1CW3iBMnJwAsJG2xppVvIOaNjIOgme36AC0V7C/VAPh3G95h5sU9HqD7KhcgZnDlIQ1w4SCMkdw==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -13058,7 +13043,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-GMIhOIVGoMuxyZ1yF49nTas4Fc1KNatJhHed/VGT5tT2xAj6fbv2/V6m9GNBo2fcHVJu4hpo52N3pURoW7ZRng==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-4G31dBR1MRdUE+VhfN8rK1Aze9fGkGK5bshQ0YSJJJ3hRom0QYlhsdJR/52xgciOkPj6V3pK/J76LHdNZnRKmA==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -13087,7 +13072,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-yt4I+djt7pTTC/akO91FsFQQikXQi7yFc0NDAGP/kvlWFNAkQoWDBgHV1dHc0ToOxyaiaoCbGYgls6vcyOaLNw==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-wfhI3kUNSXXFMBHD/8PrGw+W0Rgt7PsGGaLMaay9I9COUBWewAQHnfZWAJZRec43eFrDhu4aHFDWRTmPZbdSYg==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -13115,7 +13100,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-FUlNLb6h8DZxpoJr4ErYkDjxXR5NqIl00WyWoktLjQERKi965EpV21xXdJsYWxolJu3Db4xliQSwa7ta23wFvA==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-EeYKfoDro8/QXQo5Db+IGRV0/4cGGpv2fZyBo5wXq2gMf4xnKji5c+x92c/DEvC191amObUQy9VegZUR8ws42w==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13143,7 +13128,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-V7cgj/EiXBz1F9Hkk5zkmZXfbew03/lc35Z2JVbg9CJ95EOyRCJJ+owQHpARXnE2J4rfgMtR684cn0uV6TsrKg==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-EFs/8lFtPIU9qltnmDOxo9eRC9/1xuPBOjDahpUkXjrvLkHIGsgFC7V7Bk71VNMwXEs/SatJLs/hGCgHQXreyw==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -13170,7 +13155,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-eQVKRZ0heiIqx+SOsqvOCdowv2FjoFqV209XIDXgWvQ/kjYYWeIZZHL0HoSeBtKOO3cFAoMU5HMa0d63gSmkRA==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-lly/zU7H4MaKU5XA/uw++kj7fjX5HcQSI+UzXST/PddK8940nt9H6KSZ5j7pCo6ArvrV7tB/xiuc8e+GlvNgsQ==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -13199,7 +13184,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-146wzEoC6J0NE2G85HMG6snEcCqJsonh/bIh7iU+8514FX/2fdIKQJgk0LhRIg/Gwmo80np2MwCjlukWxTijFg==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-yo5r4NIOjNcYTsB2vVGhtkwKvEBdIErl9HiDP2NlflKeLDMjM1FnyeE3w8SdzNL6HBTHvZc+wkoQzxL9VJcz/w==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -13226,7 +13211,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-kAk8138qW0UNhZorOwLZr9YL97zFDExDc6H2lgwLi0uT9aTd6n2iYbOpiOW1TPuBaua2UDpYgfZcldd604BORw==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-t9hUctfriULu5HxPSIBkjrJUoT8J1lqbAdlc31JtaAVArjVFcRyDUFJdYORV27FTWlzztu1LKO35M+ywm/XKWQ==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -13255,7 +13240,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-R+oSZR29MBFYgcb6xNLcOLUtNJGk3pxr+Kr/baPmIr6Md0L78N2O2IxSsL1ozeH4UBeCekLyVNV71+vlLK/Svg==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-lKLcMrvsNETm9xoGh6Mw5SOUB4xTbgqqHDxeCOafvIFjxyRp3mVLM9PYhYZw9IFx1zbCuA3VgHHuA43sVVx8lA==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -13284,7 +13269,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-5WomfahBOCMmjRg3RuuX9HwevkKuprrA8o7phZIZ0NzGiA0LfYPv+YK4fQZZf06FkWs0xXc4BDVfOQDFgMEI+Q==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-svsYgAdcV8daYyD8vEn2KdDl7HitQgcH5Xh9j5K1pELGDXYFzDRG7IBwB+GIZqPPJiydF2XD1fj3ebQ8tq6fwA==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -13311,7 +13296,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-p80a1BSlQT0WHoYUqE8DXZuk59Tz7chzIZbRKBvyJMUaQwBhGktp1RknSIJ3f0YvQ4uNXATSu92p8sqKCYYo+A==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-1QKKkMqn/0QjbW81dr9IsMLG6qTulmwPt1UDsfjtcbHF7PZ3H+LAjlrINWlEXkPqnQkCD0TmHsTkfz5yXIRk+w==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -13338,7 +13323,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-L/L90VkX9Nxr3a62zzes4VeUQ7CHW5i+fx3xcW96m9kyYl1Yp5/2rSJWAfe8e7oTu06odrtmTeNKp5ncJIpbwA==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-/058Q5Qw/rxtXwZPxGwDslT4x8+oxHlGTX9GnPz1fgdsh24VW6kJAv6s18cHLyv5C1NOyId7CN7R0IXT/kWEhg==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -13367,7 +13352,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-BbyDRlZleDLR3qVrj+8DA7cVH2pAnDpjEMFe073LxR9/9Hk23RzrksKomOJJBAa/XOx98QcMCj2/K3vakvs5wQ==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-Ll2xxeRZhuX5Jk4sJYl+CVz3YywMBT2WKeP5Hq2THiqmpaL9ZJR1NIIl42q8Am472daN9MHf4oCMeFphmiTM5Q==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -13395,7 +13380,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-nPM/tK0RFUbrTbokgbCIDuzbZJ9ybC1h0ZSK5+BjA0o5AyOMq1C6FalMSQWDTezGp8Nwp4mJC5rCbqqttmbkpQ==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-omCfLwAcyTliYcQwkLep+nH7s5AU3C6S13JcjBVzmk2iP91Mw/Kj94F+BZP2erPO6/4f13egWGplaRopXAZDJQ==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -13422,7 +13407,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-weEqm02igPmQcL1Ouw1yCULK5V1PLbLIQ9xXMn1l34D3ynD7GrdMkhZ4K8zZ9p1dUqRpTXJj3c8frUJP/6WVXw==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-mJ22nMRrTh9E8ykeo827N0teb2z/jxpdiZCGx68cMroKLZM+w88hiV13t9YXAyLW19yV6BWTY6betVzVOXx6KQ==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -13449,7 +13434,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-i1jjCf4h8kB4L0nKv2KllpvC/0v2Vt8h2H5YCxlt6HrYeu5cfR2xszJm+oVZ7HnWRSFopzlnrGBRpRwc3CJ35Q==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-sF6aTjKNJwDw5aalLbJZH7vOo2+bguBaC9+u4fd20AtXFgB9BzmHqwv3FeHNbN9T3iP3dzpJtt+EjPIoXsJkgg==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -13477,7 +13462,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-CiQbegRLBCM1f/43/3kVIWuf/0ag2pGrSoCGjDZDclgCS6ugw+1r8z8FM0cmUkPzlSYc1ORm1lvsgciBMxMBSw==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-gdwxlYYEovWDiHebrbmWnMYOLSN1itDP9ej43CESv1+ayDK1hXzOklOIqkW5gRc410FLtP15BHC0sAItMmNCBg==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -13504,7 +13489,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-ACuj4DI+Xf8AXmqheH7g6uCwE0tUcFYjcEPYoqn5w7MEkUxQrUn1Pbletdt/x26OBj6baNBfYagGuNvKazfOpw==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-XwvTMW9L0DTvBryX4lfMNPdAtiXeec6N9K5sGJQ3dUy6PVlQx9AKJQMEHhmdbuk8pxMC1nKjklYzF3Ao8BF5vA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -13532,7 +13517,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-8NvI3chLtgS07rJPAtPnJBpvBcDzZK766K97e3sZ5nhDFDh/W9TdlGrEcakBFcBPAiI+6XEKz4xmMUuVcMOEpQ==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-2A3RvGvPApHcPRhnAMLaklaq2mTSdiDHAdf8n8pCQKkZOdJqg7CZV7DRiaETPr8yYlzAi1JJTCQIgbexG1Xspw==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -13561,7 +13546,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-ui/YxTA/l9uejuwwwOpBLNBBHvHMjgIfgtfsf+SiKeeXwPS1+YEh9vXbkmD/5NqtW/IUGWvbZDerl6CkjzPuxA==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-SFN/dR235EKszrCSzLu7ZcTjtmdhs5/EkEZxFr84NknAulGQy0t7e1/J8Iq45GwdJdA6MiAngFYrA0OGGrxS5w==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -13588,7 +13573,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-eIr4fJMicT1BjKT7ZXRatBX+hgK8XtT7TikAVVmogKtAvH5alWgD4CSxpQqAJf5vkRhjo00hb3GgDRSj71jd0w==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-uTSAgSkM6hUIumguZ6QKqao7h6OSvSndwYR7PMk/2PEsoYobwciLU53emkYFPu+PyCkbOYvDD4APi0fMRxMSLw==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -13615,7 +13600,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-cQGtnUzfFnpmrWa0VPPVvnbYsSoykposeU2NfLE9EQSSw9PflhRy9iQ9sEkxYWxgEoBJC3THDHRvIa1bsUIpBA==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-O0PP2/JL+drwFVJKYEDzk7fcvl9dTMlMNK54kI1j0s3E8ARpLXEoTR5rX93z8Sl5lBlX8a4fe5OQU7fzyVWt8A==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -13643,7 +13628,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-xbkdjT5f8IJTjT5XkuRrjc55IWYMYHZTiOHg8e7YUBjCKy/TdXrdRX2uulTV6VtyjgMVJ8BxYRs3vcG+D0DY1A==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-PCZIHwJFRZ2C9O/X+Hu3JbUjHvslsT9yYLw+J9TWfaSPjb355X9qoD8HRyrVmY1f3TeKLxESSKI658p9RDm32w==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13671,7 +13656,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-DcmTXX3/b6Fo0R36H4goHrxr2rDsc70VoMQtyKKOIlCMd1GHxIrog/MaU/6J23gH27tFky++0aUtBViIesAeJA==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-0lul1vFn2JCQRMAkk7Cm04e3Mxz6A6Bvn7s/3PGqgc50UWcOp/9iONX47laJ4uuVFKch73aNt5gECskQif7jpQ==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -13698,7 +13683,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-zKGNfidMbadCpi1zw2h6h+AnJ5MiHOYuTPNS/gM+ZMkm93ez9hIyavezhytcTJ82NDMLtoGoLLsMvQdOfA/7BQ==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-e38SyofQYxaQv1Gk/f4e5V3TpTb//k+UoCJWg66LZ66vm7EhUfL0EOrUs/QaMGN/oOWbHQF8KEJMDtiTWhvqQA==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -13726,7 +13711,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-58USydOwU5xiMR7N6nIxjlDOS4aWiHfZZprXoy6adDMHxNqs+rph5aD6ju0YBkMP0IUcjIxCX2JHi6JoJr3CDg==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-ev82MztNdU/yZvgwmzadrEQLPx4gRB7vUmKmJRoyebOuKjSsepCb1RplhFZJTV9hY85UsBgidinJMAfGBXXEbg==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -13753,7 +13738,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-gfSgI7WRO+C0OVTG/2YhGOQhGh+0LutZcXp6a76tcjr0NBT0s3fUUE7xcWyDP6g/uIcONNXCWGydOEgwT7y3Ow==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-iMePoFHmn8By8/8c0iFV8z14W81XHY3ksKku96pNMu5rhWSsOfqD9x2AGB0r+rv12zEuriUjuhgqI3NqcJCitg==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -13781,7 +13766,7 @@ packages:
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-fjjFQrgkPcdTxMEP3QSzbV99d/aPdqnPTCRx3CnXmCNyVJDRk79fgAkxuoV4YOXHo+iD81QVp+Mwytmin+W6wA==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-2mcKnqWJY6dH/8FwFB0QHf3kXW6xTKotXAmDm0+5ABkoSEh/wP51fpfGVVFd33LgBGkC7kZ0z5AFeXIE/VDy8Q==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -13808,7 +13793,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-5jJflLq+g/MgmywP3j+8H1S/FJJyEsgyGJJ0x/e9e7ic7I2Q4axXoVKj7FpoD3wWphYQcej3BwxWfWrIB2nmBA==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-qGqTDPRXuk9UCKgYNRQRnGZs/O7MRT4ppj453FmYry+70tLjGMQyXkT55Xmrb3ZCE13YmmsPDqU0ANL6W7moFg==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -13836,7 +13821,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-vv07mKkOLkLwui96qKRlSbMZiLW5eiosqxLIDUet9LYqMZDq+eDVeOTTkhf8NJ9qJQLpqarm/b5LhVMCBDQv4A==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-ZLlxh6EMgg+U6gI/IrNXEsqTIj0jonoBSli6CdWdPmfKv3AYbm0u7tXRwJONuFbh+o1LI8zC85/qERHPy+gvKg==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -13865,7 +13850,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-96627vSdmUEiEjYi6kHaSz4tE/7NQO+xCCvTbL/xzyKp7Gj7lzFTvEkm8eQoRVa2PvFML53GQ3GKY6nItHyeLQ==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-i7bHm3sl6er4Uh8a8vzAr/KyVf/H6KEL4t7c4EqYV9deygPCEgQJDoRskQnnPKQ80I1L7Fcpli2TUbFGeCvXUg==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -13894,7 +13879,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-PBcYTVh222/RDZC4SVb9htfo/X19HzC78crgUA8rLvdnmaYuWKN1CqT77vV05mQuac9MkSiOs1dhWQVrXqUPbw==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-BIU0JvvPQapwFEXXQvm+NDmp3xtqtreMzpx7AT/bE5uaWpNz383dY82cymN7QIW0ATyR2N2W27RjailxVM00gg==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13922,7 +13907,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-QypJrpNJamBQy2uxPlK9gNJIy3qsdxMHO9TBQ9Bpc+HvXeFJ8S+w+QeuM753d1BdZbddqBsJm34YumyFQYhjBA==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-CNkxvWGfkVxm1krmgeu0K07OD8t+7qNik4Flv2jeJvILXT2agZqf+6kMWiWBnhoKz3xAf/DhMRBWXhfsmRlAFg==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -13951,7 +13936,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-kulvcAufMp62J8v0sM2/evcBMPVhgpshUpjgN8ao9bsdvnDhDl4VdQ9m32tDJr8bDPdZMpwTtfqg5I2bYgg2CA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-NCFHie8i8SZqMtj3VgEbmaimr9ERE3qS17i0k8QB8kiOxleLWDpvgYk7J3OGrm0VswFXIRkHdaGNNCNVZMyVUw==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -13979,7 +13964,7 @@ packages:
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-3BQ3AYaoSyapn/+AngCCRdZ1Q0A59+m9p5Be+z3DoGoZjmqqBsAmfU7WmM9OBI//zEBbMQ/+Xe0mwcBhLdPi2g==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-DTZJcXdK6OGPIIW//ymlUKGMTF19pGvwm21j3JBwYQTOepoO6prEg5c5KjKG9ZmcdjWt95Hx//aNJCww41CYWw==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -14005,7 +13990,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-uxVxj3A9rqSxNd07Dm920SXSgP8dmFzw87LwE6H8Ncf6JNfXVwRaTyig5gEINXcdfFMTKNcmztRbNV2Uj2X1Og==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-QKygf6wzivk0Mko6hV6UJPNAQ875Y1hKrdL2Kow3ihG6LphK9Uo/Q5TJfeNViKvLoO06bSnPjWWDNTiM7R4X1Q==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -14032,7 +14017,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-9eJ/b+iQ9YNI4emW+AijyMXeu/O8NYpS4abBhn3EnHrfv/5XIkumLt2DU+V8K7yEFR2ZR9CknNIXa1uX5Wy1Ag==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-WS39yV50R287ybvW4L+81aRGSXwpxeYXqzDEI8W98VXSJIvvHRuNoHDpzczOwxGKvCfevNOXaZRs4D6xhvMHug==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -14061,7 +14046,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-Vlyye7gagq7bSFzYlemQ9gVuOzbJxL8kJzhS9SSo0VqcuT3cd7WZRT1X2+OI+4+wN/JhhpUo7HmE6NG0GzfbIA==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-gr3VTGxvH9FX9AWV0/JgWFdgELpgM0WkA/D9UIMyM0ZF12QhASVVqfmfumE9bNz1Elk6BPGy0fONKqkfVGojqw==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -14089,7 +14074,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-TfUz9RXnmeel4JCS/moGdyVLITgSxfRbefE5C5+VvBqe5XGUrVWFucl4Klh5fvm9J9MOw2VsRt5GpKk1dx14FA==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-c0P6WsGFKeXXqAZ1V0IrLZB9GqiipF4QatDEh7WP83s0wa3eXqSQAB+TTP64V+7+4t90UjrwnjyLsoy/lYtGYw==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -14116,7 +14101,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-kPWh9lmRB0TXWec2RWjuxic+ho3N8r4cLYFKtXf6UyOkQPYInFpUwBRfH+aM39qtWitz8Vf5gG61qGKPf1lP1Q==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-9ad2saKG3YEEy8AKIzjp6fH9pan7nbyE4tta65l4gsIGMESvlJfjtNENk0Vb9RWtd6Ey/LzvcfdluSC2KIrpdA==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -14145,7 +14130,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-DjRVrqq3CXisW6GqTSOepsfS8UnHekKrmVk8St+NYWkckBKqjb/iWt5AySrRVermzYlZQVPxkHHudMbMZ0zROQ==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-ave91ffo4kWjwFr8z+zdCmJsc/MkwEMgT86J5qc3WSWZ65qgTpohydjVNEHYYwmczUYViyVfQFWlmmRPbhQekg==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -14173,7 +14158,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-UuNN2ITF/JQEW9/ZxLa51i6+aIkazzcvBq7PYbJylda2fIldE+a+Ksu/cuh5QCC8B1+1MUfPxD09Mo0i0/vV+A==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-AgpWJpOzRt+G9LuHpF/99KoItvXSVDDwgcxwea0eStwmnCATQLsemXYk7eLjCwKAeVEFMPwEwjtr+Cqo5oHldA==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -14202,7 +14187,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-tf7F2/eA8MoYNE5DK6h9vcq0H1vROqTceLpuvKMMAtT+lgOFjV23wQLJOXAqWZsSxIYHzdBLOo4fe5lzc0Mqag==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-+HOUG5fzMkumwrm8jxIyVFH6XFmpwSm4U38KXeK6mbVH1fCeE7MUn8620dWl1pr6QS4/zy4MG1P5IN1TGxN6TQ==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -14229,7 +14214,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-gykGW0dxrTavzfDa5a8weJdCtRg+BRMIz+LccArlom/XYvzOoiEiFlf13rUQls2uLBggYZYuO9OfMZ561j1hMw==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-j5mzFTFvaAy721kvWG+by3nN8RbobZRpmi09KupgMR2dgq9zDwa6UkDvgNoElW6g1Hn4ORiw9+HG4Dkvil3URQ==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -14258,7 +14243,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-sHHmB0adMkDqgfz1/5z9glmlm8jJDoYYQ3yvzmYeKO4FitprGqkfOIirahFRutilPtqmQCl18gulbK65NfZfiw==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-/QhteADwJLC8+qwMVcuLe6O3tFnL94Yr7ILviN7y3Ec2SlJOazfFXTxURMg8jsVfYJSg3ED66eE0LxCu62aitg==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -14287,7 +14272,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-NhzuzkYcj6K5DItEJheAUeHO9tIKwHbW2I6P3pA0TWiyk5CWnPSt4Ml/XL+M3NdkGbWOd6QsBxmeeOHCJKqkIg==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-oEaxBoMQaILY6+j76wRvpSoxS2C0+vU9dhEV2rrcXYl7y1A00FF1qMdtBEFQpAldKxW0Sd+lEnVQVWO49who5A==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -14314,7 +14299,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-/lxRRpt2dVknBCUDyCZujFpXOefuP+qpqxeZXz7wgSMGrfb6leH94pEq2qzDYvws8JW+48Bop8iUUWcDoRD48Q==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-Trmg+i9MNckKg3Rj+fuwebWApa4wGay8uy2QAvl65h2+u07kzKzSBKv98Alt83HTbgmOb3FKqpdNb4JKAW63XQ==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -14343,7 +14328,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-m8+ExcAHjGYJnrSyAaHLTTCHmyDXuIM5saObdVmYvAjBhe91FIeSAncU0IxyRG0Sh6SDbTedWQZBxnNilsTycQ==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-kSYrwkBYQ8uDLIbkynlwewGl5GqDc30XwaI/deooU/uEtA8r8JTCKEcc07jC8oUu691FMpzs8qOKKSxxKpXiPA==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -14370,7 +14355,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridnetwork.tgz:
-    resolution: {integrity: sha512-v2uTcW9lnfbFy885rAXW/sV5MreXi13tPgE8l0LdpFExw/gHBy5g7ozFo67cvBsOfsBxPOyWGLVgk5KL5kPcsw==, tarball: file:projects/arm-hybridnetwork.tgz}
+    resolution: {integrity: sha512-JPnQicVldRQVRBqOu9f6p+YBuXm59qekKmhF98+RU+AWKZdnrynTflXp/M6woaLg2pUq2gbk7ZkCYgnHkt40UA==, tarball: file:projects/arm-hybridnetwork.tgz}
     name: '@rush-temp/arm-hybridnetwork'
     version: 0.0.0
     dependencies:
@@ -14399,7 +14384,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-lrc2PmSkC9E2s/7KDdhpI2Xjrznbw2G3KhR6XaPRYr+DAZ5AaM2/KXUJK2YVdegjwvmde3rvyuINf1A4wrTkaA==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-su3x1D2QjSvUEcihXjVN5yYuczNbyyK2xorjCy1Spf3oafPw5uJdcqegbPmTd/8hLcXX1jbO/h/wznsbaDxddQ==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -14428,7 +14413,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-dmUABb25MHr5d3Mm80P0rr+cQBJQ+7gEe8q/kzZhS9bdbdtQ8PQIeDgZBBKpkl335coybyhw0vlkv/SUaAxbCQ==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-gOuxVIUUdoO7yKU9n9vgcCGwnCIQzalLxgpdeKJPYQBQOPszdFGIXqKSI+P+ayu1Msdk+bwA67fJg0t/AnCEeA==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -14455,7 +14440,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-oAlToI0A+ONo/y0yo/0wgZ0BqgYuTkcgItrPq9qv/aHUr7qpanfAJBKFtepOD8W8NdO3qOIvThYodLb22SKD4w==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-UtlYZsMZGXkBk+3ZRUioGmiv5ZokDKfCv8eb6pnx5kkQBqiRfn/LiY3SlmlBjnv0d11hqvrjXGjd9EHC97tPxg==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -14483,7 +14468,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-4xO8axSe6MnkRe/OQ5k6OY2Kw1P+UAjzf/5lAYg6vFc9sUf0gbwM2EsLPOjyqVmv5sdkKmLOTosKt+6y1Cgdcw==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-/ZVlsK5XohOT8TKAEp+PqIuAiVXyZi7Dz0rp6rm3st4+eUXzaZQpbwqKtf/HifeRdhJp0EQytK9iybQu1wAnAQ==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14511,7 +14496,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-5QrD0R4UDz9qRNrzblmQEOy8SQwg2qy5isw7so7hBQzsMbTKRnKDdqj1fZ9fylz9kiM1ZgLdVGETI1Q/V900sA==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-epwLCyNLgPaDqB/e3FrO7eIdXOaUsTODstcyMcQXdfrileSkwEXhieE8/8NfdZkWAqttQMc8JhMrL53+jD5L/w==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -14539,7 +14524,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-M61k3TaoY/D5mgWieuU1EdpHoW/EMKqfWupqg4J881bdclz4bujj2JIwkPqokSTRhA0zjWPbhS3OckBvjsWl7w==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Knel3NvGuS4TLpVoyB78gRLKSRG0aHGgDsVbMZbmaAvvmrV2Jpf7+5PF8QIBCqPaOg6LXfVH/d80X+Mgr6yhGA==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14567,7 +14552,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-RiMDiERZbRaZ6W6IZm3XYurZLXRE6FYoDjC465IWWxEVaNKuvT40dJ6qDwBtCVlmsXXRpWA1KZqRY2/AAim8Ew==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-hc3/Ar0DSXbCngJNXAWQYA71lEGnTII089+lwbnpipJrYb7V7TcIzYnbY/dBrDgYptGeOfA9By3Pt4vDPX1Udg==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -14596,7 +14581,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-uJGoq6bRSAMP2JIiWjuhQOi8H2w+fShQyzUztMUFjmE6zo2/CCtKn4/KqT+emM0+hl7idyVeSTl7wZOOjsGhYQ==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-ZawLoZTNj+kIEQvG+Nm1Hr+LbOn1g4hpvwMqsLVI1SLwNTAafa6yqaIHLUK5c5WJ0rM2HK6qXc7lWdfiYWD4bA==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -14624,7 +14609,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-Em0CLLtHiMxTW7pSWXLqaZ+H58zHWGMHO3/VYbtwltFolAHyGIaR2FrPEXmBUdiolowEAacZAfFZSpgApfva9A==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-Zi1IWF7tDkM4PM21JIPUTdxzoB9ZzX8vFftVa6y/74GunzdDzVeXaVI/sYuSG3RLFtl1nqcydvW0mm+ndPrsWg==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -14652,7 +14637,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-tct8WekKAEA5Nl1SpK2n1pBRwRbQAHwOFkgnjCOsvvttLwqbhf4izyCZCKVaeJowm/e7G6K2mL1wW3B94CcxHg==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-ibSKAY+p9q6Qdmuo8NYZERkDNbT36Q0+6gAkTgON4Ig6XCFb7YULfmdicojCVzRpPAfMKoZ8lj0aOSz0IgNwxQ==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -14680,7 +14665,7 @@ packages:
     dev: false
 
   file:projects/arm-largeinstance.tgz:
-    resolution: {integrity: sha512-SgoCDqVz8ZCm/f0tUqhdJtBPuMLHyLys620z1z969oH+PriuTIdowxnK7V/0Ur2ginK+hnSkFmPoWMAvZEXfWg==, tarball: file:projects/arm-largeinstance.tgz}
+    resolution: {integrity: sha512-8HzgSnCct3GLv0S9c9OfINUltmmHOJDKAKY5zsbHgtJUE+8OkwfrfByUvUT1c+fyXAIrNrmb7LfXipZnwarSPA==, tarball: file:projects/arm-largeinstance.tgz}
     name: '@rush-temp/arm-largeinstance'
     version: 0.0.0
     dependencies:
@@ -14709,7 +14694,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-/k3gMQBZiB+tdIbojXK9RY66BlLfVQkMPnzz0OvTn3H0pgKkYZ+oO6VSnyB8542isiETKnbNS8f9wnA3VCJ4OA==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-1C4u8Gvu2DHOcaVGwYgvaIwFs+4WX1ssXFbbqXiYlfMOLBBQ4PYPfv0BI+vZGxbvq3gqNKTBVXNQ2sD/HJSXkQ==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -14735,7 +14720,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-pwlhippus7K3azqWbd4BUE/HQhpzdl9jFC3b2pHsXzi/voudrZoVtUVDL9tZJ1fTlKlFXTsodq6KHHJA8+HyFA==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-NcpvGsHbHhs5URMs1BK9FjXYUGNrGz4rq8lQZdAf1eU313GgwquLJsmok56xjlgMS9ZdFUo1lQ4Ujf7duZFSOQ==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -14763,7 +14748,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-glTkrZKl6aDt8qYJDJepBzcISVSw+jQaF10UHstwuJeW9nCixbAurWZwTLb/Jx7Q/1fQ4MwCK9Ek1yBXjInwxQ==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-oHGepDKtRr35Hq9ipyCkiL6qaMSEV0dVbF+2RBw6u94n/dyKV3+n5cg9QuGda30RGF153bZSNT7bILNuNRmtZA==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14790,7 +14775,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-xAZJPhkURwmZXzFKgV9hbHGBlKK7KOyVf2Gf0LpRWL3bcUxlgF+oxwRPcWDeS6/8oxcpYsvh+lWSFDVSFxlPqw==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-QPOaHYJpSMUb28FOlXr80Ahg7/toAgF20Ck5Sk+8TDzBPVqTUMK97x7zD7afAC7cvU3e+zaUWnit5mILzXxGdQ==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -14816,7 +14801,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-tF48ZJw3xy7KZrGXP31JxLUNoLvqdsQK2yN5uOrBp2C49B6Wek8NC7ezzTSgp7aT+eZL2oOlWV1tMhRYrQ1xzQ==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-2EH/3G3rS0D3Ux1dOlQHSRGf+aVMo4FTZoV54Y/Hvps/u2Ul18wxO2iXN8XlsKWFBSvlqnhXlO8Jzwk2Qdr2sw==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -14844,7 +14829,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-0ryQsFOtmufEoc3DfwMVLnFnSyh4QqCenGYhbg2+iE5ayz+JnUinrtrzd+Y0UAtWWZrELOsza6CZ75ObJjAEWA==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-XwIE+/kSyi/z9fpzx0aYXfX3Mnz/Pk2CFTcXgJLq3QcmNkwh/971aFzvSFLbOl+vd9BbxKq1rrNQbUyYw/EMnQ==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -14871,7 +14856,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-Yk0Kq6i66UGUFInyit2BiuUTUzbbHagSTS6kzbY6YIpd+mO0l86ew4vXtD+ct7ti9NgITxls/Wh8pBvkZw9LEw==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-HKHRxH5R+gSlGstLHquCnDPY3AEN5WTpzBuJyB5S+B3exqXHt9Uf0aYEWl/d2SC7sw/FbnnPKr7gFC3tx+oPWg==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -14898,7 +14883,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-xZQCpD/7rq98cw+buvWy78KMB0JDi7Teyibns5SU3dzTS4na4jhcu/Y1ub/CNHWnQKXrdDU6ZS7cX1cvCFiChw==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-HXTd4/xycIvONZ4afODmRf74sW29n4LV3CedzIdSBe3D9CJzkJO60QKA1B0v6r4FxlBaY+CJRN0Mnc+ery4/Ow==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -14925,7 +14910,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-WYaYVlvF/ACmK7fFrX7h4Qi2nr78XqllDFLT2ZY+wxM0ItXz1rYJTNm9BjPLts4iRZkN89tCTy2m7SompZpmMg==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-ESGkDUitT8Ga1V0TAY84Ex6HvhMhIxtyi+a2zTLVGHTIpOMsNS9FpgHta9C10hw3vd6iToM9Ge8JStaq0Rjy6A==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -14949,7 +14934,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-zhxljaMMqxpVA8KlRbYyN4KkOiXda85fKazI3mTFga9rZbl7jVlRF+keOEffKM0UElV5aBQ57LCwvGDft5Wv7g==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-15ePf9m72iaTHye+N4K/jkE57NF0QP6lH7+7GvbzUBfHEJWmYL8IVVNhtg4fOK10X6sJhLLHJjp2uZbSSHuXcQ==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -14977,7 +14962,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-6YWZVd0NXq9iMjz4/T3DtlKjuh3I4EhMkY4GByWtyUZKloR9c0avFdzt8wFcWlPS3Ox48HOKOJZzpIA+jqGA/Q==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-W0J/jJERnR0dmS+3e/Sh6+MAxKPVuCpV3Qg5DYAsuXE7Oiz6vzMhE5acwEWRs545e0PfVi7ltwYrZx/DCfin/w==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -15005,7 +14990,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-z43i6d4AM959f3BDtsxgm2tj3o9NITRl/97SPqJG34WUXGo/SWX38WJnnD3VKOcpXAJyc5SDW4RxPTqLnPUWwQ==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-sAeTBSjF0TrAg8ZDFuNbjLK7zw5p0JZoVpzTYEYBBH62cnivKu6rR/vE+5oU/xRXcj80MK5S+008rHl1XUk4bg==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -15032,7 +15017,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-TJ1+YPYExRBwUpXDPVOv0feh34TtBev7eGpkyg4yiCj9nLM7q+2UvuPeNdV+eo4JeeYoO9CMAxnRS6fukVJGxA==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-7g/7vAVROietCRqHhQczMO3TZ3G6/TNzCdjFbX+bMLLjlUbGHQ1DoDDx3RgT3bgvb7fjgtNf203l5iY6HA0yxg==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -15059,7 +15044,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-AzCqREubz8hvMMEXzbhMy0yt1TqhX/Wl58zGLi+w43R/PIk68UwsEMDdk5d72RkAA+MPUyyOZw1QQzYKEzAiOQ==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-4fpjOgv+ZmTYZiuk2hjEn95c6gqTHACf2MbXpnPTvIMBbSLRtfzar8odAaawQyRoSoFd3t1ua/SknvJbCROBVQ==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -15086,7 +15071,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-GplySvcSJzNlCU0v30dk+qZYlqhE9HpCdpH7pz/vcLmlo0bkPYWSGneSfmH2j7t5P3W90W7eJkuKqY38cOPZtA==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-qIGb9ovWfNUyIxnH1mVi8RxTO76sRZF35McDdDREHjKZUmrur48Wi7bwjjkcSo+31yXkpH034gWNTSVFN5oBjA==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -15113,7 +15098,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-NCTvS4+4hqNlHUTxCj8cgNXCiM+rN2x8Gs/HT4APXxDxsaF3nBcb7qBGGa2zoWstWV+vsBzG7nCzMQjJepVJgQ==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-Cu1MXzrZhz8dtWEClKHozz2MS8Vgx+QXWiOCDE+F0m1SBvDfu8BbI3k8tr7XeSYSyS0u/cmZgNSH6pESRQZ6jw==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -15140,7 +15125,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-17EIxEj1hjVt/725+nph/dC43R8/XHWIJDRfqcjpafDUuajmF1OctPpowzygfTokdl6B76B27Q6dP1OL4w/bAA==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-wh2IhW+LI6oXMVopavVPYiePcxRtPX7Q4+hCwE0VB+VkoORyFvpUr5LoJSuShlKk4kCxzZ/NVR9PhGtLHw90SQ==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -15168,7 +15153,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-3XYih3zKi3uosRyLrPhkgc12VqBEu181CSYSVUWuY1uwsoqTXeXVRh1cxMS3doUGCBE//dRVY8mdRYbQQWryBg==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-nr7qBBHTJ9L5Wa3oPbacUn8WMG/b8XEUX2pBP2W99RMfZwQboDNoUmCJfZBAe3+bDgensRhAfCAFRUHC+NIC7Q==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -15195,7 +15180,7 @@ packages:
     dev: false
 
   file:projects/arm-migrationdiscoverysap.tgz:
-    resolution: {integrity: sha512-CBr7RFsS6AtmxnorU6i8c8r1MjrMhHwVdLYl71mWw0XKUje8nN1FpXqi+iZBVtWXueJbJxqoEn+OZEbcFnMzoQ==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
+    resolution: {integrity: sha512-/58QkkbPWvlRkHZ82AH3308Q8kTAWcaZ+vmPiiR1zUwu4gG6qAVwYztdAxiQSEL+wwdwlECCbKNdE8HdyI+ojQ==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
     name: '@rush-temp/arm-migrationdiscoverysap'
     version: 0.0.0
     dependencies:
@@ -15224,7 +15209,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-MCz+AF+INKODVrVuXWQpiQw7dZo3yfqRqKEO3EVcKpzQZ8lOFYEiH4MjjcgP/7uBQ6MoMiZFokfS7SUg2UWJqg==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-mYMqtxQvCgM6ABzwqFzURTm/72HjAPuYAvON2hSW8DKVx+DwjNJBxtzUAiUaF9sz9kToQrZq4H3jEoSNi2cFDw==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -15250,7 +15235,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-38qCk8xSuVHFkx9uzVlI4eZtZnkWGX5YSORDP5Sg5FEebJtTI7BLzZu7rQyxXMObJqmbsQ8Gb3MurI219UA7kw==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-l9aDbs0yn3fgfYaSIUCWih0boIX4xjBKxgZfBvcUvK87Kmh+2c5E+ZSf5EEDD+HdLur+JbTDQNsHLSgnnYcj4w==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -15279,7 +15264,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-xpm8G/dwjPs928EqUFOoCc1jEv7PIQulBdsK1eNGDSpavyMvmsQhyTqxF+hYBy33Hn1+ZzFJBsczs3iD3pRu3w==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-OtFztgi9ZebA89etMLxud59YzSAU0QWBojdhQc589R0m2bSgp7ezA/3F3no5Vpq5I3sbMiM3b2hJJcfCUCLpMg==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15306,7 +15291,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-rXl7edH/qvF0PYRHIG+FI9crymep+YwvWyTb7tcN9r83mZtEtiYF+QGVO7RLCdehL+vFF/7T9WuqREE1PL/FbA==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-+86n0sOb2pHJt54znFEU6mSQull/zPJiYk34ZwOEu9j+yV0vyM/zH2nP7+oCFNHQhsWXw/aEV+xLyK9PBKkS5Q==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -15335,7 +15320,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-wms2tTY9d/+q8KQgbe9rMzVd0P9vMMs3fVrar0KsX/9882+uW/l375GB3URdF+YYoQU6kD7eWn71WVFuImQd6Q==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-dv59ZHFgayesinE0Q+Sv8PL6f7fcqhhQrfVJBKi9beg7S6oRwQdLxqvzLqqMOxWjkPB83xcL59cppYEdOmrshQ==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -15362,7 +15347,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-Agl0v1uHW/0iBWZT68DS7x+7y8SrdNxPg3G4BzFqKqITTM003/VgevzpyrNsEgTXKwvX4Eh43ntXCEpVQ7EgnA==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-vXu4wYvNy64Xl6lVKe3lc42zWm4OMsKGdkp5bJOYF9VUBM46i3BvvnDUw7mKrVDAleBD2tYTf3Gi3V32KNmIWQ==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -15390,7 +15375,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-1X+YfhD5XHJPgV5LCC7PFLmw7jaRYFziFip+oCJ7LCyiAg/SEAfcIKXMLCOw/mkNUUHjydLPhQZO5JgP9NvIYg==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-RDWCCNwD9/oULV1iPSGJIpASIxCBx2oDBw3+AtryMQhqe08jXxC031IZvarrDxzXIK7GUYHjGqjQif9TGrtapg==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -15417,7 +15402,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-fwMdYUd7M1lCHRhq+NqdbcxROM/28yb4dY/MCfA1U+jGscT87SJxMeG1kvdL07nPbZNSJZipz6x9ZQfW5g2eEA==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-pOdIk5S/lua3V2AbVToXWQVJvD0Y9vnkxXtI2WMUBta4LzwU1a+u6wSy179jjwWLoF0NSl2k+SPM1CFBOa8xMQ==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -15446,7 +15431,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-xqUIgz0LPpFnh5iOFVSQSsGiHDwwbj0JCdz0IfEWdwAxnw3kZaE8kUhrt7uGbEPfjVeOQo5R1wLwX5Vd6lRILQ==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-P9gsoLacK5vBOudeiBqXvUfByqbMyzA9a9BwAIk+YtY3yx4gCJhucOZz8/Re8qthAlzhOgiIiRFEueVfbEty2g==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -15475,7 +15460,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-2ErRpVFtaIgnUnsf11TRoYfsj24IdBPbsv/E0OFTd8arwQ+kLYsryyLzUci50MD1e6TFAZkT1fj+qStyncU1kA==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-jUizsGft+IaSV4dVsGvqEs9YlNRXr95MLHdbPSJvaVg2Drg2DbJOIaTkuN8PA9ZioByQMaC2UkohnRDgKoSleQ==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15503,7 +15488,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-sC/H3h9c1KTtaLnpbhjYtoVPODySjVFi/ojxjJqDZE27MTMZUEuX51Pd3627reXfAW/zNEraz6EIjfOGFEtk3A==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-tgvYdaDyO8T+RIcHFgzvWQJGQ6HYvVSSACY6uiVTQaxGTqo7TelTLmbITCqvzVkC6/9okwsyt3/jQOujkUEBdg==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -15547,7 +15532,7 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-F7mZgCIXIhzaSyzANC7S0WVvnXHvqvUkc42TNEpNOiGlTyJrw4aOEf2nEOBZpsjyE/3dhewfmETXcbOs0Vkj+w==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-Fh4avqDFl16vp3IcgKruGFKuS8XdBu/YeEioeqAEBo3a8hw//670BWav5Rq2pFG3BfajHwFW/viSHYa17HCqfw==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
@@ -15576,7 +15561,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-tEkSKetFATRR+7azywwrHLuZuMxp+3pAdXqHoIL24PbCwdEUUilt6kAaKuJ7QcVUe//SRX2gGA8J4Dv2xiUonw==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-CH+eDQX6znEFeOhwYKpAqUEl70aI8SRBRuo4HsadCSuSXv5WuRKORchU4iUL5sFtvYctiXA8bfzsw4UXiaNlGA==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -15604,7 +15589,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-1iEFBhh7KjrAKk9TSaf2H51UwLgoEtM2g5jYQX++HO3t5KCiA18+R3oR0ryxXAIGKDtSJxeoVon2QMbUQbcR3A==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-1p84TW64zcorijPqmQV9K0jjAN7WAanXemkgowhDafVS2oQvPR17sPcCKArQt9oDNlArutTi0yWnSyeHQe2XHQ==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -15631,7 +15616,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-WSc9L4iaHnkNedSlLj3/ZS+2qvDK7GSlvGcCRCdnakwHgji9FAQo4zqKB883kLsxpwTUoHsWE93t5mSA5Sntlg==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-b4HUjMmSQmNgevNY/hbb5RGkTFjw6MagRRSjyL8RP5PTND3CEbkJ4hBPzUthHW8M2rOnJOFq/6YGP6vJJjrYXw==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -15660,7 +15645,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-wX2Ftaz72wNXWh4FRjiMNHepLIWMuZbRF3lJ96bFMi4dKap6J4Y+D6xCirRyWrJqZ1DnbVx9HUWwYkPIdHUPuw==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-eXvWVpdZsTLaBST6yHKFaDVItaPoWwKg8nOD0ABSX8mNUW8u/E10qKN+mZCZciCCwz5T/ahjllzMWLPMEwPzSg==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -15689,7 +15674,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-9i6Q5wNT4UJYKvzxrLdhu6pBPCUL8LYXFOPQYWP30lHVXwfnTbZFRNrgn33mCI5X5znBmpf770DCmk4gu0A9Vw==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-uFK4aEscWmbbGRAjsd1O23LJsVLC5ENselS8E5O27BOjFv2MrBQh3JWrUwlVqM6GFOAEOgjfq13h0IMfK2zpFw==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -15718,7 +15703,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-OdGhJItcG9+XpO2pKJC+iQF9LWp436SWi38lqiqnoQb88s0JYUzD6gQ0mKPFdQTuqr8B/lIyHldzOJk8RENiJg==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-ZP4TAA58pwh2Q65emluaL0n+yD658mcGzQQtJcaElaaG+X15ECjC3cyKgJrG7e4tOBIfA5Buu4lBYu/TksooIQ==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -15745,7 +15730,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-8MB3tie90r02DPn+6RZ2v5nMnpWRNoV8AjRZt1F3gp5V9Rg8YI870HDvikGp/OwWmVgqr9scK/1dloUWMYASiA==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-3hIVH5xwnE8jc8LmmcYjbP2OeM6Y3n0Vsu+iFR8BtBs6F+kCkCVAc3yA2QY7jnHj0uxyShVEwuGX+cbYqehn9g==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -15773,7 +15758,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-BqACGfnLmKJY9L9jafJFpaVp+xOC5/qIWYSREvzCgt3VK+azM81h6c0AdB38CElz/t6BpGlNMeDs6mFZr6ZQ4w==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-khD9/OBJegHMjKy18hczKQm6AmdXuqiyLGiyPPKVem0Flnk4lzPlWhgWvEQk2kvkGF0wB66wtQNXn6Y28mcxcQ==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -15800,7 +15785,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-/ekG64alUOiA3PxrPSo8Bv7P42slNDGsGb39mRBUJILqfgdny4TDaeJKG0CPOMGLoTXHXrHa26mrWr7SQpVkoQ==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-QcV454ox88w2w0OGVFWhL2hAImzJYJvLROeiCUXh4KFxKC3zOPiK5x3pGyalH+/RuBFjWYxSQrZU4zUFxbsQjw==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -15828,7 +15813,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-zssf1grbdXWRBm3xroT1qcn9EEoDAJJZECpaMuLztLEg1eq++OmsJ0vebPgNZcqWi0eUBzya0iBl42sKjKrs0A==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-avjknCgtKCN5/TlfMcjWrAKuqduamY0IpTmYvAl3XOt7/HfaonOTtLgw6JhDuqIi1SX+ZgrrgJVMmtc2Vp7IEw==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -15857,7 +15842,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-VARjt/Bn0ba1GpRDcWv6aufLIPwbEa0iRLlXeHnbTvyabYMzBGDJnjPvnT6of0YhIloHJhoxKGfkX7v4tIDeuw==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-rtxI2gJqL42pzYLALYC6sIfWyouawnVCEP4yZKfGusbH8Ji0PYlBuXnepXlH8TT0ZafMQAvMY3IWiMYF1bznOg==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -15883,7 +15868,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-aHunwqAkSWHxkPZUmUV8agi3OvruizmBhKnjMqGoTnErkpX1MFJ++M7P65KpCoRxQwMFm+0gH4HNB3GzYTwbhQ==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-S9fm6MMNZhyF9kr5H8j8yVFr4dYedvfkZhKY8aKqyKdDnF+il1dSWuIEXE+P1fFTUPpQOhx33w0+qU59F/SgQA==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -15912,7 +15897,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-nKx3oeC6zCuNf7OepgGEYj0eqrAIzYuOBqaMor5lsfR4r7QuiVMCYlx6gR22QYGsPvgVJDPK31cdzV1h/eUW4Q==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-zPDkU8eaJgopLiIETF3KWE196D+QF40hvhAWsDnT1DGUbA8q0vQ3Rxav1AsxYeljBVD7H4Ii0VDXdGHcb7QRaA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15939,7 +15924,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-JebGZhAfdTBqKRF/m+MbzCrbMGTI+hXtPgG4wOBAyNghJqh02jEBTxzhfcWBWX0mxCMQrgo6mzk8guY+x4AFRw==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-NHFC/SmpupeyJvwAttiBDpn5fLbk5I0yyZCj2maqgdOWJfHi2h8PrfmZNN06lqq60u9AbM/0Yf44NHo+ofncAA==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -15966,7 +15951,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-UYCFZcfEvVKgMS5dDEbf0VhMJQ+SPy3hJbusCYqpf51fBzfaf60ZSISHM/wRFVeyPfhtI5mBRBGZKpO6kFD+dQ==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-bB474u4D11GZLz0E0R0N8XLSEFYu+2VURGYs8jbvf/0JQ3gZQ7pfyN280uJQLc31H2qMRrTHV172Clix3gyOeA==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -15994,7 +15979,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-fwhmrGLAbV+R4lg4lSLPo/oMiREbvkpO7VDTbStO9HockVVCLrmktFCLYFlgRKZ31ReGFmVlOQvieeBOsx/SCg==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-K58T8AIN4f6fRzmXTfiZkIo8wQTCsTZIUNCrFenWhibeaMwg/ALPvbIlMh6o/AZyQkeIbd6U8NkNTp+ejWoSrA==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -16021,7 +16006,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-tiFKPIgBNJDv4d7MBkjC7fMYM9e4R0Ae1hk9Qa3b/Paas/Ug82MU+CEnM66Oii6COmK6mi8GRpfd/Fvxs4qc+Q==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-RiD7OIYqhPy492PT0YVC5m/cVqqp6qxxCkcOgUWaONulO5K8Cy/2wOPev2blHGJ06N91wfQcZ7PhZHkq+tnB5w==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -16050,7 +16035,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-46e9XUqnKSrgAZ3RTZH7IJyF6c6XcJfL/MhhfxybQJkd5SiYa6GiPrE2HjknVujoppIYThHxyxI/5ZoA9S3Sng==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-PLNqcAjyFud5qowPUfb9UuAmoO1j2Gy+FZPWrH3GPKzPwXfGsKhI0CXDdFa9ZFPNnvrxsRdwNIvzo2iqDmZWVA==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -16077,7 +16062,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-scCwokSbDHlJDBd5vkazD+vRXpEhTR6RzLCdOMC92QrHBAmxIgTRUE3937WScSnZVh3gAdGqnPjTjE5RwvGyIg==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-5A4s9SJadP76+7jTriXhAOWicptvCtSTzoMzrUC8Y7LbJ8fLNl8mbGfZcnazs5odSesn5z3BLQO59TEAcdB8Fg==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -16105,7 +16090,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-8HpQ5IbUKx96aXdSUBBPuiT53ijxJVF5BoRZ0RH7hc5YLfmgUMwoAOBnwyQT7KfyEJgx7p5eO2C90cxThiYSjg==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-hvyKQimGddCrHmqr2ul5x2VIEX3lVPtMcgRupyIuPkUw8/oHl4j4RYPFXb5uTKnUn9WHTpg1qy6fxjcW6sziCA==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -16132,7 +16117,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-Mg5E9wQ72H88lFkK/x0tZ9Zhga1onKoWuHuNII1JkHiBLC1GunT8D49qJva8VwL8+DouHKSRYxsalkBP8BqyEQ==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-laKSgoqQoPbziKfyqYmWcvVj1prxmwrQ+Tsn92VGjXABCAg4B7sD82oNiDxHXF3TUckYYZlITMOLSNz5hpRHiQ==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -16160,7 +16145,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-Uac5p6HXHHGCtPU/C1Z/FGEVPgvS4b9KP3IRNhZycYUxtJpoPpxZioFgYLDpl4KjSivXWS+t6QtS/PSOsadRiw==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-cTfSKyI94MXx6wFkcyB76vxp8Xb3wPqP8U3Ct3T8kvJVlMcfFb8+xEd79mHVrt31kOOy8lasKGF+PWcqt/famQ==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -16187,7 +16172,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-WfEymIDHA0BGBEL9BA3QW3XR1InPiDXZbNiYf3uiGAqKoq3ic9V4Fr1dYvaz9D3qRdOeFWFYpZNV1QUpcSyPbQ==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-Z+DQoQNziquOhzq9LgatxlxH6nygTrauVKqvR1gf2+/iu2Osp9tpN/1kB9lYl7wgl0IPI7kPSD4qbPfy00Znqg==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -16216,7 +16201,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-4dkFITc8rWUEh+7u/j4e5X9KO3hmTswyH4gFdxnej7sBclg4G9vTUnDDIJTFpV4bh8IKfKJcx+awp4+GOLsjNA==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-MzOJbRyF6ex6bgfHn0WEZCHog2tx1y22fqb+rTrM4jVfqPllFPNbIPONNoO50F811YKwx90CYIOszsJactcrCQ==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -16244,7 +16229,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-atHMXDzArF8OYgR/qnq/AuGx4q1Xr+sTOfALg0p2tY5HO1B3/cXfkrljIvBB+441joJbXx4Jd1mAjaa2JKpBvQ==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-6mwykSnEfc+t9VhlI89wX/tHaXwy2zPp12iJttRrDlvtFmpAvkYScE+fCk6tMLUxnM7KrnNWFTIKjSE3jEiYiw==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -16273,7 +16258,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-9c7/dI4c55R7sTumD8ZfF8WClSwARlzzYgS1GERbTIx+1+KwuB1mOw1cxbRTne14HoV9zQwgFAA1aSdIFXfkAQ==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-cOkrcr8hPf6beLZ39lfKpzI+OXbfbCk1dKP57sUhi1/l/oamtMKdKt9trXelUtROeXCAwRHfBPO42t4bUKqn6Q==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -16302,7 +16287,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-8XuxHQQuZtuHMfGXLMRqPItxpjXZHu8/a0EqGMOfy+xfFiT5xUhn1XW648rx1qHCtPKJ+9gOvsYpCEQOdo+V9Q==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-QKF3Vybk9bpIGteIxZOf92L/L9MscdzqhVV4lOuYT3IelKo6Zx48A71rpp0edf+DFO8L5JhRbvUIs/OtQCZHnA==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -16330,7 +16315,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-c8Q1GeTnTWSAKEKBMSdiEhgiWr38bTj7jY8lSnNc761Kiem6LBHfc9OFQff17d9un+FcBLjTLfKWDxn+H3imbg==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-taZ1ElaVDCw/d96QK8ThyOUdR+p5Qa4cQbsdYjXLyElqQzFEKBOpicAMKKrKfLBJAk4iMI9tn/uii8i/Bot3uw==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -16359,7 +16344,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-SkvZbw0vdrUkwy06wKSnmOA1bVDqUbkVKlZtZ2wWj9r22LP5/8BNWD62hf4NY/krwtV5DNIw9k79wUzQU7nArw==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-jMbyshWHxwKg3WNpfAwcreWB9t6zzUztpF16Zc4BXIvDZyy9E1Pith6CDXgwyGQ687HjmdwpmHVW14aCD23prQ==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -16387,7 +16372,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-cxvgz9B5y97/LbUwH7LnvR8KM+xwG98wjHhu6QNOM3o2kUpzy+hDQkzGl/YMHrwtt76NviI+znsNvzFliVU6Ww==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-EeUU34H3/QAF93a2Ulsp6Bk+N5IDS7ifw3gNBeYjdRPHP82EH/+OSRYb3MWupPrHqSdQVbiE8Qin3a705BpiMg==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -16416,7 +16401,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-wmuU+D9Ct65C2NVy6euKu+CKQrXYtzKUdz4uf/GqF0TO5aBdMANnbJIuENQ8hCuMFNo/bBYIukij7326NSh7Qw==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-SGVEQP83T1NAw3FS+el73OVK0FnFl2YK2/upiJ4d5GqCyXxMajm2ZMcCiRXbY6jYSXUFdHVn7hhuaODQ9h5RRw==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -16445,7 +16430,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-92aU7dPmuoIukvw2RJhRa7+v1al8WyU2VMS5+qRgVmK7T8gHFGvRWFsN7OxHnc3lYlnSMP+m/YzJ1/H8/yGCZw==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-JfG9KMmDNAjbxC5UE5dwqjGrWFB/t46UvX4iPl4XezHLmhOUEgt9iGnMmJ13/n5ldQGRWJlO/ygse+e/qGKayQ==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -16473,7 +16458,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-ZDQw6qNxPZU2u3DbffHHUvMGnHUU62ZnoQamy1wo598sk/kGF6AJY2afW9gfuh8kLmdPUI5uz1L/B42IeeC5rg==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-566IfIiP/WsorBdginQBe+z0RNcZ5/VMBwSZt266yfnqp489MvAW1ADGyQOJSeRpyJPDBNzqfyD/Ulmp3xX8Zw==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -16501,7 +16486,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-7niiTh5FlTJ1j+3J1igrX/EbpZd/8NYMTIZr8Pdk4TEd+wBVPyno7Ye1IipDKkLEwLFoXQxcbQYX6OawscIFlw==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-y0Qn29PJMNT/nkv8XWNzTgyR7DwOnAuyrF++EHmTywkgyHbj/LqEI1DmmBVeJRIoWE1QulgZBrN2ockFRTQNMw==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -16529,7 +16514,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-3y/nRUaDGzt1pNI66uXO7KBQlyMy5B2ZxglbZk10h5RbRjqNv7FVjWC9Sp5LaX/eC8VAOTZcHQrkPZlpyvjZdg==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-8zO/C8iO5/GkqZBLzCAJKHZCZuAOMLVW3aWozDGUEfFoA2UtXu/G5jqLIfWiRw5ex8LrcE9y1+4wguhruc4nvw==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -16555,7 +16540,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-j9G6CKa8wbP8z67Ix9FvEmCd7e/IqLDukzo31s0FpWMJOT2v0kM/fq+uKjnVFCZvH8e83MlWKK7kM+vkPelwAw==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-24X7+rTC8culmoUoEu8rgtBP8VJuz+jdnJP4D/AHjeyuDDW3xqm5ZkfRBtZEKw94R5KXreTWqyTD0lB71VMriA==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -16582,7 +16567,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-gc2y2f8XU7IRCb3lfNafTYVMQnrgRr8FAl0Ld0ucoGXDCbpw5J8m8glAS+0a7gg70mnGfWBCl3cn4Y6dh0tk9Q==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-6o0qC1yDZTMzVp5FgE/D7m+Xz0H03YtoaAar3RxO0PRvihRAcEjBEFnbc1jwYHM57PwaMIUHYIW4T4kZCtWd6g==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -16610,7 +16595,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-dFlp4H2eED3C+ew4DVDsv4B2t2W3XMMHa2DgLB3V1pE2Vukz7mkLA1k+zfo5o5uNMwJaxHEbj7W3GwvlCjx3pA==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-bbnMcksESPcsjC9r1VU4ydUAJDgnQGQ85lt6A9PQnYlOaVWXXoByeAOrmGkvP6kIwIZwJr1TvjD+ShO87wRKLQ==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16638,7 +16623,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-pZGtNoIjAt123gU9tnqcSC3z/Y1mTVNUmDJX2h6mbEwUfLUbdI0OarqbrfRhCdzuAJng0HhxebJBeBRzLfluMw==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-vUy9B2ZqIdszArhaetgkI9Q9k3Bc26MlnUhrDtrjURlEBdbNoattunjWCwvwcOWF48l1UHFMXoW1ZdayA34aDw==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -16665,7 +16650,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-ILIZAz/pLFeGis6Pbq9unOZtdh57qm8w8q+RlhM5XbG61aMY/UhijqE7TKd0Q5ZBARy6gL0XCg4uJcAAUB83jQ==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-FkPOpX84A57rNqKeCNdIYUbNfDkij6UVV8w1+Wcs4+3NTLo6p3T0Yii3CJoN5HbzUHfLFLr+/j6QhfaMJcsHug==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -16693,7 +16678,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-4pcMOSHGFJ3JEtL1tNikO9gjTka97q1JobetfuC9STSpnDvLxxIwbl8aJUK2iJw8hI9k+YqW5zPzcCP7IpDp2w==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-CyKYFCZExcf76R/w2+zTpt9Ya4SKvRyRxXfq06AMU3qyPx8hwH7EnzwHXHRpOPGtZqdM9+9AWU7Weirc5oesaw==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -16721,7 +16706,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-xso0HTuDU9vOzSRbT4wR7/hMSWuIWKdGkDJYerWi4Twed6Bmw3N+BUM+bEb+mlOFTzqON8Y6xvjnVh/6x18dYQ==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-4TnOIz1GI/Ys8VeJxuUTtdKGZiPTNnpVGSCExmoq2VIDsffM6jOEcQ1ou4AxCAHCgLfEXmgS+FN4QsgU1V9+dw==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -16749,7 +16734,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-YWmRDwAVV9NWUk6sENuHm0ZKN9uYT7+Bg9Dg/tkyRHQ3zAYymprSDsKCwCrHcZOafLDAKbneZdW7/y0zmZOLTw==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-FcCeZYccmvwKTW/XlD3cRFd/96HK1lGklOiw+T/H2vqs6VqhBxrbghiXWkhnmeLlH+lIyA8tB4jwGuCgIZmkAw==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -16778,7 +16763,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-/hn3Qk/Lb8Z7V//ymzJaxYQ8BbyGsMB/q/jJBIBykOXZxJP5YmNMieVno2++iTDjkzuJevKbrMRdhfc+zGApAw==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-aJ1sIQ1N8puWqo5WY1BOBaxl+jBy6OG3nIiZkZlDvkK80/kAbvfpGUPWJTKnUPGvnUS/VOS3Vs6miRtz/DrdCw==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -16806,7 +16791,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-ghGf3Rf/W8JNrxRwUEGQ0SRJR/0To53SP+uYhfUxgiogKmbu9gm555IGGzM1SySDR0Kl93EQa8n45EoN5fYQiw==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-qAwc169lpOhPi88Tot4gDzRRbnbT9zuaD3hNnVkwlMezbp4yIXmw/pAIWZ5/bDK3Dr3bm45ZxJ4Ms5cAr2PXBg==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -16834,7 +16819,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-IukKOBDmZL9aXD47F751/26XdYiFV5jaIro3thiqlSyUhwDJ5lwt3LSO4VsdyXx3cotAKUtXG2Msz8iQtaTB6g==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-nEEABCVRMN2Fh7BsUDZwpJgPb2Jl92qdozqRckSl8cu7LM2yTe6w1+tsKuY/BOb/r/lFik4YVQldOfkRL45Jdg==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -16862,7 +16847,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-zDWynqftU3DMtVBOAsjjiYl7DK0uHLs+OFpjSRUbunJ0aEz51lMBd/GEHn7/ogCNrio07FlapmNcx7fAynl7+Q==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-GEOaZHsoPW8zmFtsq/FGu3Q/ixm2vXdHthWXZjv0IFGCxAXFxb8bclnkBOhme76B4S4vU8wnaXkSCSVZ4DQzdw==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -16891,7 +16876,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-4VgtaC/K3/9dwONzK/5FZtKoH0Io3xP34LFzQsyNvtl53RLUaxM6//nvYofMDX3yQ4B8fS6JYucnHDkkQC5nOg==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-dRoHynVL8KTkJ9bX82bHjCiDoYlHimXJVznVEvUvc52GODTqjErAlLg9zb6eH6MX0JgpY7xQ0TZyKemucxKzBQ==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -16917,7 +16902,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-mNitcbozjWYAB3xHWt3dCGLc/KRk+jYTTpCbHvp8Ahv2CBzk+vyTmIpHgR/TcpEGCZVxJajryyk+D7XyjiTKvg==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-gOfMZoQtqKFaI5oH/96RiJORc4uCpISqAnVBKNAMKFgTxGq2B2HV/mGK9diue3B2qZ1rHQdJfvPXk6y+MAv1Bw==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -16945,7 +16930,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-o71XSPxPT+R2EjjxK0Hvyw1SqFRnl14xKqY8yaIKdeWe1RUiUr64Q++4QwiJ2YC6Y1AVrft3cpE5VIDtyggbRA==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-ZkLxPkOjSCvxjL6SA53Gm8P6Tucmv/YUJONWGEvw/P94rqF2H4mtZAB7VB3RRYUwEOOlm6xQbmFPWICP2LlwKw==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -16974,7 +16959,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-bZJIS3XrmAsIyuHP+Ios3G0CIKJ64jET8K/dArZRdHIDF9zsdNJu/iFZwDEwYPBqyOZQpANJrLriA0RfimD0JQ==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-YIorafCuFgzPx+RNUfL/pymZJtzaH3qJr1O68881qE6AIFvn0fhXtvcFBRNq8Y4N15FFxmaefgEsUwwYCdmA4A==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -17018,7 +17003,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-lL/23GIUbxUAd2JjACi2SUDR4qidvEKSj2RsGRVnmLDxuSXnUBwWWxwwML5toxqSWUulm79NuGqNa4hFLzHrTQ==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-PSUIznFu2aXZ5y2081qR49LYJW5M+nRCdjRwwC1r7R1zt55mEoaLPGYIgNYW007/nC81dUN5g707mTkDIuOgLQ==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -17045,7 +17030,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-GboOwrESbbN0kR3iEHu8KN3HNHIkC62B+DVyyrTTwrlsTXYW/fFLv0svkS4PYG70+NCvPwe5bEuts6gcPD8pnw==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-rIxOXIUeBPKYTlefJCOpc7pA3l5DksCytLTx6+U/J8QzWZIC0U7liETRTZAt3ih+pMGTak8xM/pilgql0PA/ng==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -17073,7 +17058,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-9z0kXr5pABxmk4Uy805cS+ryXfnzYYnVLJ/B3h98hOyYz5CUGiq/UEh+FxLtgvMgfVKWkSh6tijo4eLSQ1xywg==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-UR1+rvhOKOEefhf5zludXBj5sq4gAw0eTkssZaROBvwhmLy33FpZRt+xp0DtMUFZM8ksM11xon8xH1h3+8x93Q==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -17100,7 +17085,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-O7siuB5YEfgo7Pz2XqKY+QG58mgC+nijh0zpBeNXfsg10I/nxL52dESjsNVoVtfhkg7P9WNB1TR4vZntTHzviA==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-VH9lPlKKLzGhDBjZHXM6r3kzcolr0yKVLYOcXSFxrw0xLAcRRBSMAcwdBW56ftF9t73hc1h5Tw3N8JAEWnY7ZA==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -17129,7 +17114,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-BFVz0BahqjfDsoLzbDshidBGtejH3ywl6g0H/XlerEEsOczZNDYoNW2QB16K6lALIOM4/e3xTH9LlF9s+Wd5NQ==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-Awn4ZlCeTydXAEmla1Lb49I9eCRRN/NhnW74MjWarHebjsbSVV/zBR1IWKbkOAodeFuKeMVBDVwQ0qthccYLfQ==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -17157,7 +17142,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-88UZUjq/HCLzaCxKN4ncQGDBNQ8brS+hMFGkHSTZvadYkcJd2n/8NU+2Ii9LBzDrKT5TOk1v4N1jMyhPgfCOVg==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-53IBOVq2t77lFP1AXuKc0Pi4sBQx1YzNGimIIrYjnmO0LpfMPh9YcuOMbSeQpisc19EyxrSfDf74WZmQdDOJ5g==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -17186,7 +17171,7 @@ packages:
     dev: false
 
   file:projects/arm-springappdiscovery.tgz:
-    resolution: {integrity: sha512-Zxp/Fm4vVaHmcX1k6vlT8nbjGfsWUbZ6PFr9voZRpwz3F11B+iCwZcQaxo+j389s7YgP+tDntX4rWxK1ESaF5Q==, tarball: file:projects/arm-springappdiscovery.tgz}
+    resolution: {integrity: sha512-Up3UWmc4CbYP48Inx9hh1kJthqDCbseRQk+v+dz2HvsMFvWGZr1uqUc8Ui/62LLjkgGHuxRiswdcD0eCA0O8oQ==, tarball: file:projects/arm-springappdiscovery.tgz}
     name: '@rush-temp/arm-springappdiscovery'
     version: 0.0.0
     dependencies:
@@ -17215,7 +17200,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-5sw2qwytqL43+ZVU+Ip8mJC83Kq58F99ynm3CxqCea0AEfz/bvuQ/hzhH9TfqGAT0kT/N456F1px94QQXWZ7eg==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-R+9Kuw+5n9BaT/lPZeqx58lptOSUeSgAnNA8NXNuv3mGKaReEX/jlIriwDkDDyCiDoqiiU8/hNSd8rV3Jk59TQ==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -17244,7 +17229,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-TiaruQg7Yo7q/CzDqEsk0w7ai4/3VqRNCyanE69NPAq8eVi1tNGQGksvMKirUidH+8G015+p/01TqAp3srgVGw==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-AndblFerTuFr7qeeNrLVsSpcnjt74zDK9WV05epg4rwzRm3s/2Cyvq4GriM3+thiwfrcUM6LDQIcc5+ZzU3Bjg==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -17272,7 +17257,7 @@ packages:
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-nKks/HYO9C9Y4z6ui/mDxQiFWukJu4BpXsOcYUaAdTdvueaJP1+oSxpRJwe1Zl7XMliD4G70WObPp7PoZsrfSQ==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-NMM2D3A4bLsqCUqS8JGEoU5R0PxvwpLl+ZG3arvZmd1VRrUYYEPOJYSQIa3sGqhC86cGq03ZwueFKPvqpx6QEw==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -17300,7 +17285,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-/CV5DDNYynYHgraHafJH+skgMiUmHeS2ssy6X6czUqvdaAtBniX1xHRgF3m4QOh0k2xzQr2ayO6geniBijfaRg==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-wPy14O+Trv5rPqsbZpZs2nKuagt3l7aROsORwe4NUciTubTp0fOBZ4whfweeaA7+PTrDNGG3ceeEcXIjnj8UCw==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -17328,7 +17313,7 @@ packages:
     dev: false
 
   file:projects/arm-storageactions.tgz:
-    resolution: {integrity: sha512-+wxGZA+doLREsjt2CBhUAIakZ1KrjCRM87ZURpbUUUH8A78jODExWQyNoFciFhyRR4cQWu9MoB+thYmVORVruQ==, tarball: file:projects/arm-storageactions.tgz}
+    resolution: {integrity: sha512-11YHZxbo/PdYOvMKoqJgaDQLQpbjoEbcRZBP4rMZicUU7y+jKhcjZXEnljjcLK9rSPS4hytj+i1Wzd0AatHAWw==, tarball: file:projects/arm-storageactions.tgz}
     name: '@rush-temp/arm-storageactions'
     version: 0.0.0
     dependencies:
@@ -17357,7 +17342,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-oZ1rWK+lavCO66FO1DrQwlKJm05KMOPmlV/AONNZP7jqwOmBw3VNOCzcQdWWnEXn5aQbd6SduRNIPth4Je4DxQ==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-ZCJMnVd/P3qcr/zOoq1KNRNJTNm5a4+uyh6gJmJYmZZ4aHNYeVff+Ga32HwVpmOQ/6BnWw7J6GWfe3+VjxpiXg==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -17386,7 +17371,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-g3tYYChBIvC6O+TL0z6eLcRKyE+5sA97nJG8A32Mn3XgHFqFwpUxB5insQrNAT7MsAY/hX7VMbaSHB3qRv+zVw==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-nYW1VT3ZHNA+1sCUszExPT+LKS9D0hMSqrX6O6QoTbVrqd+Y1zBjuuiDB9tdKdUtvfp9UCM9FGkBdJsCpi6OAw==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -17413,7 +17398,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-MtIE2WA+bWfwETXekXejeu7BFNOAjHhA8/G7luh76wnmmPo5ySsJwE+K6zT/pH8STMdXlOeDeKiFU39aVOnLxg==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-+kzNdur/yZizlDfwUwFHkjDA0Fm9bCDTuzWzPdHAlktQDAfdt7BpoIw5cGmCcBHPhkeAKQ+B3sfP++BcQO/sHA==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -17441,7 +17426,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-thdpR2gualrD+Simm/EWePP3aKJfzk5GZZhIXTpYoX2V8ZJ5HoUCBbLbKgUAZHNMdkQ7LfuOAtELEMDAqk+Eow==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-6mwPYWAQL/H01n5FXbgHlwGV8xlZxWpJ81fPiNsf1k/L/XKpFdBUaqjnj7OZ8Lctclj4KgayVTQt1CdFuVnIcg==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -17468,7 +17453,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-JhQBNWMN8kQGxckOaq7Zyt1xDsx4Aqvc65oZAN1Hl4q4k8I1SD/BijvnLpm9q6fEbwUc8DOefiee7KxCFB9uCw==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-qJQiDw4ybnrU/1aA9r1I+PjF8DfWUTWwsFlWf8krt8Et0TwjG/iyf55y5wMz8MvfqtuOrjJVw4IFrW+0iAlQCQ==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -17495,7 +17480,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-jUcQ2fuj3y3NZl8TrhQ/1CIsWQ2LiLTEvvC9UzDQqRxOyY9cxdq89fnT2biqkgGh8Q93It1w7FZekMkgI5v/Gw==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-ayXjT6NajN/qdoPO7Mr3jOHH62mUH5W+dabSul0mj57NBRwHhKZqw+zjbe7w2imO9GD97JAfRh2UqNksCxjB9g==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -17522,7 +17507,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-cU4RDfZTKktkN9LVjY1DdZAuebauoi+9Z5Ko/HukVWMnERDTHgBixuvg3MqKOU4OUgHXatUFJpUDKszGXwBnDg==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-pBlfCtvMvPSIGtMML1x+eRxetMm8cORt7CMjId3DOFkNFQKGhUIKQfGDJebK1whh+qfgG/W7XeoZA9/6Be/Guw==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -17551,7 +17536,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-rmQYFUAgPilW0ECBWTU6EsAo0z2BvVoZKbZK3AMmw9pmXbeeasZb6m3I/WnySFAfcfrq1VzZK6zmzbFdafYg1Q==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-NizuL63SPjsZr41uDgstk4f9eE+zibFXqlH2Ihh+rY3/dKRRhJD90Er8vfZ7ZWHRHvLT2Csb/ltBl5vp1A0+NQ==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -17578,7 +17563,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-P4R3BFAs+gxcnw5GWiWLBKqK7cMIukmYNMukkFEx/0pBjvsOdoAfcoxH/PtyZubJZUQRUiJYgLhV47yNNrG91w==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-5IFFDs55Ah09DyFMJiNxY3gah8MmiyGxzgOPDi5+fJURYP5dBN67zHfp89T8yRk4fnzhHr1CIIVqxLaclHOtAw==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -17605,7 +17590,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-q94iX9GHyqBwpZhCliuIQx/ynAwGZoas9VdaIdV+Q7GGpK6/PPUkvtnBBmBk0A2ltAEt48VsOs0KVrX6v1erOw==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-fI49OZ4cRCjQNzGdg9DyZmYErZ0o3HLCzopJZFCU19+8qDl4wbVQwYcAJrk2BTZvjBGZW7mDSvG5vhZT7EQESQ==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -17634,7 +17619,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-NwQHjMBLxaiF7rAzwfk3dJDEUcH0785JZvfUU6N9vhGSdKObaArNNvRCt/w9pG0peaIji7DDRH2K8d1ovNcFsQ==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-z/swGOIBeL5uJAopLi7EFbjfdCg5bmo+e3zDcY2HbwW0HjIiof+ixY090+1vZWHg92AThVkob2K2l536xuBGMw==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -17662,7 +17647,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-iLSxzHBmYJPhwtqrziqo86rWR7YTFAacBybDkDryWp7Gr4DhG5K8h6K1DjwzIzkqfMFxyoKsjdz5XLwYoiRIiA==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-nk1/2PRvCV+3FTkFsHpjP0uGfb6taDC5Z8Xs42icJkJ0jrIDDQItErgSQP+9pIarqWzR7Uby29JgFp9CeuWuTQ==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -17688,7 +17673,7 @@ packages:
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-FJ+Stz5CB4fDwYegkPfqIYip3lHh8NUZ7U4npdnWnlOXqowC+32TFnrzBmIsGPLrR9U270LusVl4K5M9n93e8A==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-B2U20KXCVEHr0i6jiouooJOJFfn3vjK5suZ36zFx75VbPg3Urj4WtmEWWV8NsHAd0ziBqvixajvqLbuJjiumqQ==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -17716,7 +17701,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-p+sG9HcXVRSDh1JyLnf50g+OGo2LORwgkFZCDc10NYLNHVF+zkvUH6wzTJPnvhFKyOvvTQDP0WDLKhHT4hmmcg==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-e2YVynIEMreO5CAxja/J6jplz7kxXO0M2ciaOMfL+0Ipt1osirl2qdH9s4oGNmU2nwW7mTqFc6kjwazQIrQI4Q==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -17743,7 +17728,7 @@ packages:
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-8a4f66lAWqIq/AI30/xSYMi+Fl95quiZAn6YHkfeCalPwpOLhIGpkFu7MOdSjArspYAgyS7HZvHCYMPGstnyIQ==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-0XtmAgA+2KwLtZDA9vGTZneXU1hoCPlUWKXNyWEHVKISIaQwykBeaUO0ja46aLmSNO17Y6pjXNLj1KE7StHAmw==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -17770,7 +17755,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-RaWpUfpxc6vY0ZrqkLT0Qw7e4A/cP+8zSHzNQUfrgOLk8M2k8wjNPe7Yfry5ONcgZid6GmJVQC3qw2QdTyUX6A==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-aIiFvnKg7bl8Xsctw/9SUUv0myGxXzHqtc5gAZT+8f6hcPqkBEf0TWKK8U3mpdUWKiUnqBu9MjlTGahGyKQXDQ==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -17798,7 +17783,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-sGyijNNk0sJsoRcI3URuTY5iekQq0jWFfbN0g7cEXjTv0RNA8C+/HdOHOjsHuhlf30b0uKYTLrs6k3PIeYyS8A==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-d8ixsM8HyPte2Ysr5wPXXmTh51toKeHUdTo+U3zBi9HftuedvHQ5zfeHoiSXE70jYXtCJG2XsrVBPSCe5q3MuA==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -17826,7 +17811,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-oOuvXFV6BEPm7GC0SP8y8cgcUF8OX/h7FAz4Prnd/Hb6CWtbpoZfAhmCKl08lY6D8D8Th7cd1sBbm24jRvn7jQ==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-5E5XHxr1MSziR8ux+HvU6EkuL4PZO2X+slMyf0G0slPdnFHd36AgkEX3CPgXbhQRu3a5MR2G7dkoINR01iIg4A==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -17854,7 +17839,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-vkyWNTZ/YXUW6Usxlz+iYfPwTBq1moBA/JZQ8f4X+zYq8eVVt1jLbDKvnFQDUqHeZVP5Op3Ah6Gy36OMM/MJCQ==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-O98HWJDvw+8Q5xZ75GATWFuxJo5T08bjtgLWwcZdnJ2YD2n09IAF+tfBFjaPu/g+uPHXkJ0ktvhxIs59PcjoxA==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -17881,7 +17866,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-eRxIr8JyiJLqIXBQfAfUtOAjnLAMJxU1FKCinsdbdJA1z4uniut9DO7RLJnfSs5IcjMjYkVwieGoMPZ4nQxo9Q==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-jfQsOfe6We8IuUnGX7UGXQrA/W787xIkTPDJ0iq8PhOmgCxmfr0lqduHy7SNQQlFopmS6habe546/V8o/TD3HA==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -17909,7 +17894,7 @@ packages:
     dev: false
 
   file:projects/arm-workloadssapvirtualinstance.tgz:
-    resolution: {integrity: sha512-z5+lG06+Ml+yy2Ha8FwXYPamkEYtFqOU2YX3wOLQuFs/OPhVgCh0vF0lcguBXe19Sqo3gAIGN7x6kj5Tw0CEUg==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
+    resolution: {integrity: sha512-p24wM2EF68iB2a6EB5lpc7zVBeK3gYWcpfqaF7x4z5J+uHTPb4exc2FS+iClU1ef7zyn/weBpicbcZV94VTFNA==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
     name: '@rush-temp/arm-workloadssapvirtualinstance'
     version: 0.0.0
     dependencies:
@@ -17938,7 +17923,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-cqp+xCBrfIggjMDmqcwuR2qmGWYN13qyCrbC7gJaxnNyayNEcNcDtvuOcAiS1bSpFmZ0OheuJMye+K9pSCJ2tQ==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-OXUHPFH94t5w32NRDcsnDVquRPLC9b9yWt49VlHJ3JiXr2zKgIS5yjej/2FS8PpaI+rW+lsZe53ou9TuR1DEXw==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -17964,7 +17949,7 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-JJBZc+sGaBDqjETHwgsLH+D8J+Q6QX+du1CJlEbg7p3POQVcKVjQLeQS55MFztcmz0rqF9G8dXyfCpWDqgdf2Q==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-YycTDXUWCKQFOsVjbWFvR/sXJKsFl/mgfWDH/tFEap+O++lo70NxnbkXmPxEp8F7vHxVSbJLzcjD5pAB2Eavrw==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
@@ -18015,7 +18000,7 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-mvYb8qPxJPGUnb17b6imS/AND1O6DSuhN7v5ZT7Dancbv9Dx+kEE6Rpm9xwATS4nMf29aqpxb8HuDjDgVCDh0A==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-JEcL0Z0ARNafV7BOpaMZkJP0s0y/NKGFssVNMRZ9f2hcREUmEasEowfUi3Up6ao+rhvZXtxIY2Lre7PJJoKj1w==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
@@ -18058,7 +18043,7 @@ packages:
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-88g/zKXvUD7oo+CtwWsZPUo9XqStdTU/2nJMfZvvSeLe/4Yp6sFTxeV/dprWO/Sge9cwfvuky2aLTVeMEdSDWw==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-JgzuFoo9sgl8zfWE7umH/VEE7OjImvbWAYYGRIlCTHtrWtDhS+iTaRpPld1zkyXSeDOFuISQFvawTSt3z14plw==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
@@ -18106,7 +18091,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-WrFqxOHhdvXUvfx25YTIRjvL6cRH+4yHK//nrYGinbb7XC7xFaYX0UxMTjuX/Ly2ryQ8qOEUCDnis5AsXqO2bQ==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-PpH5xzdZBfMCH+Es2CARZYbyYPw2Pg48iUlHTHW6b7tqRdswLnHqxH/7dC+knqwZe2qIRQ4ubrfdKfdYHDzgyg==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
@@ -18158,7 +18143,7 @@ packages:
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-xvkA/m/hD8l1Pdux3pJ3ue4dl0z0GRxk6vjdoyDPaC2CUOWKVeglgk/pOg5mjd+qcuTkKBG3YeJ9XbM8vTzTxQ==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-n9NGMl/S6+rHeWqdCFjSi0oO2dNUQqHAYvspGcJqeT1uJRmqfjS1CCP4lk/7FyTTq8w2zhrBnvb0wD9w7ih38g==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
@@ -18205,7 +18190,7 @@ packages:
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-+wK/BlGMoZrPYUZKYotuLLhTXwQcmcCRpmPEwDzoS3dgXYP8To5dwvgS7hioFVBZBz9DdOfqj2CBteD6GydOMQ==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-OmZUyLP3SBHJjftKr7BZONlhDBKJmFwT2etdhRqeJUFCVGlt1jUktFqsuFp039oiDEkivs8W1/pELiAc8k2rrw==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
@@ -18246,14 +18231,14 @@ packages:
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-HSKnQ8WCb5ATYUnuvHKfe4oqTPhigVznnjP5GLKwr8dT/3/33tz47mERXvn98FnIET3IkMbGUjVGWZaF+ptilw==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-yR/S28KhwCe1UMGtlSwbmqnbN0eAlADVXqJzI0DcIIqc5hoFXw2i5Ca17ksizh1aV8vyg66W+xdTkHvwhH2Y/Q==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-credential': 1.0.4
       '@azure-tools/test-recorder': 3.1.2
       '@azure/abort-controller': 1.1.0
-      '@azure/msal-node': 1.18.4
+      '@azure/msal-node': 2.7.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -18293,7 +18278,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-SDlAUsOmzJQ5zYS5gIeOKgVHOtNhWQk6KxhlzT84hhRx38PpIgN0YmQSWBWtWhvzD6ITc79InD5o/ziPxSMecg==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-TZIA6jPIxNwnZ4xWDmEBoTaWGpcaUPSea3rQv9OQxNMI6BgXoXftHqxaVp7vJ5tRjtKjkPsNU97RDdm3/xoJJw==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
@@ -18342,7 +18327,7 @@ packages:
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-ixj/Oi212GdCIms0MU28oiBRhyDyMMQW64S8nmD2psaom2J+mCYNNy410D/U67zwdt/mryOHxNi5hNEnT0MJeA==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-ngA49bdYGHuYEIzbQRHMilqzvKo5pd40dN11am6V1IjY4PCcgJjILdTOM6cumRfSyE6zWN1gYwpP6iNY394zSA==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
@@ -18385,7 +18370,7 @@ packages:
     dev: false
 
   file:projects/communication-messages.tgz:
-    resolution: {integrity: sha512-tmsRcgb0e5VJKuavSE8iowUz5Ds4ib04BtQYF4OkaT/Yd4/J8sojNm9ouAj75mH1+Kf1IdixD2VBdlDvNUHTzg==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-STDPgzEuqCBprCfTy73SrFDX+CxfIuFvuPBRx1BmBGBoI5Je/7YAR1txZiunGyu/6vIgsuQks5JVwDcwzuSY0A==, tarball: file:projects/communication-messages.tgz}
     name: '@rush-temp/communication-messages'
     version: 0.0.0
     dependencies:
@@ -18430,7 +18415,7 @@ packages:
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-PQ/Jm4daF8yUgygmtudMNX/RRKooGjNNLSMlmC8KY5QL9E8jiWQZ4H1GPCy1h7J51AziVR9JnkmOm+IkzdNGNg==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-sJOhkw2pFI/uQMJkPsLj+YVGTR0JRQsvXc8XCkMnwUJnxJM7srHBkoq2tzN4geeCczwdCEuvgIP4RoN2udX9VA==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
@@ -18475,7 +18460,7 @@ packages:
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-dhRMk1DLfYY9n+1V+XZYMr4OykklCT9VFCaH2UfB5hHHvlJpKmzJslBNSVANhZXNIGX6/gdYzGTiljKzZ3gahw==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-W38G0j67rwRTzzF+2MnNkNPk+O7tFE9wi06ANHZk2kYXZWoU4McQWu5qh4FckFX0zPm0QoV+0W+lUinu9nSNqQ==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
@@ -18521,7 +18506,7 @@ packages:
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-v1yUsjGjGfPhPKMJwG41a39RPdkzLn3cYsyKVW1QFlh576Hskz+oTTmqPKfml6rrVjhM0ln+AhyCz3q2kwAJEw==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-IDN5zu/j29w43/Uj2Ji7Tg0s4+j5Fk1nagQLSb4wsJBvteVCM6To2n62Y0G0WS97BmgEJlq27boLa/iLhppFDw==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
@@ -18557,7 +18542,7 @@ packages:
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-ofIy25Uq+b3JI5TzyaRdLrFd7lTpcZtP/b2WG6bqOssnKkDBX99kEPC/0aTMAraXbGsDh7CQB1Sn5hOuZBnpxw==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-d3g/zWs5j9vRCA+Tp5U8mVOYFeBnA9lnKk6KgTY72DwKIzwzb39sIyJ9aY71wdiULH8HoOlKncljp1LNO5bC5g==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
@@ -18603,7 +18588,7 @@ packages:
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-g4kNYNctO6mSmfZqzCZcIHrls3ELKFf/pyjRWjXPbOjE07m/VzHS8jTJB1/SrgvJ9Nk+qX1EI8SdWpiMk/HZDw==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-OYHIgi82kUHMIbE+z2ewXcwlnpy+sKjWTVHJYs3WM4S5+8KPFReV4Hi1grHfQqT/hEVF1H62uxfwPWGftZ5Cxw==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
@@ -18649,7 +18634,7 @@ packages:
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-+VahGIhs+fXZqbcfwdi7s1o6m1y/cDnNx9h5aKnCi0T28t0Sb3pEjfl72NT0zta1anmlWTJX0gSexqqt6AERNg==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-nVzMbRSLwJycwr8LJxu7yHRNNul0f4eLuaFCr8MKo0gEJWRwrGivgtXpm2f6SO2inhDukSiBvjCiBCcoNggvbA==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
@@ -18695,7 +18680,7 @@ packages:
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-S+mJZuHH/cexXz9Yvmkfww3sA4B23tp8+KAdHn5iHTtzgFnmNWT3DP3c34/6jjpH3tJGWB8i62dA+GAqOFZBCw==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-PFb2p9o/skXwiJDnmGdh8oK1LTIZEyidzsIqe61tZOYOSnFTZ3kjbson5Jba1m87GUoXVQgK6wqCsOVt8/PrRw==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
@@ -18738,7 +18723,7 @@ packages:
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-b5KHNZay0hGqUTRG3EF2ztRoNTVWw1R9wZba6Cul2Zja6yfYoRXEgfm4ljOjz/OepTSQE0EI0Qxg3coiFYnNhg==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-lfaJbLFXPiArSG0azF7Ot2clckxOL/0CyNv5rGY99rprZ6DpNs+UrHrRgp8DQ6naoK9IrQg95yBAHptiwKLSeQ==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
@@ -18767,7 +18752,7 @@ packages:
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-NdY/RoLdkEB112C2lMwL+3owWQidOgPjNGEfydbcthPw9dfCaM+NIfy+RGzT4ABcSIHplbuKtY9It95s4pfwig==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-STgz0CQQkiK0qXwOB78XXqfQtAShxMTX/kN6/J2GhaSMJgT6DAic4JJ6JCOQNaZ3iveDhiJOOs//mwXgWIKYag==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -18812,7 +18797,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-XqN9jd4jAU410pt3HRPPtox6N+++YSghHFkiEtFQchvejUfqtXs57uA/s16HLDakJzM7p7JZ3NcFq+c5Sy5YNg==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-NJUzWuyAqDCk06/wS2uzPdGBD6HZDiovO//Tk5p/15t01KH1rfStBCMOt6gSVYJyjizZsy1WjOoI6u+GDBRn/w==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -18854,7 +18839,7 @@ packages:
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-/6kT3mlGdqCsDUTDapj8SmabF/ghgtMZIjTuB2FwljGCNk1WkrDBn5bT0mos2ATUbxRGRvvJEBYlnfzU2f48oA==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-N4s7aEHR95gGEzqayxdq4NwBTPio2xp3/wXtZjxEUfNvPSOKwSiFyDzIux/XEexUqyvvZAxlwIYEMWCZuKCJdQ==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
@@ -18887,7 +18872,7 @@ packages:
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-nwMKAVR0OmsGVIQRl04NRNtnt803gJtRRUGk9fF8J0kgIbcsHUIQrY8dvc59mMPnytTzsRys/gtv0Osu6TMuLg==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-pUoogFhCkGxrKYXfSbzch5FQgPN8Kynj83yz7zI3KlaM7LQeCNc7DS0sRBPa6a6Nmkun80+frBfu6pceiVs7aw==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
@@ -18920,7 +18905,7 @@ packages:
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-g1l+xddYE5nOE6dK5Aj6M9NgqVLq9pIczD9+JOjNjo8grFwRI4uccuPbmj7/JbwAx4FwhGkEJrxiKtYfP0Qw0g==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-YcRRCI/ntYu+obp0lwRDyN7YpQkyFU2k/YOv3Mtq83UuhXWE0FhpYrLE6OSXFP99hVZx459JernKV4LnmnYugg==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
@@ -18953,7 +18938,7 @@ packages:
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-E/kn1AT15H49vVHP19CrMXPgkv1jbpDnhNyyh4ZrQubAxftBD8YLRXTKe9RoiqPRHX3rtlFnJKcT+Upy50WJqg==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-X5mdnyaMvvP9/bW0cqZssQhvrzHuS5+oL0LOj8U/7ULFQ5Rb8KFSKRkNP+BR+ZET0oT8h8gPfWn5rLzH6Cbjzw==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
@@ -18985,7 +18970,7 @@ packages:
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-leqSl365yrynrAn9iKk8KOxzSXZad1NYiAMuiHvjakIVF1H9ZFFd4SvOjTWylZc/JNNw98ff/zxGeXT3do8sMg==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-FazhSUMeKUSuO9Pt2cN5SmOPa4xNTJOiZ2NguALkKcNlb+sWcm93bVRarBw7nYqdutIt5Dd+VfVMj/Da7pzYTA==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
@@ -19018,7 +19003,7 @@ packages:
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-zAhWxYgFmxUoeMvZggP7SYMPNPVg+NgyvCbn+6M2jnKp4BHo1WJXdoZ9EtJl0qYQ8Hv1v7/zL8ZPGbxN13AfzQ==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-DSxax3ChehVwb0XQJGMk1ZS4p5hWNKA1xcxbNE9wR0t+/x/04IW48SyPIRml2pQyl4cA5e5UaZ+C9jjbargUPg==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
@@ -19051,7 +19036,7 @@ packages:
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-x1BGAnFJ7U+Sql8tAruxzEo0Z1ZK3vJVkW0YAxMIrtS2D2EcVvthAUgciwDA2lRM0gwGQgMCT2LaiaAsp0AwJg==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-a5OeCm7meRZDuyEm4c+vj9zUcnUT3bpQkLugO2awbIDcA+CeSAOr7UIbw0X2k537o1ZfHkrGz9uiFrjMoWh9Rg==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -19086,7 +19071,7 @@ packages:
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-utGeRJfyLvbnhdmkaL/mSlisuJhJH+Lj6odb2QR/FYrjRPJ43xRgRHtFR1Yww1B1Zh1IGe7Hvlw4P0jf2awsMA==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-pWEkBiYdA/0zL6G6UzhXiL+vc7cb4KDqExzjGZHcTKqab3uvRp3h7Ekeay/CxSUVaWqSAFG1/76Qzlg2hJhPIw==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
@@ -19120,7 +19105,7 @@ packages:
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-xJP1eB8WqoggXPniJY9lluvGjGMz5VX5rTcjeKQds9IQFq2sMz09iupZsppUski7pgTjw0ymYuhyZxxZ6aZlRg==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-NNxGzhBl08otZQtaBivRh0gszvoOzg/Eg6xIRHMtcU4zFaU8KTDDiM2e3GRHWHOCT4YaRo49t36ru779GiFF9A==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
@@ -19153,7 +19138,7 @@ packages:
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-IUTmZ7O8kWXZfWAB+LZPob0h4HxvfZwTAQlPYKOjPLn9WoaAYXefPIEE7pcbHJBPXOhiYVZeuo1w2udk16sGAw==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-sqnRhuiCQ4/YdO6CwbquqGAw0zYExM/pww3jzN5JloYt2WxeLqgjQYtbmtHFULv1CFs3rDmFaaPpgklFXEv3lA==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
@@ -19186,7 +19171,7 @@ packages:
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-nt5EuFMwixQpTKYjaO/w8jVFhUmZ634/3Yy9WMVU2EfDEJbh/gpzuOfgX93SEi1sE+cOuYu7VXEUUw9pz/pStw==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-9m+yOkaJZLClwnltdazB17mGqT6HJT7cXgXcgPAuPlkfi1O2h0OgeklI+1NjNVvk5a+IBRQxvEFaAQE0recB4A==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
@@ -19221,7 +19206,7 @@ packages:
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-7xCXogjW/Da5kGwhphkXhhuXNcy9n9V9DK+AjgrtPKVp5M2yOgRGhXy8Q9FdJcsoK6OOUW3Z2X4NuZfvFtxV8w==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-3otNMWMXWvj5nltGDSpt4gcC9QpYmjpjMdX1QVJ2RYWFs+4g9IkVztZVImTaZw8YGIllvTWtMIm1s0TUSjD+0A==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -19262,7 +19247,7 @@ packages:
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-r0pC+0n17ucWMkCnnWxrj6LfiGevHKnQwj6vuGHs6hpFvBKTY2gWl3sM+f+Uk6N57a41q6CO45Nf4eJc94DgzQ==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-H1nHMisP/hVpYa21i71KWIUirH5P/b4nfgKxFyyh/i+kb9aDdqpnkRERDOtptLP7ToC3ccL/mLNLWBtNzMbZLQ==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -19306,7 +19291,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-iFoEi3zDqvJZ/RsurEdOYNkourtx9f2HQmM9DxoeQRV+WbpNACiD8OEhcTqNUQe782nJAzPnJallqSdyqdsXiQ==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-3vqk5DJS05qFHPJIzjPUWeY2zJ62HDxNrI2P233VcACHDIjbFarhoYG4dcAO6q4ben0gcaP5aJGvfHrjRTq1JQ==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -19351,7 +19336,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-kJelWWZ7mp2zIuZtMHCPX164vdHoSCySOVWMXH91FXykMcI6NnnMGzRIsR6DdgtpgfZIGRRgnp2OguhTd/4PWQ==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-g9g7FpOlBgd4Z0p3UhU0gT2MFZiteY1oL4n0h0SErQ6ofpTb/4OMrp0M5yVTNqA2FEdWJ/8yvKny4VY+bcJOWA==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -19414,7 +19399,7 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-UGzIJ9r9JfJ+83rwicioebSkG7HgbvyIB/Diq1DVeKYPl7GnxFHP+yysk0fGzn0W6LC2IXdSeMJzCqX0i5GS8w==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-AUnVz40RqP3ak/TjjuUoNx4QmGNTySyz3ChSrPLwZnFb9xbTglIrLm1Ah+ZSEQnLdWwKNBB6CYylfpAJRIRxdw==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
@@ -19459,7 +19444,7 @@ packages:
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-dVYYgI1O1OEAu/VSUR6xOrlxoX+FZgh/n32yFa+YHZlu8Ojvya1UUHkPnunwaWX+miZeEv8OPNAmaHaPj094qg==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-cAqAyAWzcDmnFpR1+KZulAy9tdz0dp3ddlZokmgOH8hadBmxD/J3TIAYdnT4aoMasf52QEvWikJUmk+Kf2vIkw==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -19505,7 +19490,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-7g5JY9REh7cnQ8icAKyFw7wG396kVMfq09zIs/6YvxiYLmRHA+ghrUFc4s7nw+sqnle5uzLTa3YoipiYiCBEUA==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-4kJjYGl8PS0sg8UvFeF7IfrjnNInmem6gSOgNfNFtjhdnX21Kab8XViSVfRPHl6O2YwbQhNqJAdkjFtY7FD22w==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -19524,7 +19509,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-68dDQoERAti0YN6GNbXPlHBtV4FYwAmBlkxqXnnPq4/Awd6zaIGx34hDX5N6h/tFyUFN7RNl1KKQlX/PB9EH+Q==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-O3a4WUWUd/g9VP0DdICyRi+llYZ4cjfKHUdrfpF8ifNk2VUfMyHYtfwMS2kN9Wa6wGNO8rGbfxjQH8MantWduw==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19571,7 +19556,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-Gf45Hwyc2+TvLSsYxCz2Xw9mNElN9CwHtek3YRjexY3NtJSRhgducgvPd4DnPujOStnV6ePa9TYCjqBvNpWDUA==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-x29Uy1+g/5pm2LxEvgGx2/PB83jx233JjGKw3VUZuahg1PTdYhLF4AmzAXEpZCGRTLRxNSFrj4cuNKLTAVq8/g==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -19631,7 +19616,7 @@ packages:
     dev: false
 
   file:projects/eventgrid-namespaces.tgz:
-    resolution: {integrity: sha512-DOOyIJuo+blGBLvrHYmVGQbjwq+fF0CRTVNrqmAFXgo7l4nNhiOq7j0hII9peIK0mfa4PnY0aAoa8+OqeU1ZWg==, tarball: file:projects/eventgrid-namespaces.tgz}
+    resolution: {integrity: sha512-ys4Jki7Mjc1aXZIy+Hl8otyfotiM/5nEADs+iYccvOKvXQB+4+4wKsXyu69fzj2CzjU7R9d8LNNXMWl8DWkZjw==, tarball: file:projects/eventgrid-namespaces.tgz}
     name: '@rush-temp/eventgrid-namespaces'
     version: 0.0.0
     dependencies:
@@ -19677,7 +19662,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-WbS+qO07HHL+s0QmEfW3mml4Op3/tfKfrynL7fWUYPCBP2FmHzG3qpS/XaLadbxfuGxTMS1s0xj3OnIpeTrjAg==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-neKDorYK1tSwlKyBhFBu0E3IaqzegqvmODdHhs8KAgUTVDzLGz6zSDDhPrH+NPd0DDSfsBiCbvai8g1DrjWMgg==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -19720,7 +19705,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz:
-    resolution: {integrity: sha512-I9MZa8dwJN56njgtZGvQPOlhKT8OxlD+o94dvnpU3yJ00EsVFhtZZhn/bLt1PeJejrhq5NIgMKF3EnarXVPMNQ==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-SnsO3IgxXWKIGlDcC5N4lckvfH3GTmxkK9ED7yh0nQktix6TpdDpthZeu+zLa/S3Z/GvJwcrxCCsld33qzBssA==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
@@ -19770,7 +19755,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz:
-    resolution: {integrity: sha512-QILU58jfGWWXUZ5UF35V1iJ9RuNbl2lFVLTOGQKNKOi8aCOKC9ajXYckc9cro6KZ1p6JgfsKGfCkT9+trC7cFg==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-IbLaNUXJSGqRiGEH6xfz//6rYp733MCNysKb3jP35dBLm+oJYEksKi0Bl0554DQ5cLCPUEAG0gYFq6Wbn7ZyoA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
     dependencies:
@@ -19817,7 +19802,7 @@ packages:
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-8IIOr5Fj6x4p2tdkr0kqIpiy/owVngKR/53RsJY42a0wap8h9Nh3fdXjDGbWt4OxVUqCX7zBqEx3ZP85FnB/Rw==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-xs0pEg/BAbw+22kBcupalajdUmBFZOaRRrDs2LP417BmnrnNBUnoiP5FdTXrPVcO5dnoe+8hn50eis+kFV/0Rw==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -19862,7 +19847,7 @@ packages:
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-WilgrR1wz/AU6OsMr7sEgQMWRQ8AxWVS8TcillvMkygJWGYyGRbnBLzwJdOQm6sLDGDQrbQJL7iwEwU7yi4DsQ==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-CFmaV0s31N+Oaev0Qztu5/A+kaTbQ4yUGzoH9EEayPf/iy/bxMvFsMoCOZCyy0arCaiI2DvtY9Z6yrBHfs/6+w==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
@@ -19907,7 +19892,7 @@ packages:
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-wAQ9Eow5Ck6MhKJlXn3anXBbhWD5/jAhx566i689M6ae1yld/G+d43ogQs2Bu9A3/FHKBl39J0KJxt+cI1jMCQ==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-2WbkeL5XgBymZaEfZ3Z1NDrG7Zl7RbitD6ShkSP8Ld4aFoc2y5LV6DseTbklJWOXrp0USrSJPFpRe8Sr4HKugA==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
@@ -19952,7 +19937,7 @@ packages:
     dev: false
 
   file:projects/health-insights-radiologyinsights.tgz:
-    resolution: {integrity: sha512-KZrSKR9MgcPWhkX5o5jXjlMkhc6s5x09ZJyxbqSsNa3HUkv64yOFWTEbVrg6fVOZaUM1q7XpsdyLYmWcH1XQHA==, tarball: file:projects/health-insights-radiologyinsights.tgz}
+    resolution: {integrity: sha512-TzmRu2u1vZAKiGAct4ydnYx7e5Ql+VFo9KZ/3FAfhdA6q5S/gjVmXdqoVT3UjEmIdcL5OEmodXKPDbLVpqyLSQ==, tarball: file:projects/health-insights-radiologyinsights.tgz}
     name: '@rush-temp/health-insights-radiologyinsights'
     version: 0.0.0
     dependencies:
@@ -19997,7 +19982,7 @@ packages:
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-wvxeFf3OYYuV8f8GsMozjwfo5R6FIffXJJldfIen8fpzPrdx/Hcl1QU5wIGcUnb9ITSDLIHfOC8pc3Dg+W7f5Q==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-5Tx+xXaVFKyqQ0fHsF31Vmd+qkfCKBcxo5c3VkogP0t+BcS091YskB4rmD+jFPJrvA+Drho0XKiW/0OkbzTMkQ==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
@@ -20024,7 +20009,7 @@ packages:
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-wO0/E7EPOpBPhhA3JxK0OX7xt0r1XK78ogJhBEKnAuzhFmnVEppNDl+yMdQBakm8BHGWHGwbF74BhjHUa9e1RQ==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-KpS9umQ/eBTqVsD4KZWksLoMOlEoQrCwzqMfNRJJtyPLRiyNwv2js/fK1BfMC0f/LFhtVOP3wSU73OTm3mnRZQ==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
@@ -20059,7 +20044,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-XVL39+PQt9zydfxfWNVF1/qn/YyMU3ovBSmfdcIbZNldVi7bHEqDx98PmW0BfZR69TxzH7O6j+GGGx1Y0ppwHg==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-X4/ewlTjO8+I35hVHWIZzA0NI8PZ+6ttgQ0ae4WeEWkfj0+rKB4RgFTxB1jqLfRdyq82HA2Ck8Im6y5bL6DyJQ==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -20093,7 +20078,7 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-hWed2j8U0hgxdtii80Xtph8sCHGhmcQaOL+QIBNdkVJIEfdOXn0PBB+rIc0GvGrbuQroZdliW4uhvLWF5vCHPQ==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-v5z+teG0kNN0CQsrseByqh8/HOGggU+UxmrZmxLAZ90aOrWwx5mZMO5SFoB9bsYhvA2K6SVbhWTeV1DgcxANjA==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
@@ -20150,7 +20135,7 @@ packages:
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-Xy16jYkwLy2R3gwb3e+4bEVtbczlos/qhi8hmvVQULL6m20+C4JMpylfJUcbDUJ55mmrUOJICR/lg/5TFPEi6g==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-JRoesxbL7bTzQkg7xnxh1WJnljRcWAA0fQRq2IlH+ZBA2RrM7qtrgWDXX4Zr/CMdPnC9sJhQ3BQ9UO0GZPXgvw==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -20197,7 +20182,7 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-n728QY5u9ezwj3ftEk4QEbO54aBbiOaTD9hibtWM+tWmXkpDaoJNxddONt8cD1p8Qh4vLT+ISjBnkW/Pisetew==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-YaKWAROuxbmzRoWpKW4ooc2yipqmH/SMC0ixjiszP1SbVdyu5APx0TdoizeZq/yjG0eUTOLsPEeovBzOAom70w==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
@@ -20242,7 +20227,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-QyOf4Er+JioddXuubSGkQyR/9/Gt1A6flEEWMJRGLoZ+RFeXvNgJLAPanhNbc4S7Vr6EZQOdQ6lbb1zcEEneQQ==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-gBnkhbgT2XWqRlPKecITuJJ8HxOpN2g+25VVAVMqrSOZ0ARwxE7uJDM4jM69MkpsL6BNCxTezVYxzwsR8DzOBg==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -20274,7 +20259,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-hrMQSWhC9qeFtOZgDFvaJNd4ucvyC7jOr95Kj3KlORknvakWk9ESw23yP3xCcnQFrGVlCRhEqPIy7C0iE3PUPg==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-9yVRq0MferuJlTzsKRfALp2KbYARVlxGEwnjQtkEkVymBHwfOvOOKJDs/cZu4aeZ6aDKd88KOHupcZXESLD/NA==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -20319,7 +20304,7 @@ packages:
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-aCby+VTo/82L78CBg0N0F/YiwdTGou8lOuGmqKovabgt0Jrnl2do4gnFIUnkmLVFcA4aqtyFbwn+K8BouH2l5w==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-ZzUZgL8qIVQ/iNcmX0Mwtb4OS5oBUvlaZ/xaqmnkXCXBOoozmOWhdRKjbb/UIZTZ/B1pFIki/OKoBl9sYCr9FQ==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
@@ -20348,7 +20333,7 @@ packages:
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-WvkPQFe8ljahcYF+mF7kqP53BdCWbqkQJ5qcD6WpcliPXJcZvCfLv+7fDJWRHtOYgB11ZeveExJ+8ebljU+JMQ==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-F9CoDUdRkjLI/+wFQ6HgS7bQoozRL1zgnhcbMp+HqqELOsuwoQX5sV+YVC5wOggeH/NtDlQkp3fXsAGVRBt8fA==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -20394,7 +20379,7 @@ packages:
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-WyBJcmhqagqFDmx7Bi2A8lMQ9tKTam99J/LSiVkjAkdIQV4uo2aTk7ckff34tajKp449GJeLtVMMAo7n92cSOQ==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-vVDU+9R8B7Nj14cZVOexvOsW8nXdwvpCMFtJ3LVk6ZbXRTQOwZ8wczT/Zd1cfP3r6VzLVGOqUuvxTCxGy78h0A==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -20437,7 +20422,7 @@ packages:
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-0nehicbHJIznIt19eRD7ZSrORFsjv2Hpxc+PRcDqDSbZHZAZmX2M1P3qtW866hL5pFk8cqyZ+xM9hr87ofRcCQ==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-9pqZRkrANbNOuIbTGvlmkcR/iU5u2SIdz55cOnnEIlf7P45FYHd90W0Ci0PeWxiBOZsmcU5bzQGyOUMxpbmsMw==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
@@ -20484,7 +20469,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-ouvnfYuLlGrO5PRrxG4WOQ3/O8n3/bS6ZzJXx5AOg01PipvOPp0+X0Ey9pxv3d0gzE2nkcz4VQ69JxK/v5oNSg==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-cAlFCDM8ztSRQ8G26K1NhIy4KG+HWex7TF3Mhzlp3ORwShK3BmsazZPVT5p/jFpcu7HZZaR7OvzVyJbqrH+pig==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -20518,7 +20503,7 @@ packages:
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-z5SUs9m2xkEPa3zBIruU1rewGrw+vBVs/5pXdGERh/UpRU7jFY4MY9FExkYT1VWmzvz2MaWPPM4OWRdRCCKH8w==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-QIhTVn61xHtnfPSTPENVD1iSyZoHPvtoPCiLIvX7TdwAjqp8AvGSpuWA1G+h2k20qd3tRBjYzs0LzkDYyvSVEQ==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
@@ -20536,7 +20521,7 @@ packages:
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-rDqQe0iBVpSynlMVeMnQ2WexWygjWlOrLFuPqlqnUJGEgymz+4wkXTy4ruBB4SQhvduYwnz0ltTABfNZg0AIeg==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-WrR6mjntnCI1MBVv609EcH35WBVxmbkM0N9Ae1lskvx3zC2geKKGk+CdRUvvF7lu280twt6l4HwTPddnJwuZ9w==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
@@ -20581,7 +20566,7 @@ packages:
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-8vHtypsK1Y35WVBCvZVpItJVNRWnDpUmQRpulHDegYFxGqDJkGN36jkp2GUmvjeeoRiiNjp0qTFh8RVAur30NA==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-jEf/dLb5yr6POTg+QWbSLWdBm2y7230bJNbYSPdYvNZtE7ko60Tm3xWXVnixNX0SfFB2b2y7oVUXLs8mIwpySA==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
@@ -20626,7 +20611,7 @@ packages:
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-0jjh/d2Vby1ZulefjucYwMVll/a6P41wK8U1KVNqhIk+jQrPTYvx+W7ZPbmnwBxfocRjBG67KJiQS/lLynRVIA==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-6bFzohkhACT3kDteYdMvZLOVAq0Srqkz+POCSz8XvdmVB4iJpcR7dgIyulLD0psDF2Qu5sS2biJ66stmtPHj1Q==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
@@ -20671,7 +20656,7 @@ packages:
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-5jpGFia/3ORSbREajIUDKzzroronO4CTe7l7S+wKOH0qZIGO3vbR09FIzTrDCe1rstqTUxvL6TqelOo9krtd+A==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-78CncVFISVSuCu0Lsqgz49prq1LvgE+T1kdfVK66rvA0TwvVs2oKBlNsb3m85Na8PX7TwE3hAsg7bfF1LJ/gOw==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
@@ -20716,7 +20701,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-RV/DldKuNzqW7VRwOD0Yu5eTGlN0ttZYAVnEO4fuVnzGKHaYWOxuKjqH+tJzSEi65b69suF8ZT0hPDiyPMORvQ==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-/PW8rZ1TAnKsUwXiHOSgJze6HWCT+K7VuQn3fdR/F9QrSFV4zNLWINpp9YI07mFprRUuFPVOYVUk8eWTLaOS/g==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -20760,7 +20745,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-2naYZykJV0i7rJyzCwByAWMA3Wb8IP7njrRomvRoTp7CnLLOwHNJVUV65Yd1Cz+M6bVL9TyFugHrdVnMqb6QOg==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-KcGdBmdkVNFALvqBsXwbvM2eLt180eH4mLGvNe17ITnbLXzFsCn1HZadrRYnbj/Gq/Bf9YaSe0d4Cp/oA/X+4w==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -20807,7 +20792,7 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-HdkufUS5H4Ypr/1+cJ8EQcD9C30Jir9slYsZjgs9wCBhPHBtn8wOer0XDhSTJ4W4JnuR2XE3zc5JyHGeRZ2HKA==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-2u15yJgthiFRvamHInxtcoPhxPynLh1lNdXF95NDdXlt4Eoqn1RumKuzrSX/PzIQEVU+OUrNAi9EmktTV395/A==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
@@ -20827,7 +20812,7 @@ packages:
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-ZTloYpng15fEuAYhjBsuhCh5j9kQ6Oqmf3OLNITQUtZiBOQ0Ut9RtXqTVcD7n9XzuZFD93Sbm/UFOzTasHQ+KA==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-y8YI8Riu6+E6f0cQi2GL16sG6OSKL/pLlUpmNyyaJgmuJn4/93fe8hw5e+gkPwqvtmB2sDvDlUGBJPG+oVGjSA==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -20876,7 +20861,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-eMrq4+ULqblWktWz+Ko1Z0Ks9OB3fHasHudqBrhVJKo5skbfbQMlvmnuYAmVqZ5Zwm1o6OrsTgvErJNnYYhYMA==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-ctsRTUaFJ3Q1fC5FW1tzVMDe0FTtSeMlci8gk8e/F8Rfv8Xd5c+ruk7vAut3tN7n7fOjh7YuVSHglOLCXo/5zg==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -20911,7 +20896,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-C+nIR7ErkNg8p/U8troHdXhdmPQOLJdQpvEZapicAeAjeZ9UqxY/N4U43uY2IZURyASpcnZxSiDb4YagxXcGcQ==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-Rk1rsUTA/+kfk9+tqP9Wm9gf2qy7tOgAf3tRIhmgYZACtRooM2z72hMrrDng8OfeKHULME5W9F3fqL7P3+CQSg==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -20957,7 +20942,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-qhJ09fwX+sw2L8MGjYL+phAWFKi2Q1cck0xXlcQo5Zu03tW4okRJ53Oa5AnyhLaD7D53vNrMQ99JZZVQWCtSfg==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-RHJR8hvuysryOVJ9AXD0Pk4JfOiO6mEDE30858SG03t7JnL4KpB0rMNF63Uyfy1A8e8+2Je4jyATjz6xZiwlaQ==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -21001,7 +20986,7 @@ packages:
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-4hAxeZ+Zbm2yd/sYr8PybENBo33t/+3GGg/IoxbfE3hQa00k6yhUs9bI67jgPp/429irNN/KP15su7clYwBM3w==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-2R3txsKyMf7FSo3SOnQ8fkVfbl4XFuXVSqL0Cbf6vgrltaJCqpEjwzYyBPAKmE2On37k/L+HfYDCYLE0idYFrQ==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
@@ -21035,7 +21020,7 @@ packages:
     dev: false
 
   file:projects/openai-1.tgz:
-    resolution: {integrity: sha512-Oh6mjgg4aIC4BxoitkWBhaGVkIT9AbA2lyaaeZepHLNrOdlGIo2IGUqIyHGg/aEP2G0hI2UTCEl2YHn2h2HUwA==, tarball: file:projects/openai-1.tgz}
+    resolution: {integrity: sha512-VP8VdGWPgUFletoc3QohMKNDmQQwsChvDj9JtOSzW+J+IGMSqXumSYrdPiFsqvy/PD061/o0qstPvasUb9qFpg==, tarball: file:projects/openai-1.tgz}
     name: '@rush-temp/openai-1'
     version: 0.0.0
     dependencies:
@@ -21079,7 +21064,7 @@ packages:
     dev: false
 
   file:projects/openai-assistants.tgz:
-    resolution: {integrity: sha512-tA0aRE86blOl0L7X3Jb/AWYye1NICetDvlRMQlT4KlKLPwhTHkg2xe9rTi/q6SIHe4mT0raB0tMcO9IQKE5tNA==, tarball: file:projects/openai-assistants.tgz}
+    resolution: {integrity: sha512-m8urDTxiPaOnEGUxYiKZAOWddEhUA3Ym4/MqB4vvKDHHhbEEOR+Rqq7+eSmlce/3UPRvxKaSY3/t7QJNozwu2w==, tarball: file:projects/openai-assistants.tgz}
     name: '@rush-temp/openai-assistants'
     version: 0.0.0
     dependencies:
@@ -21122,7 +21107,7 @@ packages:
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-/oWVZz8J325fP1hfTuEHKSsac3iJSJ1UdEkVKQh1wvH4Ih0hTIg3SfCxGT8IDCDKppJ7e9jw6YIzU6Nn3Riv1Q==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-YCl9X0UlCUKuPLNUPXV4yew2s4mBVPAXkcPwLuDS8GId2QGI6mqwdbHuUaRIq3CAxJG3TVMXQ/B9aRttwcxRTQ==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
@@ -21140,7 +21125,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-nqmF74Al0EL0qqgcmwyoEey2c2M4Qc2DQASK5jNvHoNbt8/c6drvj9T57lK8SxocNP5gokUgweuIfuUfFSQL4w==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-EJ1/HDNzAuJgM9k0mLSQ0MNu5KaQeRDHQAKaZ3h0TLJGDmpW+8Y2SjeoURUfvPVO1NzbGb7FVRTjKE8qJC17kQ==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -21184,7 +21169,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-lrzhp4aLSc14YZDXXOjMAAVi0kLy+LsbOk1jLIAnXC0GUM4ElXXOwDATONbky346s9QhoVxpnsFsLhB3qa952g==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-zf/qeCiSBzwBC+4vUSCNiAz2HXaoPEtGPQ3ZL4ow2fOIbM0G3krOCQgWwE/+CPPVcOIk2aXQ9styAYtXDeIK7g==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -21202,7 +21187,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-uOomAJN9a//f49NC+n/XiXbfPLPtRGDcNPKtDtlTs2O2Ii/xlcEtsquDs31lccW/rA++KigAAhOa2YyKVxWXHw==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-V5eM5PdijHEVgo79ZTjq1gNvh0FTv3e678mZHhgeZsM0Z/n6siUKg9KzKrOkhOMSa80TgLV+3ZyIxmMyGnNt1A==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -21220,7 +21205,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-FK3uwYwVG4JU0E55VPDHuHChwsuKHlDeBJ0xSAhvytpFRTdaBaZhVZgbEIi8M0Iu9kUKuKhtnLXtX2acK/givQ==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-EI0v5BNYVGw+UEvxRTVY/Yg2Intp7uxcy3dcfHSzdbdxwfBKj/S3xdOTC3eJ9hPu2kd1OWJZ1A6K6OQENIIO+Q==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -21238,7 +21223,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-2eOz03HNHKCo7H1HLVnrlYdEW5qka1SzmMjMiGceXuP8STu03wBxvlSer0lN6T0ekJa4dgbS/GPyufh/lwvhuQ==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-2VYDb+RN2Y79uOw7uJoUe9hxS5yZWUArmYGNxD4P15lFECy1y7Qsh8o9054mrqUHFLTZRcZo1KgzZOGjhuWB8A==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -21256,7 +21241,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-m6LgfVtYJ9nxqnIXXiKcHgyvgBf5B185zWW7JPbbeVfQVmr5Xdzqkz0WXWc+CcTF++NpwNEspjcZORfD0IXTeQ==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-mBRrscrjyagQGNmhRBeA0zYUchSX3PKH40/VJsKpHAuGawxZeVymmoEjA3uQCblY8YYyF6b3rST9ifn8RYbKMQ==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -21275,7 +21260,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-QL4EkBV+8EEZG1EmfGH87489mjfmN3k4niRUwi/C+aSiieE5QhTgFxgpu0MZTP3mHWpaGIbou3rGs0E/pRRN7A==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-gR4YkZbX7kyqHh9gh/Vbo90HQPdw08Pt0GiAZdrPdM1FW1mVIoR5BeIIC3H9Fb82/LQ1I+oFg+FY2VIQNZb4kA==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -21293,7 +21278,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-SWS8BT3UmWdu9T0biIaVJai83648gdtyrnrQ841GAaYM7H1n2IgsHx0SAXnBoq2eJmVhQU9enRoVx7qsbOCXYQ==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-9qADB0VOk07rYjuwvBTFP1+/kKKpDH0t/eV4uxsEiBb0sy1xSfXCHYJe/spDsIVrdGp3CinRiRyFWD3PWDSbFA==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -21316,7 +21301,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-FkJCM5n7DYsf2lzR3Ag2tqxiVn8GU6bZpAuZNIK6BZXLByrUUf8dk7NDYPXHwhs2NaZORzdXy6yNlLqJRHmWgw==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-FYo4ko2VEcSKWnaLMm6WsCAUMI4LcXN428YMm2iUorgWvWyeado13sbE+SHjSKgzkh26eUXB0bupEEdQKKc7bg==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -21334,7 +21319,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-NtzbPTiRsQgWkCn0a8gkN0J+aKl4Dfl/K1fvOT4QfwzAWf3qaXtbmqvd9laMHajWej+1wo+Vu7tGLPM6hqpfZg==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-my2s1O4skXXIMxC89ecO1/eZlR3+IgNj4XN5vu3JG3a48TKuxiOw/EcTuaeFktt6xMo1dciv+LuYurbFSWh64A==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -21355,7 +21340,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-mB74n6wsIzYFESIifHaaO32a80MTYZNkvhYb5rrHuzjTlqcZKfanZuBPdVAFHjy1m/KZeHVjX5CzY/rFpdD8sw==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-a0a/rYZ7+OJo2V1ZNGNpyTkAPxxvTv+KFu7BUyms81FuggrrECUsybfwz3mbG8nIoh8UEB+BY5OXuyN48ZbZ0w==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -21373,7 +21358,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-rhKinZeldvz8kS8Zebo5R4wwPR6yo7DiKAjFjq4WjYKZE3sso/P/4lAnAfra7+cSrbUnLaqtttcRHTiUyRlodg==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-qCSQ/DGC/ektxrIAO19e0Vs/WCCUD1Z2C+bWpUVktBMk/y/dlXqvqa1aGbUDZr2leKcoNDHNCIITNRPxiOwoTQ==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -21392,7 +21377,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-+yIjlo71XYU45sBck5hfiQ9eZTtC04sgGgfq1LoDQQEvGPk26QHFvPymVLRTmMqocVg6e9JPdWI0oAVvYQqSCQ==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-yGY/0yT8zg1HYq8Ucj3OpeaP715AgIiXcLFuwD8UTZ4Td5xoDRhpi+zs0sUnAZhDESM2JE45vFIaaSXc2fRzNg==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -21412,7 +21397,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-GJCzDI0mRTjoOF7TRA5vjusz/vG00P8aKllNTCNtbDfkjIr7pMAllPdDWcDhsLWpMeZsrteEobGie/NicFNPSw==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-39cRS8XoyWK9FnoWWQ53ytmG25u4YRLOkO6NHeGkBWngKGzyTL4XGDGJaupTnkg52b3/jQLB4M5KoVXeDFIlGg==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -21432,7 +21417,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-pzhQuSUnujNF4bBF2pz/rNl6kaYJaRyfrQMytPA9bU9d4rcP9bNsjXCnEGEpXSC5jmh/QF8n2ju/0wh6G3ANrw==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-n98oiCMoAu2WGDp7PAsTLQkfSv1s31Mr79hAP7KEVuPd+nGDGsW2FKCkiqUymnKNdZ8Lhq9Wf1U4RtKVTYGWtw==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -21452,7 +21437,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-ZROFv8zQw7Jpd3oWAFke47F6/KQdUQccNRHVPiZePgE/Ij2kGGEhMP9KjvvZ44Q1TnT8OnqJv88gmFRUO4wmJg==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-e+SLLqcGfUACYhdT3pVFDE2UwEzv3RFQoAxwFQrQDy9Dlcdq9mRfcj7uVD/qlwmV41Cc3nkTecR7CDPV2Lt+Sw==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -21470,7 +21455,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-yQRbYhfNZ51zmExqjIc0RIUOH1paTiR2eGdTYqJRBAvl+1NLq1AlkzACQt01R0kIVl65F9TlRYJ2yQ1f+Ipb7Q==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-NIBhtV7js8LNjZFPQbm4sebhUGMBmocQnp1t/VpksvRjqaky0R6d58qJkdM2H+fmP7yoJ2WpCq2VeOElBYMtlQ==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21488,7 +21473,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-fj+lO15eGUCQExahDiadTpLSCnRHu1TsCdIh7p7TLo+jKM0819zN4xIhuMLN6lxXJoIObSBtLTRAuRzxwGAN9A==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-MrB6574lLqsFH/l+ul47XUkhX4sDjhuKDsjVbH1OOebyyyDOTf1zeNisWDbDFaTBOvLDkhpBHrZ+jTMsl7VaSg==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -21506,7 +21491,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-chc4hfyQbQkoS8IbBiXnLTIsr/Af0p98Jhjgyi3oKut9SGf4MnoupIL262HX15Z8PXnN5Cq7P0nw42s7jTkxFA==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-9dTQa/x2rpqPpnMJ6z3qnLyLMH24VHVaK8kkfXP1jlNLaQEl52sPlJBE2/E/PKTl2uEAN6sS2gKDJtCRFSIHqA==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -21524,7 +21509,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-/RA+5alnBXvM3HLl8q1uPw/Hdqd5gB2V5qpaXonlCE7C10jQ233TxOz+OFa0JYLYZlck+5/u+Yf9LA8JYEidqA==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-UFP3FipO4FvsGdpFZDDoBA/Ll5b+wtD1wXkn3pih01oa0r68UmvYwY7lGZWpj3yCI1l2UGzayn/r4LIIUNT8iw==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -21543,7 +21528,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-uzOm6V4LesEx4etYTgPNSvTFLhdwb/HC7kDOTUJuD3YgCwu6SO1psK1q+yC7Y7hjXk9ZreKmSE3kpzcMuNIXLA==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-X95Hh6NnKKUcwXClbV9iQIxP+1FeXIRs0AvD3NXMctlvTTHFwCmy8MrjwSbOZmbzedg6oVE+8rEBdl4nQpeyZQ==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -21563,7 +21548,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-Jz4y+ZPirsfYMZ3A9Z5rHD8rqG2tX72FvG7+PCkVuaWszL5814GhXAO1HgHovagQzFYyqtYTmlBod4jiR8D2UA==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-gnVzxlY1vrAzRzZwxxYq0IpU2a7YPUY19+GM3mhITC1zWOgyJG34mkJgcxO7zIXPJe/4cVUQju5/2ffQ2SpU8w==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -21581,7 +21566,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-tofYs152ezkrv4HoggV0PK6q2THSgnPEtsXjU2xPX1ptV8015o1pNMb0Ida/CgHlFccTKmcWgq3xH2iA10fNyA==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-IqNMSbO7Zr0HoLvLmtadH8jS8exN3/o/yV+wmm82TAfGWzvo+H/AAHsbDQwE9KOUnfGzeprtrXw/cAW2+m75DA==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -21601,7 +21586,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-PDcmow06NkRgxBuWrX0v469wUEPB33LC6ZoQNxG/G9lPwNJ9mv7RbP3jF0OFmdWS+K9gAbfPd554MHJ1nrSRvA==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-R//6vCw8iYaZIH9hz0Cdc+eL42f8/wFyQPERFgqX1m5pjAOs67OLZsURMisUTvRa3GfDLxf34WD0G5CAVVhNgA==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -21621,7 +21606,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-uIF9I90xnGVCYEiiTK8BpWXrpiZH7GiBQ8ruTKhAdxo8/N5fFb/bk9q1fbMmps4LS3hGKCEqYFjWYXJBEvvhew==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-M95aBoz6WTfr7yf191nBbOEvzgjcfhbaNGn2UOL+gz4Tk9u4KoVOahyrqRagZ62e5jN8it0mWWEMXvzG659T8g==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -21640,7 +21625,7 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-9RsnU74mXZeoNC1gme1BKunIbmLAEj2XcDpkRcOpt/HMWDr67cOLJwE7xShqhpfuHQGrJd+5fePHJdxXeskzKA==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-PUnGResfnZa+vhEhEL4V9yu0MPFDnWXH6KVN/i2zXGCNaZQM15xKOFVba9+fwV1VF4lV7+ayLoWeJy6uca6NJA==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
@@ -21683,7 +21668,7 @@ packages:
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-55u+SMndjDIxDVP6kYxpst7mO3ieNqSBOnWKG0s0tftPN+QcC4sZn3VcJDt3PQtPC5yjGVEeW+wWwoBJvvRtNg==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-v58KQ1E7RV5cWZsZk2Wv2uuPelcosDFMim0hhHZ/x90FwNKwULin9VG6vXKTe4RnhGbPsPltMK+tC/2Bjtb0qw==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
@@ -21726,7 +21711,7 @@ packages:
     dev: false
 
   file:projects/purview-datamap.tgz:
-    resolution: {integrity: sha512-biBLDZlcRLlBkSf9qHaZQb7MJUDoKCAvnfEAstKYY1vNYGp2krWKIlNzGWnYxronr49iJvnnfIB4H4EFo7Kkmg==, tarball: file:projects/purview-datamap.tgz}
+    resolution: {integrity: sha512-0ovOsF88FEldIxZL67Z6DjYLSzAMycAPJeTZ+9RMQgA8beIpO+15J5c4SHFwUOBM+Pz3BeMQ6sZ4e6W9KC22RQ==, tarball: file:projects/purview-datamap.tgz}
     name: '@rush-temp/purview-datamap'
     version: 0.0.0
     dependencies:
@@ -21770,7 +21755,7 @@ packages:
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-96UJu2KMlggKtph8ks0SPk36vNZE8DmbqItjuBuluvEGmQ8QpauWJLFdcrM4KYCwdK3vNcwwPbp5ZWp3AOIsOQ==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-sDm6p7mU7+/1oqGM15tBsYFjVneQozGQRnJvWLTPRgyzoRaIHIuDPyDBNNOMNtgny7nucMDQNcQa0wJNle6Gtg==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
@@ -21813,7 +21798,7 @@ packages:
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-iJbonB/0uo5CDka1ezmJmsDX9guvly8bG2ZOsKMhUQGq+2bK+q9DYT796/oXySo43yuLM3X9w/XJ5ZO7k6p0sA==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-x6pimB65XmA1bXBDol5SltDStTnWzSQmJOUufZmZTe9tJ4MWhEiDffQKCBo1l4u5DzUkUkxWm7ZsW4fhfDPx/g==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
@@ -21858,7 +21843,7 @@ packages:
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-Iftl1scPmyE6vQKG956yOmsEcj7NoIBtP63nWMiK466i7C7XPXk3af5NqxKuSXgFjpHJJKllr8A/JouWhWmvnQ==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-Nk21E5yGcu87ebwWQFwevN1ozAh61PL4MpRvbABMOcv1eNsg+pE1IZqnAyVeH5fLiBO26kOHBSY8Q2Etiag2bg==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
@@ -21902,7 +21887,7 @@ packages:
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-tvbrwz/J2Hn0SMkargmofRoGmdO/7y0I/QytUmMawWhgS85F7Xrm6XDaPhG0QD7FldLy5d82rXpF4F/OB//xuQ==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-dDRCjBIEwXbSH3Unpq7o8+ndqzEYtFaO18U01pJtevHC2e5WjwXSxsmOPYSeghjHcIHJs0KaljkOfmgaGOt62Q==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -21948,7 +21933,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-zeU56v6ZN0z6V1pWWC0SVwTLd69TRBdtPG2KSmCq4kv4cI637cDKLXu6tZK3aEx5A7CjYQRpUDt3fVimqIEMvA==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-sOm7Ox9tYUVWazlrpflmFFShSAN3gKr+zPVh7XOtqusZ8SqrNJ0g3bf6nu0riPOnlvr1F2T/u0jmZKFnLfyeLg==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -22000,7 +21985,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-uOlZ//8oiIyMnqBER3E2sUOXPIEtLJVFdrVHhp9niL5/1NGGvlqfK6ZsDAfp7IpQYRWo+BREsyeG8NxVEcPrDg==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-baD2ACrM59kwQ+IeZe+1Xjx9KmMW9Bx6FgIr7yYej+hpwMWbxAl7Nn14nS317XGApYRTz1WODF3iBolCY0C8Sw==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -22042,7 +22027,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-UsH+7WYxvN9yWzaeJlDCMYYfHe6Gqf24KJdQB079fB7p1zvTllvY/rYE2lWWup+7Mp82+KXOoVg1ALv7V09fPQ==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-kwLpnF+W5m0/GzVwgJU+6zs4z8lLLXdmjYKKh9emN13ybIHfBDrZCqCyUcWqNj1aZ2/WsSHgm64UG6hp/FAfxw==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -22082,7 +22067,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-ijt2RGREy7LgIya8t8CeZHO2yQTN/KG7f8hTg3jClI8zybT9/6wDkAVFFd1mZKcEjq7zcLBKup0ZkOFPleUlVQ==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-hcIXqU0YNUHGzXwPM/VtFzULpOkU9v9/L3jEhYk8/ytWLBeSqSjzyl4allwHCKWjI9wZJKy3hXp7vXw4XZa5Iw==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -22128,7 +22113,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-eJjePiy0DfOz3dOk/ZNEC09oKlNJd50/ianjAR1ne0vTgZYZu+VVs/FBVx1M/qHsjE3XSIuSXLeIgTZzqG1kqA==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-9AnL34brJ5svj76fCLRHZwrCTOkT4O9kdeOAx6FAXp965o7nmQRR/E28cWDEwhtMMxwZ2pO+PUYYW/jRdRk/UA==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -22189,7 +22174,7 @@ packages:
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-KFctlkt6yfKlY4OAsxQWYnETIUNHPNDPmOsEJddGc9cB3+E4HWk936K8AkvXebUrezBucOZz/UXmmgP/tVOy2A==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-7P/r/0Ncc7GPeRi+k/J2XuudbZK9Jn354kLcUZxDC0/wWeEODKDaIijl2HqkQyKX3HVJNy8uJtqJrtOJ993n0A==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -22239,7 +22224,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-QCwygJnfrsUApbAMd85oB11cCP5rQtiODHGIM30eas0kdWxmGJ93hGvkRlFI/mXjmaQmx8Myl8cPCXeVI2UVlQ==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-y5VjwucWQal+YmIoxW2GyYqdPHbcImDMWZQPzg/tcPp2jy+VualvbA3RkM0QMWc1/BlAZ4sr51M3jlfs/snPrQ==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -22286,7 +22271,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-Rr4iJu0zT6081KP32DRPBAe28AnB0xGFTXBucaeRrMIA3Q0oySj3iHrvcO/KS7lCur8QMeqSCdCCtML6llF0KQ==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-K9GA+pIpIieO3l4uoBkpzE+L5yT52FXzIrVTvmbShOdIxPapIEY4ejqKDkdJE1bXarqmLmiPqza3fSXtpGgPXA==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -22337,7 +22322,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-eil9UvouRgg/WMqQo3Kd1GifMeXGVwFvq3RohWGumMQAOkjDZi6w+RZreycPbub7AOLV80poYWB+GRbODCU5bA==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-7ZkPy4XMc6yUKiBR8tFig+XavYYkjiyTmlujdhxHGcRx0VxcCnemxNilNUwiB8Mb5tpY4Pl8OhMBGwkwXjNmSg==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -22386,7 +22371,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-tF/6KeZIghz/RPFaqY3Rbt+AyWqIIdp6GdTygp+q1TkG/2enNso9Um58IBA0myw5159aDSX/558ahJKTv9pFdw==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-HsizcYoQGq0xkPQcYaHoAy7C3yCWpC9TZeI6874SQi+iCwCSMXvsQXNYEzlXKxWvfGAcxJ/LDru1Pz4RWsAL2g==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -22430,7 +22415,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-iIgedB8YahYYOy2Ss495paZAitRtlUqoSZkyNjDefBjJ2yCUq5ikOuq1GHWpS6VqJdu+UXfB+7Pm2HKaFdO6GQ==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-vZ9BCMNAuKoyqK+CYBgDTeiKIUXa50YYoDkupsCmGzYzAXqkB1/VIzq5YvKZirVj9TMhxKWE6LymyVkTQSKKzQ==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -22475,7 +22460,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-TCucOGGIt3l1zeNxV1dliNGdpBxLhoCb6dxR1t6jHpqUSKzCLttOF8utPHOR+dozFOsWLuzci4NYI4HECukAjQ==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-iVtABvYKFaI6dfz77JibSz5e2GBXFSy6C7grpecmcQDNCpSbkcg1p7LDiOISaCoBP7SrjMNXdjb2fU2xBOSwZQ==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
@@ -22521,7 +22506,7 @@ packages:
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-61qaVfs8y3w/5ZkivBtyZZzjHG/V9vTe0Kapp2sQFpTXbJAVZ0vbMFO7L2Ypj0EY6VFDTfCwkK0/Ux/RHx/Dkw==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-XL+w4nLYm3UKkoKACtDAH2a74gYerZMf5TSBxs/miW9POgzSfCyGr4EpaYCTR9RPlxPLgSUmxTbiAxqkqadVCA==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
@@ -22568,7 +22553,7 @@ packages:
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-LOzKGvo2h8YNm9o5a87mvgCkctHDXXaHdbq2DLPLZpkdfI8boJbvze3omd2sBZQmefkzBAiHwJN3NtQZ2M+ocg==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-DM3qdX73I5CHR/d61MAvTXUfYQlXFGwnakCvtdT0Zx75qdxG1Ad1rpUobISAeUtSGJGY/8rpoJU5TF2rLRtRvg==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
@@ -22617,7 +22602,7 @@ packages:
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-7Md2InBHuvcJrSmthDCVno/KFbBbVSwom7VGSQE+ftGizpzOPTcVTxVd9Q3qHbulJDp1nX28T461OPGnkMjKNg==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-UGBag/ADb7HdfkSSR/334LOJc4zUjVOa9lfMekzI5s1D3VLjXyLd5K55gPHJ2r+vT4YPs52WzIHTJVAxRZXHlQ==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
@@ -22660,7 +22645,7 @@ packages:
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-h7sGQ/KbBE1xyEmt1sLRwO3Qxn9c30VpWt+XLgEndkOzT51pzigD1wAdA2Z7tXWmemoNQiUi4LNbKSBAAXrxOg==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-KVul5ga2bYNl/08CgEWMpVmnsue/ea0ylODpJiZMa4pWaAIb/ktIMlkDuHqDFtgzbMVxT2I0L+wRzvGwe9w46w==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
@@ -22698,7 +22683,7 @@ packages:
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-V3yuoB/LVjnJAv+Cw05bFuvqyemQRj8+Op2OtjTOBRhSxfHAD+F3FyrS5CxqhynbWrzUwSW69Kbp3+qx2fdN8g==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-8BxXKx9o5dmLUxOQNcK7K+co+va6sOgL/Mdt95E4uLSZ56ekhsD6yi/JPae4HK4ffl1Pr/qDlIE5iO3oBCqebg==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
@@ -22741,7 +22726,7 @@ packages:
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-lxZeg0zDLXXMjbma1DD+mITg5s3WpHO8lv4edvoMaxcyt9pbAvrmIwxTunP4yZR/QaElDsRukKkTX8xxF5tnBw==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-ULes4UKGHVLgjwDbIm78HNR1blOskT6OZZCFc2Zg3V5sUn0te6i5zkEU8Pu6tHt1RDNRkTEqk1xtJQFvIbvB8Q==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
@@ -22784,7 +22769,7 @@ packages:
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-l+9aEgfGCxz0hXouOXhqy+9tfU6q5OoSPnFTSc0iwt5hra649qLvKrrvpxdfQED6T8HL36Q7CP51EwKGFzy+tg==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-dZQiyCeWYCV7xjBoecUkOlZh/2ZWV+tc6kxlr25kpPxilvlnglKxIWJbuzRE+GtWaSR5CDqsWHXOooR+FKZvoQ==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
@@ -22842,7 +22827,7 @@ packages:
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-a0r55fkyHzyP0Fv8gvyrx7e/6XOHi8tkbXIMjjoidAAVWC9LfKVeIOaHGXl5Jio5EDMFtU8Tnk8ouqK+luhr3w==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-GV4XFVH74kBbd+wSeoqMkhGl2UHp4w4/1BUPaY3s92p9WUYECFqWE2ZQsICVoUG7/9T8vbyFvju3hb0ulML+Iw==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -22859,7 +22844,7 @@ packages:
     dev: false
 
   file:projects/test-perf.tgz:
-    resolution: {integrity: sha512-eCcCwe+SGSmOt4GBA750BoYWLV7cnEc5E2Dn6D7aoszG9JtCnI1lsY66kFo5D4uLPzM1Kxoud6l5El9oCDyP2Q==, tarball: file:projects/test-perf.tgz}
+    resolution: {integrity: sha512-ZwPBFlm7U2LjZCUqsJJrNubufkZA5WPNQvRqlj9yXXYaSrtQtcV8LutkBWMy3BTFP3QlPU/7Omj/MeLt7BNnBA==, tarball: file:projects/test-perf.tgz}
     name: '@rush-temp/test-perf'
     version: 0.0.0
     dependencies:
@@ -22887,7 +22872,7 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-0Auhcihv3///v0ZEO5JOvtRjG68Wk5AS1YO7D1tAJAPIM1SD0RcSu96r5iZGp6RDfxo6RY26CqxsRSJ8AIg7lQ==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-uSuHsll96Rm4DUoy7GZCjx4/oL0VJKnbDAA6acFM0V2yc3Ciourrm8UFt3zx3ACNGB0k5ic31BjiwZzuDHrbPA==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
@@ -22925,7 +22910,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-uf7jHfyR4w/5UiwsXP0XKAcm5RUaMgEfNS5No5hvB41Z64MtXXiHugen9N81PYuiEV5u9uXnMJ10YVJj4BD7Eg==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-u4u9CDY3LLHpKg7655DGRsaWaieW93zWY7S0K3e+VOzqwMfGtVPCynsjQ0pfH+7yWl2YuR4HA6Frnitfauq4JQ==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -22962,7 +22947,7 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-knbQovJn5RRWWHnz8F7WtfJyFrA4xCmTqosFHk7GjcCUlQNOp1g0Z7iu6e5Ss0La+UfabEhEw2rb+HepIX4RLA==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-ro8IOPSSW3hygWlIFemeTAP8ExMeHPcpwHPiX7o6k1jPGYXWUzGTPpdaOQnps10wVNph2eqVds0obMesPG2zcQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
@@ -22998,7 +22983,7 @@ packages:
     dev: false
 
   file:projects/vite-plugin-browser-test-map.tgz:
-    resolution: {integrity: sha512-mCraP3jfWR4/X9V0+o2LLCczyZ/MvB7LfMgdSJ+K2Fg0eg4CmjhL4QaQi24JrhG8BgqVmM7GumlmMkbafTwomA==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
+    resolution: {integrity: sha512-qKZHdG8f3LTACHV3PdZsjAm8dC+A9GyANO24iYg7ATkihTPXf4nO8l7RR9Ur1bHkDyqqMq2AIosv0QhEH5pvnQ==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
     name: '@rush-temp/vite-plugin-browser-test-map'
     version: 0.0.0
     dependencies:
@@ -23013,7 +22998,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-UUJeySPukfOYCSy8jbrlUZ7kqR4ueC+opN5E1+2RlyVZMHygayfjPqN8v8OmcHeZkyMP8M+yFDHp3xucdtgE6Q==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-e/+oQgvM6BCztVx1KnhiTJcZkpe6CyebYAOa0yMnVDgIxd9z9q+T4r/6jAs0VSlv9Qny8pDSEeo/tbnZVpsGcQ==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
@@ -23073,7 +23058,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-Kjj2imsxyUU03ts0Fk5gAlEmv3ZoQLWUEEqVPiUeH088a4aa/bhCeK14BKQBmuy0ZM+/AyT/Uo8wtAHKlJQrSA==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-0afOJdm9yzFnddrmlL+oW+urxhQsspJ18eZ4q7Bi7okVYNWshYrEMLxr8VdyrL0wd+Hi3sEAitQK9WZ4w/iJjg==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -23128,7 +23113,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-X7efP+De3b4yxStDlLCJI1XXg0hFE1dpOgn0FSFS3Rj1cn+okb8yKOjjeazQfHtUPTP0VpBRH7ynlxL2pMMhMw==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-1KXDQC/vek462OUFGix4sSGDxyFX+RqzfU+rDbHvEZlOlxRI+qaIob0xacubuIJ9d3d4ljKPPSIty6yzA4kRfQ==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -23164,7 +23149,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-VLCPbR8SERP0STkMvFpYHEr58Afh/4XbAq++Vm2gSy3U9k1vP2WTJ5w/gA37FxcqVfacIg5mbMpl34ZdRIynXg==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-/pc2NXi/GdnLLOmjGYaVy+H0vhC89641nBiRqHDLuxreTEx8bUJX7b81w8P7mqbsnTJik2gzQoBJTIUqTFiKvg==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -113,7 +113,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.0.1",
-    "@azure/msal-node": "^1.3.0",
+    "@azure/msal-node": "^2.7.0",
     "@azure/test-utils": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",
     "@types/chai": "^4.1.6",
@@ -140,7 +140,6 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.0",
     "typescript": "~5.4.5",
-    "ts-node": "^10.0.0",
-    "esm": "^3.2.18"
+    "ts-node": "^10.0.0"
   }
 }


### PR DESCRIPTION
as @azure/msal-node v1 has been deprecated.
