### PR TITLE
[engsys] modular packages need ts-node/esm loader to run tests

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -24,7 +24,7 @@ export default leafCommand(commandInfo, async (options) => {
   const isModuleProj = await isModuleProject();
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
-  const defaultMochaArgs = `--loader=ts-node/esm -r ts-node/register ${reporterArgs} --full-trace`;
+  const defaultMochaArgs = `${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
   );
@@ -33,9 +33,9 @@ export default leafCommand(commandInfo, async (options) => {
     : '--timeout 1200000 --exclude "test/**/browser/*.spec.ts" "test/**/*.spec.ts"';
   const command = {
     command: isModuleProj
-      ? `mocha ${defaultMochaArgs} ${mochaArgs}`
+      ? `mocha --loader=ts-node/esm ${defaultMochaArgs} ${mochaArgs}`
       : // eslint-disable-next-line no-useless-escape
-        `cross-env TS_NODE_COMPILER_OPTIONS="{\\\"module\\\":\\\"commonjs\\\"}" mocha ${defaultMochaArgs} ${mochaArgs}`,
+        `cross-env TS_NODE_COMPILER_OPTIONS="{\\\"module\\\":\\\"commonjs\\\"}" mocha -r ts-node/register ${defaultMochaArgs} ${mochaArgs}`,
     name: "node-tests",
   };
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -24,7 +24,7 @@ export default leafCommand(commandInfo, async (options) => {
   const isModuleProj = await isModuleProject();
   const reporterArgs =
     "--reporter ../../../common/tools/mocha-multi-reporter.js --reporter-option output=test-results.xml";
-  const defaultMochaArgs = `--loader=ts-node -r ts-node/register ${reporterArgs} --full-trace`;
+  const defaultMochaArgs = `--loader=ts-node/esm -r ts-node/register ${reporterArgs} --full-trace`;
   const updatedArgs = options["--"]?.map((opt) =>
     opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
   );


### PR DESCRIPTION
Some packages have the option in .mocharc but this is more centralized.  Packages whose tests haven't been migrated to vitest yet still need this.
