### PR TITLE
[identity] Add consumer_passthrough support to MSALClient and improve logging

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -17,15 +17,36 @@ export interface PluginConfiguration {
    * Configuration for the cache plugin.
    */
   cache: {
+    /**
+     * The non-CAE cache plugin handler.
+     */
     cachePlugin?: Promise<msalNode.ICachePlugin>;
+    /**
+     * The CAE cache plugin handler - persisted to a different file.
+     */
     cachePluginCae?: Promise<msalNode.ICachePlugin>;
   };
   /**
    * Configuration for the broker plugin.
    */
   broker: {
+    /**
+     * True if the broker plugin is enabled and available. False otherwise.
+     *
+     * It is a bug if this is true and the broker plugin is not available.
+     */
+    isEnabled: boolean;
+    /**
+     * If true, MSA account will be passed through, required for WAM authentication.
+     */
     enableMsaPassthrough: boolean;
+    /**
+     * The parent window handle for the broker.
+     */
     parentWindowHandle?: Uint8Array;
+    /**
+     * The native broker plugin handler.
+     */
     nativeBrokerPlugin?: msalNode.INativeBrokerPlugin;
   };
 }
@@ -86,6 +107,7 @@ function generatePluginConfiguration(options: MsalClientOptions): PluginConfigur
   const config: PluginConfiguration = {
     cache: {},
     broker: {
+      isEnabled: options.brokerOptions?.enabled ?? false,
       enableMsaPassthrough: options.brokerOptions?.legacyEnableMsaPassthrough ?? false,
       parentWindowHandle: options.brokerOptions?.parentWindowHandle,
     },
@@ -125,7 +147,6 @@ function generatePluginConfiguration(options: MsalClientOptions): PluginConfigur
         ].join(" "),
       );
     }
-
     config.broker.nativeBrokerPlugin = nativeBrokerInfo!.broker;
   }
 

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -144,6 +144,7 @@ describe("MsalClient", function () {
 
         sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
           broker: {
+            isEnabled: false,
             enableMsaPassthrough: false,
           },
           cache: {
@@ -187,6 +188,7 @@ describe("MsalClient", function () {
 
         sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
           broker: {
+            isEnabled: false,
             enableMsaPassthrough: false,
           },
           cache: {

--- a/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
@@ -105,6 +105,7 @@ describe("#generatePluginConfiguration", function () {
       assert.strictEqual(result.broker.nativeBrokerPlugin, nativeBrokerPlugin);
       assert.strictEqual(result.broker.enableMsaPassthrough, true);
       assert.strictEqual(result.broker.parentWindowHandle, parentWindowHandle);
+      assert.strictEqual(result.broker.isEnabled, true);
     });
   });
 });

--- a/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalPlugins.spec.ts
@@ -25,6 +25,7 @@ describe("#generatePluginConfiguration", function () {
     const expected: PluginConfiguration = {
       cache: {},
       broker: {
+        isEnabled: false,
         enableMsaPassthrough: false,
         parentWindowHandle: undefined,
       },


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #28872

### Describe the problem that is addressed by this PR

Two things are addressed in this PR:

1. Complete porting over the logic for MSAL broker plugin to MSALClient by
adding support for legacyMSAPassthrough
2. Improve logging for MSALClient and establish some patterns
