### PR TITLE
[identity] DeviceCodeCredential uses MSALClient

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### Bug Fixes
 
+- `ClientSecretCredential`, `ClientCertificateCredential`, and `ClientAssertionCredential` no longer try silent authentication unnecessarily as per the MSAL guidelines. For more information please refer to [the Entra documentation on token caching](https://learn.microsoft.com/entra/identity-platform/msal-acquire-cache-tokens#recommended-call-pattern-for-public-client-applications). [#29405](https://github.com/Azure/azure-sdk-for-js/pull/29405)
+
 ### Other Changes
+
+- `DeviceCodeCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29405](https://github.com/Azure/azure-sdk-for-js/pull/29405)
 
 ## 4.2.0 (2024-04-30)
 

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_58e656fd32"
+  "Tag": "js/identity/identity_72abb85c88"
 }

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -18,8 +18,6 @@ import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";
 import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 import { DeveloperSignOnClientId } from "../constants";
-import { MsalDeviceCode } from "../msal/nodeFlows/msalDeviceCode";
-import { MsalFlow } from "../msal/flows";
 
 const logger = credentialLogger("DeviceCodeCredential");
 
@@ -38,7 +36,6 @@ export function defaultDeviceCodePromptCallback(deviceCodeInfo: DeviceCodeInfo):
 export class DeviceCodeCredential implements TokenCredential {
   private tenantId?: string;
   private additionallyAllowedTenantIds: string[];
-  private msalFlow: MsalFlow;
   private disableAutomaticAuthentication?: boolean;
   private msalClient: MsalClient;
   private userPromptCallback: DeviceCodePromptCallback;
@@ -75,12 +72,6 @@ export class DeviceCodeCredential implements TokenCredential {
       ...options,
       tokenCredentialOptions: options || {},
     });
-    this.msalFlow = new MsalDeviceCode({
-      ...options,
-      logger,
-      userPromptCallback: options?.userPromptCallback || defaultDeviceCodePromptCallback,
-      tokenCredentialOptions: options || {},
-    });
     this.disableAutomaticAuthentication = options?.disableAutomaticAuthentication;
   }
 
@@ -113,10 +104,6 @@ export class DeviceCodeCredential implements TokenCredential {
           ...newOptions,
           disableAutomaticAuthentication: this.disableAutomaticAuthentication,
         });
-        return this.msalFlow.getToken(arrayScopes, {
-          ...newOptions,
-          disableAutomaticAuthentication: this.disableAutomaticAuthentication,
-        });
       },
     );
   }
@@ -145,8 +132,6 @@ export class DeviceCodeCredential implements TokenCredential {
           disableAutomaticAuthentication: false, // this method should always allow user interaction
         });
         return this.msalClient.getActiveAccount();
-        // await this.msalFlow.getToken(arrayScopes, newOptions);
-        // return this.msalFlow.getActiveAccount();
       },
     );
   }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -479,7 +479,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     return withSilentAuthentication(msalApp, scopes, options, () => {
       const requestOptions: msal.DeviceCodeRequest = {
         scopes,
-        cancel: false,
+        cancel: options?.abortSignal?.aborted ?? false,
         deviceCodeCallback,
         authority: state.msalConfig.auth.authority,
         claims: options?.claims,

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -187,10 +187,15 @@ export function createMsalClient(
 
     let publicClientApp = publicApps.get(appKey);
     if (publicClientApp) {
+      msalLogger.getToken.info("Existing PublicClientApplication found in cache, returning it.");
       return publicClientApp;
     }
 
     // Initialize a new app and cache it
+    msalLogger.getToken.info(
+      `Creating new PublicClientApplication with CAE ${options.enableCae ? "enabled" : "disabled"}.`,
+    );
+
     const cachePlugin = options.enableCae
       ? state.pluginConfiguration.cache.cachePluginCae
       : state.pluginConfiguration.cache.cachePlugin;

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -343,8 +343,6 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     try {
       response = await getTokenSilent(msalApp, scopes, options);
     } catch (e: any) {
-      console.log("error from getTokenSilent");
-      console.error(e);
       if (e.name !== "AuthenticationRequiredError") {
         throw e;
       }
@@ -355,7 +353,6 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       try {
         response = await onAuthenticationRequired();
       } catch (err: any) {
-        console.error(err);
         throw handleMsalError(scopes, err, options);
       }
     }

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -393,5 +393,23 @@ describe("MsalClient", function () {
         );
       });
     });
+
+    it("supports cancellation", async function (this: Context) {
+      const client = msalClient.createMsalClient(clientId, tenantId);
+
+      const scopes = ["https://vault.azure.net/.default"];
+      // we expect the request to be aborted immediately without trying to reach the network
+      const abortSignal = AbortSignal.abort();
+      const request = client.getTokenByDeviceCode(
+        scopes,
+        () => {
+          // no-op
+        },
+        {
+          abortSignal,
+        },
+      );
+      await assert.isRejected(request, AbortError);
+    });
   });
 });

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -10,7 +10,7 @@ import {
   PublicClientApplication,
 } from "@azure/msal-node";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { Recorder, env } from "@azure-tools/test-recorder";
+import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
 
 import { AbortError } from "@azure/abort-controller";
 import { AuthenticationRequiredError } from "../../../src/errors";
@@ -20,6 +20,7 @@ import { credentialLogger } from "../../../src/util/logging";
 import { msalPlugins } from "../../../src/msal/nodeFlows/msalPlugins";
 import sinon from "sinon";
 import { DeveloperSignOnClientId } from "../../../src/constants";
+import { Context } from "mocha";
 
 describe("MsalClient", function () {
   describe("recorded tests", function () {
@@ -50,7 +51,11 @@ describe("MsalClient", function () {
       assert.isNotNaN(accessToken.expiresOnTimestamp);
     });
 
-    it("supports getTokenByDeviceCode", async function () {
+    it("supports getTokenByDeviceCode", async function (this: Context) {
+      if (isLiveMode()) {
+        // Skip in CI live tests since this credential requires user interaction.
+        this.skip();
+      }
       const scopes = ["https://vault.azure.net/.default"];
       const clientId = DeveloperSignOnClientId;
       const tenantId = env.IDENTITY_SP_TENANT_ID || env.AZURE_TENANT_ID!;

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -19,6 +19,7 @@ import { assert } from "@azure-tools/test-utils";
 import { credentialLogger } from "../../../src/util/logging";
 import { msalPlugins } from "../../../src/msal/nodeFlows/msalPlugins";
 import sinon from "sinon";
+import { DeveloperSignOnClientId } from "../../../src/constants";
 
 describe("MsalClient", function () {
   describe("recorded tests", function () {
@@ -45,6 +46,25 @@ describe("MsalClient", function () {
       });
 
       const accessToken = await client.getTokenByClientSecret(scopes, clientSecret);
+      assert.isNotEmpty(accessToken.token);
+      assert.isNotNaN(accessToken.expiresOnTimestamp);
+    });
+
+    it("supports getTokenByDeviceCode", async function () {
+      const scopes = ["https://vault.azure.net/.default"];
+      const clientId = DeveloperSignOnClientId;
+      const tenantId = env.IDENTITY_SP_TENANT_ID || env.AZURE_TENANT_ID!;
+
+      const clientOptions = recorder.configureClientOptions({});
+      const client = msalClient.createMsalClient(clientId, tenantId, {
+        tokenCredentialOptions: { additionalPolicies: clientOptions.additionalPolicies },
+      });
+
+      const accessToken = await client.getTokenByDeviceCode(scopes, (info) => {
+        console.log(
+          `To complete the test recording, please go to ${info.verificationUri} and use code ${info.userCode} to authenticate.`,
+        );
+      });
       assert.isNotEmpty(accessToken.token);
       assert.isNotNaN(accessToken.expiresOnTimestamp);
     });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29377 

### Describe the problem that is addressed by this PR

This PR makes the following changes to the Identity library:

1. Migrates DeviceCodeCredential to the MSALClient flow
2. Skips silent authentication for client credential based flows
3. Allows passing disableAutomaticAuthentication as an option param instead of during client construction

The reason this is important and exciting is because DeviceCodeCredential is the first PublicClientApplication based
flow that is being migrated to MSALClient!

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
