### PR TITLE
[identity] Migrate regional authority support to MSALClient

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -328,7 +328,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       msalApp.acquireTokenByClientCredential({
         scopes,
         authority: state.msalConfig.auth.authority,
-        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
+        azureRegion: calculateRegionalAuthority(),
         claims: options?.claims,
       }),
     );
@@ -349,7 +349,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       msalApp.acquireTokenByClientCredential({
         scopes,
         authority: state.msalConfig.auth.authority,
-        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
+        azureRegion: calculateRegionalAuthority(),
         claims: options?.claims,
         clientAssertion,
       }),
@@ -370,7 +370,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     return withSilentAuthentication(msalApp, scopes, options, () =>
       msalApp.acquireTokenByClientCredential({
         scopes,
-        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
+        azureRegion: calculateRegionalAuthority(),
         authority: state.msalConfig.auth.authority,
         claims: options?.claims,
       }),

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -20,6 +20,7 @@ import { AuthenticationRequiredError } from "../../errors";
 import { CertificateParts } from "../types";
 import { IdentityClient } from "../../client/identityClient";
 import { MsalNodeOptions } from "./msalNodeCommon";
+import { calculateRegionalAuthority } from "../../regionalAuthority";
 import { getLogLevel } from "@azure/logger";
 import { resolveTenantId } from "../../util/tenantIdUtils";
 
@@ -327,6 +328,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       msalApp.acquireTokenByClientCredential({
         scopes,
         authority: state.msalConfig.auth.authority,
+        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
         claims: options?.claims,
       }),
     );
@@ -347,6 +349,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
       msalApp.acquireTokenByClientCredential({
         scopes,
         authority: state.msalConfig.auth.authority,
+        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
         claims: options?.claims,
         clientAssertion,
       }),
@@ -367,6 +370,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     return withSilentAuthentication(msalApp, scopes, options, () =>
       msalApp.acquireTokenByClientCredential({
         scopes,
+        azureRegion: calculateRegionalAuthority(), // only supported for certain credentials and only via env vars
         authority: state.msalConfig.auth.authority,
         claims: options?.claims,
       }),

--- a/sdk/identity/identity/src/regionalAuthority.ts
+++ b/sdk/identity/identity/src/regionalAuthority.ts
@@ -123,6 +123,11 @@ export enum RegionalAuthority {
  * @internal
  */
 export function calculateRegionalAuthority(regionalAuthority?: string): string | undefined {
+  // Note: as of today only 3 credentials support regional authority, and the parameter
+  // is not exposed via the public API. Regional Authority is _only_ supported
+  // via the AZURE_REGIONAL_AUTHORITY_NAME env var and _only_ for: ClientSecretCredential, ClientCertificateCredential, and ClientAssertionCredential.
+
+  // Accepting the regionalAuthority parameter will allow us to support it in the future.
   let azureRegion = regionalAuthority;
 
   if (


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29066

### Describe the problem that is addressed by this PR

ClientSecretCredential, ClientCertificateCredential, and ClientAssertionCredential are the only three
that support the AZURE_REGIONAL_AUTHORITY_NAME  today via the msalNodeCommon flow. 

Just for feature parity I am adding this to the same 3 credentials that
supported it before, and no other ones. I'll create an issue to investigate
whether we can remove the support entirely.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

_not_ port it over, and see if anyone cares. If they do it's easy to fix and
they would only be 1p teams

