### PR TITLE
[notification-hubs] Fix FCMV1 bugs for notification creation and list registrations

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release History
 
-## 1.2.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.1 (2024-04-25)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed FirebaseV1 Notification to use the correct `data` and create the wrapper `message`.
+  - [#29404](https://github.com/Azure/azure-sdk-for-js/issues/29404)
+  - [#29371](https://github.com/Azure/azure-sdk-for-js/issues/29371)
+- Fixed Firebase query for `listRegistrationsByChannel` to use the correct `channel` query parameter.
+  - [#29372](https://github.com/Azure/azure-sdk-for-js/issues/29372)
 
 ## 1.2.0 (2024-03-28)
 

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
@@ -560,7 +560,7 @@ export interface FirebaseLegacyWebNativePayload {
 // @public
 export interface FirebaseV1AndroidConfig {
     collapse_key?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     direct_boot_ok?: boolean;
     fcm_options?: FirebaseV1AndroidFcmOptions;
     notification?: FirebaseV1AndroidNotification;
@@ -635,7 +635,7 @@ export interface FirebaseV1NativeMessage {
     android?: FirebaseV1AndroidConfig;
     apns?: FirebaseV1ApnsConfig;
     condition?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     fcm_options?: FirebaseV1FcmOptions;
     notification?: FirebaseV1NativeNotification;
     token?: string;
@@ -684,7 +684,7 @@ export interface FirebaseV1WebPushNotification {
     }[];
     badge?: string;
     body?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     dir?: "auto" | "ltr" | "rtl";
     icon?: string;
     image?: string;

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
@@ -381,7 +381,7 @@ export function createFcmV1RegistrationDescription(description: FcmV1Registratio
 export function createFcmV1TemplateRegistrationDescription(description: FcmV1TemplateRegistrationDescriptionCommon): FcmV1TemplateRegistrationDescription;
 
 // @public
-export function createFirebaseLegacyNotificationBody(nativeMessage: FirebaseLegacyNativeMessage): string;
+export function createFirebaseLegacyNotificationBody(nativeMessage: FirebaseV1NativeMessageEnvelope): string;
 
 // @public
 export function createFirebaseV1NotificationBody(nativeMessage: FirebaseV1NativeMessage): string;
@@ -641,6 +641,11 @@ export interface FirebaseV1NativeMessage {
     token?: string;
     topic?: string;
     webpush?: FirebaseV1WebPushConfig;
+}
+
+// @public
+export interface FirebaseV1NativeMessageEnvelope {
+    message: FirebaseV1NativeMessage;
 }
 
 // @public

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -561,7 +561,7 @@ export interface FirebaseLegacyWebNativePayload {
 // @public
 export interface FirebaseV1AndroidConfig {
     collapse_key?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     direct_boot_ok?: boolean;
     fcm_options?: FirebaseV1AndroidFcmOptions;
     notification?: FirebaseV1AndroidNotification;
@@ -636,7 +636,7 @@ export interface FirebaseV1NativeMessage {
     android?: FirebaseV1AndroidConfig;
     apns?: FirebaseV1ApnsConfig;
     condition?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     fcm_options?: FirebaseV1FcmOptions;
     notification?: FirebaseV1NativeNotification;
     token?: string;
@@ -685,7 +685,7 @@ export interface FirebaseV1WebPushNotification {
     }[];
     badge?: string;
     body?: string;
-    data?: Record<string, any>;
+    data?: Record<string, string>;
     dir?: "auto" | "ltr" | "rtl";
     icon?: string;
     image?: string;

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -382,7 +382,7 @@ export function createFcmV1RegistrationDescription(description: FcmV1Registratio
 export function createFcmV1TemplateRegistrationDescription(description: FcmV1TemplateRegistrationDescriptionCommon): FcmV1TemplateRegistrationDescription;
 
 // @public
-export function createFirebaseLegacyNotificationBody(nativeMessage: FirebaseLegacyNativeMessage): string;
+export function createFirebaseLegacyNotificationBody(nativeMessage: FirebaseV1NativeMessageEnvelope): string;
 
 // @public
 export function createFirebaseV1NotificationBody(nativeMessage: FirebaseV1NativeMessage): string;
@@ -642,6 +642,11 @@ export interface FirebaseV1NativeMessage {
     token?: string;
     topic?: string;
     webpush?: FirebaseV1WebPushConfig;
+}
+
+// @public
+export interface FirebaseV1NativeMessageEnvelope {
+    message: FirebaseV1NativeMessage;
 }
 
 // @public

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmV1.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmV1.ts
@@ -44,14 +44,16 @@ async function main(): Promise<void> {
   const context = createClientContext(connectionString, hubName);
 
   const messageBody = `{
-	"notification":{
-		"title":"Notification Hub Test Notification",
-		"body":"This is a sample notification delivered by Azure Notification Hubs."
-	},
-	"data":{
-		"property1":"value1",
-		"property2":42
-	}
+    "message": {
+      "notification":{
+        "title":"Notification Hub Test Notification",
+        "body":"This is a sample notification delivered by Azure Notification Hubs."
+      },
+      "data":{
+        "property1":"value1",
+        "property2":42
+      }
+    }
 }`;
 
   const notification = createFcmV1Notification({

--- a/sdk/notificationhubs/notification-hubs/src/api/listRegistrationsByChannel.ts
+++ b/sdk/notificationhubs/notification-hubs/src/api/listRegistrationsByChannel.ts
@@ -5,8 +5,8 @@ import { RegistrationDescription, RegistrationChannel } from "../models/registra
 import { listRegistrationPagingPage, listRegistrationsAll } from "./internal/_listRegistrations.js";
 import { NotificationHubsClientContext } from "./index.js";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
-import { RestError } from "@azure/core-rest-pipeline";
 import { RegistrationQueryLimitOptions } from "../models/options.js";
+import { getFilterByChannel } from "../utils/registrationUtils.js";
 import { tracingClient } from "../utils/tracing.js";
 
 /**
@@ -47,28 +47,5 @@ export function listRegistrationsByChannel(
     throw e;
   } finally {
     span.end();
-  }
-}
-
-function getFilterByChannel(device: RegistrationChannel): string {
-  switch (device.kind) {
-    case "adm":
-      return `AdmRegistrationId eq '${device.admRegistrationId}'`;
-    case "apple":
-      return `DeviceToken eq '${device.deviceToken.toLocaleUpperCase()}'`;
-    case "baidu":
-      return `BaiduChannelId eq ${device.baiduChannelId}' and BaiduUserId eq '${device.baiduUserId}'`;
-    case "browser":
-      return `Endpoint eq '${encodeURIComponent(device.endpoint)}' and P256DH eq '${
-        device.p256dh
-      }' and Auth eq '${device.auth}'`;
-    case "gcm":
-      return `GcmRegistrationId eq '${device.gcmRegistrationId}'`;
-    case "windows":
-      return `ChannelUri eq '${encodeURIComponent(device.channelUri)}'`;
-    default:
-      throw new RestError(`Device type is unsupported`, {
-        statusCode: 400,
-      });
   }
 }

--- a/sdk/notificationhubs/notification-hubs/src/models/notificationBodyBuilder.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notificationBodyBuilder.ts
@@ -427,9 +427,19 @@ export interface FirebaseLegacyWebNativePayload {
  * @returns The JSON body to send to Notification Hubs.
  */
 export function createFirebaseLegacyNotificationBody(
-  nativeMessage: FirebaseLegacyNativeMessage,
+  nativeMessage: FirebaseV1NativeMessageEnvelope,
 ): string {
   return JSON.stringify(nativeMessage);
+}
+
+/**
+ * Represents the Firebase V1 native message envelope.
+ */
+export interface FirebaseV1NativeMessageEnvelope {
+  /**
+   * The Firebase V1 native message.
+   */
+  message: FirebaseV1NativeMessage;
 }
 
 /**
@@ -439,7 +449,7 @@ export interface FirebaseV1NativeMessage {
   /**
    * Custom key-value pairs of the message's payload.
    */
-  data?: Record<string, any>;
+  data?: Record<string, string>;
 
   /**
    * The predefined, user-visible key-value pairs of the notification payload.
@@ -529,7 +539,7 @@ export interface FirebaseV1AndroidConfig {
   /**
    * Custom key-value pairs of the message's payload.
    */
-  data?: Record<string, any>;
+  data?: Record<string, string>;
 
   /**
    * Notification to send to android devices.
@@ -754,7 +764,7 @@ export interface FirebaseV1WebPushNotification {
   /**
    * The notification's data.
    */
-  data?: Record<string, any>;
+  data?: Record<string, string>;
 
   /**
    * The direction in which to display the notification.

--- a/sdk/notificationhubs/notification-hubs/src/utils/registrationUtils.ts
+++ b/sdk/notificationhubs/notification-hubs/src/utils/registrationUtils.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RestError } from "@azure/core-rest-pipeline";
+import { RegistrationChannel } from "../models/registration.js";
+
+export function getFilterByChannel(device: RegistrationChannel): string {
+  switch (device.kind) {
+    case "adm":
+      return `AdmRegistrationId eq '${device.admRegistrationId}'`;
+    case "apple":
+      return `DeviceToken eq '${device.deviceToken.toLocaleUpperCase()}'`;
+    case "baidu":
+      return `BaiduChannelId eq ${device.baiduChannelId}' and BaiduUserId eq '${device.baiduUserId}'`;
+    case "browser":
+      return `Endpoint eq '${encodeURIComponent(device.endpoint)}' and P256DH eq '${
+        device.p256dh
+      }' and Auth eq '${device.auth}'`;
+    case "gcm":
+      return `GcmRegistrationId eq '${device.gcmRegistrationId}'`;
+    case "fcmv1":
+      return `FcmV1RegistrationId eq '${device.fcmV1RegistrationId}'`;
+    case "windows":
+      return `ChannelUri eq '${encodeURIComponent(device.channelUri)}'`;
+    default:
+      throw new RestError(`Device type is unsupported`, {
+        statusCode: 400,
+      });
+  }
+}

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationUtils.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationUtils.spec.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, it, assert } from "vitest";
+import type {
+  AdmRegistrationChannel,
+  AppleRegistrationChannel,
+  BaiduRegistrationChannel,
+  BrowserRegistrationChannel,
+  FirebaseLegacyRegistrationChannel,
+  FirebaseV1RegistrationChannel,
+  WindowsRegistrationChannel,
+} from "../../../src/models/registration.js";
+import { getFilterByChannel } from "../../../src/utils/registrationUtils.js";
+
+describe("registrationUtils", () => {
+  describe("getFilterByChannel", () => {
+    it("should return a filter string for ADM", () => {
+      const channel: AdmRegistrationChannel = {
+        kind: "adm",
+        admRegistrationId: "admRegistrationId",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "AdmRegistrationId eq 'admRegistrationId'");
+    });
+
+    it("should return a filter string for Apple", () => {
+      const channel: AppleRegistrationChannel = {
+        kind: "apple",
+        deviceToken: "deviceToken",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "DeviceToken eq 'DEVICETOKEN'");
+    });
+
+    it("should return a filter string for Baidu", () => {
+      const channel: BaiduRegistrationChannel = {
+        kind: "baidu",
+        baiduChannelId: "baiduChannelId",
+        baiduUserId: "baiduUserId",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "BaiduChannelId eq baiduChannelId' and BaiduUserId eq 'baiduUserId'");
+    });
+
+    it("should return a filter string for Browser", () => {
+      const channel: BrowserRegistrationChannel = {
+        kind: "browser",
+        endpoint: "endpoint",
+        p256dh: "p256dh",
+        auth: "auth",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "Endpoint eq 'endpoint' and P256DH eq 'p256dh' and Auth eq 'auth'");
+    });
+
+    it("should return a filter string for Firebase Legacy", () => {
+      const channel: FirebaseLegacyRegistrationChannel = {
+        kind: "gcm",
+        gcmRegistrationId: "gcmRegistrationId",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "GcmRegistrationId eq 'gcmRegistrationId'");
+    });
+
+    it("should return a filter string for Firebase V1", () => {
+      const channel: FirebaseV1RegistrationChannel = {
+        kind: "fcmv1",
+        fcmV1RegistrationId: "fcmV1RegistrationId",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "FcmV1RegistrationId eq 'fcmV1RegistrationId'");
+    });
+
+    it("should return a filter string for Windows", () => {
+      const channel: WindowsRegistrationChannel = {
+        kind: "windows",
+        channelUri: "channelUri",
+      };
+
+      const result = getFilterByChannel(channel);
+
+      assert.equal(result, "ChannelUri eq 'channelUri'");
+    });
+
+    it("should throw an error for an unsupported device type", () => {
+      const channel = {
+        kind: "unsupported",
+      };
+
+      assert.throws(() => getFilterByChannel(channel as any), "Device type is unsupported");
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR

- #29404
- #29371
- #29372

### Describe the problem that is addressed by this PR

- Fixes the issue with creating a wrapper around the entire FCM V1 notification body to include `message`.
- Changes the data types of the `data` properties from `Record<string, any>` to `Record<string, string>`.
- Fixes the `listRegistrationsByChannel` to include `fcmv1` as a parameter to query for devices.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Added unit tests for the helper for `listRegistrationsByChannel` to validate the query string returned.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
