### PR TITLE
[Identity] Testing service connections on pipeline

### DIFF
--- a/sdk/identity/identity/samples/AzureIdentityExamples.md
+++ b/sdk/identity/identity/samples/AzureIdentityExamples.md
@@ -119,11 +119,12 @@ To learn more, read [Application and service principal objects in Microsoft Entr
 
 If your application is hosted in Azure, you can make use of [Managed Identity](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview) for hassle free authentication in your production environments.
 
-| Credential with example                                                       | Usage                                                                                                                                                                                                                                                                                                                                                                        |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [WorkloadIdentityCredential](#authenticating-in-azure-with-workload-identity) | Authenticate in Azure Kubernetes environment with [Microsoft Entra Workload ID](https://learn.microsoft.com/entra/workload-id/workload-identities-overview), which [integrates with the Kubernetes native capabilities](https://learn.microsoft.com/azure/aks/workload-identity-overview) to federate with any external identity providers.                                  |
-| [ManagedIdentityCredential](#authenticating-in-azure-with-managed-identity)   | Authenticate in a virtual machine, App Service, Functions app, Cloud Shell, or AKS environment on Azure, with system-assigned managed identity, user-assigned managed identity, or app registration (when working with AKS pod identity).                                                                                                                                    |
-| [DefaultAzureCredential](#authenticating-with-defaultazurecredential)         | Tries `EnvironmentCredential`, `ManagedIdentityCredential`, `AzureCliCredential`, `AzurePowerShellCredential`, and other credentials sequentially until one of them succeeds. Use this to have your application authenticate using developer tools, service principals or managed identity based on what is available in the current environment without changing your code. |
+| Credential with example                                                                                   | Usage                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [WorkloadIdentityCredential](#authenticating-in-azure-with-workload-identity)                             | Authenticate in Azure Kubernetes environment with [Microsoft Entra Workload ID](https://learn.microsoft.com/entra/workload-id/workload-identities-overview), which [integrates with the Kubernetes native capabilities](https://learn.microsoft.com/azure/aks/workload-identity-overview) to federate with any external identity providers.                                                                                                                  |
+| [AzurePipelinesServiceConnectionsCredential](#authenticating-in-azure-pipelines-with-service-connections) | Authenticate in Azure Devops environment with [Microsoft Entra Workload ID](https://learn.microsoft.com/entra/workload-id/workload-identities-overview), which [uses Azure Resource Manager service connections](https://learn.microsoft.com/azure/devops/pipelines/library/connect-to-azure?view=azure-devops#create-an-azure-resource-manager-service-connection-that-uses-workload-identity-federation) to federate with any external identity providers. |
+| [ManagedIdentityCredential](#authenticating-in-azure-with-managed-identity)                               | Authenticate in a virtual machine, App Service, Functions app, Cloud Shell, or AKS environment on Azure, with system-assigned managed identity, user-assigned managed identity, or app registration (when working with AKS pod identity).                                                                                                                                                                                                                    |
+| [DefaultAzureCredential](#authenticating-with-defaultazurecredential)                                     | Tries `EnvironmentCredential`, `ManagedIdentityCredential`, `AzureCliCredential`, `AzurePowerShellCredential`, and other credentials sequentially until one of them succeeds. Use this to have your application authenticate using developer tools, service principals or managed identity based on what is available in the current environment without changing your code.                                                                                 |
 
 ### Examples
 
@@ -617,19 +618,20 @@ function withUserManagedIdentityCredential() {
 
 This example demonstrates authenticating the `SecretClient` from the [@azure/keyvault-secrets][secrets_client_library] using the `AzurePipelinesServiceConnectionCredential` in an Azure Pipelines environment with service connections.
 
-````ts
+```ts
 /**
  * Authenticate with AzurePipelinesServiceConnection identity.
  */
 function withAzurePipelinesServiceConnectionCredential() {
-  const clientId = "<YOUR_CLIENT_ID>"
-  const tenantId = "<YOUR_TENANT_ID>"
-  const serviceConnectionId = "<YOUR_SERVICE_CONNECTION_ID>"
+  const clientId = "<YOUR_CLIENT_ID>";
+  const tenantId = "<YOUR_TENANT_ID>";
+  const serviceConnectionId = "<YOUR_SERVICE_CONNECTION_ID>";
   const credential = new AzurePipelinesServiceConnection(tenantId, clientId, serviceConnectionId);
 
   const client = new SecretClient("https://key-vault-name.vault.azure.net", credential);
 }
 ```
+
 This credential is NOT part of `DefaultAzureCredential`.
 
 ## Chaining credentials
@@ -644,7 +646,7 @@ function withChainedTokenCredential() {
   );
   const client = new SecretClient("https://key-vault-name.vault.azure.net", credential);
 }
-````
+```
 
 ## Authenticating With Azure Stack using Azure Identity
 

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -35,17 +35,17 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     tenantId: string,
     clientId: string,
     serviceConnectionId: string,
-    options?: AzurePipelinesServiceConnectionCredentialOptions
+    options?: AzurePipelinesServiceConnectionCredentialOptions,
   ) {
     if (!clientId || !tenantId || !serviceConnectionId) {
       throw new CredentialUnavailableError(
-        `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters.`
+        `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters.`,
       );
     }
 
     checkTenantId(logger, tenantId);
     logger.info(
-      `Invoking AzurePipelinesServiceConnectionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`
+      `Invoking AzurePipelinesServiceConnectionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`,
     );
 
     if (clientId && tenantId && serviceConnectionId) {
@@ -53,13 +53,13 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
       const oidcRequestUrl = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${process.env.SYSTEM_PLANID}/jobs/${process.env.SYSTEM_JOBID}/oidctoken?api-version=${OIDC_API_VERSION}&serviceConnectionId=${serviceConnectionId}`;
       const systemAccessToken = `${process.env.SYSTEM_ACCESSTOKEN}`;
       logger.info(
-        `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`
+        `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`,
       );
       this.clientAssertionCredential = new ClientAssertionCredential(
         tenantId,
         clientId,
         this.requestOidcToken.bind(this, oidcRequestUrl, systemAccessToken),
-        options
+        options,
       );
     }
   }
@@ -74,7 +74,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
    */
   public async getToken(
     scopes: string | string[],
-    options?: GetTokenOptions
+    options?: GetTokenOptions,
   ): Promise<AccessToken> {
     if (!this.clientAssertionCredential) {
       const errorMessage = `${credentialName}: is unavailable. To use Federation Identity in Azure Pipelines, these are required as input parameters / env variables - 
@@ -102,7 +102,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
    */
   private async requestOidcToken(
     oidcRequestUrl: string,
-    systemAccessToken: string
+    systemAccessToken: string,
   ): Promise<string> {
     logger.info("Requesting OIDC token from Azure Pipelines...");
     logger.info(oidcRequestUrl);
@@ -124,12 +124,12 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
       logger.error(
         `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${
           response.status
-        }. Complete response - ${JSON.stringify(response)}`
+        }. Complete response - ${JSON.stringify(response)}`,
       );
       throw new CredentialUnavailableError(
         `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${
           response.status
-        }. Complete response - ${JSON.stringify(response)}`
+        }. Complete response - ${JSON.stringify(response)}`,
       );
     }
     const result = JSON.parse(text);
@@ -138,13 +138,13 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     } else {
       logger.error(
         `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${JSON.stringify(
-          result
-        )}`
+          result,
+        )}`,
       );
       throw new CredentialUnavailableError(
         `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${JSON.stringify(
-          result
-        )}`
+          result,
+        )}`,
       );
     }
   }
@@ -180,8 +180,8 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     if (missingEnvVars.length > 0) {
       throw new CredentialUnavailableError(
         `${credentialName}: is unavailable. Ensure that you're running this task in an Azure Pipeline, so that following missing system variable(s) can be defined- ${missingEnvVars.join(
-          ", "
-        )}.${errorMessage}`
+          ", ",
+        )}.${errorMessage}`,
       );
     }
   }

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -15,6 +15,7 @@ import { AzurePipelinesServiceConnectionCredentialOptions } from "./azurePipelin
 
 const credentialName = "AzurePipelinesServiceConnectionCredential";
 const logger = credentialLogger(credentialName);
+const OIDC_API_VERSION = "7.1";
 
 /**
  * This credential is designed to be used in ADO Pipelines with service connections
@@ -22,7 +23,6 @@ const logger = credentialLogger(credentialName);
  */
 export class AzurePipelinesServiceConnectionCredential implements TokenCredential {
   private clientAssertionCredential: ClientAssertionCredential | undefined;
-  private serviceConnectionId: string | undefined;
 
   /**
    * AzurePipelinesServiceConnectionCredential supports Federated Identity on Azure Pipelines through Service Connections.
@@ -50,7 +50,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
 
     if (clientId && tenantId && serviceConnectionId) {
       this.ensurePipelinesSystemVars();
-      const oidcRequestUrl = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${process.env.SYSTEM_PLANID}/jobs/${process.env.SYSTEM_JOBID}/oidctoken?api-version=7.1&serviceConnectionId=${this.serviceConnectionId}`;
+      const oidcRequestUrl = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${process.env.SYSTEM_PLANID}/jobs/${process.env.SYSTEM_JOBID}/oidctoken?api-version=${OIDC_API_VERSION}&serviceConnectionId=${serviceConnectionId}`;
       const systemAccessToken = `${process.env.SYSTEM_ACCESSTOKEN}`;
       logger.info(
         `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`
@@ -77,8 +77,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     options?: GetTokenOptions
   ): Promise<AccessToken> {
     if (!this.clientAssertionCredential) {
-      const errorMessage = `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters. 
-      To use Federation Identity in Azure Pipelines, these are required as inputs / env variables - 
+      const errorMessage = `${credentialName}: is unavailable. To use Federation Identity in Azure Pipelines, these are required as input parameters / env variables - 
       tenantId,
       clientId,
       serviceConnectionId,

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -122,10 +122,14 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     const text = response.bodyAsText;
     if (!text) {
       logger.error(
-        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${response.status}`
+        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${
+          response.status
+        }. Complete response - ${JSON.stringify(response)}`
       );
       throw new CredentialUnavailableError(
-        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${response.status}`
+        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${
+          response.status
+        }. Complete response - ${JSON.stringify(response)}`
       );
     }
     const result = JSON.parse(text);

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -15,7 +15,7 @@ import { AzurePipelinesServiceConnectionCredentialOptions } from "./azurePipelin
 
 const credentialName = "AzurePipelinesServiceConnectionCredential";
 const logger = credentialLogger(credentialName);
-const OIDC_API_VERSION = "7.1";
+const OIDC_API_VERSION = "7.1-preview.1";
 
 /**
  * This credential is designed to be used in ADO Pipelines with service connections

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -15,7 +15,7 @@ import { AzurePipelinesServiceConnectionCredentialOptions } from "./azurePipelin
 
 const credentialName = "AzurePipelinesServiceConnectionCredential";
 const logger = credentialLogger(credentialName);
-const OIDC_API_VERSION = "7.1-preview.1";
+const OIDC_API_VERSION = "7.1";
 
 /**
  * This credential is designed to be used in ADO Pipelines with service connections
@@ -121,17 +121,23 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     const response = await httpClient.sendRequest(request);
     const text = response.bodyAsText;
     if (!text) {
-      throw new AuthenticationError(
-        response.status,
-        `${credentialName}: Authenticated Failed. Received null token from OIDC request.`
+      logger.error(
+        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${response.status}`
+      );
+      throw new CredentialUnavailableError(
+        `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${response.status}`
       );
     }
     const result = JSON.parse(text);
     if (result?.oidcToken) {
       return result.oidcToken;
     } else {
-      throw new AuthenticationError(
-        response.status,
+      logger.error(
+        `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${JSON.stringify(
+          result
+        )}`
+      );
+      throw new CredentialUnavailableError(
         `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${JSON.stringify(
           result
         )}`

--- a/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesServiceConnectionCredential.ts
@@ -14,7 +14,6 @@ import {
 import { AzurePipelinesServiceConnectionCredentialOptions } from "./azurePipelinesServiceConnectionCredentialOptions";
 
 const credentialName = "AzurePipelinesServiceConnectionCredential";
-const OIDC_API_VERSION = "7.1";
 const logger = credentialLogger(credentialName);
 
 /**
@@ -36,31 +35,31 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     tenantId: string,
     clientId: string,
     serviceConnectionId: string,
-    options?: AzurePipelinesServiceConnectionCredentialOptions,
+    options?: AzurePipelinesServiceConnectionCredentialOptions
   ) {
     if (!clientId || !tenantId || !serviceConnectionId) {
       throw new CredentialUnavailableError(
-        `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters.`,
+        `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters.`
       );
     }
 
     checkTenantId(logger, tenantId);
     logger.info(
-      `Invoking AzurePipelinesServiceConnectionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`,
+      `Invoking AzurePipelinesServiceConnectionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`
     );
 
     if (clientId && tenantId && serviceConnectionId) {
       this.ensurePipelinesSystemVars();
-      const oidcRequestUrl = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${process.env.SYSTEM_PLANID}/jobs/${process.env.SYSTEM_JOBID}/oidctoken?api-version=${OIDC_API_VERSION}&serviceConnectionId=${this.serviceConnectionId}`;
+      const oidcRequestUrl = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${process.env.SYSTEM_PLANID}/jobs/${process.env.SYSTEM_JOBID}/oidctoken?api-version=7.1&serviceConnectionId=${this.serviceConnectionId}`;
       const systemAccessToken = `${process.env.SYSTEM_ACCESSTOKEN}`;
       logger.info(
-        `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`,
+        `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, clientId: ${clientId} and service connection id: ${serviceConnectionId}`
       );
       this.clientAssertionCredential = new ClientAssertionCredential(
         tenantId,
         clientId,
         this.requestOidcToken.bind(this, oidcRequestUrl, systemAccessToken),
-        options,
+        options
       );
     }
   }
@@ -75,7 +74,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
    */
   public async getToken(
     scopes: string | string[],
-    options?: GetTokenOptions,
+    options?: GetTokenOptions
   ): Promise<AccessToken> {
     if (!this.clientAssertionCredential) {
       const errorMessage = `${credentialName}: is unavailable. tenantId, clientId, and serviceConnectionId are required parameters. 
@@ -104,7 +103,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
    */
   private async requestOidcToken(
     oidcRequestUrl: string,
-    systemAccessToken: string,
+    systemAccessToken: string
   ): Promise<string> {
     logger.info("Requesting OIDC token from Azure Pipelines...");
     logger.info(oidcRequestUrl);
@@ -125,7 +124,7 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     if (!text) {
       throw new AuthenticationError(
         response.status,
-        `${credentialName}: Authenticated Failed. Received null token from OIDC request.`,
+        `${credentialName}: Authenticated Failed. Received null token from OIDC request.`
       );
     }
     const result = JSON.parse(text);
@@ -135,8 +134,8 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
       throw new AuthenticationError(
         response.status,
         `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${JSON.stringify(
-          result,
-        )}`,
+          result
+        )}`
       );
     }
   }
@@ -172,8 +171,8 @@ export class AzurePipelinesServiceConnectionCredential implements TokenCredentia
     if (missingEnvVars.length > 0) {
       throw new CredentialUnavailableError(
         `${credentialName}: is unavailable. Ensure that you're running this task in an Azure Pipeline, so that following missing system variable(s) can be defined- ${missingEnvVars.join(
-          ", ",
-        )}.${errorMessage}`,
+          ", "
+        )}.${errorMessage}`
       );
     }
   }

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -5,7 +5,6 @@ import { AzurePipelinesServiceConnectionCredential } from "../../../src";
 import { isLiveMode } from "@azure-tools/test-recorder";
 import { assert } from "@azure-tools/test-utils";
 import { setLogLevel } from "@azure/logger";
-setLogLevel("verbose");
 describe("AzurePipelinesServiceConnectionCredential", function () {
   const scope = "https://vault.azure.net/.default";
   const tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -4,13 +4,14 @@
 import { AzurePipelinesServiceConnectionCredential } from "../../../src";
 import { isLiveMode } from "@azure-tools/test-recorder";
 import { assert } from "@azure-tools/test-utils";
-
+import { setLogLevel } from "@azure/logger";
+setLogLevel("verbose");
 describe("AzurePipelinesServiceConnectionCredential", function () {
   const scope = "https://vault.azure.net/.default";
   const tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
   // const clientId = env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!;
 
-  it("authenticates with a valid service connection", async function () {
+  it.only("authenticates with a valid service connection", async function () {
     if (!isLiveMode()) {
       this.skip();
     }

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -7,7 +7,7 @@ import { assert } from "@azure-tools/test-utils";
 
 describe("AzurePipelinesServiceConnectionCredential", function () {
   const scope = "https://vault.azure.net/.default";
-  const tenantId = env.IDENTITY_SP_TENANT_ID || env.AZURE_TENANT_ID!;
+  const tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
   // const clientId = env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!;
 
   it("authenticates with a valid service connection", async function () {
@@ -21,7 +21,7 @@ describe("AzurePipelinesServiceConnectionCredential", function () {
     const credential = new AzurePipelinesServiceConnectionCredential(
       tenantId,
       clientId,
-      existingServiceConnectionId,
+      existingServiceConnectionId
     );
     try {
       const token = await credential.getToken(scope);

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -22,7 +22,7 @@ describe("AzurePipelinesServiceConnectionCredential", function () {
     const credential = new AzurePipelinesServiceConnectionCredential(
       tenantId,
       clientId,
-      existingServiceConnectionId
+      existingServiceConnectionId,
     );
     try {
       const token = await credential.getToken(scope);

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -4,7 +4,6 @@
 import { AzurePipelinesServiceConnectionCredential } from "../../../src";
 import { isLiveMode } from "@azure-tools/test-recorder";
 import { assert } from "@azure-tools/test-utils";
-import { setLogLevel } from "@azure/logger";
 describe("AzurePipelinesServiceConnectionCredential", function () {
   const scope = "https://vault.azure.net/.default";
   const tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
@@ -21,7 +20,7 @@ describe("AzurePipelinesServiceConnectionCredential", function () {
     const credential = new AzurePipelinesServiceConnectionCredential(
       tenantId,
       clientId,
-      existingServiceConnectionId,
+      existingServiceConnectionId
     );
     try {
       const token = await credential.getToken(scope);

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AzurePipelinesServiceConnectionCredential } from "../../../src";
-import { env, isLiveMode } from "@azure-tools/test-recorder";
+import { isLiveMode } from "@azure-tools/test-recorder";
 import { assert } from "@azure-tools/test-utils";
 
 describe("AzurePipelinesServiceConnectionCredential", function () {

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -20,7 +20,7 @@ describe("AzurePipelinesServiceConnectionCredential", function () {
     const credential = new AzurePipelinesServiceConnectionCredential(
       tenantId,
       clientId,
-      existingServiceConnectionId
+      existingServiceConnectionId,
     );
     try {
       const token = await credential.getToken(scope);

--- a/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesServiceConnection.spec.ts
@@ -11,7 +11,7 @@ describe("AzurePipelinesServiceConnectionCredential", function () {
   const tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
   // const clientId = env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!;
 
-  it.only("authenticates with a valid service connection", async function () {
+  it("authenticates with a valid service connection", async function () {
     if (!isLiveMode()) {
       this.skip();
     }


### PR DESCRIPTION
- Testing whether OIDC API 7.1 is available or not. Unfortunately, it's not available. So we only ship a preview with 7.1-preview.1
Response = {"$id":"1","innerException":null,"message":"The requested version \"7.1\" of the resource is under preview. The -preview flag must be supplied in the api-version for such requests. For example: \"7.1-preview\"","typeName":"Microsoft.VisualStudio.Services.WebApi.VssInvalidPreviewVersionException, Microsoft.VisualStudio.Services.WebApi","typeKey":"VssInvalidPreviewVersionException","errorCode":0,"eventId":3000}