### PR TITLE
[EngSys] shorten `-no-test-proxy=true` test option

### DIFF
--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -287,7 +287,8 @@ export async function isProxyToolActive(): Promise<boolean> {
     }
 
     log.info(
-      `Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000
+      `Proxy tool seems to be active at http://localhost:${
+        process.env.TEST_PROXY_HTTP_PORT ?? 5000
       }\n`,
     );
     return true;
@@ -298,7 +299,7 @@ export async function isProxyToolActive(): Promise<boolean> {
 
 async function getTargetVersion() {
   // Grab the tag from the `/eng/common/testproxy/target_version.txt` file [..is used to control the default version]
-  // 
+  //
   // In times of longer lived version override, the file eng/target_proxy_version.txt can be used to override this version
   // in both CI and local development.
   // Example content:
@@ -311,12 +312,8 @@ async function getTargetVersion() {
     const overrideExists = await fs.exists(overrideFile);
 
     if (overrideExists) {
-      contentInVersionFile = await fs.readFile(
-        overrideFile,
-        "utf-8",
-      );
-    }
-    else {
+      contentInVersionFile = await fs.readFile(overrideFile, "utf-8");
+    } else {
       contentInVersionFile = await fs.readFile(
         `${path.join(await resolveRoot(), "eng/common/testproxy/target_version.txt")}`,
         "utf-8",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -49,7 +49,7 @@
     "extract-api": "tsc -p . && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore --ignore-path ./.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skip",
-    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion] --ignore-pattern src/templates",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ignore-pattern src/templates",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -32,7 +32,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -50,7 +50,7 @@
     "test:node": "npm run clean && tsc -p . && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && tsc -p . && npm run unit-test:node && npm run bundle && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "cross-env TS_NODE_FILES=true dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "engines": {

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -52,7 +52,7 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate-certs": "node ./scripts/generateCerts.js",
     "integration-test:browser": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true karma start --single-run",
-    "integration-test:node": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true dev-tool run test:node-js-input --no-test-proxy=true -- --timeout 600000 \"dist-esm/test/internal/*.spec.js\" \"dist-esm/test/public/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\" \"dist-esm/test/internal/**/*.spec.js\"",
+    "integration-test:node": "cross-env TEST_TARGET=live DISABLE_MULTI_VERSION_TESTING=true dev-tool run test:node-js-input --no-test-proxy -- --timeout 600000 \"dist-esm/test/internal/*.spec.js\" \"dist-esm/test/public/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\" \"dist-esm/test/internal/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js",
@@ -62,7 +62,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "cross-env NODE_EXTRA_CA_CERTS=\"./certs/my-private-root-ca.crt.pem\" TEST_TARGET=mock DISABLE_MULTI_VERSION_TESTING=true dev-tool run test:node-ts-input --no-test-proxy=true -- --timeout 1200000 \"test/internal/*.spec.ts\" \"test/public/*.spec.ts\" \"test/public/**/*.spec.ts\" \"test/internal/**/*.spec.ts\"",
+    "unit-test:node": "cross-env NODE_EXTRA_CA_CERTS=\"./certs/my-private-root-ca.crt.pem\" TEST_TARGET=mock DISABLE_MULTI_VERSION_TESTING=true dev-tool run test:node-ts-input --no-test-proxy -- --timeout 1200000 \"test/internal/*.spec.ts\" \"test/public/*.spec.ts\" \"test/public/**/*.spec.ts\" \"test/internal/**/*.spec.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "//metadata": {

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -30,7 +30,7 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy=true",
+    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js",
@@ -39,7 +39,7 @@
     "test:node": "npm run clean && tsc -p . && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run clean && tsc -p . && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "dev-tool run test:node-tsx-ts --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-tsx-ts --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -33,7 +33,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "temp-unit-test": "mocha -r ts-node/register --timeout 1200000 test/node/*.spec.ts"
   },

--- a/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
@@ -50,7 +50,7 @@ export function getEnvironmentVariable(envVarName: string): string {
 /**
  * Get a predefined SAS token and Storage URI to use when backing up a KeyVault
  */
-export function getSasToken(): { blobStorageUri: string, blobSasToken: string } {
+export function getSasToken(): { blobStorageUri: string; blobSasToken: string } {
   const baseStorageUri = getEnvironmentVariable("BLOB_STORAGE_URI").replace(/\/$/, "");
   const blobStorageUri = `${baseStorageUri}/${getEnvironmentVariable("BLOB_CONTAINER_NAME")}`;
   const blobSasToken = getEnvironmentVariable("BLOB_STORAGE_SAS_TOKEN");

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -28,7 +28,7 @@
     "test:node": "npm run clean && tsc -p . && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -29,7 +29,7 @@
     "unit-test:node:debug": "dev-tool run test:node-tsx-ts -- --timeout 1200000 \"test/internal/**/*.test.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true -- --timeout 1200000 \"test/internal/functional/**/*.test.ts\"",
+    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- --timeout 1200000 \"test/internal/functional/**/*.test.ts\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "report": "nyc report --reporter=json",
     "test-opentelemetry-versions": "node test-opentelemetry-versions.js 2>&1",

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -25,10 +25,10 @@
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "test:browser": "npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-tsx-ts --no-test-proxy=true -- --timeout 1200000 \"test/internal/unit/**/*.test.ts\"",
+    "unit-test:node": "dev-tool run test:node-tsx-ts --no-test-proxy -- --timeout 1200000 \"test/internal/unit/**/*.test.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true -- \"test/internal/functional/**/*.test.ts\"",
+    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- \"test/internal/functional/**/*.test.ts\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "test-opentelemetry-versions": "node test-opentelemetry-versions.js 2>&1",
     "pack": "npm pack 2>&1"

--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -46,7 +46,7 @@
     "bundle": "tsc -p . && dev-tool run bundle",
     "build": "npm run clean && npm run bundle && dev-tool run extract-api",
     "build:test": "npm run bundle",
-    "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\"  \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf --glob dist dist-* temp types *.tgz *.log",
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "tsc -p . && dev-tool run extract-api",

--- a/sdk/openai/openai/samples-dev/audioTranscription.ts
+++ b/sdk/openai/openai/samples-dev/audioTranscription.ts
@@ -33,5 +33,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/audioTranslation.ts
+++ b/sdk/openai/openai/samples-dev/audioTranslation.ts
@@ -33,5 +33,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/bringYourOwnData.ts
+++ b/sdk/openai/openai/samples-dev/bringYourOwnData.ts
@@ -68,5 +68,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/chatCompletions.ts
+++ b/sdk/openai/openai/samples-dev/chatCompletions.ts
@@ -37,6 +37,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });
-

--- a/sdk/openai/openai/samples-dev/completions.ts
+++ b/sdk/openai/openai/samples-dev/completions.ts
@@ -34,5 +34,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/getEmbeddings.ts
+++ b/sdk/openai/openai/samples-dev/getEmbeddings.ts
@@ -37,5 +37,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/getImages.ts
+++ b/sdk/openai/openai/samples-dev/getImages.ts
@@ -39,5 +39,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/openAi.ts
+++ b/sdk/openai/openai/samples-dev/openAi.ts
@@ -34,5 +34,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/streamChatCompletions.ts
+++ b/sdk/openai/openai/samples-dev/streamChatCompletions.ts
@@ -43,5 +43,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/streamChatCompletionsWithContentFilter.ts
+++ b/sdk/openai/openai/samples-dev/streamChatCompletionsWithContentFilter.ts
@@ -64,5 +64,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/streamCompletions.ts
+++ b/sdk/openai/openai/samples-dev/streamCompletions.ts
@@ -36,5 +36,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/openai/openai/samples-dev/toolCall.ts
+++ b/sdk/openai/openai/samples-dev/toolCall.ts
@@ -62,5 +62,5 @@ export async function main() {
 }
 
 main().catch((err) => {
-  parseOpenAIError(err)
+  parseOpenAIError(err);
 });

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -56,7 +56,7 @@
     "extract-api": "tsc -p . && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"samples/**/*.{ts,js}\" \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy=true \"dist-esm/test/internal/**/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\"",
+    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy \"dist-esm/test/internal/**/*.spec.js\" \"dist-esm/test/public/**/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json README.md src test --ext .ts,.javascript,.js",
@@ -66,7 +66,7 @@
     "test:node": "npm run clean && npm run build:test:node && npm run integration-test:node",
     "test": "npm run test:node && npm run test:browser",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true -- --timeout 1200000 --full-trace \"test/internal/unit/{,!(browser)/**/}*.spec.ts\"",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- --timeout 1200000 --full-trace \"test/internal/unit/{,!(browser)/**/}*.spec.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "sideEffects": false,

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -48,7 +48,7 @@
     "extract-api": "tsc -p . && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy=true -- -t 300000  \"dist-esm/test/*.spec.js\" \"dist-esm/test/node/*.spec.js\"",
+    "integration-test:node": "dev-tool run test:node-js-input --no-test-proxy -- -t 300000  \"dist-esm/test/*.spec.js\" \"dist-esm/test/node/*.spec.js\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix",
     "lint": "eslint package.json api-extractor.json src test --ext .ts",
@@ -57,7 +57,7 @@
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "docs": "echo Skipped."
   },

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --no-eslintrc -c ../../.eslintrc.internal.json package.json src test --ext .ts",
     "pack": "npm pack 2>&1",
     "unit-test:browser": "cross-env karma start --single-run",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "test:browser": "npm run clean && npm run build:test npm run unit-test:browser",
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
@@ -33,7 +33,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-js-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-js-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [

--- a/sdk/web-pubsub/web-pubsub-client/package.json
+++ b/sdk/web-pubsub/web-pubsub-client/package.json
@@ -39,7 +39,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true -- --timeout 12000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts' --exit",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- --timeout 12000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts' --exit",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -28,7 +28,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo \"Browser is not supported.\" && exit 0",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy=true",
+    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [


### PR DESCRIPTION
The "=true" part is no longer needed after PR #28978
