### PR TITLE
[webpubsubclient] Fix a bug that 0 sequenceId won't be sent to service

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.2 (2024-05-01)
+
+### Bugs Fixed
+
+- Fix the bug that `sequenceAck` ping won't be sent if nothing has been received for a client
+
 ## 1.0.1 (2024-04-24)
 
 ### Other Changes

--- a/sdk/web-pubsub/web-pubsub-client/package.json
+++ b/sdk/web-pubsub/web-pubsub-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/web-pubsub-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Azure Web PubSub Client",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -541,7 +541,8 @@ export class WebPubSubClient {
       return;
     }
     const [isUpdated, seqId] = this._sequenceId.tryGetSequenceId();
-    if (isUpdated && (seqId !== null && seqId !== undefined)) { // seqId can be 0
+    if (isUpdated && seqId !== null && seqId !== undefined) {
+      // seqId can be 0
       const message: SequenceAckMessage = {
         kind: "sequenceAck",
         sequenceId: seqId!,

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -541,7 +541,7 @@ export class WebPubSubClient {
       return;
     }
     const [isUpdated, seqId] = this._sequenceId.tryGetSequenceId();
-    if (isUpdated && seqId) {
+    if (isUpdated && (seqId !== null && seqId !== undefined)) { // seqId can be 0
       const message: SequenceAckMessage = {
         kind: "sequenceAck",
         sequenceId: seqId!,

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -448,7 +448,7 @@ describe("WebPubSubClient", function () {
       await client.start();
 
       // simulate a update
-      client["_sequenceId"].tryUpdate(0)
+      client["_sequenceId"].tryUpdate(0);
 
       // simulate a call
       client["_trySendSequenceAck"]();

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -438,6 +438,28 @@ describe("WebPubSubClient", function () {
       mock.verify();
       client.stop();
     });
+
+    it("SequenceAck as ping", async () => {
+      const client = new WebPubSubClient("wss://service.com");
+      const testWs = new TestWebSocketClient(client);
+      makeStartable(testWs);
+
+      const writeMessageSpy = sinon.spy(client["_protocol"], "writeMessage");
+      await client.start();
+
+      // simulate a update
+      client["_sequenceId"].tryUpdate(0)
+
+      // simulate a call
+      client["_trySendSequenceAck"]();
+
+      // expect quick sequenceAck message
+      sinon.assert.calledWith(
+        writeMessageSpy,
+        sinon.match.has("kind", "sequenceAck").and(sinon.match.has("sequenceId", 0)),
+      );
+      client.stop();
+    });
   });
 
   function makeStartable(ws: TestWebSocketClient): sinon.SinonStub<[fn: () => void], void> {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-client

### Issues associated with this PR


### Describe the problem that is addressed by this PR
In the previous RP, we found a bug that if sequenceId == 0, then it won't be sent to the service. Which means if no message is received from the service, there won't be a keepalive enabled

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
