### PR TITLE
[OpenAI] [Assistants] Add `file_ids` to Thread operations.

### DIFF
--- a/sdk/openai/openai-assistants/review/openai-assistants-api.api.md
+++ b/sdk/openai/openai-assistants/review/openai-assistants-api.api.md
@@ -41,7 +41,7 @@ export function createMessage(context: AssistantsContext, threadId: string, role
 export function createRun(context: AssistantsContext, threadId: string, createRunOptions: CreateRunOptions, options?: CreateRunRequestOptions): Promise<ThreadRun>;
 
 // @public
-export function createThread(context: AssistantsContext, body: AssistantThreadCreationOptions, options?: CreateThreadOptions): Promise<AssistantThread>;
+export function createThread(context: AssistantsContext, body: AssistantThreadCreationOptions_2, options?: CreateThreadOptions): Promise<AssistantThread>;
 
 // @public
 export function createThreadAndRun(context: AssistantsContext, body: CreateAndRunThreadOptions_2, options?: CreateThreadAndRunOptions): Promise<ThreadRun>;

--- a/sdk/openai/openai-assistants/review/openai-assistants-rest.api.md
+++ b/sdk/openai/openai-assistants/review/openai-assistants-rest.api.md
@@ -58,10 +58,7 @@ export type AssistantsContext = Client & {
 
 // @public
 export interface AssistantThreadCreationOptions {
-    messages?: Array<{
-        role: string;
-        content: string;
-    }>;
+    messages?: ThreadInitializationMessage[];
     metadata?: Record<string, string>;
 }
 

--- a/sdk/openai/openai-assistants/src/api/operations.ts
+++ b/sdk/openai/openai-assistants/src/api/operations.ts
@@ -1107,12 +1107,11 @@ export function _createThreadAndRunSend(
       thread: !body.thread
         ? undefined
         : {
-            messages: body.thread?.["messages"]?.map((p) =>
-              ({
-                role: p["role"],
-                content: p["content"],
-                file_ids: p["fileIds"]
-              })),
+            messages: body.thread?.["messages"]?.map((p) => ({
+              role: p["role"],
+              content: p["content"],
+              file_ids: p["fileIds"],
+            })),
             metadata: body.thread?.["metadata"],
           },
       model: body["model"],

--- a/sdk/openai/openai-assistants/src/api/operations.ts
+++ b/sdk/openai/openai-assistants/src/api/operations.ts
@@ -40,6 +40,7 @@ import {
   AssistantDeletionStatus,
   AssistantFileDeletionStatus,
   AssistantThread,
+  AssistantThreadCreationOptions,
   CreateAndRunThreadOptions,
   CreateRunOptions,
   FileDeletionStatus,
@@ -79,7 +80,6 @@ import {
   UpdateThreadOptions,
 } from "../models/options.js";
 import {
-  AssistantThreadCreationOptions,
   CancelRun200Response,
   AssistantsContext as Client,
   CreateAssistant200Response,
@@ -1107,12 +1107,12 @@ export function _createThreadAndRunSend(
       thread: !body.thread
         ? undefined
         : {
-            messages: !body.thread?.["messages"]
-              ? body.thread?.["messages"]
-              : body.thread?.["messages"].map((p) => ({
-                  role: p["role"],
-                  content: p["content"],
-                })),
+            messages: body.thread?.["messages"]?.map((p) =>
+              ({
+                role: p["role"],
+                content: p["content"],
+                file_ids: p["fileIds"]
+              })),
             metadata: body.thread?.["metadata"],
           },
       model: body["model"],
@@ -1601,6 +1601,7 @@ export function _createThreadSend(
       messages: (body["messages"] ?? []).map((p) => ({
         role: p["role"],
         content: p["content"],
+        file_ids: p["fileIds"],
       })),
       metadata: body["metadata"],
     },

--- a/sdk/openai/openai-assistants/src/rest/models.ts
+++ b/sdk/openai/openai-assistants/src/rest/models.ts
@@ -82,16 +82,7 @@ export interface UpdateAssistantOptions {
 /** The details used to create a new assistant thread. */
 export interface AssistantThreadCreationOptions {
   /** The messages to associate with the new thread. */
-  messages?: Array<{
-    /**
-     * The role associated with the assistant thread message.
-     *
-     * Possible values: user, assistant
-     */
-    role: string;
-    /** The list of content items associated with the assistant thread message. */
-    content: string;
-  }>;
+  messages?: ThreadInitializationMessage[];
   /** A set of key/value pairs used to store additional information about the object. */
   metadata?: Record<string, string>;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai-assistants

### Issues associated with this PR
#29500 only updated the types, not the actual operations

### Describe the problem that is addressed by this PR
With #29500 PR, the `fileIds` type is added, but the actual operations (`createThread` and `createThreadAndRun`) are still missing the `file_ids` property in the message objects.

This PR adds `file_ids` to both of these two operations.

Additionally, there are some other fixes:
* The `AssistantThreadCreationOptions` in `rest/models.ts` was not updated along with #29500 PR.
* The `AssistantThreadCreationOptions` type in `api/operations.ts` was incorrectly importing from `rest/index`, instead it should be importing from `models/models`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
