### PR TITLE
[dev-tool] fix test:vitest browser config issue

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -52,8 +52,8 @@ export default leafCommand(commandInfo, async (options) => {
   // Only set if we didn't provide a config file path
   if (
     options["browser"] &&
-    updatedArgs?.indexOf("-c") !== -1 &&
-    updatedArgs?.indexOf("--config") !== -1
+    updatedArgs?.indexOf("-c") === -1 &&
+    updatedArgs?.indexOf("--config") === -1
   ) {
     args = "-c vitest.browser.config.ts";
   }

--- a/sdk/core/core-http-compat/vitest.config.ts
+++ b/sdk/core/core-http-compat/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-lro/vitest.config.ts
+++ b/sdk/core/core-lro/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-paging/vitest.config.ts
+++ b/sdk/core/core-paging/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-sse/vitest.config.ts
+++ b/sdk/core/core-sse/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-tracing/vitest.config.ts
+++ b/sdk/core/core-tracing/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-util/vitest.config.ts
+++ b/sdk/core/core-util/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/core-xml/vitest.config.ts
+++ b/sdk/core/core-xml/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],

--- a/sdk/core/ts-http-runtime/vitest.config.ts
+++ b/sdk/core/ts-http-runtime/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     reporters: ["basic", "junit"],
     outputFile: {
-      junit: "test-results.browser.xml",
+      junit: "test-results.xml",
     },
     fakeTimers: {
       toFake: ["setTimeout", "Date"],


### PR DESCRIPTION
We should use `=== -1` which means not found.

While at this, also fix result file names for NodeJS tests.