### PR TITLE
[doc][core-util] remove broken link

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -85,7 +85,6 @@
 ### Bugs Fixed
 
 - UUID fix for older versions of Node.js
-  - [#25501](https://github.com/Azure/azure-sdk-for-js/issues/25501)
   - [#25541](https://github.com/Azure/azure-sdk-for-js/issues/25541)
   - [#25538](https://github.com/Azure/azure-sdk-for-js/issues/25538)
   - [#25532](https://github.com/Azure/azure-sdk-for-js/issues/25532)


### PR DESCRIPTION
This particular GitHub issue doesn't exist. Not sure why it started failing the link verification. It is possible that this file somehow evaded checking.