### PR TITLE
[core] regen tracing samples

### DIFF
--- a/sdk/core/core-tracing/samples/v1/javascript/basicTracing.js
+++ b/sdk/core/core-tracing/samples/v1/javascript/basicTracing.js
@@ -46,7 +46,7 @@ class BasicClient {
         // You do not need to close the span.
         const result = await Promise.resolve({ value: 42 });
         return result.value;
-      }
+      },
     );
   }
 
@@ -81,11 +81,11 @@ class BasicClient {
   async withUserCallback(callback, options = {}) {
     const { span, updatedOptions } = this.tracingClient.startSpan(
       "BasicClient.withUserCallback",
-      options
+      options,
     );
     const result = this.tracingClient.withContext(
       updatedOptions.tracingOptions.tracingContext,
-      callback
+      callback,
     );
     span.setStatus({ status: "success" });
     span.end();

--- a/sdk/core/core-tracing/samples/v1/javascript/package.json
+++ b/sdk/core/core-tracing/samples/v1/javascript/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",
-  "type": "module",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/sdk/core/core-tracing/samples/v1/typescript/package.json
+++ b/sdk/core/core-tracing/samples/v1/typescript/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",
-  "type": "module",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/sdk/core/core-tracing/samples/v1/typescript/src/basicTracing.ts
+++ b/sdk/core/core-tracing/samples/v1/typescript/src/basicTracing.ts
@@ -53,7 +53,7 @@ class BasicClient {
         // You do not need to close the span.
         const result = await Promise.resolve({ value: 42 });
         return result.value;
-      }
+      },
     );
   }
 
@@ -87,15 +87,15 @@ class BasicClient {
    */
   async withUserCallback<Callback extends (...args: unknown[]) => ReturnType<Callback>>(
     callback: Callback,
-    options: OperationOptions = {}
+    options: OperationOptions = {},
   ): Promise<ReturnType<Callback>> {
     const { span, updatedOptions } = this.tracingClient.startSpan(
       "BasicClient.withUserCallback",
-      options
+      options,
     );
     const result = this.tracingClient.withContext(
       updatedOptions.tracingOptions!.tracingContext!,
-      callback
+      callback,
     );
     span.setStatus({ status: "success" });
     span.end();

--- a/sdk/core/core-tracing/samples/v1/typescript/tsconfig.json
+++ b/sdk/core/core-tracing/samples/v1/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Regenerates samples to fix any formatting issues as well as remove the `type: module` specifier as we are not generating ESM for our samples.

Resolves #29521