### PR TITLE
[eslint-plugin] improve ts-doc-internal UX experience

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -88,7 +88,9 @@ export default createRule({
       if (!exported.includes(symbol) && tsNode.jsDoc !== undefined) {
         // fetch all tags
         let TSDocTags: string[] = [];
+        let hasDocComments = false;
         tsNode.jsDoc.forEach((TSDocComment: any): void => {
+          hasDocComments = true;
           TSDocTags = TSDocTags.concat(
             TSDocComment.tags !== undefined
               ? TSDocComment.tags.map((TSDocTag: any): string => TSDocTag.tagName.escapedText)
@@ -97,9 +99,12 @@ export default createRule({
         });
 
         // see if any match hidden or internal
-        if (!TSDocTags.some((TSDocTag: string): boolean => /(internal)|(hidden)/.test(TSDocTag))) {
+        if (
+          hasDocComments &&
+          !TSDocTags.some((TSDocTag: string): boolean => /(internal)|(hidden)/.test(TSDocTag))
+        ) {
           context.report({
-            node,
+            node: (node as any).id ?? node,
             messageId: "InternalShouldBeMarked",
           });
         }


### PR DESCRIPTION
- fix false positive when there are no comments at all. There may be some internal cache nodes in the array but they don't hold any comments.
- instead of showing squiggles for whole declaration body, only report on the id node if its available.
