### PR TITLE
Adding the mediastreaming events

### DIFF
--- a/sdk/communication/communication-call-automation/assets.json
+++ b/sdk/communication/communication-call-automation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-call-automation",
-  "Tag": "js/communication/communication-call-automation_6825aad501"
+  "Tag": "js/communication/communication-call-automation_3ef2c1b54f"
 }

--- a/sdk/communication/communication-call-automation/assets.json
+++ b/sdk/communication/communication-call-automation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-call-automation",
-  "Tag": "js/communication/communication-call-automation_22a209c61b"
+  "Tag": "js/communication/communication-call-automation_6825aad501"
 }

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
@@ -22,94 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:05.3882377+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "operationContext": "addParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:05.384805+00:00",
+      "time": "2024-05-02T20:56:03.0356774+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-        "operationContext": "addParticipantsCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:20:05.4084782+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "participants": [
           {
             "identifier": {
@@ -136,24 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:05.4053451+00:00",
+      "time": "2024-05-02T20:56:03.0392942+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "operationContext": "addParticipantsCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:56:03.0785958+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:03.0754753+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
         "participants": [
           {
             "identifier": {
@@ -180,15 +180,59 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:10.2004379+00:00",
+      "time": "2024-05-02T20:56:07.6895483+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:07.7137226+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
     }
   ],
   {
@@ -214,11 +258,42 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "source": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
+        "operationContext": "addParticipantsAnswer2",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-61d7-4a89-b3e5-c01175f708cd",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:56:09.0959221+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "eventSource": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
         "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
           {
             "identifier": {
               "rawId": "sanitized",
@@ -242,46 +317,136 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 3,
+        "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
+        "callConnectionId": "27002080-61d7-4a89-b3e5-c01175f708cd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:10.1717542+00:00",
+      "time": "2024-05-02T20:56:09.5077101+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+      "subject": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
-      "type": "Microsoft.Communication.CallConnected",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
-        "operationContext": "addParticipantsAnswer2",
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:11.2760454+00:00",
+      "time": "2024-05-02T20:56:09.5110809+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:09.5071455+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
         "operationContext": "addParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -291,24 +456,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-05-01T22:20:11.5393848+00:00",
+      "time": "2024-05-02T20:56:09.5408199+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
         "participants": [
           {
             "identifier": {
@@ -344,136 +509,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:11.5382551+00:00",
+      "time": "2024-05-02T20:56:09.9410011+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "source": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:11.5399522+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:11.5393848+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+        "eventSource": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
         "participants": [
           {
             "identifier": {
@@ -511,24 +566,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "callConnectionId": "27002080-61d7-4a89-b3e5-c01175f708cd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:11.9593924+00:00",
+      "time": "2024-05-02T20:56:09.9311101+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+      "subject": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "participants": [
           {
             "identifier": {
@@ -564,26 +619,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:11.9571112+00:00",
+      "time": "2024-05-02T20:56:09.9397752+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "source": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "eventSource": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1",
         "participants": [
           {
             "identifier": {
@@ -619,81 +674,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 6,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "callConnectionId": "27002080-5f15-4ce3-b3f1-f54a160569a1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:11.9812928+00:00",
+      "time": "2024-05-02T20:56:10.3590028+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+      "subject": "calling/callConnections/27002080-5f15-4ce3-b3f1-f54a160569a1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+      "source": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 8,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:12.375946+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "eventSource": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd",
         "participants": [
           {
             "identifier": {
@@ -731,70 +731,15 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "callConnectionId": "27002080-61d7-4a89-b3e5-c01175f708cd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:12.3847125+00:00",
+      "time": "2024-05-02T20:56:10.3704124+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 8,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:12.3889442+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+      "subject": "calling/callConnections/27002080-61d7-4a89-b3e5-c01175f708cd"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_and_get_call_properties.json
@@ -22,10 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
         "participants": [
           {
             "identifier": {
@@ -52,44 +52,64 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:40.4102928+00:00",
+      "time": "2024-05-01T22:20:05.3882377+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
         "operationContext": "addParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:37:40.3634744+00:00",
+      "time": "2024-05-01T22:20:05.384805+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "operationContext": "addParticipantsCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:20:05.4084782+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
         "participants": [
           {
             "identifier": {
@@ -116,35 +136,59 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:40.3947633+00:00",
+      "time": "2024-05-01T22:20:05.4053451+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
-      "type": "Microsoft.Communication.CallConnected",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
-        "operationContext": "addParticipantsCreateCall",
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:40.4102928+00:00",
+      "time": "2024-05-01T22:20:10.2004379+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
     }
   ],
   {
@@ -170,30 +214,74 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-      "type": "Microsoft.Communication.CallConnected",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-        "operationContext": "addParticipantsAnswer2",
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:48.6373583+00:00",
+      "time": "2024-05-01T22:20:10.1717542+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+        "operationContext": "addParticipantsAnswer2",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:20:11.2760454+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
         "operationContext": "addParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -203,79 +291,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:37:48.9655424+00:00",
+      "time": "2024-05-01T22:20:11.5393848+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:48.9655424+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
         "participants": [
           {
             "identifier": {
@@ -313,189 +346,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
+        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:49.0592372+00:00",
+      "time": "2024-05-01T22:20:11.5382551+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
+      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:48.9655424+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1788-4472-967b-7f2d40b27e35",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:49.5593014+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1788-4472-967b-7f2d40b27e35"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-4a48-46d5-9052-4acc50dbd6a9",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:49.6374189+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-4a48-46d5-9052-4acc50dbd6a9"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f",
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
         "participants": [
           {
             "identifier": {
@@ -533,15 +401,400 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-5109-49a7-a383-10c99342351f",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:49.5593014+00:00",
+      "time": "2024-05-01T22:20:11.5399522+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-5109-49a7-a383-10c99342351f"
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:11.5393848+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:11.9593924+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:11.9571112+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 6,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:11.9812928+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 8,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-5819-4290-b194-7f934e569ac5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:12.375946+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-5819-4290-b194-7f934e569ac5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 6,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9dec-42bb-b6a8-575bcbad7f41",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:12.3847125+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9dec-42bb-b6a8-575bcbad7f41"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 8,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-9812-400b-be3b-e60216795c5d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:12.3889442+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-9812-400b-be3b-e60216795c5d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
@@ -22,149 +22,237 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
+      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:44.3153462+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
+        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
         "operationContext": "cancelAddCreateAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b2ae-42ed-93d9-260c55a41871",
+        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:23.8905626+00:00",
+      "time": "2024-05-01T22:20:44.3125777+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871"
+      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b2ae-42ed-93d9-260c55a41871",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:23.9061909+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b2ae-42ed-93d9-260c55a41871"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:23.9531188+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
+      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
+        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
         "operationContext": "cancelAddCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
+        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:23.9531188+00:00",
+      "time": "2024-05-01T22:20:44.3850936+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
+      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b",
+      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:44.3821736+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:46.446769+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:46.4739648+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
       "type": "Microsoft.Communication.CancelAddParticipantSucceeded",
       "data": {
-        "invitationId": "313f266e-c54a-4843-88a6-84a66b1b8f57",
+        "invitationId": "f3335e1d-aa2a-45a8-bbce-d1eb0852b01f",
         "operationContext": "cancelAdd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-71de-46ae-8a08-62b2325ab09b",
+        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CancelAddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:38:28.7198819+00:00",
+      "time": "2024-05-01T22:20:48.7432194+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-71de-46ae-8a08-62b2325ab09b"
+      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Add_a_participant_cancels_add_participant_request.json
@@ -1,4 +1,59 @@
 [
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 14,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:36.5833688+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
+    }
+  ],
   {
     "to": {
       "kind": "communicationUser",
@@ -22,10 +77,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+      "source": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "eventSource": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
         "participants": [
           {
             "identifier": {
@@ -52,64 +107,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "callConnectionId": "27002080-5add-4af8-aa80-f26c8c897165",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:44.3153462+00:00",
+      "time": "2024-05-02T20:56:42.5611738+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
+      "subject": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+      "source": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "eventSource": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
         "operationContext": "cancelAddCreateAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "callConnectionId": "27002080-5add-4af8-aa80-f26c8c897165",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:44.3125777+00:00",
+      "time": "2024-05-02T20:56:42.5571659+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
+      "subject": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
-        "operationContext": "cancelAddCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:20:44.3850936+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+      "source": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "eventSource": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
         "participants": [
           {
             "identifier": {
@@ -136,24 +171,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "callConnectionId": "27002080-8e3c-49a6-976c-57a5c1fcd9ad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:44.3821736+00:00",
+      "time": "2024-05-02T20:56:42.6431343+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
+      "subject": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+      "source": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
+        "operationContext": "cancelAddCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-8e3c-49a6-976c-57a5c1fcd9ad",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:56:42.6466462+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "eventSource": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165",
         "participants": [
           {
             "identifier": {
@@ -180,24 +235,24 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-613e-4a2c-bd5c-eb2b68884207",
+        "callConnectionId": "27002080-5add-4af8-aa80-f26c8c897165",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:46.446769+00:00",
+      "time": "2024-05-02T20:56:45.5728219+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-613e-4a2c-bd5c-eb2b68884207"
+      "subject": "calling/callConnections/27002080-5add-4af8-aa80-f26c8c897165"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+      "source": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "eventSource": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
         "participants": [
           {
             "identifier": {
@@ -224,35 +279,35 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "callConnectionId": "27002080-8e3c-49a6-976c-57a5c1fcd9ad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:46.4739648+00:00",
+      "time": "2024-05-02T20:56:45.5795851+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
+      "subject": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+      "source": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad",
       "type": "Microsoft.Communication.CancelAddParticipantSucceeded",
       "data": {
-        "invitationId": "f3335e1d-aa2a-45a8-bbce-d1eb0852b01f",
+        "invitationId": "f58fae34-cef9-4ef2-91a8-ed84e9ccff24",
         "operationContext": "cancelAdd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-34b7-4a42-8d6e-0a4bbd6d973b",
+        "callConnectionId": "27002080-8e3c-49a6-976c-57a5c1fcd9ad",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CancelAddParticipantSucceeded"
       },
-      "time": "2024-05-01T22:20:48.7432194+00:00",
+      "time": "2024-05-02T20:56:47.5392408+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-34b7-4a42-8d6e-0a4bbd6d973b"
+      "subject": "calling/callConnections/27002080-8e3c-49a6-976c-57a5c1fcd9ad"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+      "source": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+        "eventSource": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1",
         "operationContext": "listParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+        "callConnectionId": "27002080-62cc-43cb-996e-3105e64958c1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:19:57.0900297+00:00",
+      "time": "2024-05-02T20:55:55.5828566+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79"
+      "subject": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+      "source": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+        "eventSource": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1",
         "participants": [
           {
             "identifier": {
@@ -72,44 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
+        "callConnectionId": "27002080-62cc-43cb-996e-3105e64958c1",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:19:57.0930582+00:00",
+      "time": "2024-05-02T20:55:55.5862862+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79"
+      "subject": "calling/callConnections/27002080-62cc-43cb-996e-3105e64958c1"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
+      "source": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
+        "eventSource": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739",
         "operationContext": "listParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c2a2-40d4-92b3-202acf090381",
+        "callConnectionId": "27002080-bcb5-47d2-91e5-131270421739",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:19:57.1423159+00:00",
+      "time": "2024-05-02T20:55:55.6139439+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381"
+      "subject": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
+      "source": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
+        "eventSource": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739",
         "participants": [
           {
             "identifier": {
@@ -136,15 +136,15 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c2a2-40d4-92b3-202acf090381",
+        "callConnectionId": "27002080-bcb5-47d2-91e5-131270421739",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:19:57.1374213+00:00",
+      "time": "2024-05-02T20:55:55.6111175+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381"
+      "subject": "calling/callConnections/27002080-bcb5-47d2-91e5-131270421739"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_List_all_participants.json
@@ -22,63 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+      "source": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+        "eventSource": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
         "operationContext": "listParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
+        "callConnectionId": "1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:37:32.4250079+00:00",
+      "time": "2024-05-01T22:19:57.0900297+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
+      "subject": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+      "source": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 0,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:32.4250079+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
+        "eventSource": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
         "participants": [
           {
             "identifier": {
@@ -105,44 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b014-4eca-b06f-c8dfe2337605",
+        "callConnectionId": "1d001f80-5ed2-4d13-b7fe-b48a12b5ca79",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:32.4876083+00:00",
+      "time": "2024-05-01T22:19:57.0930582+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605"
+      "subject": "calling/callConnections/1d001f80-5ed2-4d13-b7fe-b48a12b5ca79"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
+      "source": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605",
+        "eventSource": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
         "operationContext": "listParticipantsCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-b014-4eca-b06f-c8dfe2337605",
+        "callConnectionId": "1d001f80-c2a2-40d4-92b3-202acf090381",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:37:32.4876083+00:00",
+      "time": "2024-05-01T22:19:57.1423159+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-b014-4eca-b06f-c8dfe2337605"
+      "subject": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+      "source": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79",
+        "eventSource": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381",
         "participants": [
           {
             "identifier": {
@@ -169,15 +136,15 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-065e-4aa6-bc19-013d801ead79",
+        "callConnectionId": "1d001f80-c2a2-40d4-92b3-202acf090381",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:33.0188504+00:00",
+      "time": "2024-05-01T22:19:57.1374213+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-065e-4aa6-bc19-013d801ead79"
+      "subject": "calling/callConnections/1d001f80-c2a2-40d4-92b3-202acf090381"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
@@ -22,29 +22,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:06.5154356+00:00",
+      "time": "2024-05-01T22:20:27.1357551+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
         "participants": [
           {
             "identifier": {
@@ -71,24 +71,43 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:06.5310077+00:00",
+      "time": "2024-05-01T22:20:27.1386497+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:20:27.1982606+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
         "participants": [
           {
             "identifier": {
@@ -115,34 +134,103 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:06.7810657+00:00",
+      "time": "2024-05-01T22:20:27.1954096+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-      "type": "Microsoft.Communication.CallConnected",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:06.7966563+00:00",
+      "time": "2024-05-01T22:20:31.716118+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:31.7606576+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
     }
   ],
   {
@@ -168,29 +256,139 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:13.968592+00:00",
+      "time": "2024-05-01T22:20:33.2736094+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:33.4579316+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:33.4516338+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
         "operationContext": "addParticipant",
         "participant": {
           "rawId": "sanitized",
@@ -200,519 +398,24 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-03-08T21:38:14.218591+00:00",
+      "time": "2024-05-01T22:20:33.4441436+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.218591+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.218591+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.218591+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.8123462+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.827968+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:14.827968+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:15.4061534+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:15.4217244+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:15.4217244+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
         "participants": [
           {
             "identifier": {
@@ -750,24 +453,79 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:15.9999232+00:00",
+      "time": "2024-05-01T22:20:33.5575377+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:33.8620095+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
         "participants": [
           {
             "identifier": {
@@ -805,24 +563,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:15.9999232+00:00",
+      "time": "2024-05-01T22:20:33.8666107+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
         "participants": [
           {
             "identifier": {
@@ -860,24 +618,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:16.0467512+00:00",
+      "time": "2024-05-01T22:20:34.1794146+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
         "participants": [
           {
             "identifier": {
@@ -898,7 +656,7 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": true,
+            "isMuted": false,
             "isOnHold": false
           },
           {
@@ -915,24 +673,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-2982-4d0a-86c9-c3065a3aeb31",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:16.5780399+00:00",
+      "time": "2024-05-01T22:20:34.2622169+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-2982-4d0a-86c9-c3065a3aeb31"
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
         "participants": [
           {
             "identifier": {
@@ -953,7 +711,7 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": true,
+            "isMuted": false,
             "isOnHold": false
           },
           {
@@ -968,26 +726,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 7,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-82f9-4ef0-80bf-b77c8dd8f03d",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:16.6092362+00:00",
+      "time": "2024-05-01T22:20:34.2970768+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-82f9-4ef0-80bf-b77c8dd8f03d"
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
         "participants": [
           {
             "identifier": {
@@ -1008,7 +766,62 @@
                 "id": "sanitized"
               }
             },
-            "isMuted": true,
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 6,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:34.58408+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
             "isOnHold": false
           },
           {
@@ -1025,15 +838,1170 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-784e-4f0a-9fd1-2ca0a8b4778d",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:16.6249232+00:00",
+      "time": "2024-05-01T22:20:34.6658812+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-784e-4f0a-9fd1-2ca0a8b4778d"
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:34.7270575+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:34.9915218+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.072378+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.1379685+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.5214958+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.5893949+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.6649693+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:35.9411828+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.0201422+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.0863245+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.3747841+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.4241817+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.5218676+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 11,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.8010112+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.8400936+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:36.9540908+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:37.220479+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:37.2427825+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:37.5364582+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:37.638903+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 15,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:37.6572688+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Mute_a_participant.json
@@ -22,29 +22,10 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:20:27.1357551+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -71,43 +52,62 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:27.1386497+00:00",
+      "time": "2024-05-02T20:56:24.9157072+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:27.1982606+00:00",
+      "time": "2024-05-02T20:56:24.9126855+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:56:24.9540166+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -134,24 +134,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:27.1954096+00:00",
+      "time": "2024-05-02T20:56:24.950739+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -178,24 +178,24 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:31.716118+00:00",
+      "time": "2024-05-02T20:56:29.8230478+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -222,15 +222,15 @@
         ],
         "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:31.7606576+00:00",
+      "time": "2024-05-02T20:56:29.8352645+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   {
@@ -256,139 +256,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:33.2736094+00:00",
+      "time": "2024-05-02T20:56:31.9762044+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:33.4579316+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 4,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:33.4516338+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.AddParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "operationContext": "addParticipant",
         "participant": {
           "rawId": "sanitized",
@@ -398,24 +288,134 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.AddParticipantSucceeded"
       },
-      "time": "2024-05-01T22:20:33.4441436+00:00",
+      "time": "2024-05-02T20:56:32.2428264+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:32.2433825+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:32.2511361+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -453,79 +453,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:33.5575377+00:00",
+      "time": "2024-05-02T20:56:32.3129776+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 7,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:33.8620095+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -563,24 +508,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:33.8666107+00:00",
+      "time": "2024-05-02T20:56:32.6758304+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -618,79 +563,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.1794146+00:00",
+      "time": "2024-05-02T20:56:32.6764395+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 7,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:34.2622169+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -728,24 +618,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.2970768+00:00",
+      "time": "2024-05-02T20:56:32.7169219+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -783,24 +673,24 @@
         ],
         "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.58408+00:00",
+      "time": "2024-05-02T20:56:33.0955043+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -836,26 +726,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 7,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.6658812+00:00",
+      "time": "2024-05-02T20:56:33.1011911+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -891,26 +781,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 7,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.7270575+00:00",
+      "time": "2024-05-02T20:56:33.1484602+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -946,26 +836,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:34.9915218+00:00",
+      "time": "2024-05-02T20:56:33.4972036+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1001,26 +891,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.072378+00:00",
+      "time": "2024-05-02T20:56:33.5184471+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1056,26 +946,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.1379685+00:00",
+      "time": "2024-05-02T20:56:33.5686234+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -1111,26 +1001,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.5214958+00:00",
+      "time": "2024-05-02T20:56:33.927731+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1166,26 +1056,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.5893949+00:00",
+      "time": "2024-05-02T20:56:33.930765+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1221,26 +1111,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.6649693+00:00",
+      "time": "2024-05-02T20:56:34.0015238+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1276,26 +1166,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:35.9411828+00:00",
+      "time": "2024-05-02T20:56:34.4157716+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -1331,26 +1221,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.0201422+00:00",
+      "time": "2024-05-02T20:56:34.4149398+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1386,26 +1276,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.0863245+00:00",
+      "time": "2024-05-02T20:56:34.4923342+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -1441,26 +1331,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 12,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.3747841+00:00",
+      "time": "2024-05-02T20:56:34.8354365+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1496,136 +1386,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 11,
+        "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.4241817+00:00",
+      "time": "2024-05-02T20:56:34.8277116+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 11,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:36.5218676+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 11,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:36.8010112+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1663,24 +1443,79 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.8400936+00:00",
+      "time": "2024-05-02T20:56:34.9103507+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 12,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:35.2436838+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1718,24 +1553,24 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:36.9540908+00:00",
+      "time": "2024-05-02T20:56:35.2524402+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1773,24 +1608,24 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:37.220479+00:00",
+      "time": "2024-05-02T20:56:35.3274747+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1828,24 +1663,24 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:37.2427825+00:00",
+      "time": "2024-05-02T20:56:35.6793917+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47",
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
         "participants": [
           {
             "identifier": {
@@ -1883,24 +1718,24 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-6b81-46bd-956d-f56f49322b47",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:37.5364582+00:00",
+      "time": "2024-05-02T20:56:35.6781074+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-6b81-46bd-956d-f56f49322b47"
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
         "participants": [
           {
             "identifier": {
@@ -1938,24 +1773,24 @@
         ],
         "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-0748-45f7-9fa1-cc8939437c37",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:37.638903+00:00",
+      "time": "2024-05-02T20:56:35.7451486+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-0748-45f7-9fa1-cc8939437c37"
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "participants": [
           {
             "identifier": {
@@ -1991,17 +1826,237 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 15,
+        "sequenceNumber": 13,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a503-4221-9a9f-6bbcbc639d85",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:37.6572688+00:00",
+      "time": "2024-05-02T20:56:36.0945481+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a503-4221-9a9f-6bbcbc639d85"
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:36.0994161+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 13,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-59ba-490c-856c-611e9eff4b91",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:36.1753239+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-59ba-490c-856c-611e9eff4b91"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 14,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1a3e-4d3b-9966-7cbc5a8a2c0f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:36.5178042+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1a3e-4d3b-9966-7cbc5a8a2c0f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 14,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-d1df-4882-a90a-c323fc2f10f7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:36.5218788+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-d1df-4882-a90a-c323fc2f10f7"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
@@ -22,94 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
+      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
-        "operationContext": "removeParticipantCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:37:57.6687101+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:37:57.6843442+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
+        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:37:57.6687101+00:00",
+      "time": "2024-05-01T22:20:18.625841+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
+      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
         "participants": [
           {
             "identifier": {
@@ -136,24 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
+        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:57.6843442+00:00",
+      "time": "2024-05-01T22:20:18.6971364+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
+      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
+      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:18.6288608+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+        "operationContext": "removeParticipantCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:20:18.7010512+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
       "type": "Microsoft.Communication.RemoveParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
+        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
         "operationContext": "removeParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -163,55 +163,55 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
+        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RemoveParticipantSucceeded"
       },
-      "time": "2024-03-08T21:37:59.1843522+00:00",
+      "time": "2024-05-01T22:20:20.2798002+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
+      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b",
+        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-60ad-44f0-a298-0c82455f948b",
+        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:37:59.2468533+00:00",
+      "time": "2024-05-01T22:20:20.3339926+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-60ad-44f0-a298-0c82455f948b"
+      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
+      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9",
+        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9791-41e0-8604-56e89212b4b9",
+        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:37:59.6062835+00:00",
+      "time": "2024-05-01T22:20:20.6154967+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9791-41e0-8604-56e89212b4b9"
+      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/CallConnection_Live_Tests_Remove_a_participant.json
@@ -1,4 +1,59 @@
 [
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-49cc-4a4e-8dc5-6d006cfffe31",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:10.3739792+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-49cc-4a4e-8dc5-6d006cfffe31"
+    }
+  ],
   {
     "to": {
       "kind": "communicationUser",
@@ -22,30 +77,63 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+      "source": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 0,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-05a4-43cb-b69d-cafdaf5b555f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:16.9261026+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "eventSource": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "callConnectionId": "27002080-05a4-43cb-b69d-cafdaf5b555f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:18.625841+00:00",
+      "time": "2024-05-02T20:56:16.9294489+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
+      "subject": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+      "source": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+        "eventSource": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
         "participants": [
           {
             "identifier": {
@@ -72,88 +160,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
+        "callConnectionId": "27002080-6d87-4912-8aa5-fc09a01dac9d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:18.6971364+00:00",
+      "time": "2024-05-02T20:56:16.9918984+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
+      "subject": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:18.6288608+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+      "source": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+        "eventSource": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
+        "callConnectionId": "27002080-6d87-4912-8aa5-fc09a01dac9d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:18.7010512+00:00",
+      "time": "2024-05-02T20:56:16.995166+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
+      "subject": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+      "source": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-05a4-43cb-b69d-cafdaf5b555f",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:17.3568773+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
       "type": "Microsoft.Communication.RemoveParticipantSucceeded",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+        "eventSource": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
         "operationContext": "removeParticipants",
         "participant": {
           "rawId": "sanitized",
@@ -163,55 +251,55 @@
           }
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
+        "callConnectionId": "27002080-6d87-4912-8aa5-fc09a01dac9d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RemoveParticipantSucceeded"
       },
-      "time": "2024-05-01T22:20:20.2798002+00:00",
+      "time": "2024-05-02T20:56:18.1172886+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
+      "subject": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+      "source": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "eventSource": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f",
         "operationContext": "removeParticipantsAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-42f2-4ec4-b516-bb2ec316b765",
+        "callConnectionId": "27002080-05a4-43cb-b69d-cafdaf5b555f",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:20:20.3339926+00:00",
+      "time": "2024-05-02T20:56:18.1549425+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-42f2-4ec4-b516-bb2ec316b765"
+      "subject": "calling/callConnections/27002080-05a4-43cb-b69d-cafdaf5b555f"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+      "source": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577",
+        "eventSource": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d",
         "operationContext": "removeParticipantCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-769e-4588-9585-56e121bf5577",
+        "callConnectionId": "27002080-6d87-4912-8aa5-fc09a01dac9d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:20:20.6154967+00:00",
+      "time": "2024-05-02T20:56:18.1683131+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-769e-4588-9585-56e121bf5577"
+      "subject": "calling/callConnections/27002080-6d87-4912-8aa5-fc09a01dac9d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
+++ b/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
@@ -22,74 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:39:29.5080308+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
         "operationContext": "recordingAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:39:29.5080308+00:00",
+      "time": "2024-05-01T22:21:51.1787521+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
         "participants": [
           {
             "identifier": {
@@ -116,44 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:29.5861543+00:00",
+      "time": "2024-05-01T22:21:51.1824884+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "operationContext": "recordingCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:39:29.5861543+00:00",
+      "time": "2024-05-01T22:21:51.281391+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "participants": [
           {
             "identifier": {
@@ -178,93 +134,49 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 3,
+        "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:34.6831704+00:00",
+      "time": "2024-05-01T22:21:51.2776745+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:39:34.6831704+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ",
-        "state": "active",
-        "startDateTime": "2024-03-08T21:39:34.3666276+00:00",
-        "recordingType": "acs",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ",
+        "state": "inactive",
+        "startDateTime": "0001-01-01T00:00:00+00:00",
+        "recordingKind": "azureCommunicationServices",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-ed42-41f0-9cbc-48ffda080121",
+        "callConnectionId": "1d001f80-f0b6-4ffd-aa4f-51309b4c1cef",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-03-08T21:39:34.6831704+00:00",
+      "time": "2024-05-01T22:21:56.3949+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzZWEyLTAxLmNvbnYuc2t5cGUuY29tL2NvbnYvYUJ3NVNTLXpSa0c0a1d5OGVzVGJXQT9pPTMzJmU9NjM4NDU1MzAwNjYzMTg0NDc0/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiI0MjFmMGIwMC1lZDQyLTQxZjAtOWNiYy00OGZmZGEwODAxMjEiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI2NzE3ZmE2MS03YTFmLTQ0MzEtYWE1ZS1hMDYwM2E1MjBhNDIifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
         "participants": [
           {
             "identifier": {
@@ -289,26 +201,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:35.3394745+00:00",
+      "time": "2024-05-01T22:21:56.3891738+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "participants": [
           {
             "identifier": {
@@ -333,26 +245,225 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 4,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:35.3394745+00:00",
+      "time": "2024-05-01T22:21:56.401532+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:56.8090352+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:56.8194108+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
+      "type": "Microsoft.Communication.RecordingStateChanged",
+      "data": {
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ",
+        "state": "active",
+        "startDateTime": "2024-05-01T22:21:56.2165918+00:00",
+        "recordingKind": "azureCommunicationServices",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-f0b6-4ffd-aa4f-51309b4c1cef",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.RecordingStateChanged"
+      },
+      "time": "2024-05-01T22:21:56.9040006+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:57.2348672+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:57.2254956+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -360,24 +471,24 @@
         },
         "operationContext": "recordingPlay",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:39:35.3550509+00:00",
+      "time": "2024-05-01T22:21:57.2688726+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "participants": [
           {
             "identifier": {
@@ -402,26 +513,26 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8f10-482b-aba4-d4a4fc26b925",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:36.5582401+00:00",
+      "time": "2024-05-01T22:21:57.7043095+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8f10-482b-aba4-d4a4fc26b925"
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645",
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
         "participants": [
           {
             "identifier": {
@@ -446,17 +557,369 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 5,
+        "sequenceNumber": 6,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-1c38-48f3-b14b-7c8146050645",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:36.5582401+00:00",
+      "time": "2024-05-01T22:21:57.7028562+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-1c38-48f3-b14b-7c8146050645"
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.116388+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.1329863+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.5203727+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.5589394+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.9401256+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 9,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:58.9710689+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 10,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:59.3400288+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 10,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:59.3801451+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
+++ b/sdk/communication/communication-call-automation/recordings/CallRecording_Live_Tests_Creates_a_call,_start_recording,_and_hangs_up.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "operationContext": "recordingAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:51.1787521+00:00",
+      "time": "2024-05-02T20:57:50.1950942+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -72,44 +72,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:51.1824884+00:00",
+      "time": "2024-05-02T20:57:50.2053023+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:50.2257353+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "operationContext": "recordingCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:51.281391+00:00",
+      "time": "2024-05-02T20:57:50.2295591+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -134,248 +178,116 @@
             "isOnHold": false
           }
         ],
-        "sequenceNumber": 1,
+        "sequenceNumber": 3,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:51.2776745+00:00",
+      "time": "2024-05-02T20:57:55.0787527+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 3,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:55.0776109+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ",
         "state": "inactive",
         "startDateTime": "0001-01-01T00:00:00+00:00",
         "recordingKind": "azureCommunicationServices",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-f0b6-4ffd-aa4f-51309b4c1cef",
+        "callConnectionId": "27002080-3c79-49b3-8b3d-09fd93fb8ad5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-05-01T22:21:56.3949+00:00",
+      "time": "2024-05-02T20:57:55.1843635+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:56.3891738+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 3,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:56.401532+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:56.8090352+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:56.8194108+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
+      "source": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged",
       "type": "Microsoft.Communication.RecordingStateChanged",
       "data": {
-        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged",
-        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ",
+        "eventSource": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged",
+        "recordingId": "eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ",
         "state": "active",
-        "startDateTime": "2024-05-01T22:21:56.2165918+00:00",
+        "startDateTime": "2024-05-02T20:57:55.0440721+00:00",
         "recordingKind": "azureCommunicationServices",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-f0b6-4ffd-aa4f-51309b4c1cef",
+        "callConnectionId": "27002080-3c79-49b3-8b3d-09fd93fb8ad5",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.RecordingStateChanged"
       },
-      "time": "2024-05-01T22:21:56.9040006+00:00",
+      "time": "2024-05-02T20:57:55.4538353+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDItcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9jUXF5Vk5leGNrT0QxUVd1S0lZZEtRP2k9MTAtNjAtNS0yMDMmZT02Mzg1MDEwMzgxNjU0NDU3OTI=/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIxZDAwMWY4MC1mMGI2LTRmZmQtYWE0Zi01MTMwOWI0YzFjZWYiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiJmNDQ1YmMwYi0zNTE3LTQ5Y2UtYmRiNC1lNTI4NjgwYzYyZDEifQ/RecordingStateChanged"
+      "subject": "calling/recordings/aHR0cHM6Ly9hcGkuZmxpZ2h0cHJveHkuc2t5cGUuY29tL2FwaS92Mi9jcC9jb252LXVzY2UtMDUtcHJvZC1ha3MuY29udi5za3lwZS5jb20vY29udi9Yb2V1RU4tYnMweXVYQUlKeXpVRnZBP2k9MTAtNjAtNi03MiZlPTYzODQ5NzU2OTIxMDgzMTk1NQ==/eyJQbGF0Zm9ybUVuZHBvaW50SWQiOiIyNzAwMjA4MC0zYzc5LTQ5YjMtOGIzZC0wOWZkOTNmYjhhZDUiLCJSZXNvdXJjZVNwZWNpZmljSWQiOiI1NGJmODg2YS00ZWM1LTQzOTAtYmEwOC1lZGJkNTg3YzAxM2IifQ/RecordingStateChanged"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -402,24 +314,24 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:57.2348672+00:00",
+      "time": "2024-05-02T20:57:55.4788233+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "participants": [
           {
             "identifier": {
@@ -446,24 +358,112 @@
         ],
         "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:57.2254956+00:00",
+      "time": "2024-05-02T20:57:55.5030288+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:55.9188964+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:55.9470245+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -471,24 +471,24 @@
         },
         "operationContext": "recordingPlay",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-05-01T22:21:57.2688726+00:00",
+      "time": "2024-05-02T20:57:56.3106116+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -515,68 +515,24 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:57.7043095+00:00",
+      "time": "2024-05-02T20:57:56.6556486+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 6,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:57.7028562+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "participants": [
           {
             "identifier": {
@@ -603,24 +559,112 @@
         ],
         "sequenceNumber": 7,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:58.116388+00:00",
+      "time": "2024-05-02T20:57:56.6550981+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:57.0885901+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 7,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:57.0721157+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "participants": [
           {
             "identifier": {
@@ -647,24 +691,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:58.1329863+00:00",
+      "time": "2024-05-02T20:57:57.5032699+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -691,24 +735,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:58.5203727+00:00",
+      "time": "2024-05-02T20:57:57.5130021+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "participants": [
           {
             "identifier": {
@@ -735,24 +779,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:58.5589394+00:00",
+      "time": "2024-05-02T20:57:57.9409817+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -779,68 +823,24 @@
         ],
         "sequenceNumber": 9,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:58.9401256+00:00",
+      "time": "2024-05-02T20:57:57.9470523+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 9,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:58.9710689+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "eventSource": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025",
         "participants": [
           {
             "identifier": {
@@ -867,24 +867,24 @@
         ],
         "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-1d78-4e41-9fa3-4090f0ca7de5",
+        "callConnectionId": "27002080-1ef0-4f1d-94ef-6645a950e025",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:59.3400288+00:00",
+      "time": "2024-05-02T20:57:58.3672445+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-1d78-4e41-9fa3-4090f0ca7de5"
+      "subject": "calling/callConnections/27002080-1ef0-4f1d-94ef-6645a950e025"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+      "source": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "eventSource": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293",
         "participants": [
           {
             "identifier": {
@@ -911,15 +911,15 @@
         ],
         "sequenceNumber": 10,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-a245-4f2e-8be3-b4f25251381d",
+        "callConnectionId": "27002080-1b4e-43d7-87a1-1dd11cd64293",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:59.3801451+00:00",
+      "time": "2024-05-02T20:57:58.3660006+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-a245-4f2e-8be3-b4f25251381d"
+      "subject": "calling/callConnections/27002080-1b4e-43d7-87a1-1dd11cd64293"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
@@ -22,30 +22,50 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
+      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
-        "operationContext": "operationContextAnswerCall",
+        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+        "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
+        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:37:18.0158141+00:00",
+      "time": "2024-05-01T22:19:42.4544281+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
+      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
+      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+        "operationContext": "operationContextAnswerCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:19:42.4098145+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
+        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
         "participants": [
           {
             "identifier": {
@@ -72,44 +92,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
+        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:18.0158141+00:00",
+      "time": "2024-05-01T22:19:42.544508+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
+      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
-        "operationContext": "operationContextCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:37:18.0627211+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
         "participants": [
           {
             "identifier": {
@@ -136,55 +136,55 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:37:18.0627211+00:00",
+      "time": "2024-05-01T22:19:42.5352074+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
+      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
+      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993",
-        "operationContext": "operationContextAnswerCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-8403-4066-abe5-59b513c6c993",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallDisconnected"
-      },
-      "time": "2024-03-08T21:37:19.7502105+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-8403-4066-abe5-59b513c6c993"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
-      "type": "Microsoft.Communication.CallDisconnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
         "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-6ea3-4c2a-8f2d-be27dfd8b713",
+        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:37:19.7345971+00:00",
+      "time": "2024-05-01T22:19:43.2610849+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-6ea3-4c2a-8f2d-be27dfd8b713"
+      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+      "type": "Microsoft.Communication.CallDisconnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+        "operationContext": "operationContextAnswerCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallDisconnected"
+      },
+      "time": "2024-05-01T22:19:43.6035907+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Create_a_call_and_hangup.json
@@ -22,50 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+      "source": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
-        "operationContext": "operationContextCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:19:42.4544281+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+        "eventSource": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
+        "callConnectionId": "27002080-2a9c-474e-adfb-1628894ae65b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:19:42.4098145+00:00",
+      "time": "2024-05-02T20:55:40.9009566+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
+      "subject": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+      "source": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+        "eventSource": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
         "participants": [
           {
             "identifier": {
@@ -92,24 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
+        "callConnectionId": "27002080-2a9c-474e-adfb-1628894ae65b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:19:42.544508+00:00",
+      "time": "2024-05-02T20:55:40.9709418+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
+      "subject": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+      "source": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
+        "operationContext": "operationContextCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-a660-426b-93b2-f1e36769d8d7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:55:40.9700169+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+        "eventSource": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
         "participants": [
           {
             "identifier": {
@@ -136,55 +136,55 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+        "callConnectionId": "27002080-a660-426b-93b2-f1e36769d8d7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:19:42.5352074+00:00",
+      "time": "2024-05-02T20:55:40.9963127+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
+      "subject": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+      "source": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+        "eventSource": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7",
         "operationContext": "operationContextCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5c4c-4dfd-b49b-983d281da0bd",
+        "callConnectionId": "27002080-a660-426b-93b2-f1e36769d8d7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:19:43.2610849+00:00",
+      "time": "2024-05-02T20:55:42.3406383+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5c4c-4dfd-b49b-983d281da0bd"
+      "subject": "calling/callConnections/27002080-a660-426b-93b2-f1e36769d8d7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+      "source": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab",
+        "eventSource": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b",
         "operationContext": "operationContextAnswerCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-7fad-40d4-9728-98207919caab",
+        "callConnectionId": "27002080-2a9c-474e-adfb-1628894ae65b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:19:43.6035907+00:00",
+      "time": "2024-05-02T20:55:42.5132651+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-7fad-40d4-9728-98207919caab"
+      "subject": "calling/callConnections/27002080-2a9c-474e-adfb-1628894ae65b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
@@ -22,24 +22,24 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9",
+      "source": "calling/callConnections/27002080-ac14-4422-a442-9cb3ec9167c3",
       "type": "Microsoft.Communication.CreateCallFailed",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9",
+        "eventSource": "calling/callConnections/27002080-ac14-4422-a442-9cb3ec9167c3",
         "resultInformation": {
-          "code": 603,
-          "subCode": 0,
-          "message": "Decline. DiagCode: 603#0.@"
+          "code": 200,
+          "subCode": 5002,
+          "message": "The conversation has ended. DiagCode: 0#5002.@"
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-ebdf-4a31-a357-5d373af8f0e9",
+        "callConnectionId": "27002080-ac14-4422-a442-9cb3ec9167c3",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CreateCallFailed"
       },
-      "time": "2024-05-01T22:19:49.5459436+00:00",
+      "time": "2024-05-02T20:55:48.5917885+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9"
+      "subject": "calling/callConnections/27002080-ac14-4422-a442-9cb3ec9167c3"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Automation_Main_Client_Live_Tests_Reject_call.json
@@ -22,24 +22,24 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827",
+      "source": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9",
       "type": "Microsoft.Communication.CreateCallFailed",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827",
+        "eventSource": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9",
         "resultInformation": {
           "code": 603,
           "subCode": 0,
           "message": "Decline. DiagCode: 603#0.@"
         },
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-d931-441b-bf88-58b09e9de827",
+        "callConnectionId": "1d001f80-ebdf-4a31-a357-5d373af8f0e9",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CreateCallFailed"
       },
-      "time": "2024-03-08T21:37:25.9377797+00:00",
+      "time": "2024-05-01T22:19:49.5459436+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-d931-441b-bf88-58b09e9de827"
+      "subject": "calling/callConnections/1d001f80-ebdf-4a31-a357-5d373af8f0e9"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
@@ -22,30 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+      "source": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+        "eventSource": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
+        "callConnectionId": "27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:26.6336858+00:00",
+      "time": "2024-05-02T20:57:25.8365713+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
+      "subject": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+      "source": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+        "eventSource": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "participants": [
           {
             "identifier": {
@@ -72,139 +72,139 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
+        "callConnectionId": "27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:26.6474315+00:00",
+      "time": "2024-05-02T20:57:25.8450995+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
+      "subject": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+      "source": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-ed21-486e-a4e1-64e945fb05d7",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:25.8764017+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+        "eventSource": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
+        "callConnectionId": "27002080-ed21-486e-a4e1-64e945fb05d7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:26.6655754+00:00",
+      "time": "2024-05-02T20:57:25.8802453+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
+      "subject": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:26.6627381+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+      "source": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
       "type": "Microsoft.Communication.PlayCanceled",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+        "eventSource": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
         "operationContext": "CancelplayToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
+        "callConnectionId": "27002080-ed21-486e-a4e1-64e945fb05d7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCanceled"
       },
-      "time": "2024-05-01T22:21:28.4030339+00:00",
+      "time": "2024-05-02T20:57:27.7688697+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
+      "subject": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+      "source": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+        "eventSource": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
+        "callConnectionId": "27002080-ed21-486e-a4e1-64e945fb05d7",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:29.6409728+00:00",
+      "time": "2024-05-02T20:57:28.9641913+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
+      "subject": "calling/callConnections/27002080-ed21-486e-a4e1-64e945fb05d7"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+      "source": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
+        "eventSource": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
+        "callConnectionId": "27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:29.7090173+00:00",
+      "time": "2024-05-02T20:57:29.0215888+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
+      "subject": "calling/callConnections/27002080-bc1c-4f7a-9f7e-b1e5abdfdf8d"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Cancel_all_media_operations.json
@@ -22,94 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:39:05.4893087+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
+        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:39:05.4893087+00:00",
+      "time": "2024-05-01T22:21:26.6336858+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
+      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
-        "operationContext": "CancelMediaCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-03-08T21:39:05.5674975+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
         "participants": [
           {
             "identifier": {
@@ -136,75 +72,139 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:05.5674975+00:00",
+      "time": "2024-05-01T22:21:26.6474315+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
+      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+        "operationContext": "CancelMediaCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-01T22:21:26.6655754+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:26.6627381+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
       "type": "Microsoft.Communication.PlayCanceled",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
         "operationContext": "CancelplayToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCanceled"
       },
-      "time": "2024-03-08T21:39:07.2549531+00:00",
+      "time": "2024-05-01T22:21:28.4030339+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
+      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+      "source": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "eventSource": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b",
         "operationContext": "CancelMediaCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-dc54-4538-9eb8-ed6ee263a7db",
+        "callConnectionId": "1d001f80-5116-47c1-af93-eafcbd04184b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:39:08.4112185+00:00",
+      "time": "2024-05-01T22:21:29.6409728+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-dc54-4538-9eb8-ed6ee263a7db"
+      "subject": "calling/callConnections/1d001f80-5116-47c1-af93-eafcbd04184b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+      "source": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b",
+        "eventSource": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b",
         "operationContext": "CancelMediaAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-9261-412e-a223-4b580dafa91b",
+        "callConnectionId": "1d001f80-5502-421e-be37-654d5a427c2b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:39:08.4737327+00:00",
+      "time": "2024-05-01T22:21:29.7090173+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-9261-412e-a223-4b580dafa91b"
+      "subject": "calling/callConnections/1d001f80-5502-421e-be37-654d5a427c2b"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
@@ -22,30 +22,63 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:52.3016596+00:00",
+      "time": "2024-05-01T22:21:13.6391563+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
+      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 0,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:13.6368129+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
         "participants": [
           {
             "identifier": {
@@ -72,88 +105,88 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:52.3172836+00:00",
+      "time": "2024-05-01T22:21:13.7117333+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
+      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:52.3642538+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:52.3642538+00:00",
+      "time": "2024-05-01T22:21:13.7145952+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
+      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:14.054183+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -161,55 +194,55 @@
         },
         "operationContext": "playToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:38:58.1299007+00:00",
+      "time": "2024-05-01T22:21:19.0982349+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
+      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-190f-4eb1-ae5b-37dadd8c0325",
+        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:38:59.0048585+00:00",
+      "time": "2024-05-01T22:21:20.1144844+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-190f-4eb1-ae5b-37dadd8c0325"
+      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-7d30-4c7e-bd99-05a35aa38603",
+        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:38:59.0673616+00:00",
+      "time": "2024-05-01T22:21:20.2027691+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-7d30-4c7e-bd99-05a35aa38603"
+      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_all_participants.json
@@ -22,63 +22,30 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+      "source": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "eventSource": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "callConnectionId": "27002080-d854-463e-b34f-df041b4166b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:13.6391563+00:00",
+      "time": "2024-05-02T20:57:13.0307121+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
+      "subject": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+      "source": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 0,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:13.6368129+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+        "eventSource": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
         "participants": [
           {
             "identifier": {
@@ -105,44 +72,44 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
+        "callConnectionId": "27002080-accc-4d63-8e83-910ffcb0e947",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:13.7117333+00:00",
+      "time": "2024-05-02T20:57:13.1934829+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
+      "subject": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+      "source": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+        "eventSource": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
+        "callConnectionId": "27002080-accc-4d63-8e83-910ffcb0e947",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:13.7145952+00:00",
+      "time": "2024-05-02T20:57:13.1967466+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
+      "subject": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+      "source": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "eventSource": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
         "participants": [
           {
             "identifier": {
@@ -169,24 +136,24 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "callConnectionId": "27002080-d854-463e-b34f-df041b4166b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:14.054183+00:00",
+      "time": "2024-05-02T20:57:13.0451875+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
+      "subject": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+      "source": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+        "eventSource": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -194,55 +161,55 @@
         },
         "operationContext": "playToAllAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
+        "callConnectionId": "27002080-accc-4d63-8e83-910ffcb0e947",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-05-01T22:21:19.0982349+00:00",
+      "time": "2024-05-02T20:57:18.619464+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
+      "subject": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+      "source": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433",
+        "eventSource": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947",
         "operationContext": "playToAllCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-92da-4583-bf24-e350cb17a433",
+        "callConnectionId": "27002080-accc-4d63-8e83-910ffcb0e947",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:20.1144844+00:00",
+      "time": "2024-05-02T20:57:19.6032694+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-92da-4583-bf24-e350cb17a433"
+      "subject": "calling/callConnections/27002080-accc-4d63-8e83-910ffcb0e947"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+      "source": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "eventSource": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3",
         "operationContext": "playToAllAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb",
+        "callConnectionId": "27002080-d854-463e-b34f-df041b4166b3",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:20.2027691+00:00",
+      "time": "2024-05-02T20:57:19.6625184+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-17b8-45ab-b8f8-a40ff4a2f0fb"
+      "subject": "calling/callConnections/27002080-d854-463e-b34f-df041b4166b3"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
@@ -22,74 +22,50 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:20:56.6093625+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+      "source": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+        "eventSource": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
+        "callConnectionId": "27002080-0bf5-4333-84e4-437418266319",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:20:56.6055587+00:00",
+      "time": "2024-05-02T20:56:55.1001687+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
+      "subject": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
+        "operationContext": "playAudioCreateCall",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:56:55.1344781+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "eventSource": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
         "participants": [
           {
             "identifier": {
@@ -116,44 +92,68 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "callConnectionId": "27002080-0bf5-4333-84e4-437418266319",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:20:56.7212193+00:00",
+      "time": "2024-05-02T20:56:55.1030184+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
+      "subject": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
-        "operationContext": "playAudioCreateCall",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:20:56.7243272+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:56:55.1315259+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
         "participants": [
           {
             "identifier": {
@@ -180,24 +180,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "callConnectionId": "27002080-0bf5-4333-84e4-437418266319",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:00.1260772+00:00",
+      "time": "2024-05-02T20:56:59.5058425+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
+      "subject": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
         "participants": [
           {
             "identifier": {
@@ -224,112 +224,24 @@
         ],
         "sequenceNumber": 4,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:00.1266587+00:00",
+      "time": "2024-05-02T20:56:59.5069318+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:05.1060722+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:05.1022709+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -337,55 +249,143 @@
         },
         "operationContext": "playAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-05-01T22:21:05.1165199+00:00",
+      "time": "2024-05-02T20:57:04.7300228+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:04.8473469+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 5,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-0bf5-4333-84e4-437418266319",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:04.8419953+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "eventSource": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "callConnectionId": "27002080-8d14-4283-858e-a24b4897df2d",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:06.7759983+00:00",
+      "time": "2024-05-02T20:57:06.1845218+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
+      "subject": "calling/callConnections/27002080-8d14-4283-858e-a24b4897df2d"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+      "source": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+        "eventSource": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
+        "callConnectionId": "27002080-0bf5-4333-84e4-437418266319",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:06.857116+00:00",
+      "time": "2024-05-02T20:57:06.2465768+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
+      "subject": "calling/callConnections/27002080-0bf5-4333-84e4-437418266319"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Play_audio_to_target_participant.json
@@ -22,30 +22,74 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:20:56.6093625+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
+        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:36.0029069+00:00",
+      "time": "2024-05-01T22:20:56.6055587+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
+      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
         "participants": [
           {
             "identifier": {
@@ -72,88 +116,132 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:36.0341077+00:00",
+      "time": "2024-05-01T22:20:56.7212193+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:36.0653533+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:38:36.0653533+00:00",
+      "time": "2024-05-01T22:20:56.7243272+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": true
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:00.1260772+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
+        "participants": [
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": true
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
+          }
+        ],
+        "sequenceNumber": 4,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-01T22:21:00.1266587+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
         "participants": [
           {
             "identifier": {
@@ -175,29 +263,29 @@
               }
             },
             "isMuted": false,
-            "isOnHold": true
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 3,
+        "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:39.7372743+00:00",
+      "time": "2024-05-01T22:21:05.1060722+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
         "participants": [
           {
             "identifier": {
@@ -219,29 +307,29 @@
               }
             },
             "isMuted": false,
-            "isOnHold": true
+            "isOnHold": false
           }
         ],
-        "sequenceNumber": 3,
+        "sequenceNumber": 5,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:38:39.7372743+00:00",
+      "time": "2024-05-01T22:21:05.1022709+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
+      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
       "type": "Microsoft.Communication.PlayCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
         "resultInformation": {
           "code": 200,
           "subCode": 0,
@@ -249,143 +337,55 @@
         },
         "operationContext": "playAudio",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.PlayCompleted"
       },
-      "time": "2024-03-08T21:38:44.6123274+00:00",
+      "time": "2024-05-01T22:21:05.1165199+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:44.6435749+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-        "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 5,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-03-08T21:38:44.6592091+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+      "source": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "eventSource": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b",
         "operationContext": "playAudioCreateCall",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-0c00-44cd-bcf7-dbf37e55eca3",
+        "callConnectionId": "1d001f80-c1e2-4934-9780-20e63f504f6b",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:38:46.2061446+00:00",
+      "time": "2024-05-01T22:21:06.7759983+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-0c00-44cd-bcf7-dbf37e55eca3"
+      "subject": "calling/callConnections/1d001f80-c1e2-4934-9780-20e63f504f6b"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+      "source": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79",
+        "eventSource": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209",
         "operationContext": "playAudioAnswer",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-abd6-405b-adcd-379e020f1e79",
+        "callConnectionId": "1d001f80-d092-4375-9827-18e856679209",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:38:46.2842181+00:00",
+      "time": "2024-05-01T22:21:06.857116+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-abd6-405b-adcd-379e020f1e79"
+      "subject": "calling/callConnections/1d001f80-d092-4375-9827-18e856679209"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
@@ -22,41 +22,49 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
+      "source": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
+        "eventSource": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
+        "callConnectionId": "27002080-8908-4891-a215-8cb889dc4915",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-05-01T22:21:37.9226869+00:00",
+      "time": "2024-05-02T20:57:37.7804147+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
+      "subject": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+      "source": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
+      "type": "Microsoft.Communication.CallConnected",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-aa36-4109-a4ac-931147bf8399",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.CallConnected"
+      },
+      "time": "2024-05-02T20:57:37.8783167+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+        "eventSource": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
         "participants": [
-          {
-            "identifier": {
-              "rawId": "sanitized",
-              "kind": "communicationUser",
-              "communicationUser": {
-                "id": "sanitized"
-              }
-            },
-            "isMuted": false,
-            "isOnHold": false
-          },
           {
             "identifier": {
               "rawId": "sanitized",
@@ -67,48 +75,7 @@
             },
             "isMuted": false,
             "isOnHold": false
-          }
-        ],
-        "sequenceNumber": 1,
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
-      },
-      "time": "2024-05-01T22:21:38.0095083+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
-      "type": "Microsoft.Communication.CallConnected",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
-        "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
-        "serverCallId": "sanitized",
-        "correlationId": "sanitized",
-        "publicEventType": "Microsoft.Communication.CallConnected"
-      },
-      "time": "2024-05-01T22:21:38.0128819+00:00",
-      "specversion": "1.0",
-      "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
-    }
-  ],
-  [
-    {
-      "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
-      "type": "Microsoft.Communication.ParticipantsUpdated",
-      "data": {
-        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
-        "participants": [
+          },
           {
             "identifier": {
               "rawId": "sanitized",
@@ -119,7 +86,29 @@
             },
             "isMuted": false,
             "isOnHold": false
-          },
+          }
+        ],
+        "sequenceNumber": 1,
+        "version": "2023-10-03-preview",
+        "callConnectionId": "27002080-aa36-4109-a4ac-931147bf8399",
+        "serverCallId": "sanitized",
+        "correlationId": "sanitized",
+        "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
+      },
+      "time": "2024-05-02T20:57:37.8506863+00:00",
+      "specversion": "1.0",
+      "datacontenttype": "application/json",
+      "subject": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399"
+    }
+  ],
+  [
+    {
+      "id": "sanitized",
+      "source": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
+      "type": "Microsoft.Communication.ParticipantsUpdated",
+      "data": {
+        "eventSource": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
+        "participants": [
           {
             "identifier": {
               "rawId": "sanitized",
@@ -130,97 +119,108 @@
             },
             "isMuted": false,
             "isOnHold": false
+          },
+          {
+            "identifier": {
+              "rawId": "sanitized",
+              "kind": "communicationUser",
+              "communicationUser": {
+                "id": "sanitized"
+              }
+            },
+            "isMuted": false,
+            "isOnHold": false
           }
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
+        "callConnectionId": "27002080-8908-4891-a215-8cb889dc4915",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-05-01T22:21:38.1545562+00:00",
+      "time": "2024-05-02T20:57:37.9425695+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
+      "subject": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+      "source": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
       "type": "Microsoft.Communication.SendDtmfTonesCompleted",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+        "eventSource": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
         "operationContext": "ContinuousDtmfRecognitionSend",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
+        "callConnectionId": "27002080-aa36-4109-a4ac-931147bf8399",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.SendDtmfTonesCompleted"
       },
-      "time": "2024-05-01T22:21:42.5309356+00:00",
+      "time": "2024-05-02T20:57:41.7354281+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
+      "subject": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+      "source": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
       "type": "Microsoft.Communication.ContinuousDtmfRecognitionStopped",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+        "eventSource": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
         "operationContext": "ContinuousDtmfRecognitionStop",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
+        "callConnectionId": "27002080-aa36-4109-a4ac-931147bf8399",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ContinuousDtmfRecognitionStopped"
       },
-      "time": "2024-05-01T22:21:43.356548+00:00",
+      "time": "2024-05-02T20:57:42.5898938+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
+      "subject": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+      "source": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
+        "eventSource": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
+        "callConnectionId": "27002080-aa36-4109-a4ac-931147bf8399",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:44.5958057+00:00",
+      "time": "2024-05-02T20:57:43.7976359+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
+      "subject": "calling/callConnections/27002080-aa36-4109-a4ac-931147bf8399"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
+      "source": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
+        "eventSource": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915",
         "version": "2023-10-03-preview",
-        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
+        "callConnectionId": "27002080-8908-4891-a215-8cb889dc4915",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-05-01T22:21:44.7615195+00:00",
+      "time": "2024-05-02T20:57:43.9962795+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
+      "subject": "calling/callConnections/27002080-8908-4891-a215-8cb889dc4915"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
+++ b/sdk/communication/communication-call-automation/recordings/Call_Media_Client_Live_Tests_Trigger_DTMF_actions.json
@@ -22,29 +22,29 @@
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
+        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:39:16.1300989+00:00",
+      "time": "2024-05-01T22:21:37.9226869+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
+      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
         "participants": [
           {
             "identifier": {
@@ -71,43 +71,43 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
+        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:16.1300989+00:00",
+      "time": "2024-05-01T22:21:38.0095083+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
+      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
       "type": "Microsoft.Communication.CallConnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallConnected"
       },
-      "time": "2024-03-08T21:39:16.2082231+00:00",
+      "time": "2024-05-01T22:21:38.0128819+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
+      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
       "type": "Microsoft.Communication.ParticipantsUpdated",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
         "participants": [
           {
             "identifier": {
@@ -134,93 +134,93 @@
         ],
         "sequenceNumber": 1,
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ParticipantsUpdated"
       },
-      "time": "2024-03-08T21:39:16.4454559+00:00",
+      "time": "2024-05-01T22:21:38.1545562+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
+      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
       "type": "Microsoft.Communication.SendDtmfTonesCompleted",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
         "operationContext": "ContinuousDtmfRecognitionSend",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
+        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.SendDtmfTonesCompleted"
       },
-      "time": "2024-03-08T21:39:21.1954969+00:00",
+      "time": "2024-05-01T22:21:42.5309356+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
+      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
       "type": "Microsoft.Communication.ContinuousDtmfRecognitionStopped",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
         "operationContext": "ContinuousDtmfRecognitionStop",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
+        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.ContinuousDtmfRecognitionStopped"
       },
-      "time": "2024-03-08T21:39:21.8830024+00:00",
+      "time": "2024-05-01T22:21:43.356548+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
+      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+      "source": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d",
+        "eventSource": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-bad1-454d-b3c5-8864182de29d",
+        "callConnectionId": "1d001f80-5157-45ec-878f-048994420f69",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:39:23.0548241+00:00",
+      "time": "2024-05-01T22:21:44.5958057+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-bad1-454d-b3c5-8864182de29d"
+      "subject": "calling/callConnections/1d001f80-5157-45ec-878f-048994420f69"
     }
   ],
   [
     {
       "id": "sanitized",
-      "source": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+      "source": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
       "type": "Microsoft.Communication.CallDisconnected",
       "data": {
-        "eventSource": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "eventSource": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd",
         "version": "2023-10-03-preview",
-        "callConnectionId": "421f0b00-df51-4e90-a348-c1afd0559a7d",
+        "callConnectionId": "1d001f80-b29b-4b55-876b-dabc6062dacd",
         "serverCallId": "sanitized",
         "correlationId": "sanitized",
         "publicEventType": "Microsoft.Communication.CallDisconnected"
       },
-      "time": "2024-03-08T21:39:23.2892567+00:00",
+      "time": "2024-05-01T22:21:44.7615195+00:00",
       "specversion": "1.0",
       "datacontenttype": "application/json",
-      "subject": "calling/callConnections/421f0b00-df51-4e90-a348-c1afd0559a7d"
+      "subject": "calling/callConnections/1d001f80-b29b-4b55-876b-dabc6062dacd"
     }
   ]
 ]

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -118,7 +118,7 @@ export interface CallAutomationClientOptions extends CommonClientOptions {
 }
 
 // @public
-export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | TeamsComplianceRecordingStateChanged | TeamsRecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed | CreateCallFailed | AnswerFailed | HoldFailed;
+export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | TeamsComplianceRecordingStateChanged | TeamsRecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed | CreateCallFailed | AnswerFailed | HoldFailed | MediaStreamingStarted | MediaStreamingStopped | MediaStreamingFailed;
 
 // @public
 export class CallAutomationEventProcessor {
@@ -595,6 +595,39 @@ export interface MediaStreamingConfiguration {
 
 // @public
 export type MediaStreamingContentType = string;
+
+// Warning: (ae-forgotten-export) The symbol "RestMediaStreamingFailed" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface MediaStreamingFailed extends Omit<RestMediaStreamingFailed, "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"> {
+    callConnectionId: string;
+    correlationId: string;
+    kind: "MediaStreamingFailed";
+    resultInformation?: RestResultInformation;
+    serverCallId: string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "RestMediaStreamingStarted" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface MediaStreamingStarted extends Omit<RestMediaStreamingStarted, "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"> {
+    callConnectionId: string;
+    correlationId: string;
+    kind: "MediaStreamingStarted";
+    resultInformation?: RestResultInformation;
+    serverCallId: string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "RestMediaStreamingStopped" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface MediaStreamingStopped extends Omit<RestMediaStreamingStopped, "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"> {
+    callConnectionId: string;
+    correlationId: string;
+    kind: "MediaStreamingStopped";
+    resultInformation?: RestResultInformation;
+    serverCallId: string;
+}
 
 // @public
 export type MediaStreamingTransportType = string;

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -39,6 +39,9 @@ import {
   CreateCallFailed,
   AnswerFailed,
   HoldFailed,
+  MediaStreamingStarted,
+  MediaStreamingFailed,
+  MediaStreamingStopped,
 } from "./models/events";
 
 import { CloudEventMapper } from "./models/mapper";
@@ -172,6 +175,15 @@ export function parseCallAutomationEvent(
     case "Microsoft.Communication.HoldFailed":
       callbackEvent = { kind: "HoldFailed" } as HoldFailed;
       break;
+    case "Microsoft.Communication.MediaStreamingStarted":
+        callbackEvent = { kind: "MediaStreamingStarted" } as MediaStreamingStarted;
+        break;
+    case "Microsoft.Communication.MediaStreamingStopped":
+        callbackEvent = { kind: "MediaStreamingStopped" } as MediaStreamingStopped;
+        break;
+    case "Microsoft.Communication.MediaStreamingFailed":
+        callbackEvent = { kind: "MediaStreamingFailed" } as MediaStreamingFailed;
+        break;
     default:
       throw new TypeError(`Unknown Call Automation Event type: ${eventType}`);
   }

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -176,14 +176,14 @@ export function parseCallAutomationEvent(
       callbackEvent = { kind: "HoldFailed" } as HoldFailed;
       break;
     case "Microsoft.Communication.MediaStreamingStarted":
-        callbackEvent = { kind: "MediaStreamingStarted" } as MediaStreamingStarted;
-        break;
+      callbackEvent = { kind: "MediaStreamingStarted" } as MediaStreamingStarted;
+      break;
     case "Microsoft.Communication.MediaStreamingStopped":
-        callbackEvent = { kind: "MediaStreamingStopped" } as MediaStreamingStopped;
-        break;
+      callbackEvent = { kind: "MediaStreamingStopped" } as MediaStreamingStopped;
+      break;
     case "Microsoft.Communication.MediaStreamingFailed":
-        callbackEvent = { kind: "MediaStreamingFailed" } as MediaStreamingFailed;
-        break;
+      callbackEvent = { kind: "MediaStreamingFailed" } as MediaStreamingFailed;
+      break;
     default:
       throw new TypeError(`Unknown Call Automation Event type: ${eventType}`);
   }

--- a/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
@@ -729,73 +729,6 @@ export interface RecordingStateResponse {
   recordingType?: RecordingType;
 }
 
-/** AnswerFailed event */
-export interface AnswerFailed {
-  /**
-   * Used by customers when calling mid-call actions to correlate the request to the response event.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly operationContext?: string;
-  /**
-   * Contains the resulting SIP code, sub-code and message.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly resultInformation?: RestResultInformation;
-  /**
-   * Call connection ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly callConnectionId?: string;
-  /**
-   * Server call ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly serverCallId?: string;
-  /**
-   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly correlationId?: string;
-}
-
-export interface RestResultInformation {
-  /** Code of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
-  code?: number;
-  /** Subcode of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
-  subCode?: number;
-  /** Detail message that describes the current result. */
-  message?: string;
-}
-
-/** The CreateCallFailed event */
-export interface CreateCallFailed {
-  /**
-   * Used by customers when calling mid-call actions to correlate the request to the response event.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly operationContext?: string;
-  /**
-   * Contains the resulting SIP code, sub-code and message.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly resultInformation?: RestResultInformation;
-  /**
-   * Call connection ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly callConnectionId?: string;
-  /**
-   * Server call ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly serverCallId?: string;
-  /**
-   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly correlationId?: string;
-}
-
 export interface CollectTonesResult {
   /** NOTE: This property will not be serialized. It can only be populated by the server. */
   readonly tones?: Tone[];
@@ -855,6 +788,15 @@ export interface DialogCompleted {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly correlationId?: string;
+}
+
+export interface RestResultInformation {
+  /** Code of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
+  code?: number;
+  /** Subcode of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
+  subCode?: number;
+  /** Detail message that describes the current result. */
+  message?: string;
 }
 
 export interface DialogFailed {
@@ -1191,32 +1133,10 @@ export interface TranscriptionUpdate {
   transcriptionStatusDetails?: TranscriptionStatusDetails;
 }
 
-export interface HoldFailed {
-  /**
-   * Used by customers when calling mid-call actions to correlate the request to the response event.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly operationContext?: string;
-  /**
-   * Contains the resulting SIP code, sub-code and message.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly resultInformation?: RestResultInformation;
-  /**
-   * Call connection ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly callConnectionId?: string;
-  /**
-   * Server call ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly serverCallId?: string;
-  /**
-   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
-   * NOTE: This property will not be serialized. It can only be populated by the server.
-   */
-  readonly correlationId?: string;
+export interface MediaStreamingUpdate {
+  contentType?: string;
+  mediaStreamingStatus?: MediaStreamingStatus;
+  mediaStreamingStatusDetails?: MediaStreamingStatusDetails;
 }
 
 /** The participant successfully added event. */
@@ -2199,6 +2119,105 @@ export interface RestHoldFailed {
   readonly correlationId?: string;
 }
 
+export interface RestMediaStreamingStarted {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Defines the result for audio streaming update with the current status and the details about the status
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly mediaStreamingUpdate?: MediaStreamingUpdate;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
+export interface RestMediaStreamingStopped {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Defines the result for audio streaming update with the current status and the details about the status
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly mediaStreamingUpdate?: MediaStreamingUpdate;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
+export interface RestMediaStreamingFailed {
+  /**
+   * Used by customers when calling mid-call actions to correlate the request to the response event.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly operationContext?: string;
+  /**
+   * Contains the resulting SIP code, sub-code and message.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly resultInformation?: RestResultInformation;
+  /**
+   * Defines the result for audio streaming update with the current status and the details about the status
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly mediaStreamingUpdate?: MediaStreamingUpdate;
+  /**
+   * Call connection ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly callConnectionId?: string;
+  /**
+   * Server call ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly serverCallId?: string;
+  /**
+   * Correlation ID for event to call correlation. Also called ChainId for skype chain ID.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly correlationId?: string;
+}
+
 /** Azure Open AI Dialog */
 export interface AzureOpenAIDialog extends BaseDialog {
   /** Polymorphic discriminator, which specifies the different types this object can be */
@@ -2745,6 +2764,87 @@ export enum KnownTranscriptionStatusDetails {
  * **transcriptionLocaleUpdated**
  */
 export type TranscriptionStatusDetails = string;
+
+/** Known values of {@link MediaStreamingStatus} that the service accepts. */
+export enum KnownMediaStreamingStatus {
+  /** MediaStreamingStarted */
+  MediaStreamingStarted = "mediaStreamingStarted",
+  /** MediaStreamingFailed */
+  MediaStreamingFailed = "mediaStreamingFailed",
+  /** MediaStreamingStopped */
+  MediaStreamingStopped = "mediaStreamingStopped",
+  /** UnspecifiedError */
+  UnspecifiedError = "unspecifiedError",
+}
+
+/**
+ * Defines values for MediaStreamingStatus. \
+ * {@link KnownMediaStreamingStatus} can be used interchangeably with MediaStreamingStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **mediaStreamingStarted** \
+ * **mediaStreamingFailed** \
+ * **mediaStreamingStopped** \
+ * **unspecifiedError**
+ */
+export type MediaStreamingStatus = string;
+
+/** Known values of {@link MediaStreamingStatusDetails} that the service accepts. */
+export enum KnownMediaStreamingStatusDetails {
+  /** SubscriptionStarted */
+  SubscriptionStarted = "subscriptionStarted",
+  /** StreamConnectionReestablished */
+  StreamConnectionReestablished = "streamConnectionReestablished",
+  /** StreamConnectionUnsuccessful */
+  StreamConnectionUnsuccessful = "streamConnectionUnsuccessful",
+  /** StreamUrlMissing */
+  StreamUrlMissing = "streamUrlMissing",
+  /** ServiceShutdown */
+  ServiceShutdown = "serviceShutdown",
+  /** StreamConnectionInterrupted */
+  StreamConnectionInterrupted = "streamConnectionInterrupted",
+  /** SpeechServicesConnectionError */
+  SpeechServicesConnectionError = "speechServicesConnectionError",
+  /** SubscriptionStopped */
+  SubscriptionStopped = "subscriptionStopped",
+  /** UnspecifiedError */
+  UnspecifiedError = "unspecifiedError",
+  /** AuthenticationFailure */
+  AuthenticationFailure = "authenticationFailure",
+  /** BadRequest */
+  BadRequest = "badRequest",
+  /** TooManyRequests */
+  TooManyRequests = "tooManyRequests",
+  /** Forbidden */
+  Forbidden = "forbidden",
+  /** ServiceTimeout */
+  ServiceTimeout = "serviceTimeout",
+  /** InitialWebSocketConnectionFailed */
+  InitialWebSocketConnectionFailed = "initialWebSocketConnectionFailed",
+}
+
+/**
+ * Defines values for MediaStreamingStatusDetails. \
+ * {@link KnownMediaStreamingStatusDetails} can be used interchangeably with MediaStreamingStatusDetails,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **subscriptionStarted** \
+ * **streamConnectionReestablished** \
+ * **streamConnectionUnsuccessful** \
+ * **streamUrlMissing** \
+ * **serviceShutdown** \
+ * **streamConnectionInterrupted** \
+ * **speechServicesConnectionError** \
+ * **subscriptionStopped** \
+ * **unspecifiedError** \
+ * **authenticationFailure** \
+ * **badRequest** \
+ * **tooManyRequests** \
+ * **forbidden** \
+ * **serviceTimeout** \
+ * **initialWebSocketConnectionFailed**
+ */
+export type MediaStreamingStatusDetails = string;
 
 /** Known values of {@link RecognitionType} that the service accepts. */
 export enum KnownRecognitionType {

--- a/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
@@ -1979,121 +1979,6 @@ export const RecordingStateResponse: coreClient.CompositeMapper = {
   },
 };
 
-export const AnswerFailed: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "AnswerFailed",
-    modelProperties: {
-      operationContext: {
-        serializedName: "operationContext",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      resultInformation: {
-        serializedName: "resultInformation",
-        type: {
-          name: "Composite",
-          className: "RestResultInformation",
-        },
-      },
-      callConnectionId: {
-        serializedName: "callConnectionId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      serverCallId: {
-        serializedName: "serverCallId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      correlationId: {
-        serializedName: "correlationId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-    },
-  },
-};
-
-export const RestResultInformation: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "RestResultInformation",
-    modelProperties: {
-      code: {
-        serializedName: "code",
-        type: {
-          name: "Number",
-        },
-      },
-      subCode: {
-        serializedName: "subCode",
-        type: {
-          name: "Number",
-        },
-      },
-      message: {
-        serializedName: "message",
-        type: {
-          name: "String",
-        },
-      },
-    },
-  },
-};
-
-export const CreateCallFailed: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "CreateCallFailed",
-    modelProperties: {
-      operationContext: {
-        serializedName: "operationContext",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      resultInformation: {
-        serializedName: "resultInformation",
-        type: {
-          name: "Composite",
-          className: "RestResultInformation",
-        },
-      },
-      callConnectionId: {
-        serializedName: "callConnectionId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      serverCallId: {
-        serializedName: "serverCallId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      correlationId: {
-        serializedName: "correlationId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-    },
-  },
-};
-
 export const CollectTonesResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2221,6 +2106,33 @@ export const DialogCompleted: coreClient.CompositeMapper = {
       correlationId: {
         serializedName: "correlationId",
         readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestResultInformation: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestResultInformation",
+    modelProperties: {
+      code: {
+        serializedName: "code",
+        type: {
+          name: "Number",
+        },
+      },
+      subCode: {
+        serializedName: "subCode",
+        type: {
+          name: "Number",
+        },
+      },
+      message: {
+        serializedName: "message",
         type: {
           name: "String",
         },
@@ -2788,42 +2700,25 @@ export const TranscriptionUpdate: coreClient.CompositeMapper = {
   },
 };
 
-export const HoldFailed: coreClient.CompositeMapper = {
+export const MediaStreamingUpdate: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "HoldFailed",
+    className: "MediaStreamingUpdate",
     modelProperties: {
-      operationContext: {
-        serializedName: "operationContext",
-        readOnly: true,
+      contentType: {
+        serializedName: "contentType",
         type: {
           name: "String",
         },
       },
-      resultInformation: {
-        serializedName: "resultInformation",
-        type: {
-          name: "Composite",
-          className: "RestResultInformation",
-        },
-      },
-      callConnectionId: {
-        serializedName: "callConnectionId",
-        readOnly: true,
+      mediaStreamingStatus: {
+        serializedName: "mediaStreamingStatus",
         type: {
           name: "String",
         },
       },
-      serverCallId: {
-        serializedName: "serverCallId",
-        readOnly: true,
-        type: {
-          name: "String",
-        },
-      },
-      correlationId: {
-        serializedName: "correlationId",
-        readOnly: true,
+      mediaStreamingStatusDetails: {
+        serializedName: "mediaStreamingStatusDetails",
         type: {
           name: "String",
         },
@@ -4363,6 +4258,159 @@ export const RestHoldFailed: coreClient.CompositeMapper = {
         type: {
           name: "Composite",
           className: "RestResultInformation",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestMediaStreamingStarted: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestMediaStreamingStarted",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      mediaStreamingUpdate: {
+        serializedName: "mediaStreamingUpdate",
+        type: {
+          name: "Composite",
+          className: "MediaStreamingUpdate",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestMediaStreamingStopped: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestMediaStreamingStopped",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      mediaStreamingUpdate: {
+        serializedName: "mediaStreamingUpdate",
+        type: {
+          name: "Composite",
+          className: "MediaStreamingUpdate",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+    },
+  },
+};
+
+export const RestMediaStreamingFailed: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestMediaStreamingFailed",
+    modelProperties: {
+      operationContext: {
+        serializedName: "operationContext",
+        readOnly: true,
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      mediaStreamingUpdate: {
+        serializedName: "mediaStreamingUpdate",
+        type: {
+          name: "Composite",
+          className: "MediaStreamingUpdate",
         },
       },
       callConnectionId: {

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -38,6 +38,9 @@ import {
   RestCreateCallFailed,
   RestAnswerFailed,
   RestHoldFailed,
+  RestMediaStreamingStopped,
+  RestMediaStreamingStarted,
+  RestMediaStreamingFailed,
 } from "../generated/src/models";
 
 import { CallParticipant } from "./models";
@@ -75,7 +78,10 @@ export type CallAutomationEvent =
   | TranscriptionFailed
   | CreateCallFailed
   | AnswerFailed
-  | HoldFailed;
+  | HoldFailed
+  | MediaStreamingStarted  
+  | MediaStreamingStopped
+  | MediaStreamingFailed;
 
 export interface ResultInformation
   extends Omit<RestResultInformation, "code" | "subCode" | "message"> {
@@ -653,4 +659,55 @@ export interface HoldFailed
   resultInformation?: RestResultInformation;
   /** kind of this event. */
   kind: "HoldFailed";
+}
+
+export interface MediaStreamingStarted
+  extends Omit<
+    RestMediaStreamingStarted,
+    "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
+  > {
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** kind of this event. */
+  kind: "MediaStreamingStarted";
+}
+
+export interface MediaStreamingStopped
+  extends Omit<
+    RestMediaStreamingStopped,
+    "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
+  > {
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** kind of this event. */
+  kind: "MediaStreamingStopped";
+}
+
+export interface MediaStreamingFailed
+  extends Omit<
+    RestMediaStreamingFailed,
+    "callConnectionId" | "serverCallId" | "correlationId" | "resultInformation"
+  > {
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** kind of this event. */
+  kind: "MediaStreamingFailed";
 }

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -79,7 +79,7 @@ export type CallAutomationEvent =
   | CreateCallFailed
   | AnswerFailed
   | HoldFailed
-  | MediaStreamingStarted  
+  | MediaStreamingStarted
   | MediaStreamingStopped
   | MediaStreamingFailed;
 

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -13,7 +13,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: package-2023-10-03-preview
 require:
-  - https://github.com/Azure/azure-rest-api-specs/blob/2f0c2b15ba41419aec1a739307b50e03178e0d4d/specification/communication/data-plane/CallAutomation/readme.md
+  - https://github.com/Azure/azure-rest-api-specs/blob/ebedc156cf07929f3f72e71e5323ecdfa402267d/specification/communication/data-plane/CallAutomation/readme.md
 package-version: 1.2.0-beta.1
 model-date-time-as-string: false
 optional-response-headers: true
@@ -164,4 +164,13 @@ directive:
   - rename-model:
       from: HoldFailed
       to: RestHoldFailed
+  - rename-model:
+      from: MediaStreamingStarted
+      to: RestMediaStreamingStarted
+  - rename-model:
+      from: MediaStreamingStopped
+      to: RestMediaStreamingStopped
+  - rename-model:
+      from: MediaStreamingFailed
+      to: RestMediaStreamingFailed
 ```


### PR DESCRIPTION
Adding the mediatreaming events (mediastreamingstarted, mediastreamingstopped and mediastreamingfailed) to eventprocessor. 

[Task 3708884](https://skype.visualstudio.com/SPOOL/_workitems/edit/3708884): [SDK][Alpha3] Audio streaming events for JS