### PR TITLE
[Monitor Opentelemetry] Detect Usage of OpenTelemetry Instrumentations for Statsbeat

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2712,6 +2712,19 @@ packages:
       - supports-color
     dev: false
 
+  /@opentelemetry/instrumentation-fs@0.12.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-Waf+2hekJRxIwq1PmivxOWLdMOtYbY22hKr34gEtfbv2CArSv8FBJH4BmQxB9o5ZcwkdKu589qs009dbuSfNmQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.24.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/instrumentation': 0.51.0(@opentelemetry/api@1.8.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@opentelemetry/instrumentation-http@0.51.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-6VsGPBnU6iVKWhVBnuRpwrmiHfxt8EYrqfnH2glfsMpsn4xy+O6U0yGlggPLhoYeOVafV3h70EEk5MU0tpsbiw==}
     engines: {node: '>=14'}
@@ -21451,7 +21464,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-sxrMN87cWN2eGVDwnr/IOqGAXWcSjgMa08Z0wndbaeW+wRBFOW9+5C3wt4oXuX/yHEqUjy/e7pttQI6WPNzYBw==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-XhihPanQxONwsuiYtinPEQ0qtOAcqUPOxRqzB5XMhzkRVAAkt3vamZPZBkusumRngPI4aLq1zIjJ596ElNN/lw==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21463,6 +21476,7 @@ packages:
       '@opentelemetry/core': 1.24.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation': 0.51.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation-bunyan': 0.38.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/instrumentation-fs': 0.12.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation-http': 0.51.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation-mongodb': 0.43.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation-mysql': 0.38.0(@opentelemetry/api@1.8.0)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Collect OpenTelemetry instrumentations in Statsbeat.
+
 ## 1.4.0 (2024-04-16)
 
 - Capture live metrics and live metrics activation in statsbeat.

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -79,7 +79,8 @@
     "rimraf": "^5.0.5",
     "sinon": "^17.0.0",
     "tsx": "^4.7.1",
-    "typescript": "~5.4.5"
+    "typescript": "~5.4.5",
+    "@opentelemetry/instrumentation-fs": "^0.12.0"
   },
   "dependencies": {
     "@azure/core-client": "^1.0.0",

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -95,7 +95,7 @@ export interface StatsbeatInstrumentations {
   ioredis?: boolean;
   knex?: boolean;
   koa?: boolean;
-  memcahed?: boolean;
+  memcached?: boolean;
   mysql2?: boolean;
   nestjsCore?: boolean;
   net?: boolean;
@@ -203,11 +203,16 @@ export enum StatsbeatInstrumentation {
   IOREDIS = 33554432,
   KNEX = 67108864,
   KOA = 134217728,
-  MEMCAHED = 268435456,
+  MEMCACHED = 268435456,
   MYSQL2 = 536870912,
   NESTJS_CORE = 1073741824,
   NET = 2147483648,
   PINO = 4294967296,
   RESTIFY = 8589934592,
   ROUTER = 17179869184,
+}
+
+export interface StatsbeatEnvironmentConfig {
+  instrumentation: StatsbeatInstrumentation;
+  feature: StatsbeatFeature;
 }

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -60,11 +60,12 @@ export interface InstrumentationOptions {
 }
 
 /**
- * Statsbeat Feature and Instrumentation Options interface
+ * Statsbeat Instrumentation Options interface.
+ * Order of the options is important as it is used to calculate the bit map.
  * @internal
  */
-export interface StatsbeatOptions {
-  /** Instrumentations */
+export interface StatsbeatInstrumentations {
+  /** Azure Monitor Supported Instrumentations */
   azureSdk?: boolean;
   mongoDb?: boolean;
   mySql?: boolean;
@@ -72,11 +73,56 @@ export interface StatsbeatOptions {
   redis?: boolean;
   bunyan?: boolean;
   winston?: boolean;
-  /** Features */
-  liveMetrics?: boolean;
-  browserSdkLoader?: boolean;
-  aadHandling?: boolean;
+  /** OpenTelemetry Instrumenatations */
+  amqplib?: boolean;
+  cucumber?: boolean;
+  dataloader?: boolean;
+  fs?: boolean;
+  lruMemoizer?: boolean;
+  mongoose?: boolean;
+  runtimeNode?: boolean;
+  socketIo?: boolean;
+  tedious?: boolean;
+  undici?: boolean;
+  cassandra?: boolean;
+  connect?: boolean;
+  dns?: boolean;
+  express?: boolean;
+  fastify?: boolean;
+  genericPool?: boolean;
+  graphql?: boolean;
+  hapi?: boolean;
+  ioredis?: boolean;
+  knex?: boolean;
+  koa?: boolean;
+  memcahed?: boolean;
+  mysql2?: boolean;
+  nestjsCore?: boolean;
+  net?: boolean;
+  pino?: boolean;
+  restify?: boolean;
+  router?: boolean;
+}
+
+/**
+ * Statsbeat Feature Options interface.
+ * Order of the options is important as it is used to calculate the bit map.
+ * @internal
+ */
+export interface StatsbeatFeatures {
   diskRetry?: boolean;
+  aadHandling?: boolean;
+  browserSdkLoader?: boolean;
+  distro?: boolean;
+  liveMetrics?: boolean;
+}
+
+/**
+ * Statsbeat Instrumentation and Feature Option interface
+ */
+export interface StatsbeatOption {
+  option: string;
+  value: boolean;
 }
 
 /**
@@ -126,6 +172,7 @@ export enum StatsbeatFeature {
 }
 
 export enum StatsbeatInstrumentation {
+  /** Azure Monitor Supported Instrumentations */
   NONE = 0,
   AZURE_CORE_TRACING = 1,
   MONGODB = 2,
@@ -134,4 +181,33 @@ export enum StatsbeatInstrumentation {
   POSTGRES = 16,
   BUNYAN = 32,
   WINSTON = 64,
+  /** OpenTelemetry Supported Instrumentations */
+  AMQPLIB = 128,
+  CUCUMBER = 256,
+  DATALOADER = 512,
+  FS = 1024,
+  LRU_MEMOIZER = 2048,
+  MONGOOSE = 4096,
+  RUNTIME_NODE = 8192,
+  SOCKET_IO = 16384,
+  TEDIOUS = 32768,
+  UNDICI = 65536,
+  CASSANDRA = 131072,
+  CONNECT = 262144,
+  DNS = 524288,
+  EXPRESS = 1048576,
+  FASTIFY = 2097152,
+  GENERIC_POOL = 4194304,
+  GRAPHQL = 8388608,
+  HAPI = 16777216,
+  IOREDIS = 33554432,
+  KNEX = 67108864,
+  KOA = 134217728,
+  MEMCAHED = 268435456,
+  MYSQL2 = 536870912,
+  NESTJS_CORE = 1073741824,
+  NET = 2147483648,
+  PINO = 4294967296,
+  RESTIFY = 8589934592,
+  ROUTER = 17179869184,
 }

--- a/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
@@ -1,0 +1,525 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  AZURE_MONITOR_STATSBEAT_FEATURES,
+  StatsbeatEnvironmentConfig,
+  StatsbeatInstrumentation,
+} from "../types";
+
+/**
+ * Patch OpenTelemetry instrumentations for statsbeat colleciton.
+ * @internal
+ */
+export function patchOpenTelemetryInstrumentations(): void {
+  const emptyStatsbeatConfig: string = JSON.stringify({ instrumentation: 0, feature: 0 });
+  /** AMQPLIB */
+  try {
+    require.resolve("@opentelemetry/instrumentation-amqplib");
+    const { AmqplibInstrumentation } = require("@opentelemetry/instrumentation-amqplib");
+    const originalInit = AmqplibInstrumentation.prototype.init;
+    AmqplibInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.AMQPLIB),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // amqplib instrumentation not found
+  }
+  /** CUCUMBER */
+  try {
+    require.resolve("@opentelemetry/instrumentation-cucumber");
+    const { CucumberInstrumentation } = require("@opentelemetry/instrumentation-cucumber");
+    const originalInit = CucumberInstrumentation.prototype.init;
+    CucumberInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.CUCUMBER),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // cucumber instrumentation not found
+  }
+  /** DATALOADER */
+  try {
+    require.resolve("@opentelemetry/instrumentation-dataloader");
+    const { DataloaderInstrumentation } = require("@opentelemetry/instrumentation-dataloader");
+    const originalInit = DataloaderInstrumentation.prototype.init;
+    DataloaderInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.DATALOADER),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // dataloader instrumentation not found
+  }
+  /** FS */
+  try {
+    require.resolve("@opentelemetry/instrumentation-fs");
+    const { FsInstrumentation } = require("@opentelemetry/instrumentation-fs");
+    const originalInit = FsInstrumentation.prototype.init;
+    FsInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.FS),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // fs instrumentation not found
+  }
+  /** LRU MEMOIZER */
+  try {
+    require.resolve("@opentelemetry/instrumentation-lru-memoizer");
+    const { LruMemoizerInstrumentation } = require("@opentelemetry/instrumentation-lru-memoizer");
+    const originalInit = LruMemoizerInstrumentation.prototype.init;
+    LruMemoizerInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |=
+          StatsbeatInstrumentation.LRU_MEMOIZER),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // LRU memoizer instrumentation not found
+  }
+  /** MONGOOSE */
+  try {
+    require.resolve("@opentelemetry/instrumentation-mongoose");
+    const { MongooseInstrumentation } = require("@opentelemetry/instrumentation-mongoose");
+    const originalInit = MongooseInstrumentation.prototype.init;
+    MongooseInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.MONGOOSE),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // mongoose instrumentation not found
+  }
+  /** RUNTIME NODE */
+  try {
+    require.resolve("@opentelemetry/instrumentation-runtime-node");
+    const { RuntimeNodeInstrumentation } = require("@opentelemetry/instrumentation-runtime-node");
+    const originalInit = RuntimeNodeInstrumentation.prototype.init;
+    RuntimeNodeInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |=
+          StatsbeatInstrumentation.RUNTIME_NODE),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // runtime node instrumentation not found
+  }
+  /** SOCKET.IO */
+  try {
+    require.resolve("@opentelemetry/instrumentation-socket.io");
+    const { SocketIoInstrumentation } = require("@opentelemetry/instrumentation-socket.io");
+    const originalInit = SocketIoInstrumentation.prototype.init;
+    SocketIoInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.SOCKET_IO),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // socket.io instrumentation not found
+  }
+  /** TEDIOUS */
+  try {
+    require.resolve("@opentelemetry/instrumentation-tedious");
+    const { TediousInstrumentation } = require("@opentelemetry/instrumentation-tedious");
+    const originalInit = TediousInstrumentation.prototype.init;
+    TediousInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.TEDIOUS),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // tedious instrumentation not found
+  }
+  /** UNDICI */
+  try {
+    require.resolve("@opentelemetry/instrumentation-undici");
+    const { UndiciInstrumentation } = require("@opentelemetry/instrumentation-undici");
+    const originalInit = UndiciInstrumentation.prototype.init;
+    UndiciInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.UNDICI),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // undici instrumentation not found
+  }
+  /** CASSANDRA */
+  try {
+    require.resolve("@opentelemetry/instrumentation-cassandra-driver");
+    const {
+      CassandraDriverInstrumentation,
+    } = require("@opentelemetry/instrumentation-cassandra-driver");
+    const originalInit = CassandraDriverInstrumentation.prototype.init;
+    CassandraDriverInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.CASSANDRA),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // cassandra instrumentation not found
+  }
+  /** CONNECT */
+  try {
+    require.resolve("@opentelemetry/instrumentation-connect");
+    const { ConnectInstrumentation } = require("@opentelemetry/instrumentation-connect");
+    const originalInit = ConnectInstrumentation.prototype.init;
+    ConnectInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.CONNECT),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // connect instrumentation not found
+  }
+  /** DNS */
+  try {
+    require.resolve("@opentelemetry/instrumentation-dns");
+    const { DnsInstrumentation } = require("@opentelemetry/instrumentation-dns");
+    const originalInit = DnsInstrumentation.prototype.init;
+    DnsInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.DNS),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // dns instrumentation not found
+  }
+  /** EXPRESS */
+  try {
+    require.resolve("@opentelemetry/instrumentation-express");
+    const { ExpressInstrumentation } = require("@opentelemetry/instrumentation-express");
+    const originalInit = ExpressInstrumentation.prototype.init;
+    ExpressInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.EXPRESS),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // express instrumentation not found
+  }
+  /** FASTIFY */
+  try {
+    require.resolve("@opentelemetry/instrumentation-fastify");
+    const { FastifyInstrumentation } = require("@opentelemetry/instrumentation-fastify");
+    const originalInit = FastifyInstrumentation.prototype.init;
+    FastifyInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.FASTIFY),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // fastify instrumentation not found
+  }
+  /** GENERIC POOL */
+  try {
+    require.resolve("@opentelemetry/instrumentation-generic-pool");
+    const { GenericPoolInstrumentation } = require("@opentelemetry/instrumentation-generic-pool");
+    const originalInit = GenericPoolInstrumentation.prototype.init;
+    GenericPoolInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |=
+          StatsbeatInstrumentation.GENERIC_POOL),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // generic pool instrumentation not found
+  }
+  /** GRAPHQL */
+  try {
+    require.resolve("@opentelemetry/instrumentation-graphql");
+    const { GraphQLInstrumentation } = require("@opentelemetry/instrumentation-graphql");
+    const originalInit = GraphQLInstrumentation.prototype.init;
+    GraphQLInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.GRAPHQL),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // graphQL instrumentation not found
+  }
+  /** HAPI */
+  try {
+    require.resolve("@opentelemetry/instrumentation-hapi");
+    const { HapiInstrumentation } = require("@opentelemetry/instrumentation-hapi");
+    const originalInit = HapiInstrumentation.prototype.init;
+    HapiInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.HAPI),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // hapi instrumentation not found
+  }
+  /** IO REDIS */
+  try {
+    require.resolve("@opentelemetry/instrumentation-ioredis");
+    const { IORedisInstrumentation } = require("@opentelemetry/instrumentation-ioredis");
+    const originalInit = IORedisInstrumentation.prototype.init;
+    IORedisInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.IOREDIS),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // IO Redis instrumentation not found
+  }
+  /** KNEX */
+  try {
+    require.resolve("@opentelemetry/instrumentation-knex");
+    const { KnexInstrumentation } = require("@opentelemetry/instrumentation-knex");
+    const originalInit = KnexInstrumentation.prototype.init;
+    KnexInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.KNEX),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // Knex instrumentation not found
+  }
+  /** KOA */
+  try {
+    require.resolve("@opentelemetry/instrumentation-koa");
+    const { KoaInstrumentation } = require("@opentelemetry/instrumentation-koa");
+    const originalInit = KoaInstrumentation.prototype.init;
+    KoaInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.KOA),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // Koa instrumentation not found
+  }
+  /** MEMCACHED */
+  try {
+    require.resolve("@opentelemetry/instrumentation-memcached");
+    const { MemcachedInstrumentation } = require("@opentelemetry/instrumentation-memcached");
+    const originalInit = MemcachedInstrumentation.prototype.init;
+    MemcachedInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.MEMCACHED),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // Memcached instrumentation not found
+  }
+  /** MYSQL2 */
+  try {
+    require.resolve("@opentelemetry/instrumentation-mysql2");
+    const { MySQL2Instrumentation } = require("@opentelemetry/instrumentation-mysql2");
+    const originalInit = MySQL2Instrumentation.prototype.init;
+    MySQL2Instrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.MYSQL2),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // mysql2 instrumentation not found
+  }
+  /** NESTJS CORE */
+  try {
+    require.resolve("@opentelemetry/instrumentation-nestjs-core");
+    const { NestInstrumentation } = require("@opentelemetry/instrumentation-nestjs-core");
+    const originalInit = NestInstrumentation.prototype.init;
+    NestInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.NESTJS_CORE),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // nestjs core instrumentation not found
+  }
+  /** NET */
+  try {
+    require.resolve("@opentelemetry/instrumentation-net");
+    const { NetInstrumentation } = require("@opentelemetry/instrumentation-net");
+    const originalInit = NetInstrumentation.prototype.init;
+    NetInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.NET),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // net instrumentation not found
+  }
+  /** PINO */
+  try {
+    require.resolve("@opentelemetry/instrumentation-pino");
+    const { PinoInstrumentation } = require("@opentelemetry/instrumentation-pino");
+    const originalInit = PinoInstrumentation.prototype.init;
+    PinoInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.PINO),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // pino instrumentation not found
+  }
+  /** RESTIFY */
+  try {
+    require.resolve("@opentelemetry/instrumentation-restify");
+    const { RestifyInstrumentation } = require("@opentelemetry/instrumentation-restify");
+    const originalInit = RestifyInstrumentation.prototype.init;
+    RestifyInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.RESTIFY),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // restify instrumentation not found
+  }
+  /** ROUTER */
+  try {
+    require.resolve("@opentelemetry/instrumentation-router");
+    const { RouterInstrumentation } = require("@opentelemetry/instrumentation-router");
+    const originalInit = RouterInstrumentation.prototype.init;
+    RouterInstrumentation.prototype.init = function () {
+      const statsbeatOptions: StatsbeatEnvironmentConfig = JSON.parse(
+        process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || emptyStatsbeatConfig,
+      );
+      process.env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
+        instrumentation: (statsbeatOptions.instrumentation |= StatsbeatInstrumentation.ROUTER),
+        feature: statsbeatOptions.feature,
+      });
+      return originalInit.apply(this, arguments);
+    };
+  } catch (error) {
+    // router instrumentation not found
+  }
+}

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -3,6 +3,7 @@
 
 import {
   AZURE_MONITOR_STATSBEAT_FEATURES,
+  StatsbeatEnvironmentConfig,
   StatsbeatFeature,
   StatsbeatFeatures,
   StatsbeatInstrumentation,
@@ -18,15 +19,71 @@ class StatsbeatConfiguration {
   private currentStatsbeatInstrumentations: StatsbeatInstrumentations = {};
   private currentStatsbeatFeatures: StatsbeatFeatures = {};
 
-  public setStatsbeatFeatures = (statsbeatFeatures?: StatsbeatFeatures, statsbeatInstrumentations?: StatsbeatInstrumentations) => {
+  public setStatsbeatFeatures = (
+    statsbeatFeatures?: StatsbeatFeatures,
+    statsbeatInstrumentations?: StatsbeatInstrumentations,
+  ) => {
+    let statsbeatEnv: StatsbeatEnvironmentConfig;
+    try {
+      statsbeatEnv = JSON.parse(process.env[AZURE_MONITOR_STATSBEAT_FEATURES] || "{}");
+    } catch (error) {
+      InternalLogger.getInstance().error(
+        "Failed to parse statsbeat config environment variable.",
+        error,
+      );
+    }
+
+    statsbeatInstrumentations = {
+      ...statsbeatInstrumentations,
+      /** OpenTelemetry Instrumentations */
+      amqplib: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.AMQPLIB ? true : false,
+      cucumber: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CUCUMBER ? true : false,
+      dataloader:
+        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.DATALOADER ? true : false,
+      fs: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.FS ? true : false,
+      lruMemoizer:
+        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.LRU_MEMOIZER ? true : false,
+      mongoose: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MONGOOSE ? true : false,
+      runtimeNode:
+        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.RUNTIME_NODE ? true : false,
+      socketIo: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.SOCKET_IO ? true : false,
+      tedious: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.TEDIOUS ? true : false,
+      undici: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.UNDICI ? true : false,
+      cassandra: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CASSANDRA ? true : false,
+      connect: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CONNECT ? true : false,
+      dns: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.DNS ? true : false,
+      express: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.EXPRESS ? true : false,
+      fastify: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.FASTIFY ? true : false,
+      genericPool:
+        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.GENERIC_POOL ? true : false,
+      graphql: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.GRAPHQL ? true : false,
+      hapi: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.HAPI ? true : false,
+      ioredis: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.IOREDIS ? true : false,
+      knex: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.KNEX ? true : false,
+      koa: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.KOA ? true : false,
+      memcached: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MEMCACHED ? true : false,
+      mysql2: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MYSQL2 ? true : false,
+      nestjsCore:
+        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.NESTJS_CORE ? true : false,
+      net: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.NET ? true : false,
+      pino: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.PINO ? true : false,
+      restify: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.RESTIFY ? true : false,
+      router: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.ROUTER ? true : false,
+    };
+
     // Merge old statsbeat options with new statsbeat options overriding any common properties
-    this.currentStatsbeatInstrumentations = { ...this.currentStatsbeatInstrumentations, ...statsbeatInstrumentations };
+    this.currentStatsbeatInstrumentations = {
+      ...this.currentStatsbeatInstrumentations,
+      ...statsbeatInstrumentations,
+    };
     this.currentStatsbeatFeatures = { ...this.currentStatsbeatFeatures, ...statsbeatFeatures };
     let instrumentationBitMap = StatsbeatInstrumentation.NONE;
     let featureBitMap = StatsbeatFeature.NONE;
-    
-    const instrumentationArray: Array<StatsbeatOption> = Object.entries(this.currentStatsbeatInstrumentations).map(entry => {
-      return { option: entry[0], value: entry[1] }
+
+    const instrumentationArray: Array<StatsbeatOption> = Object.entries(
+      this.currentStatsbeatInstrumentations,
+    ).map((entry) => {
+      return { option: entry[0], value: entry[1] };
     });
 
     // Map the instrumentation options to a bit map
@@ -36,9 +93,11 @@ class StatsbeatConfiguration {
       }
     }
 
-    const featureArray: Array<StatsbeatOption> = Object.entries(this.currentStatsbeatFeatures).map(entry => {
-      return { option: entry[0], value: entry[1] }
-    });
+    const featureArray: Array<StatsbeatOption> = Object.entries(this.currentStatsbeatFeatures).map(
+      (entry) => {
+        return { option: entry[0], value: entry[1] };
+      },
+    );
 
     // Map the feature options to a bit map
     for (let i = 0; i < featureArray.length; i++) {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -134,6 +134,7 @@ describe("Main functions", () => {
     let config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
         connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        disableOfflineStorage: true,
       },
       enableLiveMetrics: true,
       instrumentationOptions: {
@@ -162,6 +163,7 @@ describe("Main functions", () => {
     assert.ok(!(features & StatsbeatFeature.DISK_RETRY), "DISK_RETRY is set");
     assert.ok(!(features & StatsbeatFeature.BROWSER_SDK_LOADER), "BROWSER_SDK_LOADER is set");
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO is not set");
+    assert.strictEqual(features, 8);
     assert.ok(
       instrumentations & StatsbeatInstrumentation.AZURE_CORE_TRACING,
       "AZURE_CORE_TRACING not set",
@@ -170,29 +172,7 @@ describe("Main functions", () => {
     assert.ok(instrumentations & StatsbeatInstrumentation.MYSQL, "MYSQL not set");
     assert.ok(instrumentations & StatsbeatInstrumentation.POSTGRES, "POSTGRES not set");
     assert.ok(instrumentations & StatsbeatInstrumentation.REDIS, "REDIS not set");
-  });
-
-  it("should use statsbeat features if already available", () => {
-    const env = <{ [id: string]: string }>{};
-    let current = 0;
-    current |= StatsbeatFeature.AAD_HANDLING;
-    current |= StatsbeatFeature.DISK_RETRY;
-    current |= StatsbeatFeature.LIVE_METRICS;
-    env.AZURE_MONITOR_STATSBEAT_FEATURES = current.toString();
-    process.env = env;
-    let config: AzureMonitorOpenTelemetryOptions = {
-      azureMonitorExporterOptions: {
-        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
-      },
-    };
-    useAzureMonitor(config);
-    let output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
-    const numberOutput = Number(output["feature"]);
-    assert.ok(numberOutput & StatsbeatFeature.AAD_HANDLING, "AAD_HANDLING not set");
-    assert.ok(numberOutput & StatsbeatFeature.DISK_RETRY, "DISK_RETRY not set");
-    assert.ok(numberOutput & StatsbeatFeature.DISTRO, "DISTRO not set");
-    assert.ok(!(numberOutput & StatsbeatFeature.BROWSER_SDK_LOADER), "BROWSER_SDK_LOADER is set");
-    assert.ok(numberOutput & StatsbeatFeature.LIVE_METRICS, "LIVE_METRICS is not set");
+    assert.strictEqual(instrumentations, 31);
   });
 
   it("should capture the app service SDK prefix correctly", () => {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -185,15 +185,13 @@ describe("Main functions", () => {
     };
     useAzureMonitor(config);
     registerInstrumentations({
-      instrumentations: [
-        new FsInstrumentation(),
-      ]
+      instrumentations: [new FsInstrumentation()],
     });
     let output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const instrumentations = Number(output["instrumentation"]);
     assert.ok(instrumentations & StatsbeatInstrumentation.FS, "FS not set");
     assert.strictEqual(instrumentations, StatsbeatInstrumentation.FS);
-  })
+  });
 
   it("should capture the app service SDK prefix correctly", () => {
     const os = getOsPrefix();


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
Patches the opentelemetry instrumentation's init functions such that they will update our statsbeat instrumentation calculation only when customers register the instrumentation in their applications.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
