### PR TITLE
[engsys][test] reduce dependency test packages in core pipelines

### DIFF
--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -4,35 +4,28 @@ const process = require("process");
 const { spawnSync } = require("child_process");
 
 const reducedDependencyTestMatrix = {
-  'core': ['@azure-rest/core-client',
-    '@azure/ai-text-analytics',
+  'core': [
+    '@azure-rest/synapse-access-control',
     '@azure/arm-resources',
     '@azure/identity',
     '@azure/service-bus',
-    '@azure/storage-blob',
-    '@azure/template',
-    '@azure/synapse-monitoring'
+    '@azure/template'
   ],
   'test-utils': [
     '@azure-tests/perf-storage-blob',
-    '@azure-tests/perf-data-tables',
     '@azure/arm-eventgrid',
     '@azure/ai-text-analytics',
     '@azure/identity',
-    '@azure/storage-file-share',
     '@azure/template'
   ],
   'identity': [
-    '@azure-rest/core-client',
     '@azure-tests/perf-storage-blob',
     '@azure/ai-text-analytics',
     '@azure/arm-resources',
     '@azure/identity-cache-persistence',
     '@azure/identity-vscode',
-    '@azure/service-bus',
     '@azure/storage-blob',
     '@azure/template',
-    '@azure/synapse-monitoring'
   ],
 };
 


### PR DESCRIPTION
- storage has moved to core v2. the template package already covers core v2.
- remove ai-text-analytics which is another core v2 package.
- add a RLC package @azure-rest/synapse-access-control
- remove service-bus from identity's list as it doesn't use any identity functionality in CI tests.
- remove storage from test-util CI since core v2 is already covered by ai-text-analytics
- remove perf-data-tables as perf-storage-blob covers core v2
