### PR TITLE
[EngSys] upload test proxy logs to artificats from pipelines

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -55,6 +55,7 @@ jobs:
 
     variables:
       - template: ../variables/globals.yml
+      jobSuffix: $[split(variables['Agent.JobName'], ' ')[1]]
 
     steps:
       - template: ../steps/common.yml

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -56,7 +56,7 @@ jobs:
     variables:
       - template: ../variables/globals.yml
       - name: jobSuffix
-        value: ${{ split(variables['Agent.JobName'], ' ')[1] }}
+        value: $[ split(variables['Agent.JobName'], ' ')[1] ]
 
     steps:
       - template: ../steps/common.yml

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -55,7 +55,8 @@ jobs:
 
     variables:
       - template: ../variables/globals.yml
-      jobSuffix: $[split(variables['Agent.JobName'], ' ')[1]]
+      - name: jobSuffix
+        value: ${{ split(variables['Agent.JobName'], ' ')[1] }}
 
     steps:
       - template: ../steps/common.yml

--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -55,8 +55,6 @@ jobs:
 
     variables:
       - template: ../variables/globals.yml
-      - name: jobSuffix
-        value: $[ split(variables['Agent.JobName'], ' ')[1] ]
 
     steps:
       - template: ../steps/common.yml

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -50,7 +50,7 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
-        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)
+        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)/test-proxy.$(Agent.JobName).log
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
       
@@ -90,3 +90,9 @@ steps:
       testRunTitle: "$(OSName) - Browser - Unit Tests - [Node $(NodeTestVersion)]"
     condition: and(always(),eq(variables['TestType'], 'browser'))
     displayName: "Publish browser unit test results"
+
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.$(Agent.JobName).log'
+      ArtifactName: 'test proxy logs $(Agent.JobName)'
+      SbomEnabled: false

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -50,7 +50,7 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
-        cat $(Build.SourcesDirectory)/test-proxy.log
+        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
       

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -50,7 +50,7 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
-        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)/test-proxy.$(jobSuffix).log
+        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
       
@@ -93,6 +93,6 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.$(jobSuffix).log'
-      ArtifactName: 'test proxy logs $(jobSuffix)'
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.log'
+      ArtifactName: 'test proxy logs $(Agent.JobName)'
       SbomEnabled: false

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -50,7 +50,7 @@ steps:
 
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
-        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)/test-proxy.$(Agent.JobName).log
+        copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)/test-proxy.$(jobSuffix).log
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
       
@@ -93,6 +93,6 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.$(Agent.JobName).log'
-      ArtifactName: 'test proxy logs $(Agent.JobName)'
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.$(jobSuffix).log'
+      ArtifactName: 'test proxy logs $(jobSuffix)'
       SbomEnabled: false


### PR DESCRIPTION
intead of dumping the output to the console, since

- the time to output to console could be several minutes when the log file is big

- viewing the step in azure devops webste takes long time to render for big file

it's better to have it as an artifact. We don't often need to look at the log
unless there's test proxy some issue to investigate.