### PR TITLE
[keyvault] Support for service version `7.6-preview.1`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1520,8 +1520,61 @@ packages:
       - supports-color
     dev: false
 
+  /@azure/keyvault-certificates@4.8.0:
+    resolution: {integrity: sha512-zKXq6dJ+p3O789yUEs3yhpdgD4iPRfcHMXAgHBqVHIFcVaaPuXaL+WsXFF5W0bDuQhtDW4zzluOrkpa1IopOKQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.7.2
+      '@azure/core-client': 1.9.2
+      '@azure/core-http-compat': 2.1.2
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.15.2
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.9.0
+      '@azure/keyvault-common': 1.0.0
+      '@azure/logger': 1.1.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@azure/keyvault-common@1.0.0:
+    resolution: {integrity: sha512-JzK7vMMhQR+GhSteymvIZ8on3ZFJyXZ1hEQYhCP0gbFgrqHmy3c8rxdtmvxHLZ7x1C3dFal+aS00Yer9QiA01w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.7.2
+      '@azure/core-client': 1.9.2
+      '@azure/core-rest-pipeline': 1.15.2
+      '@azure/core-tracing': 1.1.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@azure/keyvault-keys@4.8.0:
     resolution: {integrity: sha512-jkuYxgkw0aaRfk40OQhFqDIupqblIOIlYESWB6DKCVDxQet1pyv86Tfk9M+5uFM0+mCs6+MUHU+Hxh3joiUn4Q==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.7.2
+      '@azure/core-client': 1.9.2
+      '@azure/core-http-compat': 2.1.2
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.15.2
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.9.0
+      '@azure/logger': 1.1.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@azure/keyvault-secrets@4.8.0:
+    resolution: {integrity: sha512-RGfpFk6XUXHfWuTAiokOe8t6ej5C4ijf4HVyJUmTfN6VjDBVPvTtoiOi/C5072/ENHScYZFhiYOgIjLgYjfJ/A==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -11657,7 +11710,7 @@ packages:
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-CXpyYQx3Kyy72JG08p+c0iXe5nwkPNAL7mjixGWimKqc5rCJjJbnED8qhFa/erZ1wDWz7bK/gH1qLdqQEHniWA==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-Hq8/cFC2GRgAyUm/r6o/lyIo4LK3Uc9JWNVhVg7Jiadt6+AR/v7iPgLAAGbtjJX7/DLcOL96FZBKclsE/kFqVA==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
@@ -11666,6 +11719,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.1.0
+      '@azure/keyvault-secrets': 4.8.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/chai': 4.3.14
       '@types/mocha': 10.0.6
@@ -20853,7 +20907,7 @@ packages:
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-wK5fFHfzYbHlXqyHHeKNWD69AaPq30250E4IDpQ1IzAe6YilmDn22VsiN7sqwRNe8RBMBVBOgNSNxDb65aMNdA==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-7eOND1JqlMj8Msn24kbavwdz2plWpLJ4dtfklliOwBVtzYdbWy95ulqQB3hA5KpXVvG2BliRp5VeIF0mqaBgxQ==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
@@ -20862,6 +20916,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.1.0
+      '@azure/keyvault-keys': 4.8.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -20886,7 +20941,7 @@ packages:
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-RSyQPclSiJllvuDCmigMHDYbqgJSmV5ijdode3utG9sxgaQ/hzoBRtL2FQ/SM9aVMt/iHytInSM6/733OioHFg==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-KgHBH9w2ogKHJc+NYdzPx2A6FmcCXCLWLZwOx9p4d6/P/2fIkE4Giia1MTQZUlZ7PEGqy5LaYl2CGlO7lfWvBg==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -20895,6 +20950,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.1.0
+      '@azure/keyvault-secrets': 4.8.0
       '@microsoft/api-extractor': 7.43.1(@types/node@18.19.31)
       '@types/mocha': 10.0.6
       '@types/node': 18.19.31
@@ -22026,11 +22082,12 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-MXHTJ5JP994gH9DA96KFQnYMHy0Isj5pWo2Idxs27Bw98WDXrU7CnRfSgxShc9RHwasnrj+ViyH4HTZiuzjdhQ==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-FwqYBl/0zUEReJ99QFaKuLWpOE00ttB5u0c/Kh1uGz66GkcSOrPicD5c4bHWiJHE4zqJz6etzP+GzAPC5PYSvA==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.1.0
+      '@azure/keyvault-certificates': 4.8.0
       '@types/node': 18.19.31
       '@types/uuid': 8.3.4
       dotenv: 16.4.5
@@ -22047,11 +22104,12 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-fp+0/ckF+tA4Fl0ZJTc5VLqRX39uwYuiSPqI2KTo6/FhkmW1Xj0nWAZoyp3KnNW7o2GmZLWnpmc7j0gWWDpkgQ==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-Byq8uTWr1a3jfNslFo9xevxX0AC+Nmp8/avN4HHYnA+Z4zKDEMwr7XhGqYcuJ3c+WjrNRUbCFeBm2nPiohPbcA==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.1.0
+      '@azure/keyvault-keys': 4.8.0
       '@types/node': 18.19.31
       '@types/uuid': 8.3.4
       dotenv: 16.4.5
@@ -22068,11 +22126,12 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-StJodfvLmN9ey/bqM3Y9hDshqy0B4wnon1KG9QiDV+th/oHSNZr0t8FXMXlH2ujdXLQ1N+f9pIwSXNQ/BypwmQ==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-PDDap1N1JwQVyoa/tqxC5iKE23kXls8SDjGyZHo9Tiy+5OGvrBv6XgxLezmpyzr1c4Ovx+nrYS1YoIOQCM26Xw==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.1.0
+      '@azure/keyvault-secrets': 4.8.0
       '@types/node': 18.19.31
       '@types/uuid': 8.3.4
       dotenv: 16.4.5

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.5.1 (Unreleased)
+## 4.6.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default service version is now `7.6-preview.1`.
 
 ## 4.5.0 (2024-02-14)
 

--- a/sdk/keyvault/keyvault-admin/assets.json
+++ b/sdk/keyvault/keyvault-admin/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-admin",
-  "Tag": "js/keyvault/keyvault-admin_4b469d86ad"
+  "Tag": "js/keyvault/keyvault-admin_a41e46c4a6"
 }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-admin",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.5.1",
+  "version": "4.6.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's administrative functions.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/README.md",

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -243,7 +243,7 @@ export enum KnownKeyVaultRoleScope {
 }
 
 // @public
-export const LATEST_API_VERSION = "7.5";
+export const LATEST_API_VERSION = "7.6-preview.1";
 
 // @public
 export interface ListRoleAssignmentsOptions extends OperationOptions {
@@ -291,7 +291,7 @@ export interface SettingsClientOptions extends CommonClientOptions {
 }
 
 // @public
-export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4" | "7.5";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";
 
 // @public
 export interface UpdateSettingOptions extends OperationOptions {

--- a/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
+++ b/sdk/keyvault/keyvault-admin/review/keyvault-admin.api.md
@@ -80,6 +80,10 @@ export class KeyVaultBackupClient {
     constructor(vaultUrl: string, credential: TokenCredential, options?: KeyVaultBackupClientOptions);
     beginBackup(blobStorageUri: string, sasToken: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
     beginBackup(blobStorageUri: string, options?: KeyVaultBeginBackupOptions): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
+    beginPreBackup(blobStorageUri: string, sasToken: string, options?: KeyVaultBeginPreBackupOptions): Promise<PollerLike<KeyVaultPreBackupOperationState, KeyVaultPreBackupResult>>;
+    beginPreBackup(blobStorageUri: string, options?: KeyVaultBeginPreBackupOptions): Promise<PollerLike<KeyVaultPreBackupOperationState, KeyVaultPreBackupResult>>;
+    beginPreRestore(folderUri: string, sasToken: string, options?: KeyVaultBeginPreRestoreOptions): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultPreRestoreResult>>;
+    beginPreRestore(folderUri: string, options?: KeyVaultBeginPreRestoreOptions): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultPreRestoreResult>>;
     beginRestore(folderUri: string, sasToken: string, options?: KeyVaultBeginRestoreOptions): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>>;
     beginRestore(folderUri: string, options?: KeyVaultBeginRestoreOptions): Promise<PollerLike<KeyVaultRestoreOperationState, KeyVaultRestoreResult>>;
     beginSelectiveKeyRestore(keyName: string, folderUri: string, sasToken: string, options?: KeyVaultBeginSelectiveKeyRestoreOptions): Promise<PollerLike<KeyVaultSelectiveKeyRestoreOperationState, KeyVaultSelectiveKeyRestoreResult>>;
@@ -114,6 +118,14 @@ export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions 
 }
 
 // @public
+export interface KeyVaultBeginPreBackupOptions extends KeyVaultBackupPollerOptions {
+}
+
+// @public
+export interface KeyVaultBeginPreRestoreOptions extends KeyVaultBackupPollerOptions {
+}
+
+// @public
 export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {
 }
 
@@ -130,6 +142,26 @@ export interface KeyVaultPermission {
     dataActions?: KeyVaultDataAction[];
     notActions?: string[];
     notDataActions?: KeyVaultDataAction[];
+}
+
+// @public
+export type KeyVaultPreBackupOperationState = KeyVaultAdminPollOperationState<KeyVaultBackupResult>;
+
+// @public
+export interface KeyVaultPreBackupResult {
+    endTime?: Date;
+    folderUri?: string;
+    startTime: Date;
+}
+
+// @public
+export interface KeyVaultPreRestoreOperationState extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
+}
+
+// @public
+export interface KeyVaultPreRestoreResult {
+    endTime?: Date;
+    startTime: Date;
 }
 
 // @public

--- a/sdk/keyvault/keyvault-admin/src/backupClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClient.ts
@@ -9,6 +9,8 @@ import {
   KeyVaultBeginPreRestoreOptions,
   KeyVaultBeginRestoreOptions,
   KeyVaultBeginSelectiveKeyRestoreOptions,
+  KeyVaultPreBackupResult,
+  KeyVaultPreRestoreResult,
   KeyVaultRestoreResult,
   KeyVaultSelectiveKeyRestoreResult,
 } from "./backupClientModels";
@@ -30,12 +32,15 @@ import { mappings } from "./mappings";
 import { KeyVaultPreBackupPoller } from "./lro/preBackup/poller";
 import { KeyVaultPreRestoreOperationState } from "./lro/preRestore/operation";
 import { KeyVaultPreRestorePoller } from "./lro/preRestore/poller";
+import { KeyVaultPreBackupOperationState } from "./lro/preBackup/operation";
 
 export {
   KeyVaultBackupOperationState,
   KeyVaultRestoreOperationState,
   KeyVaultSelectiveKeyRestoreOperationState,
   KeyVaultAdminPollOperationState,
+  KeyVaultPreBackupOperationState,
+  KeyVaultPreRestoreOperationState,
 };
 
 /**
@@ -238,7 +243,7 @@ export class KeyVaultBackupClient {
     blobStorageUri: string,
     sasToken: string,
     options?: KeyVaultBeginPreBackupOptions,
-  ): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
+  ): Promise<PollerLike<KeyVaultPreBackupOperationState, KeyVaultPreBackupResult>>;
 
   /**
    * Starts a pre-backup of an Azure Key Vault on the specified Storage Blob account, using a user-assigned Managed Identity
@@ -274,13 +279,13 @@ export class KeyVaultBackupClient {
   public async beginPreBackup(
     blobStorageUri: string,
     options?: KeyVaultBeginPreBackupOptions,
-  ): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>>;
+  ): Promise<PollerLike<KeyVaultPreBackupOperationState, KeyVaultPreBackupResult>>;
 
   public async beginPreBackup(
     blobStorageUri: string,
     sasTokenOrOptions: string | KeyVaultBeginPreBackupOptions = {},
     optionsWhenSasTokenSpecified: KeyVaultBeginPreBackupOptions = {},
-  ): Promise<PollerLike<KeyVaultBackupOperationState, KeyVaultBackupResult>> {
+  ): Promise<PollerLike<KeyVaultPreBackupOperationState, KeyVaultPreBackupResult>> {
     const sasToken = typeof sasTokenOrOptions === "string" ? sasTokenOrOptions : undefined;
     const options =
       typeof sasTokenOrOptions === "string" ? optionsWhenSasTokenSpecified : sasTokenOrOptions;
@@ -550,7 +555,7 @@ export class KeyVaultBackupClient {
     folderUri: string,
     sasToken: string,
     options?: KeyVaultBeginPreRestoreOptions,
-  ): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultRestoreResult>>;
+  ): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultPreRestoreResult>>;
 
   /**
    * Starts a pre-restore of all key materials using the SAS token pointing to a previously stored Azure Blob storage
@@ -587,7 +592,7 @@ export class KeyVaultBackupClient {
   public async beginPreRestore(
     folderUri: string,
     options?: KeyVaultBeginPreRestoreOptions,
-  ): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultRestoreResult>>;
+  ): Promise<PollerLike<KeyVaultPreRestoreOperationState, KeyVaultPreRestoreResult>>;
 
   public async beginPreRestore(
     folderUri: string,

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -41,6 +41,10 @@ export interface KeyVaultBackupPollerOptions extends OperationOptions {
  */
 export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {}
 
+/**
+ * An interface representing the optional parameters that can be
+ * passed to {@link beginPreBackup}
+ */
 export interface KeyVaultBeginPreBackupOptions extends KeyVaultBackupPollerOptions {}
 
 /**
@@ -49,6 +53,10 @@ export interface KeyVaultBeginPreBackupOptions extends KeyVaultBackupPollerOptio
  */
 export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {}
 
+/**
+ * An interface representing the optional parameters that can be
+ * passed to {@link beginPreRestore}
+ */
 export interface KeyVaultBeginPreRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
@@ -61,6 +69,26 @@ export interface KeyVaultBeginSelectiveKeyRestoreOptions extends KeyVaultBackupP
  * An interface representing the result of a backup operation.
  */
 export interface KeyVaultBackupResult {
+  /**
+   * The location of the full backup.
+   */
+  folderUri?: string;
+
+  /**
+   * The start time of the backup operation.
+   */
+  startTime: Date;
+
+  /**
+   * The end time of the backup operation.
+   */
+  endTime?: Date;
+}
+
+/**
+ * An interface representing the result of a pre-backup operation.
+ */
+export interface KeyVaultPreBackupResult {
   /**
    * The location of the full backup.
    */
@@ -103,6 +131,21 @@ export interface KeyVaultSelectiveKeyRestoreResult {
 
   /**
    * The end time of the selective key restore operation.
+   */
+  endTime?: Date;
+}
+
+/**
+ * An interface representing the result of a pre-restore operation.
+ */
+export interface KeyVaultPreRestoreResult {
+  /**
+   * The start time of the restore operation.
+   */
+  startTime: Date;
+
+  /**
+   * The end time of the restore operation.
    */
   endTime?: Date;
 }

--- a/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
+++ b/sdk/keyvault/keyvault-admin/src/backupClientModels.ts
@@ -41,11 +41,15 @@ export interface KeyVaultBackupPollerOptions extends OperationOptions {
  */
 export interface KeyVaultBeginBackupOptions extends KeyVaultBackupPollerOptions {}
 
+export interface KeyVaultBeginPreBackupOptions extends KeyVaultBackupPollerOptions {}
+
 /**
  * An interface representing the optional parameters that can be
  * passed to {@link beginRestore}
  */
 export interface KeyVaultBeginRestoreOptions extends KeyVaultBackupPollerOptions {}
+
+export interface KeyVaultBeginPreRestoreOptions extends KeyVaultBackupPollerOptions {}
 
 /**
  * An interface representing the optional parameters that can be

--- a/sdk/keyvault/keyvault-admin/src/constants.ts
+++ b/sdk/keyvault/keyvault-admin/src/constants.ts
@@ -4,14 +4,14 @@
 /**
  * Current version of the Key Vault Admin SDK.
  */
-export const SDK_VERSION: string = "4.5.1";
+export const SDK_VERSION: string = "4.6.0-beta.1";
 
 /**
  * The latest supported Key Vault service API version.
  */
-export const LATEST_API_VERSION = "7.5";
+export const LATEST_API_VERSION = "7.6-preview.1";
 
 /**
  * Supported API versions
  */
-export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4" | "7.5";
+export type SUPPORTED_API_VERSIONS = "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClient.ts
@@ -14,11 +14,15 @@ import * as Mappers from "./models/mappers";
 import { KeyVaultClientContext } from "./keyVaultClientContext";
 import {
   KeyVaultClientOptionalParams,
-  ApiVersion75,
+  ApiVersion76Preview1,
   FullBackupOptionalParams,
   FullBackupResponse,
+  PreFullBackupOptionalParams,
+  PreFullBackupResponse,
   FullBackupStatusOptionalParams,
   FullBackupStatusResponse,
+  PreFullRestoreOperationOptionalParams,
+  PreFullRestoreOperationResponse,
   FullRestoreOperationOptionalParams,
   FullRestoreOperationResponse,
   RestoreStatusOptionalParams,
@@ -40,7 +44,7 @@ export class KeyVaultClient extends KeyVaultClientContext {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion75,
+    apiVersion: ApiVersion76Preview1,
     options?: KeyVaultClientOptionalParams
   ) {
     super(apiVersion, options);
@@ -64,6 +68,21 @@ export class KeyVaultClient extends KeyVaultClientContext {
   }
 
   /**
+   * Pre-backup operation for checking whether the customer can perform a full backup operation.
+   * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
+   * @param options The options parameters.
+   */
+  preFullBackup(
+    vaultBaseUrl: string,
+    options?: PreFullBackupOptionalParams
+  ): Promise<PreFullBackupResponse> {
+    return this.sendOperationRequest(
+      { vaultBaseUrl, options },
+      preFullBackupOperationSpec
+    );
+  }
+
+  /**
    * Returns the status of full backup operation
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param jobId The id returned as part of the backup request
@@ -77,6 +96,21 @@ export class KeyVaultClient extends KeyVaultClientContext {
     return this.sendOperationRequest(
       { vaultBaseUrl, jobId, options },
       fullBackupStatusOperationSpec
+    );
+  }
+
+  /**
+   * Pre-restore operation for checking whether the customer can perform a full restore operation.
+   * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
+   * @param options The options parameters.
+   */
+  preFullRestoreOperation(
+    vaultBaseUrl: string,
+    options?: PreFullRestoreOperationOptionalParams
+  ): Promise<PreFullRestoreOperationResponse> {
+    return this.sendOperationRequest(
+      { vaultBaseUrl, options },
+      preFullRestoreOperationOperationSpec
     );
   }
 
@@ -207,6 +241,25 @@ const fullBackupOperationSpec: coreClient.OperationSpec = {
   mediaType: "json",
   serializer
 };
+const preFullBackupOperationSpec: coreClient.OperationSpec = {
+  path: "/prebackup",
+  httpMethod: "POST",
+  responses: {
+    202: {
+      bodyMapper: Mappers.FullBackupOperation,
+      headersMapper: Mappers.KeyVaultClientPreFullBackupHeaders
+    },
+    default: {
+      bodyMapper: Mappers.KeyVaultError
+    }
+  },
+  requestBody: Parameters.preBackupOperationParameters,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.vaultBaseUrl],
+  headerParameters: [Parameters.accept, Parameters.contentType],
+  mediaType: "json",
+  serializer
+};
 const fullBackupStatusOperationSpec: coreClient.OperationSpec = {
   path: "/backup/{jobId}/pending",
   httpMethod: "GET",
@@ -221,6 +274,25 @@ const fullBackupStatusOperationSpec: coreClient.OperationSpec = {
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.vaultBaseUrl, Parameters.jobId],
   headerParameters: [Parameters.accept],
+  serializer
+};
+const preFullRestoreOperationOperationSpec: coreClient.OperationSpec = {
+  path: "/prerestore",
+  httpMethod: "PUT",
+  responses: {
+    202: {
+      bodyMapper: Mappers.RestoreOperation,
+      headersMapper: Mappers.KeyVaultClientPreFullRestoreOperationHeaders
+    },
+    default: {
+      bodyMapper: Mappers.KeyVaultError
+    }
+  },
+  requestBody: Parameters.preRestoreOperationParameters,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.vaultBaseUrl],
+  headerParameters: [Parameters.accept, Parameters.contentType],
+  mediaType: "json",
   serializer
 };
 const fullRestoreOperationOperationSpec: coreClient.OperationSpec = {

--- a/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/keyVaultClientContext.ts
@@ -7,10 +7,10 @@
  */
 
 import * as coreClient from "@azure/core-client";
-import { ApiVersion75, KeyVaultClientOptionalParams } from "./models";
+import { ApiVersion76Preview1, KeyVaultClientOptionalParams } from "./models";
 
 export class KeyVaultClientContext extends coreClient.ServiceClient {
-  apiVersion: ApiVersion75;
+  apiVersion: ApiVersion76Preview1;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
@@ -18,7 +18,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion75,
+    apiVersion: ApiVersion76Preview1,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -33,7 +33,7 @@ export class KeyVaultClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-admin/4.5.1`;
+    const packageDetails = `azsdk-js-keyvault-admin/4.6.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/index.ts
@@ -185,10 +185,19 @@ export interface FullBackupOperation {
   azureStorageBlobContainerUri?: string;
 }
 
-export interface RestoreOperationParameters {
-  sasTokenParameters: SASTokenParameter;
+export interface PreBackupOperationParameters {
+  /** Azure Blob storage container Uri */
+  storageResourceUri?: string;
+  /** The SAS token pointing to an Azure Blob storage container */
+  token?: string;
+  /** Indicates which authentication method should be used. If set to true, Managed HSM will use the configured user-assigned managed identity to authenticate with Azure Storage. Otherwise, a SAS token has to be specified. */
+  useManagedIdentity?: boolean;
+}
+
+export interface PreRestoreOperationParameters {
+  sasTokenParameters?: SASTokenParameter;
   /** The Folder name of the blob where the previous successful full backup was stored */
-  folderToRestore: string;
+  folderToRestore?: string;
 }
 
 /** Restore operation */
@@ -205,6 +214,12 @@ export interface RestoreOperation {
   startTime?: Date;
   /** The end time of the restore operation */
   endTime?: Date;
+}
+
+export interface RestoreOperationParameters {
+  sasTokenParameters: SASTokenParameter;
+  /** The Folder name of the blob where the previous successful full backup was stored */
+  folderToRestore: string;
 }
 
 export interface SelectiveKeyRestoreOperationParameters {
@@ -273,6 +288,22 @@ export interface KeyVaultClientFullBackupHeaders {
   azureAsyncOperation?: string;
 }
 
+/** Defines headers for KeyVaultClient_preFullBackup operation. */
+export interface KeyVaultClientPreFullBackupHeaders {
+  /** The recommended number of seconds to wait before calling the URI specified in Azure-AsyncOperation. */
+  retryAfter?: number;
+  /** The URI to poll for completion status. */
+  azureAsyncOperation?: string;
+}
+
+/** Defines headers for KeyVaultClient_preFullRestoreOperation operation. */
+export interface KeyVaultClientPreFullRestoreOperationHeaders {
+  /** The recommended number of seconds to wait before calling the URI specified in Azure-AsyncOperation. */
+  retryAfter?: number;
+  /** The URI to poll for completion status. */
+  azureAsyncOperation?: string;
+}
+
 /** Defines headers for KeyVaultClient_fullRestoreOperation operation. */
 export interface KeyVaultClientFullRestoreOperationHeaders {
   /** The recommended number of seconds to wait before calling the URI specified in Azure-AsyncOperation. */
@@ -289,20 +320,20 @@ export interface KeyVaultClientSelectiveKeyRestoreOperationHeaders {
   azureAsyncOperation?: string;
 }
 
-/** Known values of {@link ApiVersion75} that the service accepts. */
-export enum KnownApiVersion75 {
-  /** Api Version '7.5' */
-  Seven5 = "7.5"
+/** Known values of {@link ApiVersion76Preview1} that the service accepts. */
+export enum KnownApiVersion76Preview1 {
+  /** Api Version '7.6-preview.1' */
+  Seven6Preview1 = "7.6-preview.1"
 }
 
 /**
- * Defines values for ApiVersion75. \
- * {@link KnownApiVersion75} can be used interchangeably with ApiVersion75,
+ * Defines values for ApiVersion76Preview1. \
+ * {@link KnownApiVersion76Preview1} can be used interchangeably with ApiVersion76Preview1,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.5**: Api Version '7.5'
+ * **7.6-preview.1**: Api Version '7.6-preview.1'
  */
-export type ApiVersion75 = string;
+export type ApiVersion76Preview1 = string;
 
 /** Known values of {@link RoleType} that the service accepts. */
 export enum KnownRoleType {
@@ -569,11 +600,33 @@ export type FullBackupResponse = KeyVaultClientFullBackupHeaders &
   FullBackupOperation;
 
 /** Optional parameters. */
+export interface PreFullBackupOptionalParams
+  extends coreClient.OperationOptions {
+  /** Optional parameters to validate prior to performing a full backup operation. */
+  preBackupOperationParameters?: PreBackupOperationParameters;
+}
+
+/** Contains response data for the preFullBackup operation. */
+export type PreFullBackupResponse = KeyVaultClientPreFullBackupHeaders &
+  FullBackupOperation;
+
+/** Optional parameters. */
 export interface FullBackupStatusOptionalParams
   extends coreClient.OperationOptions {}
 
 /** Contains response data for the fullBackupStatus operation. */
 export type FullBackupStatusResponse = FullBackupOperation;
+
+/** Optional parameters. */
+export interface PreFullRestoreOperationOptionalParams
+  extends coreClient.OperationOptions {
+  /** Optional pre restore parameters to validate prior to performing a full restore operation. */
+  preRestoreOperationParameters?: PreRestoreOperationParameters;
+}
+
+/** Contains response data for the preFullRestoreOperation operation. */
+export type PreFullRestoreOperationResponse = KeyVaultClientPreFullRestoreOperationHeaders &
+  RestoreOperation;
 
 /** Optional parameters. */
 export interface FullRestoreOperationOptionalParams

--- a/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/mappers.ts
@@ -483,10 +483,38 @@ export const FullBackupOperation: coreClient.CompositeMapper = {
   }
 };
 
-export const RestoreOperationParameters: coreClient.CompositeMapper = {
+export const PreBackupOperationParameters: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
-    className: "RestoreOperationParameters",
+    className: "PreBackupOperationParameters",
+    modelProperties: {
+      storageResourceUri: {
+        serializedName: "storageResourceUri",
+        type: {
+          name: "String"
+        }
+      },
+      token: {
+        serializedName: "token",
+        type: {
+          name: "String"
+        }
+      },
+      useManagedIdentity: {
+        defaultValue: false,
+        serializedName: "useManagedIdentity",
+        type: {
+          name: "Boolean"
+        }
+      }
+    }
+  }
+};
+
+export const PreRestoreOperationParameters: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "PreRestoreOperationParameters",
     modelProperties: {
       sasTokenParameters: {
         serializedName: "sasTokenParameters",
@@ -497,7 +525,6 @@ export const RestoreOperationParameters: coreClient.CompositeMapper = {
       },
       folderToRestore: {
         serializedName: "folderToRestore",
-        required: true,
         type: {
           name: "String"
         }
@@ -547,6 +574,29 @@ export const RestoreOperation: coreClient.CompositeMapper = {
         nullable: true,
         type: {
           name: "UnixTime"
+        }
+      }
+    }
+  }
+};
+
+export const RestoreOperationParameters: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestoreOperationParameters",
+    modelProperties: {
+      sasTokenParameters: {
+        serializedName: "sasTokenParameters",
+        type: {
+          name: "Composite",
+          className: "SASTokenParameter"
+        }
+      },
+      folderToRestore: {
+        serializedName: "folderToRestore",
+        required: true,
+        type: {
+          name: "String"
         }
       }
     }
@@ -724,6 +774,48 @@ export const KeyVaultClientFullBackupHeaders: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
     className: "KeyVaultClientFullBackupHeaders",
+    modelProperties: {
+      retryAfter: {
+        serializedName: "retry-after",
+        type: {
+          name: "Number"
+        }
+      },
+      azureAsyncOperation: {
+        serializedName: "azure-asyncoperation",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const KeyVaultClientPreFullBackupHeaders: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "KeyVaultClientPreFullBackupHeaders",
+    modelProperties: {
+      retryAfter: {
+        serializedName: "retry-after",
+        type: {
+          name: "Number"
+        }
+      },
+      azureAsyncOperation: {
+        serializedName: "azure-asyncoperation",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const KeyVaultClientPreFullRestoreOperationHeaders: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "KeyVaultClientPreFullRestoreOperationHeaders",
     modelProperties: {
       retryAfter: {
         serializedName: "retry-after",

--- a/sdk/keyvault/keyvault-admin/src/generated/models/parameters.ts
+++ b/sdk/keyvault/keyvault-admin/src/generated/models/parameters.ts
@@ -15,6 +15,8 @@ import {
   RoleDefinitionCreateParameters as RoleDefinitionCreateParametersMapper,
   RoleAssignmentCreateParameters as RoleAssignmentCreateParametersMapper,
   SASTokenParameter as SASTokenParameterMapper,
+  PreBackupOperationParameters as PreBackupOperationParametersMapper,
+  PreRestoreOperationParameters as PreRestoreOperationParametersMapper,
   RestoreOperationParameters as RestoreOperationParametersMapper,
   SelectiveKeyRestoreOperationParameters as SelectiveKeyRestoreOperationParametersMapper,
   UpdateSettingRequest as UpdateSettingRequestMapper
@@ -138,6 +140,11 @@ export const azureStorageBlobContainerUri: OperationParameter = {
   mapper: SASTokenParameterMapper
 };
 
+export const preBackupOperationParameters: OperationParameter = {
+  parameterPath: ["options", "preBackupOperationParameters"],
+  mapper: PreBackupOperationParametersMapper
+};
+
 export const jobId: OperationURLParameter = {
   parameterPath: "jobId",
   mapper: {
@@ -147,6 +154,11 @@ export const jobId: OperationURLParameter = {
       name: "String"
     }
   }
+};
+
+export const preRestoreOperationParameters: OperationParameter = {
+  parameterPath: ["options", "preRestoreOperationParameters"],
+  mapper: PreRestoreOperationParametersMapper
 };
 
 export const restoreBlobDetails: OperationParameter = {

--- a/sdk/keyvault/keyvault-admin/src/lro/preBackup/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/preBackup/operation.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  FullBackupOperation,
+  FullBackupResponse,
+  FullBackupStatusResponse,
+  PreFullBackupOptionalParams,
+} from "../../generated/models";
+import {
+  KeyVaultAdminPollOperation,
+  KeyVaultAdminPollOperationState,
+} from "../keyVaultAdminPoller";
+import { KeyVaultBackupResult, KeyVaultBeginBackupOptions } from "../../backupClientModels";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { KeyVaultClient } from "../../generated/keyVaultClient";
+import { tracingClient } from "../../tracing";
+
+/**
+ * An interface representing the publicly available properties of the state of a backup Key Vault's poll operation.
+ */
+export type KeyVaultPreBackupOperationState = KeyVaultAdminPollOperationState<KeyVaultBackupResult>;
+
+/**
+ * An internal interface representing the state of a backup Key Vault's poll operation.
+ */
+export interface KeyVaultPreBackupPollOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultBackupResult> {
+  /**
+   * The URI of the blob storage account.
+   */
+  blobStorageUri: string;
+  /**
+   * The SAS token.
+   */
+  sasToken?: string;
+}
+
+/**
+ * The backup Key Vault's poll operation.
+ */
+export class KeyVaultPreBackupPollOperation extends KeyVaultAdminPollOperation<
+  KeyVaultPreBackupPollOperationState,
+  string
+> {
+  constructor(
+    public state: KeyVaultPreBackupPollOperationState,
+    private vaultUrl: string,
+    private client: KeyVaultClient,
+    private requestOptions: KeyVaultBeginBackupOptions = {},
+  ) {
+    super(state, { cancelMessage: "Cancelling a full Key Vault backup is not supported." });
+  }
+
+  /**
+   * Tracing the fullBackup operation
+   */
+  private preFullBackup(options: PreFullBackupOptionalParams): Promise<FullBackupResponse> {
+    return tracingClient.withSpan(
+      "KeyVaultPreBackupPoller.preFullBackup",
+      options,
+      (updatedOptions) => this.client.preFullBackup(this.vaultUrl, updatedOptions),
+    );
+  }
+
+  /**
+   * Tracing the fullBackupStatus operation
+   */
+  private fullBackupStatus(
+    jobId: string,
+    options: KeyVaultBeginBackupOptions,
+  ): Promise<FullBackupStatusResponse> {
+    return tracingClient.withSpan(
+      "KeyVaultPreBackupPoller.fullBackupStatus",
+      options,
+      (updatedOptions) => this.client.fullBackupStatus(this.vaultUrl, jobId, updatedOptions),
+    );
+  }
+
+  /**
+   * Reaches to the service and updates the backup's poll operation.
+   */
+  async update(
+    options: {
+      abortSignal?: AbortSignalLike;
+      fireProgress?: (state: KeyVaultPreBackupPollOperationState) => void;
+    } = {},
+  ): Promise<KeyVaultPreBackupPollOperation> {
+    const state = this.state;
+    const { blobStorageUri, sasToken } = state;
+
+    if (options.abortSignal) {
+      this.requestOptions.abortSignal = options.abortSignal;
+    }
+
+    if (!state.isStarted) {
+      const serviceOperation = await this.preFullBackup({
+        ...this.requestOptions,
+        preBackupOperationParameters: {
+          storageResourceUri: blobStorageUri!,
+          token: sasToken,
+          useManagedIdentity: sasToken === undefined,
+        },
+      });
+
+      this.mapState(serviceOperation);
+    } else if (!state.isCompleted) {
+      if (!state.jobId) {
+        throw new Error(`Missing "jobId" from the full backup operation.`);
+      }
+      const serviceOperation = await this.fullBackupStatus(state.jobId, this.requestOptions);
+      this.mapState(serviceOperation);
+    }
+
+    return this;
+  }
+
+  private mapState(serviceOperation: FullBackupOperation): void {
+    const state = this.state;
+    const {
+      startTime,
+      jobId,
+      azureStorageBlobContainerUri,
+      endTime,
+      error,
+      status,
+      statusDetails,
+    } = serviceOperation;
+    if (!startTime) {
+      throw new Error(
+        `Missing "startTime" from the full backup operation. Full backup did not start successfully.`,
+      );
+    }
+
+    state.isStarted = true;
+    state.jobId = jobId;
+    state.endTime = endTime;
+    state.startTime = startTime;
+    state.status = status;
+    state.statusDetails = statusDetails;
+    state.isCompleted = !!endTime;
+
+    if (state.isCompleted && error?.code) {
+      throw new Error(error?.message || statusDetails);
+    }
+
+    if (state.isCompleted) {
+      state.result = {
+        folderUri: azureStorageBlobContainerUri,
+        startTime,
+        endTime,
+      };
+    }
+  }
+}

--- a/sdk/keyvault/keyvault-admin/src/lro/preBackup/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/preBackup/poller.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { KeyVaultAdminPoller, KeyVaultAdminPollerOptions } from "../keyVaultAdminPoller";
+import {
+  KeyVaultPreBackupOperationState,
+  KeyVaultPreBackupPollOperation,
+  KeyVaultPreBackupPollOperationState,
+} from "./operation";
+import { KeyVaultBackupResult } from "../../backupClientModels";
+
+export interface KeyVaultPreBackupPollerOptions extends KeyVaultAdminPollerOptions {
+  blobStorageUri: string;
+  sasToken?: string;
+}
+
+/**
+ * Class that creates a poller that waits until the backup of a Key Vault ends up being generated.
+ */
+export class KeyVaultPreBackupPoller extends KeyVaultAdminPoller<
+  KeyVaultPreBackupOperationState,
+  KeyVaultBackupResult
+> {
+  constructor(options: KeyVaultPreBackupPollerOptions) {
+    const {
+      client,
+      vaultUrl,
+      blobStorageUri,
+      sasToken,
+      requestOptions,
+      intervalInMs = 2000,
+      resumeFrom,
+    } = options;
+
+    let state: KeyVaultPreBackupPollOperationState | undefined;
+
+    if (resumeFrom) {
+      state = JSON.parse(resumeFrom).state;
+    }
+
+    const operation = new KeyVaultPreBackupPollOperation(
+      {
+        ...state,
+        blobStorageUri,
+        sasToken,
+      },
+      vaultUrl,
+      client,
+      requestOptions,
+    );
+
+    super(operation);
+
+    this.intervalInMs = intervalInMs;
+  }
+}

--- a/sdk/keyvault/keyvault-admin/src/lro/preRestore/operation.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/preRestore/operation.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  FullRestoreOperationResponse,
+  PreFullRestoreOperationOptionalParams,
+  RestoreOperation,
+  RestoreStatusResponse,
+} from "../../generated/models";
+import {
+  KeyVaultAdminPollOperation,
+  KeyVaultAdminPollOperationState,
+} from "../keyVaultAdminPoller";
+import { KeyVaultBeginPreRestoreOptions, KeyVaultRestoreResult } from "../../backupClientModels";
+
+import { AbortSignalLike } from "@azure/abort-controller";
+import { KeyVaultClient } from "../../generated/keyVaultClient";
+import { OperationOptions } from "@azure/core-client";
+import { tracingClient } from "../../tracing";
+
+/**
+ * An interface representing the publicly available properties of the state of a Key Vault's pre-restore poll operation.
+ */
+export interface KeyVaultPreRestoreOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {}
+
+/**
+ * An internal interface representing the state of a Key Vault's poll operation.
+ * @internal
+ */
+export interface KeyVaultPreRestorePollOperationState
+  extends KeyVaultAdminPollOperationState<KeyVaultRestoreResult> {
+  /**
+   * The URI of the blob storage account.
+   */
+  folderUri: string;
+  /**
+   * The SAS token.
+   */
+  sasToken?: string;
+  /**
+   * The Folder name of the blob where the previous successful full backup was stored
+   */
+  folderName?: string;
+}
+
+/**
+ * An interface representing a Key Vault's pre-restore poll operation.
+ */
+export class KeyVaultPreRestorePollOperation extends KeyVaultAdminPollOperation<
+  KeyVaultPreRestorePollOperationState,
+  KeyVaultRestoreResult
+> {
+  constructor(
+    public state: KeyVaultPreRestorePollOperationState,
+    private vaultUrl: string,
+    private client: KeyVaultClient,
+    private requestOptions: KeyVaultBeginPreRestoreOptions = {},
+  ) {
+    super(state, {
+      cancelMessage: "Cancelling the restoration full Key Vault backup is not supported.",
+    });
+  }
+
+  /**
+   * Tracing the preFullRestore operation
+   */
+  private preFullRestore(
+    options: PreFullRestoreOperationOptionalParams,
+  ): Promise<FullRestoreOperationResponse> {
+    return tracingClient.withSpan(
+      "KeyVaultPreRestorePoller.fullRestore",
+      options,
+      (updatedOptions) => this.client.preFullRestoreOperation(this.vaultUrl, updatedOptions),
+    );
+  }
+
+  /**
+   * Tracing the restoreStatus operation.
+   */
+  private async restoreStatus(
+    jobId: string,
+    options: OperationOptions,
+  ): Promise<RestoreStatusResponse> {
+    return tracingClient.withSpan(
+      "KeyVaultPreRestorePoller.restoreStatus",
+      options,
+      (updatedOptions) => this.client.restoreStatus(this.vaultUrl, jobId, updatedOptions),
+    );
+  }
+
+  /**
+   * Reaches to the service and updates the pre-restore poll operation.
+   */
+  async update(
+    options: {
+      abortSignal?: AbortSignalLike;
+      fireProgress?: (state: KeyVaultPreRestorePollOperationState) => void;
+    } = {},
+  ): Promise<KeyVaultPreRestorePollOperation> {
+    const state = this.state;
+    const { folderUri, sasToken, folderName } = state;
+
+    if (options.abortSignal) {
+      this.requestOptions.abortSignal = options.abortSignal;
+    }
+
+    if (!state.isStarted) {
+      const serviceOperation = await this.preFullRestore({
+        ...this.requestOptions,
+        preRestoreOperationParameters: {
+          folderToRestore: folderName,
+          sasTokenParameters: {
+            storageResourceUri: folderUri,
+            token: sasToken,
+            useManagedIdentity: sasToken === undefined,
+          },
+        },
+      });
+
+      this.mapState(serviceOperation);
+    } else if (!state.isCompleted) {
+      if (!state.jobId) {
+        throw new Error(`Missing "jobId" from the pre-restore operation.`);
+      }
+      const serviceOperation = await this.restoreStatus(state.jobId, this.requestOptions);
+      this.mapState(serviceOperation);
+    }
+
+    return this;
+  }
+
+  private mapState(serviceOperation: RestoreOperation): void {
+    const state = this.state;
+    const { startTime, jobId, endTime, error, status, statusDetails } = serviceOperation;
+
+    if (!startTime) {
+      throw new Error(
+        `Missing "startTime" from the pre-full-restore operation. Pre-restore did not start successfully.`,
+      );
+    }
+
+    state.isStarted = true;
+    state.jobId = jobId;
+    state.endTime = endTime;
+    state.startTime = startTime;
+    state.status = status;
+    state.statusDetails = statusDetails;
+
+    state.isCompleted = !!endTime;
+
+    if (state.isCompleted && error?.code) {
+      throw new Error(error?.message || statusDetails);
+    }
+
+    if (state.isCompleted) {
+      state.result = {
+        startTime,
+        endTime,
+      };
+    }
+  }
+}

--- a/sdk/keyvault/keyvault-admin/src/lro/preRestore/poller.ts
+++ b/sdk/keyvault/keyvault-admin/src/lro/preRestore/poller.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { KeyVaultAdminPoller, KeyVaultAdminPollerOptions } from "../keyVaultAdminPoller";
+import {
+  KeyVaultPreRestoreOperationState,
+  KeyVaultPreRestorePollOperation,
+  KeyVaultPreRestorePollOperationState,
+} from "./operation";
+import { KeyVaultRestoreResult } from "../../backupClientModels";
+
+export interface KeyVaultPreRestorePollerOptions extends KeyVaultAdminPollerOptions {
+  folderUri: string;
+  sasToken?: string;
+  folderName?: string;
+}
+
+/**
+ * Class that creates a poller for the pre-restore operation.
+ */
+export class KeyVaultPreRestorePoller extends KeyVaultAdminPoller<
+  KeyVaultPreRestoreOperationState,
+  KeyVaultRestoreResult
+> {
+  constructor(options: KeyVaultPreRestorePollerOptions) {
+    const {
+      client,
+      vaultUrl,
+      folderUri,
+      sasToken,
+      folderName,
+      requestOptions,
+      intervalInMs = 2000,
+      resumeFrom,
+    } = options;
+
+    let state: KeyVaultPreRestorePollOperationState | undefined;
+
+    if (resumeFrom) {
+      state = JSON.parse(resumeFrom).state;
+    }
+
+    const operation = new KeyVaultPreRestorePollOperation(
+      {
+        ...state,
+        folderUri,
+        sasToken,
+        folderName,
+      },
+      vaultUrl,
+      client,
+      requestOptions,
+    );
+
+    super(operation);
+
+    this.intervalInMs = intervalInMs;
+  }
+}

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -11,12 +11,12 @@ generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file:
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/rbac.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/backuprestore.json
-  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/settings.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/rbac.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/backuprestore.json
+  - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/settings.json
 output-folder: ../
 source-code-folder-path: ./src/generated
-package-version: 4.5.1
+package-version: 4.6.0-beta.1
 use-extension:
   "@autorest/typescript": "6.0.0-beta.15"
 ```

--- a/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/utils/common.ts
@@ -61,7 +61,7 @@ export function getSasToken(): { blobStorageUri: string; blobSasToken: string } 
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.2", "7.3", "7.4", "7.5"] as const;
+export const serviceVersions = ["7.2", "7.3", "7.4", "7.5", "7.6-preview.1"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.1 (Unreleased)
+## 4.9.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default service version is now `7.6-preview.1`.
 
 ## 4.8.0 (2024-02-14)
 

--- a/sdk/keyvault/keyvault-certificates/assets.json
+++ b/sdk/keyvault/keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-certificates",
-  "Tag": "js/keyvault/keyvault-certificates_c4d7677a4b"
+  "Tag": "js/keyvault/keyvault-certificates_aa818207c6"
 }

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-certificates",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.8.1",
+  "version": "4.9.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-certificates/README.md",

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -89,7 +89,7 @@ export class CertificateClient {
 // @public
 export interface CertificateClientOptions extends ExtendedCommonClientOptions {
     disableChallengeResourceVerification?: boolean;
-    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5";
+    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -15,7 +15,7 @@ import {
 /**
  * The latest supported KeyVault service API version
  */
-export const LATEST_API_VERSION = "7.5";
+export const LATEST_API_VERSION = "7.6-preview.1";
 
 /**
  * The optional parameters accepted by the KeyVault's CertificateClient
@@ -24,7 +24,7 @@ export interface CertificateClientOptions extends ExtendedCommonClientOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5";
+  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";
 
   /**
    * Whether to disable verification that the authentication challenge resource matches the Key Vault domain.

--- a/sdk/keyvault/keyvault-certificates/src/constants.ts
+++ b/sdk/keyvault/keyvault-certificates/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.8.1";
+export const SDK_VERSION: string = "4.9.0-beta.1";

--- a/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/keyVaultClient.ts
@@ -11,7 +11,7 @@ import * as coreHttpCompat from "@azure/core-http-compat";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import {
-  ApiVersion75,
+  ApiVersion76Preview1,
   KeyVaultClientOptionalParams,
   GetCertificatesOptionalParams,
   GetCertificatesResponse,
@@ -80,7 +80,7 @@ import {
 
 /** @internal */
 export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
-  apiVersion: ApiVersion75;
+  apiVersion: ApiVersion76Preview1;
 
   /**
    * Initializes a new instance of the KeyVaultClient class.
@@ -88,7 +88,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion75,
+    apiVersion: ApiVersion76Preview1,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -103,7 +103,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-certificates/4.8.1`;
+    const packageDetails = `azsdk-js-keyvault-certificates/4.9.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/generated/models/index.ts
@@ -504,20 +504,20 @@ export type DeletedCertificateBundle = CertificateBundle & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion75} that the service accepts. */
-export enum KnownApiVersion75 {
-  /** Api Version '7.5' */
-  Seven5 = "7.5"
+/** Known values of {@link ApiVersion76Preview1} that the service accepts. */
+export enum KnownApiVersion76Preview1 {
+  /** Api Version '7.6-preview.1' */
+  Seven6Preview1 = "7.6-preview.1"
 }
 
 /**
- * Defines values for ApiVersion75. \
- * {@link KnownApiVersion75} can be used interchangeably with ApiVersion75,
+ * Defines values for ApiVersion76Preview1. \
+ * {@link KnownApiVersion76Preview1} can be used interchangeably with ApiVersion76Preview1,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.5**: Api Version '7.5'
+ * **7.6-preview.1**: Api Version '7.6-preview.1'
  */
-export type ApiVersion75 = string;
+export type ApiVersion76Preview1 = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -16,11 +16,11 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/certificates.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/certificates.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.8.1
+package-version: 4.9.0-beta.1
 openapi-type: data-plane
 ```
 

--- a/sdk/keyvault/keyvault-certificates/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/utils/common.ts
@@ -35,7 +35,7 @@ export async function assertThrowsAbortError(cb: () => Promise<any>): Promise<vo
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4", "7.5"] as const;
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6-preview.1"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.1 (Unreleased)
+## 4.9.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default service version is now `7.6-preview.1`.
 
 ## 4.8.0 (2024-02-14)
 

--- a/sdk/keyvault/keyvault-keys/assets.json
+++ b/sdk/keyvault/keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-keys",
-  "Tag": "js/keyvault/keyvault-keys_ed94a0d29e"
+  "Tag": "js/keyvault/keyvault-keys_a6e8a3f999"
 }

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-keys",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.8.1",
+  "version": "4.9.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's keys.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-keys/README.md",

--- a/sdk/keyvault/keyvault-keys/src/constants.ts
+++ b/sdk/keyvault/keyvault-keys/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.8.1";
+export const SDK_VERSION: string = "4.9.0-beta.1";

--- a/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/keyVaultClient.ts
@@ -12,7 +12,7 @@ import * as coreRestPipeline from "@azure/core-rest-pipeline";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import {
-  ApiVersion75,
+  ApiVersion76Preview1,
   KeyVaultClientOptionalParams,
   JsonWebKeyType,
   CreateKeyOptionalParams,
@@ -75,7 +75,7 @@ import {
 } from "./models";
 
 export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
-  apiVersion: ApiVersion75;
+  apiVersion: ApiVersion76Preview1;
 
   /**
    * Initializes a new instance of the KeyVaultClient class.
@@ -83,7 +83,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion75,
+    apiVersion: ApiVersion76Preview1,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -98,7 +98,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-keys/4.8.1`;
+    const packageDetails = `azsdk-js-keyvault-keys/4.9.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/generated/models/index.ts
@@ -437,20 +437,20 @@ export type DeletedKeyItem = KeyItem & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion75} that the service accepts. */
-export enum KnownApiVersion75 {
-  /** Api Version '7.5' */
-  Seven5 = "7.5"
+/** Known values of {@link ApiVersion76Preview1} that the service accepts. */
+export enum KnownApiVersion76Preview1 {
+  /** Api Version '7.6-preview.1' */
+  Seven6Preview1 = "7.6-preview.1"
 }
 
 /**
- * Defines values for ApiVersion75. \
- * {@link KnownApiVersion75} can be used interchangeably with ApiVersion75,
+ * Defines values for ApiVersion76Preview1. \
+ * {@link KnownApiVersion76Preview1} can be used interchangeably with ApiVersion76Preview1,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.5**: Api Version '7.5'
+ * **7.6-preview.1**: Api Version '7.6-preview.1'
  */
-export type ApiVersion75 = string;
+export type ApiVersion76Preview1 = string;
 
 /** Known values of {@link JsonWebKeyType} that the service accepts. */
 export enum KnownJsonWebKeyType {

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -18,7 +18,7 @@ export { KeyType, KnownKeyTypes, KeyOperation };
 /**
  * The latest supported Key Vault service API version
  */
-export const LATEST_API_VERSION = "7.5";
+export const LATEST_API_VERSION = "7.6-preview.1";
 
 /**
  * The optional parameters accepted by the KeyVault's KeyClient

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -10,12 +10,12 @@ add-credentials: false
 core-http-compat-mode: true
 use-core-v2: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/keys.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/keys.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 disable-async-iterators: true
 api-version-parameter: choice
-package-version: 4.8.1
+package-version: 4.9.0-beta.1
 use-extension:
   "@autorest/typescript": "6.0.0-beta.19"
 ```

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.hsm.spec.ts
@@ -77,12 +77,13 @@ onVersions({ minVer: "7.2" }).describe(
       });
     });
 
-    // Temporarily setting max version of 7.3 until resolution of https://github.com/Azure/azure-sdk-for-net/issues/32260
-    onVersions({ minVer: "7.3", maxVer: "7.3" }).describe("releaseKey", () => {
+    describe("releaseKey", () => {
       let attestation: string;
       let encodedReleasePolicy: Uint8Array;
 
       beforeEach(async () => {
+        await recorder.setMatcher("BodilessMatcher");
+
         const attestationUri = env.AZURE_KEYVAULT_ATTESTATION_URI;
         const releasePolicy = {
           anyOf: [
@@ -193,7 +194,10 @@ onVersions({ minVer: "7.2" }).describe(
           uint8ArrayToString(updatedKey.properties.releasePolicy!.encodedPolicy!),
         );
 
-        assert.equal(decodedReleasePolicy.anyOf[0].anyOf[0].equals, "false");
+        // This object gets sanitized in playback mode so cannot make assertion
+        if (!isPlaybackMode()) {
+          assert.equal(decodedReleasePolicy.anyOf[0].anyOf[0].equals, "false");
+        }
       });
 
       it("errors when key is exportable without a release policy", async () => {

--- a/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/keyClient.spec.ts
@@ -418,7 +418,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     }
   });
 
-  onVersions({ minVer: "7.3" }).describe("releaseKey", () => {
+  describe("releaseKey", () => {
     let attestation: string;
     let encodedReleasePolicy: Uint8Array;
 

--- a/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/utils/common.ts
@@ -7,7 +7,7 @@ import { env } from "@azure-tools/test-recorder";
 /**
  * The known API versions that we support.
  */
-export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4", "7.5"] as const;
+export const serviceVersions = ["7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6-preview.1"] as const;
 
 /**
  * Fetches the service version to test against. This version could be configured as part of CI

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.1 (Unreleased)
+## 4.9.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The default service version is now `7.6-preview.1`.
 
 ## 4.8.0 (2024-02-14)
 

--- a/sdk/keyvault/keyvault-secrets/assets.json
+++ b/sdk/keyvault/keyvault-secrets/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-secrets",
-  "Tag": "js/keyvault/keyvault-secrets_66216a7633"
+  "Tag": "js/keyvault/keyvault-secrets_1ce119211a"
 }

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-secrets",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.8.1",
+  "version": "4.9.0-beta.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's secrets.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-secrets/README.md",

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -134,7 +134,7 @@ export class SecretClient {
 // @public
 export interface SecretClientOptions extends ExtendedCommonClientOptions {
     disableChallengeResourceVerification?: boolean;
-    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5";
+    serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";
 }
 
 // @public

--- a/sdk/keyvault/keyvault-secrets/src/constants.ts
+++ b/sdk/keyvault/keyvault-secrets/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "4.8.1";
+export const SDK_VERSION: string = "4.9.0-beta.1";

--- a/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/keyVaultClient.ts
@@ -12,7 +12,7 @@ import * as coreRestPipeline from "@azure/core-rest-pipeline";
 import * as Parameters from "./models/parameters";
 import * as Mappers from "./models/mappers";
 import {
-  ApiVersion75,
+  ApiVersion76Preview1,
   KeyVaultClientOptionalParams,
   SetSecretOptionalParams,
   SetSecretResponse,
@@ -47,7 +47,7 @@ import {
 
 /** @internal */
 export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
-  apiVersion: ApiVersion75;
+  apiVersion: ApiVersion76Preview1;
 
   /**
    * Initializes a new instance of the KeyVaultClient class.
@@ -55,7 +55,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
    * @param options The parameter options
    */
   constructor(
-    apiVersion: ApiVersion75,
+    apiVersion: ApiVersion76Preview1,
     options?: KeyVaultClientOptionalParams
   ) {
     if (apiVersion === undefined) {
@@ -70,7 +70,7 @@ export class KeyVaultClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-keyvault-secrets/4.8.1`;
+    const packageDetails = `azsdk-js-keyvault-secrets/4.9.0-beta.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/generated/models/index.ts
@@ -215,20 +215,20 @@ export type DeletedSecretItem = SecretItem & {
   readonly deletedDate?: Date;
 };
 
-/** Known values of {@link ApiVersion75} that the service accepts. */
-export enum KnownApiVersion75 {
-  /** Api Version '7.5' */
-  Seven5 = "7.5"
+/** Known values of {@link ApiVersion76Preview1} that the service accepts. */
+export enum KnownApiVersion76Preview1 {
+  /** Api Version '7.6-preview.1' */
+  Seven6Preview1 = "7.6-preview.1"
 }
 
 /**
- * Defines values for ApiVersion75. \
- * {@link KnownApiVersion75} can be used interchangeably with ApiVersion75,
+ * Defines values for ApiVersion76Preview1. \
+ * {@link KnownApiVersion76Preview1} can be used interchangeably with ApiVersion76Preview1,
  *  this enum contains the known values that the service supports.
  * ### Known values supported by the service
- * **7.5**: Api Version '7.5'
+ * **7.6-preview.1**: Api Version '7.6-preview.1'
  */
-export type ApiVersion75 = string;
+export type ApiVersion76Preview1 = string;
 
 /** Known values of {@link DeletionRecoveryLevel} that the service accepts. */
 export enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -8,7 +8,7 @@ import { ExtendedCommonClientOptions } from "@azure/core-http-compat";
 /**
  * The latest supported KeyVault service API version
  */
-export const LATEST_API_VERSION = "7.5";
+export const LATEST_API_VERSION = "7.6-preview.1";
 
 /**
  * The optional parameters accepted by the KeyVault's KeyClient
@@ -17,7 +17,7 @@ export interface SecretClientOptions extends ExtendedCommonClientOptions {
   /**
    * The accepted versions of the KeyVault's service API.
    */
-  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5";
+  serviceVersion?: "7.0" | "7.1" | "7.2" | "7.3" | "7.4" | "7.5" | "7.6-preview.1";
 
   /**
    * Whether to disable verification that the authentication challenge resource matches the Key Vault domain.

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -16,9 +16,9 @@ generate-metadata: false
 add-credentials: false
 core-http-compat-mode: true
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/7452e1cc7db72fbc6cd9539b390d8b8e5c2a1864/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.5/secrets.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/8af9817c15d688c941cda106758045b5deb9a069/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.1/secrets.json
 output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
-package-version: 4.8.1
+package-version: 4.9.0-beta.1
 ```

--- a/sdk/keyvault/keyvault-secrets/test/public/utils/common.ts
+++ b/sdk/keyvault/keyvault-secrets/test/public/utils/common.ts
@@ -32,6 +32,7 @@ export const serviceVersions: readonly NonNullable<ServiceVersion>[] = [
   "7.3",
   "7.4",
   "7.5",
+  "7.6-preview.1",
 ] as const;
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-admin`
- `@azure/keyvault-certificates`
- `@azure/keyvault-keys`
- `@azure/keyvault-secrets`

### Issues associated with this PR

- Resolves #29341

### Describe the problem that is addressed by this PR

- Re-record and bump service version for all four Key Vault packages
- Add support for new feature in keyvault-admin: pre-backup and pre-restore.
  - Two new LROs which can be called to verify whether a backup or restore operation can be performed. From what I understand, this is a "dry run" of the backup or restore operation and takes the same parameters.

### To do

- Test the new features. The new features have not widely deployed yet so am unable to test and make recordings.