### PR TITLE
[Monitor OpenTelemetry Exporter] Add Performance Counter Name Mapping

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Capture and export measurements when creating log records from the Application Insights 3.X SDK.
 
+### Other Changes
+
+- Convert OTel-valid performance counter names to appropriate breeze names.
+
 ## 1.0.0-beta.22 (2024-04-16)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
@@ -45,3 +45,29 @@ export interface PersistentStorage {
   shift(): Promise<unknown>;
   push(value: unknown[]): Promise<boolean>;
 }
+
+/**
+ * Performance Counter OpenTelemetry compliant names.
+ * @internal
+ */
+export enum OTelPerformanceCounterNames {
+  PRIVATE_BYTES = "Private_Bytes",
+  AVAILABLE_BYTES = "Available_Bytes",
+  PROCESSOR_TIME = "Processor_Time",
+  PROCESS_TIME = "Process_Time",
+  REQUEST_RATE = "Request_Rate",
+  REQUEST_DURATION = "Request_Execution_Time",
+}
+
+/**
+ * Breeze Performance Counter names.
+ * @internal
+ */
+export enum BreezePerformanceCounterNames {
+  PRIVATE_BYTES = "\\Process(??APP_WIN32_PROC??)\\Private Bytes",
+  AVAILABLE_BYTES = "\\Memory\\Available Bytes",
+  PROCESSOR_TIME = "\\Processor(_Total)\\% Processor Time",
+  PROCESS_TIME = "\\Process(??APP_WIN32_PROC??)\\% Processor Time",
+  REQUEST_RATE = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Requests/Sec",
+  REQUEST_DURATION = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Request Execution Time",
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
@@ -5,6 +5,16 @@ import { Attributes } from "@opentelemetry/api";
 import { DataPointType, Histogram, ResourceMetrics } from "@opentelemetry/sdk-metrics";
 import { TelemetryItem as Envelope, MetricsData, MetricDataPoint } from "../generated";
 import { createTagsFromResource } from "./common";
+import { BreezePerformanceCounterNames, OTelPerformanceCounterNames } from "../types";
+
+const breezePerformanceCountersMap = new Map<string, string>([
+  [OTelPerformanceCounterNames.PRIVATE_BYTES, BreezePerformanceCounterNames.PRIVATE_BYTES],
+  [OTelPerformanceCounterNames.AVAILABLE_BYTES, BreezePerformanceCounterNames.AVAILABLE_BYTES],
+  [OTelPerformanceCounterNames.PROCESSOR_TIME, BreezePerformanceCounterNames.PROCESSOR_TIME],
+  [OTelPerformanceCounterNames.PROCESS_TIME, BreezePerformanceCounterNames.PROCESS_TIME],
+  [OTelPerformanceCounterNames.REQUEST_RATE, BreezePerformanceCounterNames.REQUEST_RATE],
+  [OTelPerformanceCounterNames.REQUEST_DURATION, BreezePerformanceCounterNames.REQUEST_DURATION],
+]);
 
 function createPropertiesFromMetricAttributes(attributes?: Attributes): {
   [propertyName: string]: string;
@@ -48,8 +58,12 @@ export function resourceMetricsToEnvelope(
           properties: {},
         };
         baseData.properties = createPropertiesFromMetricAttributes(dataPoint.attributes);
+        let perfCounterName;
+        if (breezePerformanceCountersMap.has(metric.descriptor.name)) {
+          perfCounterName = breezePerformanceCountersMap.get(metric.descriptor.name);
+        }
         const metricDataPoint: MetricDataPoint = {
-          name: metric.descriptor.name,
+          name: perfCounterName ? perfCounterName : metric.descriptor.name,
           value: 0,
           dataPointType: "Aggregation",
         };

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.test.ts
@@ -22,7 +22,7 @@ import {
   RequestData,
 } from "../../src/generated";
 import assert from "assert";
-import { Tags } from "../../src/types";
+import { BreezePerformanceCounterNames, OTelPerformanceCounterNames, Tags } from "../../src/types";
 import { Context, getInstance } from "../../src/platform";
 
 const context = getInstance();
@@ -113,6 +113,249 @@ describe("metricUtil.ts", () => {
       const meter = provider.getMeter("example-meter-node");
       // Create Counter instrument with the meter
       const counter = meter.createCounter("counter");
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+  });
+
+  describe("#performanceMetricsToEnvelope", () => {
+    it("should create private bytes envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.PRIVATE_BYTES,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.PRIVATE_BYTES);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+    it("should create available bytes envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.AVAILABLE_BYTES,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.AVAILABLE_BYTES);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+    it("should create processor time envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.PROCESSOR_TIME,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.PROCESSOR_TIME);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+    it("should create process time envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.PROCESS_TIME,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.PROCESS_TIME);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+    it("should create request rate envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.REQUEST_RATE,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.REQUEST_RATE);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey");
+      assertEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Metric",
+        100,
+        "MetricData",
+        expectedTags,
+        expectedBaseData,
+      );
+    });
+    it("should create request duration envelopes with the correct name", async () => {
+      const expectedTags: Tags = {
+        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
+        "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
+      };
+      const expectedBaseData = {
+        name: BreezePerformanceCounterNames.REQUEST_DURATION,
+        value: 1,
+        dataPointType: "Aggregation",
+        count: 1,
+      };
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(OTelPerformanceCounterNames.REQUEST_DURATION);
       counter.add(1);
       provider.forceFlush();
       await new Promise((resolve) => setTimeout(resolve, 800));

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/types.ts
@@ -28,12 +28,12 @@ export interface MetricDependencyDimensions extends StandardMetricBaseDimensions
 }
 
 export enum PerformanceCounterMetricNames {
-  PRIVATE_BYTES = "\\Process(??APP_WIN32_PROC??)\\Private Bytes",
-  AVAILABLE_BYTES = "\\Memory\\Available Bytes",
-  PROCESSOR_TIME = "\\Processor(_Total)\\% Processor Time",
-  PROCESS_TIME = "\\Process(??APP_WIN32_PROC??)\\% Processor Time",
-  REQUEST_RATE = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Requests/Sec",
-  REQUEST_DURATION = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Request Execution Time",
+  PRIVATE_BYTES = "Private_Bytes",
+  AVAILABLE_BYTES = "Available_Bytes",
+  PROCESSOR_TIME = "Processor_Time",
+  PROCESS_TIME = "Process_Time",
+  REQUEST_RATE = "Request_Rate",
+  REQUEST_DURATION = "Request_Execution_Time",
 }
 
 export type MetricDimensionTypeKeys =


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Performance counter names should be converted from OpenTelemetry valid names to the those appropriate for breeze to avoid OTel warnings.

### Are there test cases added in this PR? _(If not, why?)_
Yes, in the `metricUitl.tests.ts`.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
