### PR TITLE
Upgrade to a version ESRP Release that supports federated auth

### DIFF
--- a/eng/pipelines/templates/steps/npm-release-task.yml
+++ b/eng/pipelines/templates/steps/npm-release-task.yml
@@ -9,10 +9,14 @@ parameters:
 steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
   - ${{ if eq(parameters.Registry, 'https://registry.npmjs.org/') }}:
-      - task: EsrpRelease@6
+      - task: EsrpRelease@7
         inputs:
           displayName: 'Publish ${{parameters.Artifact.name}} to ESRP'
-          ConnectedServiceName: 'ESRP Release Service'
+          ConnectedServiceName: 'Azure SDK Engineering System'
+          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+          KeyVaultName: 'AzureSDKEngKeyVault'
+          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
           Intent: 'PackageDistribution'
           ContentType: 'npm'
           FolderLocation: ${{parameters.PathToArtifacts}}


### PR DESCRIPTION
EsrpRelease@6 required a custom service connection that held an aad app secret in its configuration. The latest version, EsrpRelease@7, uses a standard ARM service connection, moving most of the configuration settings (KeyVaultName, AuthCertName ...) from the custom connection into the task itself.