### PR TITLE
[core-amqp] disable tshy selfLink

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -87,7 +87,8 @@
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
-    }
+    },
+    "selfLink": false
   },
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
similar to other core packages, we don't need selfLink as we uses "paths" in
tsconfig to map the package to .src/index.ts