### PR TITLE
[EngSys] enable build cache for more packages in core - ci pipelines

### DIFF
--- a/sdk/resources/arm-resources/config/rush-project.json
+++ b/sdk/resources/arm-resources/config/rush-project.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../common/config/rush-project.json",
+}

--- a/sdk/servicebus/service-bus/config/rush-project.json
+++ b/sdk/servicebus/service-bus/config/rush-project.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../common/config/rush-project.json",
+}

--- a/sdk/template/template/config/rush-project.json
+++ b/sdk/template/template/config/rush-project.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../common/config/rush-project.json",
+}

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -123,7 +123,8 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -96,7 +96,8 @@
     "esmDialects": [
       "browser",
       "react-native"
-    ]
+    ],
+    "selfLink": false
   },
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
Build cache was enabled for most of our commonly built packages in PR
https://github.com/Azure/azure-sdk-for-js/pull/27409.

This PR enables build cache for several more packages that get built in core -
ci pipelines to further reduce time on packages when they haven't changed.