### PR TITLE
[identity] Migrate UsernamePasswordCredential to MSALClient

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Other Changes
 
 - `DeviceCodeCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29405](https://github.com/Azure/azure-sdk-for-js/pull/29405)
+- `UsernamePasswordCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29656](https://github.com/Azure/azure-sdk-for-js/pull/29656)
+
 
 ## 4.2.0 (2024-04-30)
 

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_bda4cd295c"
+  "Tag": "js/identity/identity_ab49cd04bb"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_ab49cd04bb"
+  "Tag": "js/identity/identity_a7eb8b7286"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_72abb85c88"
+  "Tag": "js/identity/identity_bda4cd295c"
 }

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -61,7 +61,7 @@ export class UsernamePasswordCredential implements TokenCredential {
 
     this.msalClient = createMsalClient(clientId, this.tenantId, {
       ...options,
-      tokenCredentialOptions: options || {},
+      tokenCredentialOptions: options ?? {},
     });
   }
 

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -6,12 +6,11 @@ import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
-import { MsalFlow } from "../msal/flows";
-import { MsalUsernamePassword } from "../msal/nodeFlows/msalUsernamePassword";
 import { UsernamePasswordCredentialOptions } from "./usernamePasswordCredentialOptions";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";
+import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 
 const logger = credentialLogger("UsernamePasswordCredential");
 
@@ -24,7 +23,9 @@ const logger = credentialLogger("UsernamePasswordCredential");
 export class UsernamePasswordCredential implements TokenCredential {
   private tenantId: string;
   private additionallyAllowedTenantIds: string[];
-  private msalFlow: MsalFlow;
+  private msalClient: MsalClient;
+  private username: string;
+  private password: string;
 
   /**
    * Creates an instance of the UsernamePasswordCredential with the details
@@ -55,13 +56,11 @@ export class UsernamePasswordCredential implements TokenCredential {
       options?.additionallyAllowedTenants,
     );
 
-    this.msalFlow = new MsalUsernamePassword({
+    this.username = username;
+    this.password = password;
+
+    this.msalClient = createMsalClient(clientId, this.tenantId, {
       ...options,
-      logger,
-      clientId,
-      tenantId,
-      username,
-      password,
       tokenCredentialOptions: options || {},
     });
   }
@@ -91,7 +90,12 @@ export class UsernamePasswordCredential implements TokenCredential {
         );
 
         const arrayScopes = ensureScopes(scopes);
-        return this.msalFlow.getToken(arrayScopes, newOptions);
+        return this.msalClient.getTokenByUsernamePassword(
+          arrayScopes,
+          this.username,
+          this.password,
+          newOptions,
+        );
       },
     );
   }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -46,8 +46,31 @@ export interface GetTokenWithSilentAuthOptions extends GetTokenOptions {
  * Represents a client for interacting with the Microsoft Authentication Library (MSAL).
  */
 export interface MsalClient {
+  /**
+   * Retrieves an access token by using a user's username and password.
+   *
+   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param username - The username provided by the developer.
+   * @param password - The user's password provided by the developer.
+   * @param options - Additional options that may be provided to the method.
+   * @returns An access token.
+   */
+  getTokenByUsernamePassword(
+    scopes: string[],
+    username: string,
+    password: string,
+    options?: GetTokenOptions,
+  ): Promise<AccessToken>;
+  /**
+   * Retrieves an access token by prompting the user to authenticate using a device code.
+   *
+   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param userPromptCallback - The callback function that allows developers to customize the prompt message.
+   * @param options - Additional options that may be provided to the method.
+   * @returns An access token.
+   */
   getTokenByDeviceCode(
-    arrayScopes: string[],
+    scopes: string[],
     userPromptCallback: DeviceCodePromptCallback,
     options?: GetTokenWithSilentAuthOptions,
   ): Promise<AccessToken>;
@@ -60,7 +83,7 @@ export interface MsalClient {
    * @returns An access token.
    */
   getTokenByClientCertificate(
-    arrayScopes: string[],
+    scopes: string[],
     certificate: CertificateParts,
     options?: GetTokenOptions,
   ): Promise<AccessToken>;
@@ -74,7 +97,7 @@ export interface MsalClient {
    * @returns An access token.
    */
   getTokenByClientAssertion(
-    arrayScopes: string[],
+    scopes: string[],
     clientAssertion: string,
     options?: GetTokenOptions,
   ): Promise<AccessToken>;
@@ -495,6 +518,29 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     });
   }
 
+  async function getTokenByUsernamePassword(
+    scopes: string[],
+    username: string,
+    password: string,
+    options: GetTokenOptions = {},
+  ): Promise<AccessToken> {
+    msalLogger.getToken.info(`Attempting to acquire token using username and password`);
+
+    const msalApp = await getPublicApp(options);
+
+    return withSilentAuthentication(msalApp, scopes, options, () => {
+      const requestOptions: msal.UsernamePasswordRequest = {
+        scopes,
+        username,
+        password,
+        authority: state.msalConfig.auth.authority,
+        claims: options?.claims,
+      };
+
+      return msalApp.acquireTokenByUsernamePassword(requestOptions);
+    });
+  }
+
   function getActiveAccount(): AuthenticationRecord | undefined {
     if (!state.cachedAccount) {
       return undefined;
@@ -508,5 +554,6 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     getTokenByClientAssertion,
     getTokenByClientCertificate,
     getTokenByDeviceCode,
+    getTokenByUsernamePassword,
   };
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -49,7 +49,7 @@ export interface MsalClient {
   /**
    * Retrieves an access token by using a user's username and password.
    *
-   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
    * @param username - The username provided by the developer.
    * @param password - The user's password provided by the developer.
    * @param options - Additional options that may be provided to the method.
@@ -64,7 +64,7 @@ export interface MsalClient {
   /**
    * Retrieves an access token by prompting the user to authenticate using a device code.
    *
-   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
    * @param userPromptCallback - The callback function that allows developers to customize the prompt message.
    * @param options - Additional options that may be provided to the method.
    * @returns An access token.
@@ -77,7 +77,7 @@ export interface MsalClient {
   /**
    * Retrieves an access token by using a client certificate.
    *
-   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
    * @param certificate - The client certificate used for authentication.
    * @param options - Additional options that may be provided to the method.
    * @returns An access token.
@@ -91,7 +91,7 @@ export interface MsalClient {
   /**
    * Retrieves an access token by using a client assertion.
    *
-   * @param arrayScopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
    * @param clientAssertion - The client assertion used for authentication.
    * @param options - Additional options that may be provided to the method.
    * @returns An access token.

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -21,6 +21,7 @@ import { msalPlugins } from "../../../src/msal/nodeFlows/msalPlugins";
 import sinon from "sinon";
 import { DeveloperSignOnClientId } from "../../../src/constants";
 import { Context } from "mocha";
+import { getUsernamePasswordStaticResources } from "../../msalTestUtils";
 
 describe("MsalClient", function () {
   describe("recorded tests", function () {
@@ -70,6 +71,20 @@ describe("MsalClient", function () {
           `To complete the test recording, please go to ${info.verificationUri} and use code ${info.userCode} to authenticate.`,
         );
       });
+      assert.isNotEmpty(accessToken.token);
+      assert.isNotNaN(accessToken.expiresOnTimestamp);
+    });
+
+    it("supports getTokenByUsernamePassword", async function () {
+      const scopes = ["https://vault.azure.net/.default"];
+      const { username, password, clientId, tenantId } = getUsernamePasswordStaticResources();
+
+      const clientOptions = recorder.configureClientOptions({});
+      const client = msalClient.createMsalClient(clientId, tenantId, {
+        tokenCredentialOptions: { additionalPolicies: clientOptions.additionalPolicies },
+      });
+
+      const accessToken = await client.getTokenByUsernamePassword(scopes, username, password);
       assert.isNotEmpty(accessToken.token);
       assert.isNotNaN(accessToken.expiresOnTimestamp);
     });

--- a/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
@@ -18,10 +18,6 @@ describe("UsernamePasswordCredential (internal)", function () {
   let getTokenSilentSpy: Sinon.SinonSpy;
   let doGetTokenSpy: Sinon.SinonSpy;
   let recorder: Recorder;
-  let clientId: string;
-  let tenantId: string;
-  let username: string;
-  let password: string;
 
   beforeEach(async function (this: Context) {
     const setup = await msalNodeTestSetup(this.currentTest);
@@ -36,8 +32,6 @@ describe("UsernamePasswordCredential (internal)", function () {
       PublicClientApplication.prototype,
       "acquireTokenByUsernamePassword",
     );
-
-    ({ clientId, tenantId, username, password } = getWellKnownStaticResources());
   });
 
   afterEach(async function () {
@@ -109,6 +103,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("Authenticates silently after the initial request", async function (this: Context) {
+    const { clientId, password, tenantId, username } = getStaticTestResources();
     // todo: validate these exist or throw with meaningful error
     const credential = new UsernamePasswordCredential(
       tenantId,
@@ -135,6 +130,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("Authenticates with tenantId on getToken", async function (this: Context) {
+    const { clientId, password, tenantId, username } = getStaticTestResources();
     const credential = new UsernamePasswordCredential(
       tenantId,
       clientId,
@@ -148,6 +144,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("authenticates (with allowLoggingAccountIdentifiers set to true)", async function (this: Context) {
+    const { clientId, password, tenantId, username } = getStaticTestResources();
     if (isPlaybackMode()) {
       // The recorder clears the access tokens.
       this.skip();
@@ -187,7 +184,7 @@ describe("UsernamePasswordCredential (internal)", function () {
  *
  * @returns A set of well-known static resources for the tests.
  */
-function getWellKnownStaticResources() {
+function getStaticTestResources() {
   const clientId = DeveloperSignOnClientId;
   const tenantId = env.AZURE_IDENTITY_TEST_TENANTID;
   if (!tenantId) {

--- a/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
@@ -7,11 +7,11 @@ import { AzureLogger, setLogLevel } from "@azure/logger";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
 import { Recorder, env, isPlaybackMode } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
-import { DeveloperSignOnClientId } from "../../../src/constants";
 import { PublicClientApplication } from "@azure/msal-node";
 import Sinon from "sinon";
 import { UsernamePasswordCredential } from "../../../src";
 import { assert } from "chai";
+import { getUsernamePasswordStaticResources } from "../../msalTestUtils";
 
 describe("UsernamePasswordCredential (internal)", function () {
   let cleanup: MsalTestCleanup;
@@ -103,7 +103,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("Authenticates silently after the initial request", async function (this: Context) {
-    const { clientId, password, tenantId, username } = getStaticTestResources();
+    const { clientId, password, tenantId, username } = getUsernamePasswordStaticResources();
     // todo: validate these exist or throw with meaningful error
     const credential = new UsernamePasswordCredential(
       tenantId,
@@ -130,7 +130,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("Authenticates with tenantId on getToken", async function (this: Context) {
-    const { clientId, password, tenantId, username } = getStaticTestResources();
+    const { clientId, password, tenantId, username } = getUsernamePasswordStaticResources();
     const credential = new UsernamePasswordCredential(
       tenantId,
       clientId,
@@ -144,7 +144,7 @@ describe("UsernamePasswordCredential (internal)", function () {
   });
 
   it("authenticates (with allowLoggingAccountIdentifiers set to true)", async function (this: Context) {
-    const { clientId, password, tenantId, username } = getStaticTestResources();
+    const { clientId, password, tenantId, username } = getUsernamePasswordStaticResources();
     if (isPlaybackMode()) {
       // The recorder clears the access tokens.
       this.skip();
@@ -174,43 +174,3 @@ describe("UsernamePasswordCredential (internal)", function () {
     AzureLogger.destroy();
   });
 });
-
-/**
- * These tests rely on static resources fetched from the identity test secrets vault and "merged" into the test environment in CI.
- *
- * A helper function validates that these resources are present in the environment as they are not deployed per run.
- *
- * When in doubt, reach out to the feature crew for help.
- *
- * @returns A set of well-known static resources for the tests.
- */
-function getStaticTestResources() {
-  const clientId = DeveloperSignOnClientId;
-  const tenantId = env.AZURE_IDENTITY_TEST_TENANTID;
-  if (!tenantId) {
-    throw new Error(
-      "AZURE_IDENTITY_TEST_TENANTID must be present in the environment to run the tests.",
-    );
-  }
-
-  const username = env.AZURE_IDENTITY_TEST_USERNAME;
-  if (!username) {
-    throw new Error(
-      "AZURE_IDENTITY_TEST_USERNAME must be present in the environment to run the tests.",
-    );
-  }
-
-  const password = env.AZURE_IDENTITY_TEST_PASSWORD;
-  if (!password) {
-    throw new Error(
-      "AZURE_IDENTITY_TEST_PASSWORD must be present in the environment to run the tests.",
-    );
-  }
-
-  return {
-    clientId,
-    tenantId,
-    username,
-    password,
-  };
-}

--- a/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
@@ -5,7 +5,7 @@
 
 import { AzureLogger, setLogLevel } from "@azure/logger";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { Recorder, env, isPlaybackMode } from "@azure-tools/test-recorder";
+import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
 import { Context } from "mocha";
 import { PublicClientApplication } from "@azure/msal-node";
 import Sinon from "sinon";
@@ -45,38 +45,38 @@ describe("UsernamePasswordCredential (internal)", function () {
     try {
       new UsernamePasswordCredential(
         undefined as any,
-        env.AZURE_CLIENT_ID!,
-        env.AZURE_USERNAME!,
-        env.AZURE_PASSWORD!,
+        "azure_client_id",
+        "azure_username",
+        "azure_password",
       );
     } catch (e: any) {
       errors.push(e);
     }
     try {
       new UsernamePasswordCredential(
-        env.AZURE_TENANT_ID!,
+        "azure_tenant_id",
         undefined as any,
-        env.AZURE_USERNAME!,
-        env.AZURE_PASSWORD!,
+        "azure_username",
+        "azure_password",
       );
     } catch (e: any) {
       errors.push(e);
     }
     try {
       new UsernamePasswordCredential(
-        env.AZURE_TENANT_ID!,
-        env.AZURE_CLIENT_ID!,
+        "azure_tenant_id",
+        "azure_client_id",
         undefined as any,
-        env.AZURE_PASSWORD!,
+        "azure_password",
       );
     } catch (e: any) {
       errors.push(e);
     }
     try {
       new UsernamePasswordCredential(
-        env.AZURE_TENANT_ID!,
-        env.AZURE_CLIENT_ID!,
-        env.AZURE_USERNAME!,
+        "azure_tenant_id",
+        "azure_client_id",
+        "azure_username",
         undefined as any,
       );
     } catch (e: any) {

--- a/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
@@ -104,7 +104,6 @@ describe("UsernamePasswordCredential (internal)", function () {
 
   it("Authenticates silently after the initial request", async function (this: Context) {
     const { clientId, password, tenantId, username } = getUsernamePasswordStaticResources();
-    // todo: validate these exist or throw with meaningful error
     const credential = new UsernamePasswordCredential(
       tenantId,
       clientId,

--- a/sdk/identity/identity/test/msalTestUtils.ts
+++ b/sdk/identity/identity/test/msalTestUtils.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { env } from "@azure-tools/test-recorder";
+import { DeveloperSignOnClientId } from "../src/constants";
+
 export const PlaybackTenantId = "12345678-1234-1234-1234-123456789012";
 
 /**
@@ -57,3 +60,50 @@ export const openIdConfigurationResponse: Record<string, string | string[] | boo
   msgraph_host: "graph.microsoft.com",
   rbac_url: "https://pas.windows.net",
 };
+
+interface UsernamePasswordStaticResources {
+  clientId: string;
+  tenantId: string;
+  username: string;
+  password: string;
+}
+
+/**
+ * Certain tests rely on static resources fetched from the identity test secrets vault and "merged" into the test environment in CI.
+ *
+ * A helper function validates that these resources are present in the environment as they are not deployed per run.
+ *
+ * When in doubt, reach out to the feature crew for help.
+ *
+ * @returns A set of well-known static resources for the tests.
+ */
+export function getUsernamePasswordStaticResources(): UsernamePasswordStaticResources {
+  const clientId = DeveloperSignOnClientId;
+  const tenantId = env.AZURE_IDENTITY_TEST_TENANTID;
+  if (!tenantId) {
+    throw new Error(
+      "AZURE_IDENTITY_TEST_TENANTID must be present in the environment to run the tests.",
+    );
+  }
+
+  const username = env.AZURE_IDENTITY_TEST_USERNAME;
+  if (!username) {
+    throw new Error(
+      "AZURE_IDENTITY_TEST_USERNAME must be present in the environment to run the tests.",
+    );
+  }
+
+  const password = env.AZURE_IDENTITY_TEST_PASSWORD;
+  if (!password) {
+    throw new Error(
+      "AZURE_IDENTITY_TEST_PASSWORD must be present in the environment to run the tests.",
+    );
+  }
+
+  return {
+    clientId,
+    tenantId,
+    username,
+    password,
+  };
+}

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -59,9 +59,9 @@ export async function msalNodeTestSetup(
         AZURE_CLIENT_SECRET: "azure_client_secret",
         AZURE_USERNAME: "azure_username",
         AZURE_PASSWORD: "azure_password",
-        AZURE_IDENTITY_TEST_TENANTID: "",
-        AZURE_IDENTITY_TEST_USERNAME: "",
-        AZURE_IDENTITY_TEST_PASSWORD: "",
+        AZURE_IDENTITY_TEST_TENANTID: PlaybackTenantId,
+        AZURE_IDENTITY_TEST_USERNAME: "azure_username",
+        AZURE_IDENTITY_TEST_PASSWORD: "azure_password",
         IDENTITY_SP_CLIENT_ID: "",
         IDENTITY_SP_TENANT_ID: "",
         IDENTITY_SP_CLIENT_SECRET: "",
@@ -100,6 +100,11 @@ export async function msalNodeTestSetup(
     await recorder.addSanitizers(
       {
         bodySanitizers: [
+          {
+            regex: true,
+            target: 'username=[^&"]+', // env sanitizers do not handle matching urlencoded params well (@ character is urlencoded)
+            value: "username=azure_username",
+          },
           {
             regex: true,
             target: 'client_secret=[^&"]+',

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -57,8 +57,6 @@ export async function msalNodeTestSetup(
         AZURE_TENANT_ID: PlaybackTenantId,
         AZURE_CLIENT_ID: playbackClientId,
         AZURE_CLIENT_SECRET: "azure_client_secret",
-        AZURE_USERNAME: "azure_username",
-        AZURE_PASSWORD: "azure_password",
         AZURE_IDENTITY_TEST_TENANTID: PlaybackTenantId,
         AZURE_IDENTITY_TEST_USERNAME: "azure_username",
         AZURE_IDENTITY_TEST_PASSWORD: "azure_password",

--- a/sdk/identity/identity/test/public/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/usernamePasswordCredential.spec.ts
@@ -4,15 +4,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { Recorder, delay, env, isLiveMode } from "@azure-tools/test-recorder";
+import { Recorder, delay } from "@azure-tools/test-recorder";
 
 import { AbortController } from "@azure/abort-controller";
 import { Context } from "mocha";
 import { UsernamePasswordCredential } from "../../../src";
 import { assert } from "@azure-tools/test-utils";
-
-// https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/Constants.cs#L9
-const DeveloperSignOnClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
+import { getUsernamePasswordStaticResources } from "../../msalTestUtils";
 
 describe("UsernamePasswordCredential", function () {
   let cleanup: MsalTestCleanup;
@@ -30,14 +28,13 @@ describe("UsernamePasswordCredential", function () {
   const scope = "https://vault.azure.net/.default";
 
   it("authenticates", async function (this: Context) {
-    const tenantId = env.AZURE_IDENTITY_TEST_TENANTID || env.AZURE_TENANT_ID!;
-    const clientId = isLiveMode() ? DeveloperSignOnClientId : env.AZURE_CLIENT_ID!;
+    const { tenantId, clientId, username, password } = getUsernamePasswordStaticResources();
 
     const credential = new UsernamePasswordCredential(
       tenantId,
       clientId,
-      env.AZURE_IDENTITY_TEST_USERNAME || env.AZURE_USERNAME!,
-      env.AZURE_IDENTITY_TEST_PASSWORD || env.AZURE_PASSWORD!,
+      username,
+      password,
       recorder.configureClientOptions({}),
     );
 
@@ -47,14 +44,13 @@ describe("UsernamePasswordCredential", function () {
   });
 
   it("allows cancelling the authentication", async function () {
-    const tenantId = env.AZURE_IDENTITY_TEST_TENANTID || env.AZURE_TENANT_ID!;
-    const clientId = isLiveMode() ? DeveloperSignOnClientId : env.AZURE_CLIENT_ID!;
+    const { tenantId, clientId, username, password } = getUsernamePasswordStaticResources();
 
     const credential = new UsernamePasswordCredential(
       tenantId,
       clientId,
-      env.AZURE_IDENTITY_TEST_USERNAME || env.AZURE_USERNAME!,
-      env.AZURE_IDENTITY_TEST_PASSWORD || env.AZURE_PASSWORD!,
+      username,
+      password,
       recorder.configureClientOptions({
         authorityHost: "https://fake-authority.com",
       }),
@@ -79,16 +75,15 @@ describe("UsernamePasswordCredential", function () {
   });
 
   it("supports tracing", async function (this: Context) {
-    const tenantId = env.AZURE_IDENTITY_TEST_TENANTID || env.AZURE_TENANT_ID!;
-    const clientId = isLiveMode() ? DeveloperSignOnClientId : env.AZURE_CLIENT_ID!;
+    const { clientId, tenantId, username, password } = getUsernamePasswordStaticResources();
 
     await assert.supportsTracing(
       async (tracingOptions) => {
         const credential = new UsernamePasswordCredential(
           tenantId,
           clientId,
-          env.AZURE_IDENTITY_TEST_USERNAME || env.AZURE_USERNAME!,
-          env.AZURE_IDENTITY_TEST_PASSWORD || env.AZURE_PASSWORD!,
+          username,
+          password,
           recorder.configureClientOptions({}),
         );
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29409 

### Describe the problem that is addressed by this PR

Migrates UsernamePasswordCredential to the MSALClient flow, simplifying the implementation.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
- [x] Add MSALClient recorded test
